### PR TITLE
NER driver refactor: flatten backend trait, enable stackable backends

### DIFF
--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -9,7 +9,7 @@ mod session;
 mod types;
 
 pub use detector::{Detection, Detector, PiiClass, RegexDetector};
-pub use ner::{LabelMap, NerDetector, NerLoadError, NerOptions, VerifiedArtifacts};
+pub use ner::{LabelMap, NerBackendKind, NerDetector, NerLoadError, NerOptions, VerifiedArtifacts};
 pub use pipeline::{Error, NerConfig, Pipeline, PipelineBuilder, Result};
 pub use redaction_log::{DocumentKind, RedactionEntry, RedactionLogger, SqliteLogger};
 pub use rule::{Action, ClassRule, ColumnRule, Context, DefaultRule, Rule};

--- a/crates/gaze/src/ner.rs
+++ b/crates/gaze/src/ner.rs
@@ -57,18 +57,28 @@ pub struct NerOptions {
     pub locale: Option<String>,
 }
 
+/// Driver-style enum for NER backends. Backends are swappable under a common
+/// `NerBackend` trait; each owns its own model-specific state. Multiple
+/// `NerDetector` instances (e.g. a BERT token-classifier plus a GLiNER
+/// zero-shot model) can be stacked in the same `Pipeline` — span-conflict
+/// resolution picks winners across all detectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NerBackendKind {
+    /// Standard BERT-family token classifier: fixed label vocabulary, BIO/IOB2
+    /// subword tagging, merged via `merge_bio_spans`. Driven by ONNX Runtime.
     Ort,
