### PR TITLE
docs: finalize v0.3.0 project documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - PR #10 follow-up — `Custom:` namespace round-trip + hallucination
   tests.
+- **Homebrew formula SHA placeholders replaced** with the real
+  `gaze-aarch64-apple-darwin` digest
+  (`baa7edb79d84fea5d74377f82877c5069d861381a9f6012aa55af2264a8287f4`)
+  once the tag-triggered release workflow published the binary. Closes
+  the rc.1 "Known gaps" entry — `brew install Naoray/gaze/gaze` now
+  resolves without the cask fallback.
 
 ## [0.3.0-rc.2] — 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,34 @@
 
 Channel-agnostic redaction workspace for AI-facing production tooling.
 
-The workspace now has two crates:
+The workspace has two crates:
 
-- `crates/gaze` — shared redaction core library (and, in v0.3, the standalone `gaze clean` / `gaze restore` CLI)
+- `crates/gaze` — shared redaction core library and the standalone `gaze clean` / `gaze restore` CLI
 - `crates/debug-proxy` — MCP debug server for MySQL + Laravel logs
+
+## Install (v0.3.0)
+
+Apple Silicon macOS via Homebrew (tap):
+
+```bash
+brew install Naoray/gaze/gaze
+```
+
+Direct binary download from the release assets:
+
+```bash
+curl -LO https://github.com/Naoray/gaze/releases/download/v0.3.0/gaze-aarch64-apple-darwin
+chmod +x gaze-aarch64-apple-darwin
+mv gaze-aarch64-apple-darwin /usr/local/bin/gaze
+```
+
+Linux and Intel macOS binaries are not published in v0.3.0; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release` in the meantime.
 
 ## Workspace Layout
 
 ```text
 crates/
-  gaze/         core library + standalone CLI (v0.3)
+  gaze/         core library + standalone CLI
   debug-proxy/  MCP debug server consumer
 ```
 
@@ -28,14 +46,16 @@ Pure Rust library for:
 - redaction logging
 - pluggable sandbox trait shape for future action-side work
 
-v0.3 adds a standalone CLI that consumes the library for LLM pipe-mode integration (Laravel wrapper ships out-of-tree via `gaze/laravel`). See `docs/roadmap/v0.3/cli.md` for the surface and `docs/roadmap/v0.3/laravel.md` for the host integration.
+The standalone CLI consumes the library for LLM pipe-mode integration (Laravel wrapper ships out-of-tree via `gaze/laravel`). See `docs/roadmap/v0.3/cli.md` for the surface and `docs/roadmap/v0.3/laravel.md` for the host integration.
 
 #### CLI Example
 
 ```bash
 echo "Email alice@example.com now" | gaze clean --policy=policy.toml
