### PR TITLE
solo #5: reserve built-in class names, fix Custom/built-in collision

### DIFF
--- a/crates/gaze/src/detector.rs
+++ b/crates/gaze/src/detector.rs
@@ -19,8 +19,6 @@ pub enum PiiClass {
     Custom(String),
 }
 
-const RESERVED_CUSTOM_CLASS_NAMES: &[&str] = &["email", "name", "location", "organization"];
-
 impl PiiClass {
     pub fn custom(name: &str) -> Self {
         let mut normalized = String::new();
@@ -35,12 +33,6 @@ impl PiiClass {
             } else {
                 pending_underscore = true;
             }
-        }
-
-        // Reserve built-in slot names so custom classes cannot emit the same
-        // PascalCase token prefix as built-in classes during tokenization.
-        if RESERVED_CUSTOM_CLASS_NAMES.contains(&normalized.as_str()) {
-            return Self::Custom(format!("_custom_{normalized}"));
         }
 
         Self::Custom(normalized)
@@ -107,10 +99,10 @@ mod tests {
     use super::PiiClass;
 
     #[test]
-    fn custom_reserved_name_gets_prefixed() {
+    fn custom_name_normalizes_without_reserved_rewrite() {
         assert_eq!(
             PiiClass::custom("email"),
-            PiiClass::Custom("_custom_email".to_string())
+            PiiClass::Custom("email".to_string())
         );
     }
 }

--- a/crates/gaze/src/detector.rs
+++ b/crates/gaze/src/detector.rs
@@ -19,6 +19,8 @@ pub enum PiiClass {
     Custom(String),
 }
 
+const RESERVED_CUSTOM_CLASS_NAMES: &[&str] = &["email", "name", "location", "organization"];
+
 impl PiiClass {
     pub fn custom(name: &str) -> Self {
         let mut normalized = String::new();
@@ -34,6 +36,13 @@ impl PiiClass {
                 pending_underscore = true;
             }
         }
+
+        // Reserve built-in slot names so custom classes cannot emit the same
+        // PascalCase token prefix as built-in classes during tokenization.
+        if RESERVED_CUSTOM_CLASS_NAMES.contains(&normalized.as_str()) {
+            return Self::Custom(format!("_custom_{normalized}"));
+        }
+
         Self::Custom(normalized)
     }
 
@@ -90,5 +99,18 @@ impl Detector for RegexDetector {
                 source: self.source.clone(),
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PiiClass;
+
+    #[test]
+    fn custom_reserved_name_gets_prefixed() {
+        assert_eq!(
+            PiiClass::custom("email"),
+            PiiClass::Custom("_custom_email".to_string())
+        );
     }
 }

--- a/crates/gaze/src/main.rs
+++ b/crates/gaze/src/main.rs
@@ -19,13 +19,17 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use gaze::{
-    Action, ClassRule, DefaultRule, DocumentKind, Pipeline, PiiClass, RawDocument,
-    Policy, PolicyError, RedactionEntry, RedactionLogger, RegexDetector, Result as GazeResult,
-    Scope, Session, SensitiveSnapshot,
+    Action, ClassRule, DefaultRule, DocumentKind, PiiClass, Pipeline, Policy, PolicyError,
+    RawDocument, RedactionEntry, RedactionLogger, RegexDetector, Result as GazeResult, Scope,
+    SensitiveSnapshot, Session,
 };
 
 #[derive(Parser, Debug)]
-#[command(name = "gaze", version, about = "Channel-agnostic PII redaction for LLM pipes")]
+#[command(
+    name = "gaze",
+    version,
+    about = "Channel-agnostic PII redaction for LLM pipes"
+)]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,
@@ -85,10 +89,7 @@ enum CliError {
 impl CliError {
     fn exit_code(&self) -> u8 {
         match self {
-            Self::StdinParse
-            | Self::EmptyInput
-            | Self::InputTooLarge
-            | Self::InvalidEncoding => 1,
+            Self::StdinParse | Self::EmptyInput | Self::InputTooLarge | Self::InvalidEncoding => 1,
             Self::PolicyConfig => 2,
             Self::UnknownToken
             | Self::InvalidSignature
@@ -291,12 +292,13 @@ fn run_restore(format: &str, max_bytes: u64) -> std::result::Result<(), CliError
         .decode(request.session_blob.as_bytes())
         .map_err(|_| CliError::StdinParse)?;
 
-    let session = Session::import(SensitiveSnapshot::from(blob_bytes)).map_err(|err| match err {
-        gaze::Error::InvalidSnapshotSignature => CliError::InvalidSignature,
-        gaze::Error::InvalidSnapshotVersion(_) => CliError::InvalidBlobVersion,
-        gaze::Error::BlobExpired { .. } => CliError::BlobExpired,
-        _ => CliError::Pipeline,
-    })?;
+    let session =
+        Session::import(SensitiveSnapshot::from(blob_bytes)).map_err(|err| match err {
+            gaze::Error::InvalidSnapshotSignature => CliError::InvalidSignature,
+            gaze::Error::InvalidSnapshotVersion(_) => CliError::InvalidBlobVersion,
+            gaze::Error::BlobExpired { .. } => CliError::BlobExpired,
+            _ => CliError::Pipeline,
+        })?;
 
     let pass1 = restore_pass1(&session, &request.text)?;
     restore_pass2_validate(&pass1)?;
@@ -365,11 +367,12 @@ fn restore_pass1(session: &Session, text: &str) -> std::result::Result<String, C
 ///
 /// Any remaining token-shaped substring means the LLM invented a token the
 /// session never emitted → `UnknownToken`. Three shapes cover the library's
-/// output: PascalCase `Class_N`, lowercase `class_n` FormatPreserve, and the
-/// format-preserved email shape. \b word boundaries keep legitimate text like
-/// `hostName_1s-record` from triggering false positives.
+/// output: PascalCase `Class_N`, namespaced `Custom:name_N`, lowercase
+/// `class_n` / `custom:name_n` FormatPreserve, and the format-preserved email
+/// shape. \b word boundaries keep legitimate text like `hostName_1s-record`
+/// from triggering false positives.
 fn restore_pass2_validate(text: &str) -> std::result::Result<(), CliError> {
-    static PATTERN: &str = r"\b[A-Z][a-zA-Z]+_\d+\b|\b[a-z][a-z_]+_\d+\b|\bemail\d+@example\.test\b";
+    static PATTERN: &str = r"\bCustom:[a-z][a-z0-9_]*_\d+\b|\bcustom:[a-z][a-z0-9_]*_\d+\b|\b[A-Z][a-zA-Z]+_\d+\b|\b[a-z][a-z_]+_\d+\b|\bemail\d+@example\.test\b";
     let re = Regex::new(PATTERN).map_err(|_| CliError::Pipeline)?;
     if re.is_match(text) {
         return Err(CliError::UnknownToken);

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -82,12 +82,16 @@ impl Session {
     }
 
     pub fn tokenize(&self, class: &PiiClass, raw: &str) -> Result<String> {
-        self.intern_mapping(class, raw, |index| format!("{}_{}", class_name(class), index))
+        self.intern_mapping(class, raw, |index| {
+            format!("{}_{}", class_name(class), index)
+        })
     }
 
     pub fn format_preserving_fake(&self, class: &PiiClass, raw: &str) -> Result<String> {
         self.intern_mapping(class, raw, |index| match class {
             PiiClass::Email => format!("email{index}@example.test"),
+            // Lowercasing preserves the dedicated `custom:` sentinel namespace
+            // for format-preserving fakes, so restore can detect them too.
             _ => format!("{}_{}", class_name(class).to_ascii_lowercase(), index),
         })
     }
@@ -143,7 +147,9 @@ impl Session {
     }
 
     pub fn restore(&self, token: &str) -> Option<String> {
-        self.value_by_token.get(token).map(|value| value.value().clone())
+        self.value_by_token
+            .get(token)
+            .map(|value| value.value().clone())
     }
 
     pub fn export(&self) -> Result<SensitiveSnapshot> {
@@ -247,7 +253,9 @@ impl Session {
                 },
                 entry.token.clone(),
             );
-            session.value_by_token.insert(entry.token.clone(), entry.raw);
+            session
+                .value_by_token
+                .insert(entry.token.clone(), entry.raw);
             if let Some(index) = parse_token_index(&entry.token) {
                 let mut next = session.next_by_class.entry(entry.class).or_insert(0);
                 if *next < index {
@@ -367,25 +375,7 @@ fn class_name(class: &PiiClass) -> String {
         PiiClass::Name => "Name".to_string(),
         PiiClass::Location => "Location".to_string(),
         PiiClass::Organization => "Organization".to_string(),
-        PiiClass::Custom(name) => custom_class_name(name),
-    }
-}
-
-fn custom_class_name(name: &str) -> String {
-    let mut out = String::new();
-    for segment in name.split('_').filter(|segment| !segment.is_empty()) {
-        let mut chars = segment.chars();
-        if let Some(first) = chars.next() {
-            out.push(first.to_ascii_uppercase());
-            for ch in chars {
-                out.push(ch.to_ascii_lowercase());
-            }
-        }
-    }
-    if out.is_empty() {
-        "Custom".to_string()
-    } else {
-        out
+        PiiClass::Custom(name) => format!("Custom:{name}"),
     }
 }
 
@@ -439,7 +429,10 @@ mod tests {
         let message = b"gaze";
         let signature = signing_key.sign(message);
 
-        assert!(signing_key.verifying_key().verify(message, &signature).is_ok());
+        assert!(signing_key
+            .verifying_key()
+            .verify(message, &signature)
+            .is_ok());
     }
 
     #[test]
@@ -512,21 +505,59 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_distinguishes_builtin_and_reserved_custom_class_names() {
+    fn tokenize_distinguishes_builtin_and_custom_class_names() {
         let session = Session::new(Scope::Ephemeral).expect("session");
-        let custom_email = PiiClass::custom("email");
+        for (builtin, name) in [
+            (PiiClass::Email, "email"),
+            (PiiClass::Name, "name"),
+            (PiiClass::Location, "location"),
+            (PiiClass::Organization, "organization"),
+        ] {
+            let builtin_value = format!("{name}-builtin");
+            let custom_value = format!("{name}-custom");
 
-        let builtin_token = session
-            .tokenize(&PiiClass::Email, "alice@corp.com")
-            .expect("builtin token");
-        let custom_token = session
-            .tokenize(&custom_email, "hello")
-            .expect("custom token");
+            let builtin_token = session
+                .tokenize(&builtin, &builtin_value)
+                .expect("builtin token");
+            let custom_class = PiiClass::custom(name);
+            let custom_token = session
+                .tokenize(&custom_class, &custom_value)
+                .expect("custom token");
 
-        assert_eq!(builtin_token, "Email_1");
-        assert_eq!(custom_token, "CustomEmail_1");
-        assert_ne!(builtin_token, custom_token);
-        assert_eq!(session.restore(&builtin_token).as_deref(), Some("alice@corp.com"));
-        assert_eq!(session.restore(&custom_token).as_deref(), Some("hello"));
+            assert_eq!(builtin_token, format!("{}_1", class_name(&builtin)));
+            assert_eq!(custom_token, format!("Custom:{name}_1"));
+            assert_ne!(builtin_token, custom_token);
+            assert_eq!(
+                session.restore(&builtin_token).as_deref(),
+                Some(builtin_value.as_str())
+            );
+            assert_eq!(
+                session.restore(&custom_token).as_deref(),
+                Some(custom_value.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn tokenize_distinguishes_custom_classes_with_matching_pascal_case() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let first_class = PiiClass::custom("email");
+        let second_class = PiiClass::custom("custom_email");
+
+        let first_token = session
+            .tokenize(&first_class, "alice@corp.com")
+            .expect("first custom token");
+        let second_token = session
+            .tokenize(&second_class, "hello")
+            .expect("second custom token");
+
+        assert_eq!(first_token, "Custom:email_1");
+        assert_eq!(second_token, "Custom:custom_email_1");
+        assert_ne!(first_token, second_token);
+        assert_eq!(
+            session.restore(&first_token).as_deref(),
+            Some("alice@corp.com")
+        );
+        assert_eq!(session.restore(&second_token).as_deref(), Some("hello"));
     }
 }

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -510,4 +510,23 @@ mod tests {
             Err(Error::InvalidSnapshotSignature)
         ));
     }
+
+    #[test]
+    fn tokenize_distinguishes_builtin_and_reserved_custom_class_names() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let custom_email = PiiClass::custom("email");
+
+        let builtin_token = session
+            .tokenize(&PiiClass::Email, "alice@corp.com")
+            .expect("builtin token");
+        let custom_token = session
+            .tokenize(&custom_email, "hello")
+            .expect("custom token");
+
+        assert_eq!(builtin_token, "Email_1");
+        assert_eq!(custom_token, "CustomEmail_1");
+        assert_ne!(builtin_token, custom_token);
+        assert_eq!(session.restore(&builtin_token).as_deref(), Some("alice@corp.com"));
+        assert_eq!(session.restore(&custom_token).as_deref(), Some("hello"));
+    }
 }


### PR DESCRIPTION
## Summary
`PiiClass::Custom("email")` previously collided with built-in `PiiClass::Email` because both normalised to the same token prefix `Email_N`. The restore map lost one of them on a second insert. This PR rejects / renames custom class names that collide with built-in slots.

Closes solo todo #5. Related: counselors review §3 (codex).

## Test plan
- [ ] Unit test: `PiiClass::custom("email")` produces a Custom variant that does not emit `Email_N` tokens.
- [ ] Unit test: `Session::tokenize` on both classes emits distinct tokens + both map back via `restore`.
- [ ] `cargo test -p gaze` green.