### PR TITLE
solo #3: policy.toml loader + Pipeline::from_policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "trybuild",
  "unicode-normalization",

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
+toml = "0.8"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 tracing = "0.1"
 unicode-normalization = "0.1"

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -2,6 +2,7 @@ mod detector;
 mod ner;
 mod normalize;
 mod pipeline;
+mod policy;
 mod redaction_log;
 mod rule;
 mod sandbox;
@@ -11,6 +12,10 @@ mod types;
 pub use detector::{Detection, Detector, PiiClass, RegexDetector};
 pub use ner::{LabelMap, NerBackendKind, NerDetector, NerLoadError, NerOptions, VerifiedArtifacts};
 pub use pipeline::{Error, NerConfig, Pipeline, PipelineBuilder, Result};
+pub use policy::{
+    DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec, SessionPolicy,
+    SessionScope,
+};
 pub use redaction_log::{DocumentKind, RedactionEntry, RedactionLogger, SqliteLogger};
 pub use rule::{Action, ClassRule, ColumnRule, Context, DefaultRule, Rule};
 pub use sandbox::{

--- a/crates/gaze/src/main.rs
+++ b/crates/gaze/src/main.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 
 use gaze::{
     Action, ClassRule, DefaultRule, DocumentKind, Pipeline, PiiClass, RawDocument,
-    RedactionEntry, RedactionLogger, RegexDetector, Result as GazeResult, Scope, Session,
-    SensitiveSnapshot,
+    Policy, PolicyError, RedactionEntry, RedactionLogger, RegexDetector, Result as GazeResult,
+    Scope, Session, SensitiveSnapshot,
 };
 
 #[derive(Parser, Debug)]
@@ -79,7 +79,6 @@ enum CliError {
     BlobExpired,
     Pipeline,
     Io,
-    #[allow(dead_code)] // Emitted once solo #3 lands policy.toml loader with file-open path.
     PolicyOpen,
 }
 
@@ -223,7 +222,7 @@ fn require_json_format(format: &str) -> std::result::Result<(), CliError> {
 }
 
 fn run_clean(
-    _policy: Option<&std::path::Path>,
+    policy: Option<&std::path::Path>,
     format: &str,
     session_ttl: u64,
     max_bytes: u64,
@@ -232,8 +231,21 @@ fn run_clean(
     let raw = read_stdin_text(max_bytes)?;
 
     let counter = Arc::new(CountingLogger::default());
-    let pipeline = build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>)
-        .map_err(|_| CliError::PolicyConfig)?;
+    let pipeline = match policy {
+        Some(path) => {
+            let policy = Policy::load(path).map_err(map_policy_error)?;
+            Pipeline::from_policy(&policy)
+                .map_err(map_pipeline_error)?
+                .with_redaction_logger(ArcLogger(
+                    Arc::clone(&counter) as Arc<dyn RedactionLogger>
+                ))
+        }
+        None => {
+            tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
+            build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>)
+                .map_err(|_| CliError::PolicyConfig)?
+        }
+    };
 
     let session = Session::new(Scope::Persistent {
         ttl: Duration::from_secs(session_ttl),
@@ -293,6 +305,20 @@ fn run_restore(format: &str, max_bytes: u64) -> std::result::Result<(), CliError
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
     println!("{json}");
     Ok(())
+}
+
+fn map_policy_error(err: PolicyError) -> CliError {
+    match err {
+        PolicyError::Io(_) => CliError::PolicyOpen,
+        _ => CliError::PolicyConfig,
+    }
+}
+
+fn map_pipeline_error(err: gaze::Error) -> CliError {
+    match err {
+        gaze::Error::Policy(policy_err) => map_policy_error(policy_err),
+        _ => CliError::Pipeline,
+    }
 }
 
 /// Pass 1 — exact-literal alternation built from `session.tokens()`.

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -96,6 +96,14 @@ impl Pipeline {
         builder.build()
     }
 
+    pub fn with_redaction_logger<L>(mut self, logger: L) -> Pipeline
+    where
+        L: RedactionLogger + 'static,
+    {
+        self.redaction_loggers.push(Arc::new(logger));
+        self
+    }
+
     pub fn redact(&self, session: &Session, raw: RawDocument) -> Result<CleanDocument> {
         match raw {
             RawDocument::Structured(fields) => {

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -8,10 +8,12 @@ use thiserror::Error;
 use crate::detector::{Detection, Detector};
 use crate::ner::{NerDetector, NerOptions};
 use crate::normalize::normalize;
+use crate::policy::{DetectorKind, Policy, PolicyError, RuleSpec};
 use crate::redaction_log::{DocumentKind, RedactionEntry, RedactionLogger};
 use crate::rule::{Action, Context, Rule};
 use crate::session::Session;
 use crate::types::{CleanDocument, RawDocument, Value};
+use crate::{ClassRule, ColumnRule, DefaultRule, RegexDetector};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -35,6 +37,8 @@ pub enum Error {
     Sqlite(String),
     #[error("ner load error: {0}")]
     NerLoad(#[source] crate::ner::NerLoadError),
+    #[error("policy error: {0}")]
+    Policy(#[from] PolicyError),
 }
 
 #[derive(Clone)]
@@ -47,6 +51,49 @@ pub struct Pipeline {
 impl Pipeline {
     pub fn builder() -> PipelineBuilder {
         PipelineBuilder::default()
+    }
+
+    pub fn from_policy(policy: &Policy) -> Result<Pipeline> {
+        let mut builder = Pipeline::builder();
+
+        for detector in &policy.detectors {
+            builder = match &detector.kind {
+                DetectorKind::Regex => builder.detector(RegexDetector::with_source(
+                    &detector.pattern,
+                    detector.class.clone(),
+                    &detector.name,
+                )?),
+                DetectorKind::Unknown(kind) => {
+                    return Err(PolicyError::BadTtl(format!(
+                        "unknown detector.kind '{kind}'"
+                    ))
+                    .into())
+                }
+            };
+        }
+
+        for rule in &policy.rules {
+            builder = match rule {
+                RuleSpec::Class { class, action } => {
+                    builder.rule(ClassRule::new(class.clone(), *action))
+                }
+                RuleSpec::Column { column, action } => {
+                    builder.rule(ColumnRule::new(column, *action))
+                }
+                RuleSpec::Default { action } => builder.rule(DefaultRule::new(*action)),
+            };
+        }
+
+        if let Some(ner) = &policy.ner {
+            if ner.model_dir.is_some() {
+                builder = builder.with_ner_config(NerConfig {
+                    model_dir: ner.model_dir.clone(),
+                    locale: ner.locale.clone(),
+                })?;
+            }
+        }
+
+        builder.build()
     }
 
     pub fn redact(&self, session: &Session, raw: RawDocument) -> Result<CleanDocument> {
@@ -353,12 +400,14 @@ fn build_context(field_name: Option<&str>) -> Context {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use super::*;
     use crate::detector::{Detection, PiiClass};
     use crate::ner::test_support::detector_with_detections;
     use crate::rule::{ClassRule, DefaultRule};
     use crate::session::{Scope, Session};
     use std::sync::Mutex;
+    use tempfile::tempdir;
 
     /// Shared-handle test double: callers keep an `Arc<Mutex<Vec<_>>>` and
     /// clone it into the logger, letting the builder take ownership while
@@ -471,5 +520,51 @@ mod tests {
         let entries = entries.lock().unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().all(|e| !e.conflict_loser));
+    }
+
+    #[test]
+    fn pipeline_builds_from_policy_and_detects_email() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.toml");
+        fs::write(
+            &path,
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+        )
+        .unwrap();
+
+        let policy = Policy::load(&path).unwrap();
+        let pipeline = Pipeline::from_policy(&policy).unwrap();
+        let session = Session::new(Scope::Ephemeral).unwrap();
+
+        let clean = pipeline
+            .redact(
+                &session,
+                RawDocument::Text("Reach alice@example.com today".to_string()),
+            )
+            .unwrap();
+
+        match clean {
+            CleanDocument::Text(text) => assert_eq!(text, "Reach Email_1 today"),
+            other => panic!("expected text output, got {other:?}"),
+        }
     }
 }

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -1,0 +1,370 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::{Action, PiiClass};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Policy {
+    pub session: SessionPolicy,
+    pub detectors: Vec<DetectorSpec>,
+    pub rules: Vec<RuleSpec>,
+    pub ner: Option<NerPolicy>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionPolicy {
+    pub scope: SessionScope,
+    pub ttl_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionScope {
+    Ephemeral,
+    Conversation,
+    Persistent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectorSpec {
+    pub kind: DetectorKind,
+    pub name: String,
+    pub pattern: String,
+    pub class: PiiClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetectorKind {
+    Regex,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NerPolicy {
+    pub model_dir: Option<PathBuf>,
+    pub locale: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuleSpec {
+    Class { class: PiiClass, action: Action },
+    Column { column: String, action: Action },
+    Default { action: Action },
+}
+
+#[derive(Debug, Error)]
+pub enum PolicyError {
+    #[error("failed to parse policy.toml: {0}")]
+    TomlParse(#[source] toml::de::Error),
+    #[error("failed to read policy file: {0}")]
+    Io(#[source] std::io::Error),
+    #[error("unknown pii class: {0}")]
+    UnknownClass(String),
+    #[error("invalid regex for detector '{name}': {source}")]
+    BadRegex {
+        name: String,
+        #[source]
+        source: regex::Error,
+    },
+    #[error("session.ttl_secs is required when session.scope = \"persistent\"")]
+    MissingTtl,
+    #[error("invalid session.ttl_secs: {0}")]
+    BadTtl(String),
+    #[error("policy must define at least one rule")]
+    NoRules,
+    #[error("policy must define at least one detector")]
+    NoDetectors,
+}
+
+impl Policy {
+    pub fn load(path: &Path) -> Result<Policy, PolicyError> {
+        let raw = fs::read_to_string(path).map_err(PolicyError::Io)?;
+        let raw: RawPolicy = toml::from_str(&raw).map_err(PolicyError::TomlParse)?;
+        raw.try_into()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPolicy {
+    session: RawSessionPolicy,
+    #[serde(rename = "detector", default)]
+    detectors: Vec<RawDetectorSpec>,
+    #[serde(rename = "rule", default)]
+    rules: Vec<RawRuleSpec>,
+    #[serde(default)]
+    ner: Option<RawNerPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSessionPolicy {
+    scope: String,
+    ttl_secs: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawDetectorSpec {
+    kind: String,
+    name: String,
+    pattern: String,
+    class: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawNerPolicy {
+    model_dir: Option<String>,
+    locale: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRuleSpec {
+    kind: String,
+    class: Option<String>,
+    column: Option<String>,
+    action: String,
+}
+
+impl TryFrom<RawPolicy> for Policy {
+    type Error = PolicyError;
+
+    fn try_from(raw: RawPolicy) -> Result<Self, Self::Error> {
+        let session = parse_session(raw.session)?;
+
+        let mut detectors = Vec::with_capacity(raw.detectors.len());
+        for detector in raw.detectors {
+            detectors.push(parse_detector(detector)?);
+        }
+        if detectors.is_empty() {
+            return Err(PolicyError::NoDetectors);
+        }
+
+        let mut rules = Vec::with_capacity(raw.rules.len());
+        for rule in raw.rules {
+            rules.push(parse_rule(rule)?);
+        }
+        if rules.is_empty() {
+            return Err(PolicyError::NoRules);
+        }
+
+        let ner = raw.ner.map(parse_ner).transpose()?;
+
+        Ok(Self {
+            session,
+            detectors,
+            rules,
+            ner,
+        })
+    }
+}
+
+fn parse_session(raw: RawSessionPolicy) -> Result<SessionPolicy, PolicyError> {
+    let scope = match raw.scope.as_str() {
+        "ephemeral" => SessionScope::Ephemeral,
+        "conversation" => SessionScope::Conversation,
+        "persistent" => SessionScope::Persistent,
+        other => return Err(PolicyError::BadTtl(format!("unknown session.scope '{other}'"))),
+    };
+
+    match scope {
+        SessionScope::Persistent => match raw.ttl_secs {
+            Some(0) => Err(PolicyError::BadTtl(
+                "session.ttl_secs must be greater than zero".to_string(),
+            )),
+            Some(ttl_secs) => Ok(SessionPolicy {
+                scope,
+                ttl_secs: Some(ttl_secs),
+            }),
+            None => Err(PolicyError::MissingTtl),
+        },
+        _ => {
+            if raw.ttl_secs == Some(0) {
+                return Err(PolicyError::BadTtl(
+                    "session.ttl_secs must be greater than zero".to_string(),
+                ));
+            }
+            Ok(SessionPolicy {
+                scope,
+                ttl_secs: raw.ttl_secs,
+            })
+        }
+    }
+}
+
+fn parse_detector(raw: RawDetectorSpec) -> Result<DetectorSpec, PolicyError> {
+    regex::Regex::new(&raw.pattern).map_err(|source| PolicyError::BadRegex {
+        name: raw.name.clone(),
+        source,
+    })?;
+
+    Ok(DetectorSpec {
+        kind: match raw.kind.as_str() {
+            "regex" => DetectorKind::Regex,
+            other => DetectorKind::Unknown(other.to_string()),
+        },
+        name: raw.name,
+        pattern: raw.pattern,
+        class: parse_class(&raw.class)?,
+    })
+}
+
+fn parse_rule(raw: RawRuleSpec) -> Result<RuleSpec, PolicyError> {
+    let action = parse_action(&raw.action)?;
+    match raw.kind.as_str() {
+        "class" => {
+            let class = raw
+                .class
+                .ok_or_else(|| PolicyError::UnknownClass("missing rule.class".to_string()))?;
+            Ok(RuleSpec::Class {
+                class: parse_class(&class)?,
+                action,
+            })
+        }
+        "column" => Ok(RuleSpec::Column {
+            column: raw
+                .column
+                .ok_or_else(|| PolicyError::BadTtl("missing rule.column".to_string()))?,
+            action,
+        }),
+        "default" => Ok(RuleSpec::Default { action }),
+        other => Err(PolicyError::BadTtl(format!("unknown rule.kind '{other}'"))),
+    }
+}
+
+fn parse_ner(raw: RawNerPolicy) -> Result<NerPolicy, PolicyError> {
+    Ok(NerPolicy {
+        model_dir: raw.model_dir.map(expand_home).transpose()?,
+        locale: raw.locale,
+    })
+}
+
+fn expand_home(path: String) -> Result<PathBuf, PolicyError> {
+    if let Some(rest) = path.strip_prefix("~/") {
+        let home = env::var("HOME")
+            .map_err(|_| PolicyError::BadTtl("HOME is not set for ~/ expansion".to_string()))?;
+        Ok(PathBuf::from(home).join(rest))
+    } else {
+        Ok(PathBuf::from(path))
+    }
+}
+
+fn parse_class(input: &str) -> Result<PiiClass, PolicyError> {
+    match input {
+        "email" => Ok(PiiClass::Email),
+        "name" => Ok(PiiClass::Name),
+        "location" => Ok(PiiClass::Location),
+        "organization" => Ok(PiiClass::Organization),
+        custom if custom.starts_with("custom:") => {
+            let name = custom.trim_start_matches("custom:");
+            if name.trim().is_empty() {
+                return Err(PolicyError::UnknownClass(input.to_string()));
+            }
+            Ok(PiiClass::custom(name))
+        }
+        _ => Err(PolicyError::UnknownClass(input.to_string())),
+    }
+}
+
+fn parse_action(input: &str) -> Result<Action, PolicyError> {
+    match input {
+        "tokenize" => Ok(Action::Tokenize),
+        "redact" => Ok(Action::Redact),
+        "format_preserve" => Ok(Action::FormatPreserve),
+        "generalize" => Ok(Action::Generalize),
+        "preserve" => Ok(Action::Preserve),
+        other => Err(PolicyError::BadTtl(format!("unknown rule.action '{other}'"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn loads_policy_and_expands_home() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.toml");
+        fs::write(
+            &path,
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[ner]
+model_dir = "~/.cache/gaze/model"
+locale = "de"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+        )
+        .unwrap();
+
+        let old_home = env::var_os("HOME");
+        env::set_var("HOME", "/tmp/gaze-home");
+        let policy = Policy::load(&path).unwrap();
+        match old_home {
+            Some(value) => env::set_var("HOME", value),
+            None => env::remove_var("HOME"),
+        }
+
+        assert_eq!(policy.session.scope, SessionScope::Persistent);
+        assert_eq!(policy.session.ttl_secs, Some(86400));
+        assert_eq!(policy.detectors.len(), 1);
+        assert_eq!(policy.rules.len(), 2);
+        assert_eq!(
+            policy.ner.unwrap().model_dir,
+            Some(PathBuf::from("/tmp/gaze-home/.cache/gaze/model"))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_keys() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.toml");
+        fs::write(
+            &path,
+            r#"
+[session]
+scope = "ephemeral"
+bogus = true
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = ".+"
+class = "email"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+        )
+        .unwrap();
+
+        assert!(matches!(Policy::load(&path), Err(PolicyError::TomlParse(_))));
+    }
+}

--- a/crates/gaze/tests/cli_pipe.rs
+++ b/crates/gaze/tests/cli_pipe.rs
@@ -4,6 +4,7 @@
 //! in `docs/roadmap/v0.3/cli.md` §"Test strategy". Each test maps 1:1 to a
 //! numbered item in that section.
 
+use std::fs;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use serde_json::{json, Value};
+use tempfile::tempdir;
 
 use gaze::{PiiClass, Scope, Session};
 
@@ -63,6 +65,36 @@ fn restore_json(session_blob: &str, text: &str) -> (Option<i32>, Vec<u8>, Vec<u8
 
 fn parse_stderr_variant(stderr: &[u8]) -> Value {
     serde_json::from_slice(stderr).expect("stderr is one-line JSON")
+}
+
+fn write_minimal_policy() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+    (dir, path)
 }
 
 /// Build a session blob by hand via the library. Used where the stub CLI
@@ -420,4 +452,71 @@ fn t15_stats_detections_excludes_preserve() {
 fn t15b_stats_detections_excludes_preserve_verbatim_spec() {
     let (_, _, detections) = clean_ok("Alice at alice@example.com works at Acme Corp.");
     assert_eq!(detections, 1, "tokenized email counts; preserved Organization does not");
+}
+
+#[test]
+fn t16_clean_with_policy_tokenizes_email() {
+    let (_dir, policy_path) = write_minimal_policy();
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", policy_path.display())])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "stderr={}", String::from_utf8_lossy(&out.stderr));
+    let value: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(value["clean_text"].as_str().unwrap(), "Email Email_1 now");
+}
+
+#[test]
+fn t17_missing_policy_path_emits_policy_open() {
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", "--policy=/definitely/missing/policy.toml"])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(4));
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyOpen", "exit": 4 })
+    );
+}
+
+#[test]
+fn t18_malformed_policy_emits_policy_config() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+bogus = true
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = ".+"
+class = "email"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", path.display())])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
 }

--- a/docs/roadmap/v0.3/examples/policy-phase-0.toml
+++ b/docs/roadmap/v0.3/examples/policy-phase-0.toml
@@ -1,0 +1,40 @@
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[detector]]
+kind = "regex"
+name = "german_ibans"
+pattern = '\bDE\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{2}\b'
+class = "custom:iban"
+
+[[detector]]
+kind = "regex"
+name = "german_phone_numbers"
+pattern = '(?x)\b(?:\+49|0)(?:[\s\-]?\d){7,14}\b'
+class = "custom:german_phone"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:iban"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:german_phone"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"


### PR DESCRIPTION
## Summary
- Adds `crates/gaze/src/policy.rs` with `Policy` struct, TOML parsing, and validation.
- Adds `Pipeline::from_policy(policy)` helper in `pipeline.rs`.
- Wires `gaze clean --policy=<path>` through the new loader; falls back to stub pipeline when omitted.
- Example `policy.toml` at `docs/roadmap/v0.3/examples/policy-phase-0.toml`.

Closes solo todo #3. Spec: `docs/roadmap/v0.3/cli.md` §\"Pipeline wiring today vs. after solo #3\".

## Test plan
- [x] `cargo test -p gaze` — unit + integration suite green
- [x] `gaze clean --policy=policy-phase-0.toml < email.txt` tokenizes
- [x] `gaze clean --policy=/nonexistent` → exit 4 `PolicyOpen`
- [x] `gaze clean --policy=malformed.toml` → exit 2 `PolicyConfig`