-# {"clean_text":"Email Email_1 now","session_blob":"<base64>","stats":{"detections":1}}
+# {"clean_text":"Email <Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
 ```
+
+Counter-family tokens (`<Email_N>`, `<Name_N>`, `<Location_N>`, `<Organization_N>`, `<Custom:name_N>`) are wrapped in angle brackets so the LLM cannot silently dissolve them into adjacent words. Format-preserving email tokens (`email1@example.test`) intentionally stay bare — the whole point is to look like a real email.
 
 #### Policy Configuration
 
@@ -151,18 +171,29 @@ cargo clippy -p gaze -p debug-proxy --all-targets --all-features -- -D warnings
 
 ## Status
 
-Implemented for the v0.2 rewrite:
+Shipped in v0.3.0 (2026-04-24):
 
-- shared `gaze` core
-- `debug-proxy` consumer
-- core sandbox trait shape
-
-In progress for v0.3:
-
+- shared `gaze` core library
+- `debug-proxy` MCP consumer
 - standalone `gaze clean` / `gaze restore` CLI (see `docs/roadmap/v0.3/cli.md`)
-- `policy.toml` loader → `Pipeline::from_policy(...)` helper
+- `policy.toml` loader + `Pipeline::from_policy(...)` helper
+- angle-bracket-wrapped counter tokens + `gaze::token_shape` grammar
+- two-pass restore (exact token match + shape-validator) with `UnknownToken` fail-closed signal
+- session TTL enforcement (`issued_at` on snapshot payload, `BlobExpired` exit bucket)
+- structured stderr JSON with stable exit buckets
+- Apple Silicon macOS binary + Homebrew tap formula
 
-Deferred beyond v0.3:
+v0.4 (in flight, plan under review — not imminent):
+
+- engine / corpus crate split
+- `RecognizerRegistry` trait for stackable detectors
+- full TOML rulepack schema
+- DACH + EN locale infrastructure
+- `.invalid` domain switch for format-preserving fakes
+- dictionary detector + typed `Context` envelope
+- text-provenance fingerprint (library-side blob↔text scope isolation)
+
+Deferred beyond v0.4:
 
 - real sandbox backend implementations
 - k-anonymity / query-budget controls

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -5,7 +5,7 @@ build its detection-and-redaction pipeline. It declares which detectors run,
 which PII classes they emit, and what action the pipeline takes when each class
 is found.
 
-This document describes the schema as shipped in v0.3.0-rc.2. The canonical
+This document describes the schema as shipped in v0.3.0. The canonical
 parser lives at [`crates/gaze/src/policy.rs`](../crates/gaze/src/policy.rs);
 the CLI wiring is in [`crates/gaze/src/main.rs`](../crates/gaze/src/main.rs).
 For the full CLI contract — exit codes, stderr discipline, blob format — see
@@ -56,7 +56,7 @@ Run it:
 
 ```console
 $ echo "Email alice@example.com now" | gaze clean --policy=minimal.toml