-    Redact,
+    /// GLiNER-family zero-shot / open-schema extractor: entity type strings
+    /// passed at inference, output is a span-score matrix. Shape reserved;
+    /// backend implementation lands when GLiNER artifacts are pinned.
+    Gliner,
 }
 
 impl NerBackendKind {
     fn parse(raw: Option<&str>) -> Result<Self, NerLoadError> {
         match raw.map(str::trim).filter(|value| !value.is_empty()) {
             None => Ok(Self::Ort),
-            Some("ort") | Some("onnxruntime") => Ok(Self::Ort),
-            Some("redact") => Ok(Self::Redact),
+            Some("ort") | Some("onnxruntime") | Some("bert-ort") => Ok(Self::Ort),
+            Some("gliner") | Some("gliner-ort") => Ok(Self::Gliner),
             Some(other) => Err(NerLoadError::UnsupportedBackend {
                 backend: other.to_string(),
             }),
@@ -78,7 +88,7 @@ impl NerBackendKind {
     fn as_str(self) -> &'static str {
         match self {
             Self::Ort => "ort",
-            Self::Redact => "redact",
+            Self::Gliner => "gliner",
         }
     }
 }
@@ -131,25 +141,22 @@ enum NerRuntimeError {
     Output(String),
 }
 
+/// Driver contract: produce byte-offset detections against a pre-normalized
+/// input string. Each backend owns its own model-specific state (label map,
+/// id2label for BERT, entity-type list for GLiNER, etc.) — the trait stays
+/// shape-agnostic so new backends plug in without changing `NerDetector`.
 trait NerBackend: Send + Sync {
-    fn detect(
-        &self,
-        input: &str,
-        labels: &LabelMap,
-        id2label: &[String],
-        source: &str,
-    ) -> Result<Vec<Detection>, NerRuntimeError>;
+    fn detect(&self, input: &str) -> Result<Vec<Detection>, NerRuntimeError>;
 }
 
-/// NER detector backed by a pinned local model artifact set.
+/// NER detector backed by a pinned local model artifact set. Multiple
+/// `NerDetector` instances with different backends may be stacked in the
+/// same `Pipeline`; span-conflict resolution picks winners across detectors.
 pub struct NerDetector {
     #[allow(dead_code)]
     model_dir: PathBuf,
-    #[allow(dead_code)]
     backend_kind: NerBackendKind,
     locale: Option<String>,
-    labels: LabelMap,
-    id2label: Vec<String>,
     backend: Box<dyn NerBackend>,
 }
 
@@ -234,14 +241,14 @@ impl NerDetector {
 
     pub fn load_with_options(model_dir: &Path, options: NerOptions) -> Result<Self, NerLoadError> {
         let verified = Self::verify_artifacts(model_dir)?;
-        let backend = load_backend(&verified)?;
+        let backend_kind = verified.backend_kind;
+        let model_dir_path = verified.model_dir.clone();
+        let backend = load_backend(verified)?;
 
         Ok(Self {
-            model_dir: verified.model_dir,
-            backend_kind: verified.backend_kind,
+            model_dir: model_dir_path,
+            backend_kind,
             locale: options.locale,
-            labels: verified.labels,
-            id2label: verified.id2label,
             backend,
         })
     }
@@ -305,8 +312,7 @@ impl NerDetector {
 
 impl Detector for NerDetector {
     fn detect(&self, input: &str) -> Vec<Detection> {
-        let source = format!("ner/{}", self.backend_kind.as_str());
-        match self.backend.detect(input, &self.labels, &self.id2label, &source) {
+        match self.backend.detect(input) {
             Ok(detections) => detections,
             Err(err) => {
                 tracing::warn!(backend = self.backend_kind.as_str(), error = %err, "ner: backend detect failed");
@@ -316,13 +322,19 @@ impl Detector for NerDetector {
     }
 }
 
+/// BERT-family token-classification backend. Owns its tokenizer, ONNX session,
+/// label map, `id2label` vocab, and pre-computed source tag. BIO/IOB2 subword
+/// tags are merged via `NerDetector::merge_bio_spans`.
 struct OrtBackend {
     tokenizer: tokenizers::Tokenizer,
     session: Mutex<ort::session::Session>,
+    labels: LabelMap,
+    id2label: Vec<String>,
+    source: String,
 }
 
 impl OrtBackend {
-    fn load(model_dir: &Path) -> Result<Self, NerLoadError> {
+    fn load(model_dir: &Path, labels: LabelMap, id2label: Vec<String>) -> Result<Self, NerLoadError> {
         let tokenizer = tokenizers::Tokenizer::from_file(model_dir.join(TOKENIZER_FILE))
             .map_err(|err| NerLoadError::Tokenizer(err.to_string()))?;
         let session = ort::session::Session::builder()
@@ -332,18 +344,18 @@ impl OrtBackend {
         Ok(Self {
             tokenizer,
             session: Mutex::new(session),
+            labels,
+            id2label,
+            source: format!("ner/{}", NerBackendKind::Ort.as_str()),
         })
     }
 }
 
 impl NerBackend for OrtBackend {
-    fn detect(
-        &self,
-        input: &str,
-        labels: &LabelMap,
-        id2label: &[String],
-        source: &str,
-    ) -> Result<Vec<Detection>, NerRuntimeError> {
+    fn detect(&self, input: &str) -> Result<Vec<Detection>, NerRuntimeError> {
+        let labels = &self.labels;
+        let id2label: &[String] = &self.id2label;
+        let source = self.source.as_str();
         let encoded = self
             .tokenizer
             .encode(input, true)
@@ -425,10 +437,14 @@ impl NerBackend for OrtBackend {
     }
 }
 
-fn load_backend(verified: &VerifiedArtifacts) -> Result<Box<dyn NerBackend>, NerLoadError> {
+fn load_backend(verified: VerifiedArtifacts) -> Result<Box<dyn NerBackend>, NerLoadError> {
     match verified.backend_kind {
-        NerBackendKind::Ort => Ok(Box::new(OrtBackend::load(&verified.model_dir)?)),
-        NerBackendKind::Redact => Err(NerLoadError::UnsupportedBackend {
+        NerBackendKind::Ort => Ok(Box::new(OrtBackend::load(
+            &verified.model_dir,
+            verified.labels,
+            verified.id2label,
+        )?)),
+        NerBackendKind::Gliner => Err(NerLoadError::UnsupportedBackend {
             backend: verified.backend_kind.as_str().to_string(),
         }),
     }
@@ -569,6 +585,42 @@ fn config_to_id2label(
     Ok(out)
 }
 
+/// Test-only helpers for stacking multiple `NerDetector` instances with
+/// in-memory fake backends. Lets pipeline tests verify Layer-1 stackability
+/// without real ONNX artifacts.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    struct FixedBackend {
+        detections: Vec<Detection>,
+    }
+
+    impl NerBackend for FixedBackend {
+        fn detect(&self, _input: &str) -> Result<Vec<Detection>, NerRuntimeError> {
+            Ok(self.detections.clone())
+        }
+    }
+
+    /// Build a `NerDetector` that emits a fixed detection set, bypassing the
+    /// SHA256-pinned artifact contract. For tests only.
+    pub(crate) fn detector_with_detections(
+        source: &str,
+        detections: Vec<Detection>,
+    ) -> NerDetector {
+        let kind = match source {
+            "gliner" => NerBackendKind::Gliner,
+            _ => NerBackendKind::Ort,
+        };
+        NerDetector {
+            model_dir: PathBuf::from("/test/fake"),
+            backend_kind: kind,
+            locale: None,
+            backend: Box::new(FixedBackend { detections }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -633,20 +685,32 @@ mod tests {
     #[test]
     fn verify_artifacts_honors_explicit_backend_selection() {
         let dir = setup_dir_with_config(
-            br#"{"backend":"redact","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
+            br#"{"backend":"gliner","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
         );
         let verified = NerDetector::verify_artifacts(dir.path()).expect("verify");
-        assert_eq!(verified.backend_kind, NerBackendKind::Redact);
+        assert_eq!(verified.backend_kind, NerBackendKind::Gliner);
     }
 
     #[test]
-    fn load_fails_closed_for_unsupported_backend() {
+    fn load_fails_closed_for_gliner_backend_until_impl_lands() {
         let dir = setup_dir_with_config(
-            br#"{"backend":"redact","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
+            br#"{"backend":"gliner","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
         );
         let err = NerDetector::load(dir.path()).unwrap_err();
         assert!(
-            matches!(err, NerLoadError::UnsupportedBackend { .. }),
+            matches!(&err, NerLoadError::UnsupportedBackend { backend } if backend == "gliner"),
+            "unexpected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_fails_closed_for_unknown_backend() {
+        let dir = setup_dir_with_config(
+            br#"{"backend":"nonesuch","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
+        );
+        let err = NerDetector::load(dir.path()).unwrap_err();
+        assert!(
+            matches!(&err, NerLoadError::UnsupportedBackend { backend } if backend == "nonesuch"),
             "unexpected: {err:?}"
         );
     }

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -202,17 +202,23 @@ impl PipelineBuilder {
         self
     }
 
-    /// Wire up the NER detector from a resolved model directory.
+    /// Wire up a transformer NER detector from a resolved model directory.
+    ///
+    /// **Additive / stackable.** Each call appends another `NerDetector` to
+    /// the pipeline. Stacking multiple backends (for example, a BERT-family
+    /// token classifier plus a GLiNER zero-shot extractor) is supported —
+    /// the span-conflict resolver picks winners across all detectors by
+    /// span length, then insertion order.
     ///
     /// Fail-closed defaults:
-    /// - `None` or empty path → NER is disabled, a `tracing::warn!` is emitted,
-    ///   and the pipeline still builds with regex + index detectors intact.
+    /// - `None` or empty path → NER is disabled for this call, a `tracing::warn!`
+    ///   is emitted, and the pipeline still builds with other detectors intact.
     /// - `Some(path)` → `NerDetector::load` must succeed; any load error
     ///   propagates as `Error::NerLoad` and the pipeline does NOT build.
     ///
     /// No runtime downloads. Caller resolves the model directory from
-    /// `[ner] model_dir` in `policy.toml` or the
-    /// `${XDG_DATA_HOME:-~/.local/share}/gaze/models/davlan-mbert-ner-hrl/` default.
+    /// `[ner] model_dir` in `policy.toml` or the platform default under
+    /// `${XDG_DATA_HOME:-~/.local/share}/gaze/models/`.
     pub fn with_ner_model_dir(self, model_dir: Option<&Path>) -> Result<Self> {
         self.with_ner_config(NerConfig {
             model_dir: model_dir.map(Path::to_path_buf),
@@ -220,6 +226,8 @@ impl PipelineBuilder {
         })
     }
 
+    /// Additive / stackable — see `with_ner_model_dir`. Call repeatedly to
+    /// stack backends with different locales or model artifacts.
     pub fn with_ner_config(self, config: NerConfig) -> Result<Self> {
         let NerConfig { model_dir, locale } = config;
         match model_dir {
@@ -338,5 +346,128 @@ fn generalize_token(class: &crate::detector::PiiClass) -> String {
 fn build_context(field_name: Option<&str>) -> Context {
     Context {
         field_name: field_name.map(str::to_string),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detector::{Detection, PiiClass};
+    use crate::ner::test_support::detector_with_detections;
+    use crate::rule::{ClassRule, DefaultRule};
+    use crate::session::{Scope, Session};
+    use std::sync::Mutex;
+
+    /// Shared-handle test double: callers keep an `Arc<Mutex<Vec<_>>>` and
+    /// clone it into the logger, letting the builder take ownership while
+    /// the test retains read access.
+    struct CapturingLogger {
+        entries: Arc<Mutex<Vec<RedactionEntry>>>,
+    }
+
+    impl RedactionLogger for CapturingLogger {
+        fn log(&self, entry: &RedactionEntry) -> Result<()> {
+            self.entries.lock().unwrap().push(entry.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn stacked_ner_detectors_resolve_via_span_conflict() {
+        // Input: "Alice Smith works here" — byte spans: Alice=0..5, full name=0..11.
+        let text = "Alice Smith works here";
+        let short_detection = Detection {
+            span: 0..5,
+            class: PiiClass::Name,
+            source: "ner/bert".to_string(),
+        };
+        let long_detection = Detection {
+            span: 0..11,
+            class: PiiClass::Name,
+            source: "ner/gliner".to_string(),
+        };
+
+        let bert = detector_with_detections("ort", vec![short_detection]);
+        let gliner = detector_with_detections("gliner", vec![long_detection]);
+
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+
+        let pipeline = Pipeline::builder()
+            .detector(bert)
+            .detector(gliner)
+            .rule(ClassRule::new(PiiClass::Name, Action::Redact))
+            .rule(DefaultRule::new(Action::Preserve))
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .build()
+            .expect("pipeline");
+
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = pipeline
+            .redact(&session, RawDocument::Text(text.to_string()))
+            .expect("redact");
+
+        let out = match clean {
+            CleanDocument::Text(t) => t,
+            _ => panic!("expected text"),
+        };
+
+        // Longer span wins: full name replaced, trailing " works here" preserved.
+        assert_eq!(out, "[REDACTED] works here");
+
+        let entries = entries.lock().unwrap();
+        assert_eq!(entries.len(), 2, "expected one winner + one loser: {entries:?}");
+        let winner = entries.iter().find(|e| !e.conflict_loser).expect("winner");
+        let loser = entries.iter().find(|e| e.conflict_loser).expect("loser");
+        assert_eq!(winner.source, "ner/gliner", "longer span should win");
+        assert_eq!(loser.source, "ner/bert", "shorter span should lose");
+    }
+
+    #[test]
+    fn stacked_detectors_both_win_when_spans_disjoint() {
+        let text = "Alice visited Berlin";
+        let alice = Detection {
+            span: 0..5,
+            class: PiiClass::Name,
+            source: "ner/bert".to_string(),
+        };
+        let berlin = Detection {
+            span: 14..20,
+            class: PiiClass::Location,
+            source: "ner/gliner".to_string(),
+        };
+
+        let bert = detector_with_detections("ort", vec![alice]);
+        let gliner = detector_with_detections("gliner", vec![berlin]);
+
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+
+        let pipeline = Pipeline::builder()
+            .detector(bert)
+            .detector(gliner)
+            .rule(ClassRule::new(PiiClass::Name, Action::Redact))
+            .rule(ClassRule::new(PiiClass::Location, Action::Redact))
+            .rule(DefaultRule::new(Action::Preserve))
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .build()
+            .expect("pipeline");
+
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = pipeline
+            .redact(&session, RawDocument::Text(text.to_string()))
+            .expect("redact");
+
+        let out = match clean {
+            CleanDocument::Text(t) => t,
+            _ => panic!("expected text"),
+        };
+
+        assert_eq!(out, "[REDACTED] visited [REDACTED]");
+        let entries = entries.lock().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().all(|e| !e.conflict_loser));
     }
 }


### PR DESCRIPTION
## Summary

Prepares the NER subsystem to accept non-BERT backends (GLiNER zero-shot / open-schema) alongside the existing BERT token-classifier, per the 2026-04-17 substrate audit that recommended pivoting away from Davlan/mBERT (AFL-3.0) toward GLiNER-X (Apache-2.0).

- **Flatten \`NerBackend\` trait.** Drop the BERT-specific \`labels\` / \`id2label\` / \`source\` args from \`detect(&self, input)\`. Each backend owns its own model-specific state. This is the minimum contract change needed to plug in GLiNER's span-score output shape without bending a BIO-flavored interface.
- **Push BERT state into \`OrtBackend\`.** Labels, \`id2label\` vocab, and the pre-computed \`ner/ort\` source tag move off \`NerDetector\` into \`OrtBackend\`. \`NerDetector\` becomes a thin delegator.
- **Swap \`NerBackendKind::Redact\` → \`Gliner\`.** \`Redact\` is gone for good (censgate/redact rejected per architectural decision). \`Gliner\` variant is shape-reserved and fails closed as \`UnsupportedBackend\` until real artifacts land — next PR wires the actual GLiNER ONNX runner.
- **Document stackability.** \`PipelineBuilder::with_ner_model_dir\` and \`with_ner_config\` are additive and chainable — call twice to stack a BERT detector and a GLiNER detector; the span-conflict resolver picks winners across both.
- **Stacking tests.** Two new \`pipeline::tests\` cases exercise stacked NerDetectors via an in-memory fake backend: one proves the longer span wins on overlap (and the loser is logged with \`conflict_loser=true\`), the other proves disjoint detections from different backends both apply.

Fail-closed artifact load contract (SHA256SUMS verification, \`MissingArtifact\` / \`ChecksumMismatch\` paths) is unchanged. BIO merge logic is unchanged.

## Test plan

- [x] \`cargo test -p gaze\` — 46 tests across lib + integration + doctests + UI suites, all green
- [x] \`cargo check --workspace\` — gaze, debug-proxy, ghostwriter all build
- [x] All existing NER unit tests still pass without modification
- [x] New stacking tests: longer span wins, disjoint spans both apply
- [x] Gliner variant rejected with expected error until real impl lands

## Follow-up

- Wire real GLiNER backend (knowledgator/gliner-x-small quantized ONNX) in a separate PR
- Update scripts/fetch-ner-model.sh for the new pinned artifact