-{"clean_text":"Email Email_1 now","session_blob":"<base64>","stats":{"detections":1}}
+{"clean_text":"Email <Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
 ```
 
 This is the same fixture the CLI integration suite uses
@@ -178,12 +178,14 @@ prefix for user-defined classes.
 
 ### Built-ins
 
-| `class` value     | `PiiClass` variant       | Default token shape (`tokenize`) | Format-preserve shape    | Generalize shape   |
-|-------------------|--------------------------|----------------------------------|--------------------------|--------------------|
-| `"email"`         | `PiiClass::Email`        | `Email_1`, `Email_2`, …          | `email1@example.test`    | `[EMAIL]`          |
-| `"name"`          | `PiiClass::Name`         | `Name_1`, `Name_2`, …            | `name_1`, `name_2`, …    | `[NAME]`           |
-| `"location"`      | `PiiClass::Location`     | `Location_1`, …                  | `location_1`, …          | `[LOCATION]`       |
-| `"organization"`  | `PiiClass::Organization` | `Organization_1`, …              | `organization_1`, …      | `[ORGANIZATION]`   |
+| `class` value     | `PiiClass` variant       | Default token shape (`tokenize`)     | Format-preserve shape    | Generalize shape   |
+|-------------------|--------------------------|--------------------------------------|--------------------------|--------------------|
+| `"email"`         | `PiiClass::Email`        | `<Email_1>`, `<Email_2>`, …          | `email1@example.test`    | `[EMAIL]`          |
+| `"name"`          | `PiiClass::Name`         | `<Name_1>`, `<Name_2>`, …            | `name_1`, `name_2`, …    | `[NAME]`           |
+| `"location"`      | `PiiClass::Location`     | `<Location_1>`, …                    | `location_1`, …          | `[LOCATION]`       |
+| `"organization"`  | `PiiClass::Organization` | `<Organization_1>`, …                | `organization_1`, …      | `[ORGANIZATION]`   |
+
+Counter-family `tokenize` shapes wrap in angle brackets as of v0.3.0 so the LLM cannot dissolve them into adjacent words. Format-preserve shapes stay bare — the whole point of format-preserve is to look like a real value of that type.
 
 Counters are per-class and per-session; the same raw value is interned so it
 always maps to the same token within one session.
@@ -217,18 +219,18 @@ produce the same internal class.
 Custom tokens carry a `Custom:` namespace prefix so they cannot collide with
 built-ins or with each other:
 
-| Policy `class`           | Normalised name | `tokenize` token       | `format_preserve` token | `generalize` token |
-|--------------------------|-----------------|------------------------|-------------------------|--------------------|
-| `"custom:order_id"`      | `order_id`      | `Custom:order_id_1`    | `custom:order_id_1`     | `[ORDER_ID]`       |
-| `"custom:tenant_slug"`   | `tenant_slug`   | `Custom:tenant_slug_1` | `custom:tenant_slug_1`  | `[TENANT_SLUG]`    |
-| `"custom:song"`          | `song`          | `Custom:song_1`        | `custom:song_1`         | `[SONG]`           |
+| Policy `class`           | Normalised name | `tokenize` token         | `format_preserve` token | `generalize` token |
+|--------------------------|-----------------|--------------------------|-------------------------|--------------------|
+| `"custom:order_id"`      | `order_id`      | `<Custom:order_id_1>`    | `custom:order_id_1`     | `[ORDER_ID]`       |
+| `"custom:tenant_slug"`   | `tenant_slug`   | `<Custom:tenant_slug_1>` | `custom:tenant_slug_1`  | `[TENANT_SLUG]`    |
+| `"custom:song"`          | `song`          | `<Custom:song_1>`        | `custom:song_1`         | `[SONG]`           |
 
 A class string of `"custom:"` (empty name) is rejected with `PolicyConfig`.
 
 `custom:email` and other names that mirror built-ins are safe to use — the
 `Custom:` prefix keeps them in their own counter family, so `custom:email`
-emits `Custom:email_1` while built-in email detections continue to emit
-`Email_1`.
+emits `<Custom:email_1>` while built-in email detections continue to emit
+`<Email_1>`.
 
 ## Detectors
 
@@ -272,7 +274,7 @@ then act on the classes the model produces.
 
 | `action` value      | What it does                                                                                                       |
 |---------------------|--------------------------------------------------------------------------------------------------------------------|
-| `"tokenize"`        | Replace the matched span with a counter-family token (`Email_1`, `Name_2`, `Custom:order_id_3`, …). Restorable via the session blob. |
+| `"tokenize"`        | Replace the matched span with an angle-bracketed counter-family token (`<Email_1>`, `<Name_2>`, `<Custom:order_id_3>`, …). Restorable via the session blob. |
 | `"redact"`          | Replace the matched span with the literal string `[REDACTED]`. Not restorable — the original value is dropped from the session map. |
 | `"format_preserve"` | Replace with a fake value that preserves the surface shape (`email1@example.test` for emails; `name_1`, `location_1`, `custom:order_id_1` for everything else). Restorable. |
 | `"generalize"`      | Replace with a bracketed class label: `[EMAIL]`, `[NAME]`, `[LOCATION]`, `[ORGANIZATION]`, or `[CUSTOM_NAME]` (uppercased custom name with underscores preserved). Restoration returns the label, not the original value. |
@@ -344,7 +346,7 @@ action = "preserve"
 ```
 
 Input `Reach Alice at alice@example.com or +49 30 1234567` produces
-`Reach Alice at Email_1 or [REDACTED]`.
+`Reach Alice at <Email_1> or [REDACTED]`.
 
 ### Example B — Custom class for tenant order IDs
 
@@ -369,7 +371,7 @@ kind = "default"
 action = "preserve"
 ```
 
-`Order ORD-123456 is queued.` → `Order Custom:order_id_1 is queued.`
+`Order ORD-123456 is queued.` → `Order <Custom:order_id_1> is queued.`
 
 ### Example C — Format-preserving emails for downstream parsers
 

--- a/docs/roadmap/v0.3/cli.md
+++ b/docs/roadmap/v0.3/cli.md
@@ -1,6 +1,6 @@
 # Gaze — Standalone CLI (v0.3 Pipe Mode)
 
-**Status:** Spec / in-flight for v0.3. The `gaze` binary is being built in
+**Status:** Shipped in v0.3.0 (2026-04-24). The `gaze` binary lives in
 `crates/gaze` alongside the library. See [`laravel.md`](laravel.md) for the
 host-side wrapper that shells out to this CLI.
 
@@ -15,22 +15,23 @@ below cite `docs/research/gaze-threat-model.md`.
 
 ## Known pre-release gaps (v0.3.0)
 
-This spec describes the **intended v0.3.0 contract**. The following items are
-promised-but-stubbed and must land before the CLI leaves pre-release. Callers
-building against this document should treat them as blockers:
+> **Historical — all gaps closed in v0.3.0 (2026-04-24).** This table tracked the
+> pre-release blockers between the v0.3 spec and the shipping binary. Every row
+> below was resolved before v0.3.0 tagged. Kept here so readers cross-referencing
+> earlier commits can see what landed when.
 
 | Gap | Tracked by | Status |
 |---|---|---|
-| `--policy` argument accepted but ignored; `clean` uses a hardcoded stub pipeline (email-only) | solo #3 (policy.toml loader) | parallel work |
-| `issued_at` field on `SnapshotPayload` — missing today → `BlobExpired` cannot fire | solo #4 (library TTL enforcement) | **ship-blocks v0.3.0 payload format** |
-| `PiiClass::Custom("email")` collides with built-in `PiiClass::Email` — both produce `Email_N` | solo #5 (reserve built-in names) | library-side |
-| Library does not expose a placeholder-matching API — CLI's token grammar duplicates library internals | solo #6 (library placeholder API) | library-side |
-| `panic::set_hook`, `clap::try_parse` error routing, SIGPIPE documentation — stderr sanitisation is aspirational without these | this spec's §"Stderr discipline" | CLI-side, lands with impl |
-| CLI `CliError` enum has 4 variants (`StdinParse`, `PolicyConfig`, `Pipeline`, `Io`); spec lists 9 | follow-up commits on `gaze-v03-cli` branch | CLI-side, lands with `restore` impl |
+| `--policy` argument accepted but ignored; `clean` uses a hardcoded stub pipeline (email-only) | solo #3 (policy.toml loader) | ✅ shipped in v0.3.0-rc.1 (`Policy::load` + `Pipeline::from_policy`) |
+| `issued_at` field on `SnapshotPayload` — missing today → `BlobExpired` cannot fire | solo #4 (library TTL enforcement) | ✅ shipped in v0.3.0-rc.1 (`issued_at` on payload, `BlobExpired` exit bucket 3) |
+| `PiiClass::Custom("email")` collides with built-in `PiiClass::Email` — both produce `Email_N` | solo #5 (reserve built-in names) | ✅ shipped in v0.3.0-rc.1 (custom namespace fix — emits `Custom:{name}_N`) |
+| Library does not expose a placeholder-matching API — CLI's token grammar duplicates library internals | solo #6 (library placeholder API) | ✅ shipped in v0.3.0 final (`gaze::token_shape::pattern()` + `contains_token()`) |
+| `panic::set_hook`, `clap::try_parse` error routing, SIGPIPE documentation — stderr sanitisation is aspirational without these | this spec's §"Stderr discipline" | ✅ shipped in v0.3.0-rc.1 (panic hook + `Cli::try_parse` route through structured stderr) |
+| CLI `CliError` enum has 4 variants (`StdinParse`, `PolicyConfig`, `Pipeline`, `Io`); spec lists 9 | follow-up commits on `gaze-v03-cli` branch | ✅ shipped in v0.3.0-rc.1 (full typed `CliError` with `UnknownToken`, `Tamper`, `VersionByte`, `EmptyInput`, `InvalidEncoding`, `BlobExpired`, `MaxBytes`) |
 
-Laravel wrapper `laravel.md` was written against the *intended* contract;
-integrators reading both specs should assume the intended contract when
-planning but check the table above before enabling pipe mode in production.
+Laravel wrapper `laravel.md` targets this now-shipped contract. Integrators
+enabling pipe mode in production should pin against v0.3.0 and consult
+[`CHANGELOG.md`](../../../CHANGELOG.md) for the full shipped scope.
 
 ---
 

--- a/docs/roadmap/v0.3/laravel.md
+++ b/docs/roadmap/v0.3/laravel.md
@@ -1,6 +1,6 @@
 # Gaze — Laravel Integration (v0.3 Pipe Mode)
 
-**Status:** Roadmap / targets Gaze v0.3 — pipe mode is not shipped in v0.1. This document describes the planned integration surface so the v0.1 anonymizer core can be designed to support it without rework.
+**Status:** Gaze CLI pipe mode shipped in v0.3.0 (2026-04-24). The Laravel wrapper package (`gaze/laravel`) is still roadmap — this document describes the intended host-side integration surface against the now-shipped CLI contract. Ghostwriter-style adapters can implement the same shell-out pattern in any host language today.
 
 ---
 


### PR DESCRIPTION
Post-release doc sync for the v0.3.0 tag (merge SHA 72159156, Homebrew bump 868e8e62). Reflects shipped reality — no source or workflow changes.

## Documentation

- **README.md** — drops rc framing; adds v0.3.0 install snippet (Homebrew tap + direct binary at `https://github.com/Naoray/gaze/releases/download/v0.3.0/gaze-aarch64-apple-darwin`); flips CLI example output to the angle-bracketed `<Email_1>` counter-token shape that actually ships; rewrites Status from "in progress for v0.3" to "shipped in v0.3.0" + a v0.4 plan summary flagged as under review, not imminent.
- **CHANGELOG.md** — adds a Fixed bullet under `[0.3.0] — 2026-04-24` closing the rc.1 "Homebrew SHA placeholders" known-gap with the real `baa7edb79d84…` digest. No existing entries modified, reordered, or regenerated.
- **docs/policy.md** — bumps the "shipped in" pointer from rc.2 to v0.3.0; wraps every counter-family `tokenize` token shape (`<Email_N>`, `<Name_N>`, `<Location_N>`, `<Organization_N>`, `<Custom:name_N>`) in angle brackets across the built-in class table, custom-class table, action table, and worked examples. Format-preserve shapes stay bare (the whole point of format-preserve).
- **docs/roadmap/v0.3/cli.md** — status line reframed from "Spec / in-flight" to "Shipped in v0.3.0 (2026-04-24)". The Known-pre-release-gaps table is kept as history with each of its six rows marked ✅ shipped (solo #3, #4, #5, #6, stderr-sanitisation, full `CliError` variants). **The "Caller contract — blob↔text pairing (scope isolation)" section is untouched** per release-cycle guardrail.
- **docs/roadmap/v0.3/laravel.md** — status line now reflects CLI pipe mode shipped; Laravel wrapper package (`gaze/laravel`) remains roadmap.

## Out of scope (deliberate)

- No source code edits — the workspace Cargo.toml versions still read `0.3.0-rc.3`; a `cargo-release` bump to `0.3.0` is a v0.3.1-cycle TODO, not a docs release.
- No `.github/workflows/` edits.
- No plan/brainstorm scratchpad edits (solo todos #46, #51 untouched; reviewer verdicts #55, #57 untouched).

## Test plan

- [x] Every modified doc rereads cleanly and describes the v0.3.0 CLI surface (angle-bracketed counter tokens, shipped `policy.toml` loader, `BlobExpired` enforcement, full `CliError` variants).
- [x] All intra-repo doc links from README and docs/policy.md resolve (`docs/policy.md`, `docs/roadmap/v0.3/cli.md`, `docs/roadmap/v0.3/laravel.md`, `crates/gaze/testdata/ner/README.md`, `docs/research/ner-library-evaluation.md`).
- [x] Homebrew install snippet matches the tap published at `Naoray/gaze`.
- [x] CHANGELOG `[0.3.0]` entry preserves all existing bullets; addition is append-only under Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)