### PR TITLE
fix(v0.3.1): spec-drift fixes #41/#42/#43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - unreleased
+
+### Fixed
+
+- `gaze clean` now honors `[session]` from `policy.toml`; `--session-ttl`
+  is an explicit persistent-TTL override instead of the source of truth.
+- Broken `[ner] model_dir` configuration now exits as `PolicyConfig`
+  with exit code 2.
+- `gaze clean` now rejects `kind = "column"` rules during CLI policy load
+  instead of silently accepting rules that cannot fire for text stdin.
+
 ## [0.3.0] — 2026-04-24
 
 ### Changed

--- a/crates/gaze/src/main.rs
+++ b/crates/gaze/src/main.rs
@@ -77,6 +77,7 @@ enum CliError {
     InputTooLarge,
     InvalidEncoding,
     PolicyConfig,
+    PolicyConfigDetail(&'static str),
     UnknownToken,
     InvalidSignature,
     InvalidBlobVersion,
@@ -90,7 +91,7 @@ impl CliError {
     fn exit_code(&self) -> u8 {
         match self {
             Self::StdinParse | Self::EmptyInput | Self::InputTooLarge | Self::InvalidEncoding => 1,
-            Self::PolicyConfig => 2,
+            Self::PolicyConfig | Self::PolicyConfigDetail(_) => 2,
             Self::UnknownToken
             | Self::InvalidSignature
             | Self::InvalidBlobVersion
@@ -106,7 +107,7 @@ impl CliError {
             Self::EmptyInput => "EmptyInput",
             Self::InputTooLarge => "InputTooLarge",
             Self::InvalidEncoding => "InvalidEncoding",
-            Self::PolicyConfig => "PolicyConfig",
+            Self::PolicyConfig | Self::PolicyConfigDetail(_) => "PolicyConfig",
             Self::UnknownToken => "UnknownToken",
             Self::InvalidSignature => "InvalidSignature",
             Self::InvalidBlobVersion => "InvalidBlobVersion",
@@ -118,11 +119,19 @@ impl CliError {
     }
 
     fn emit_stderr(&self) {
-        eprintln!(
-            r#"{{"error":"{}","exit":{}}}"#,
-            self.variant_name(),
-            self.exit_code()
-        );
+        match self {
+            Self::PolicyConfigDetail(detail) => eprintln!(
+                r#"{{"error":"{}","exit":{},"detail":"{}"}}"#,
+                self.variant_name(),
+                self.exit_code(),
+                detail
+            ),
+            _ => eprintln!(
+                r#"{{"error":"{}","exit":{}}}"#,
+                self.variant_name(),
+                self.exit_code()
+            ),
+        }
     }
 }
 
@@ -247,7 +256,7 @@ fn run_clean(
 
     let counter = Arc::new(CountingLogger::default());
     let loaded_policy = match policy {
-        Some(path) => Some(Policy::load(path).map_err(map_policy_error)?),
+        Some(path) => Some(Policy::load_for_cli(path).map_err(map_policy_error)?),
         None => None,
     };
 
@@ -329,6 +338,9 @@ fn run_restore(format: &str, max_bytes: u64) -> std::result::Result<(), CliError
 fn map_policy_error(err: PolicyError) -> CliError {
     match err {
         PolicyError::Io(_) => CliError::PolicyOpen,
+        PolicyError::UnsupportedRuleKind(_) => {
+            CliError::PolicyConfigDetail("column rules not supported in CLI mode")
+        }
         _ => CliError::PolicyConfig,
     }
 }

--- a/crates/gaze/src/main.rs
+++ b/crates/gaze/src/main.rs
@@ -49,9 +49,9 @@ enum Cmd {
         /// Output format. Only `json` is supported today.
         #[arg(long, default_value = "json")]
         format: String,
-        /// Persistent session TTL in seconds. Default 24h — matches typical queue retention.
-        #[arg(long, default_value_t = 86_400)]
-        session_ttl: u64,
+        /// Override the persistent session TTL in seconds.
+        #[arg(long)]
+        session_ttl: Option<u64>,
         /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
@@ -160,7 +160,10 @@ fn main() -> ExitCode {
             // prints the crate version cleanly (required by the homebrew test
             // block).
             use clap::error::ErrorKind;
-            if matches!(err.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+            if matches!(
+                err.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) {
                 let _ = err.print();
                 return ExitCode::SUCCESS;
             }
@@ -236,22 +239,22 @@ fn require_json_format(format: &str) -> std::result::Result<(), CliError> {
 fn run_clean(
     policy: Option<&std::path::Path>,
     format: &str,
-    session_ttl: u64,
+    session_ttl: Option<u64>,
     max_bytes: u64,
 ) -> std::result::Result<(), CliError> {
     require_json_format(format)?;
     let raw = read_stdin_text(max_bytes)?;
 
     let counter = Arc::new(CountingLogger::default());
-    let pipeline = match policy {
-        Some(path) => {
-            let policy = Policy::load(path).map_err(map_policy_error)?;
-            Pipeline::from_policy(&policy)
-                .map_err(map_pipeline_error)?
-                .with_redaction_logger(ArcLogger(
-                    Arc::clone(&counter) as Arc<dyn RedactionLogger>
-                ))
-        }
+    let loaded_policy = match policy {
+        Some(path) => Some(Policy::load(path).map_err(map_policy_error)?),
+        None => None,
+    };
+
+    let pipeline = match &loaded_policy {
+        Some(policy) => Pipeline::from_policy(policy)
+            .map_err(map_pipeline_error)?
+            .with_redaction_logger(ArcLogger(Arc::clone(&counter) as Arc<dyn RedactionLogger>)),
         None => {
             tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
             build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>)
@@ -259,9 +262,12 @@ fn run_clean(
         }
     };
 
-    let session = Session::new(Scope::Persistent {
-        ttl: Duration::from_secs(session_ttl),
-    })
+    let session = match &loaded_policy {
+        Some(policy) => Session::from_policy_with_ttl_override(policy, session_ttl),
+        None => Session::new(Scope::Persistent {
+            ttl: Duration::from_secs(session_ttl.unwrap_or(86_400)),
+        }),
+    }
     .map_err(|_| CliError::Pipeline)?;
 
     let clean_doc = pipeline

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -64,10 +64,9 @@ impl Pipeline {
                     &detector.name,
                 )?),
                 DetectorKind::Unknown(kind) => {
-                    return Err(PolicyError::BadTtl(format!(
-                        "unknown detector.kind '{kind}'"
-                    ))
-                    .into())
+                    return Err(
+                        PolicyError::BadTtl(format!("unknown detector.kind '{kind}'")).into(),
+                    )
                 }
             };
         }
@@ -86,10 +85,15 @@ impl Pipeline {
 
         if let Some(ner) = &policy.ner {
             if ner.model_dir.is_some() {
-                builder = builder.with_ner_config(NerConfig {
-                    model_dir: ner.model_dir.clone(),
-                    locale: ner.locale.clone(),
-                })?;
+                builder = builder
+                    .with_ner_config(NerConfig {
+                        model_dir: ner.model_dir.clone(),
+                        locale: ner.locale.clone(),
+                    })
+                    .map_err(|err| match err {
+                        Error::NerLoad(source) => Error::Policy(PolicyError::NerLoad(source)),
+                        other => other,
+                    })?;
             }
         }
 
@@ -109,9 +113,12 @@ impl Pipeline {
             RawDocument::Structured(fields) => {
                 redact_structured(self, session, fields, DocumentKind::Structured)
             }
-            RawDocument::Text(text) => Ok(CleanDocument::Text(
-                self.redact_text(session, &text, None, DocumentKind::Text)?,
-            )),
+            RawDocument::Text(text) => Ok(CleanDocument::Text(self.redact_text(
+                session,
+                &text,
+                None,
+                DocumentKind::Text,
+            )?)),
         }
     }
 
@@ -154,20 +161,14 @@ impl Pipeline {
             let raw = text[detection.detection.span.clone()].to_string();
             let context = build_context(field_name);
             let action = self.action_for(&detection.detection, &context);
-            self.log_entry(
-                &detection,
-                field_name,
-                document_kind.clone(),
-                action,
-                false,
-            )?;
+            self.log_entry(&detection, field_name, document_kind.clone(), action, false)?;
 
             let replacement = match action {
                 Action::Tokenize => Some(session.tokenize(&detection.detection.class, &raw)?),
                 Action::Redact => Some("[REDACTED]".to_string()),
-                Action::FormatPreserve => Some(
-                    session.format_preserving_fake(&detection.detection.class, &raw)?,
-                ),
+                Action::FormatPreserve => {
+                    Some(session.format_preserving_fake(&detection.detection.class, &raw)?)
+                }
                 Action::Generalize => Some(generalize_token(&detection.detection.class)),
                 Action::Preserve => None,
             };
@@ -301,11 +302,8 @@ impl PipelineBuilder {
                 Ok(self)
             }
             Some(path) => {
-                let detector = NerDetector::load_with_options(
-                    &path,
-                    NerOptions { locale },
-                )
-                .map_err(Error::NerLoad)?;
+                let detector = NerDetector::load_with_options(&path, NerOptions { locale })
+                    .map_err(Error::NerLoad)?;
                 Ok(self.detector(detector))
             }
         }
@@ -329,9 +327,12 @@ fn redact_structured(
     let mut clean = BTreeMap::new();
     for (key, value) in fields {
         let value = match value {
-            Value::String(text) => serde_json::Value::String(
-                pipeline.redact_text(session, &text, Some(&key), document_kind.clone())?,
-            ),
+            Value::String(text) => serde_json::Value::String(pipeline.redact_text(
+                session,
+                &text,
+                Some(&key),
+                document_kind.clone(),
+            )?),
             Value::I64(value) => serde_json::Value::Number(value.into()),
         };
         clean.insert(key, value);
@@ -360,7 +361,9 @@ fn translate_detection(
     })
 }
 
-fn select_winners(mut detections: Vec<IndexedDetection>) -> (Vec<IndexedDetection>, Vec<IndexedDetection>) {
+fn select_winners(
+    mut detections: Vec<IndexedDetection>,
+) -> (Vec<IndexedDetection>, Vec<IndexedDetection>) {
     detections.sort_by(|a, b| {
         let a_len = a.detection.span.end - a.detection.span.start;
         let b_len = b.detection.span.end - b.detection.span.start;
@@ -373,10 +376,9 @@ fn select_winners(mut detections: Vec<IndexedDetection>) -> (Vec<IndexedDetectio
     let mut winners = Vec::new();
     let mut losers = Vec::new();
     for detection in detections {
-        if winners
-            .iter()
-            .any(|winner: &IndexedDetection| overlaps(&winner.detection.span, &detection.detection.span))
-        {
+        if winners.iter().any(|winner: &IndexedDetection| {
+            overlaps(&winner.detection.span, &detection.detection.span)
+        }) {
             losers.push(detection);
             continue;
         }
@@ -408,12 +410,12 @@ fn build_context(field_name: Option<&str>) -> Context {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use super::*;
     use crate::detector::{Detection, PiiClass};
     use crate::ner::test_support::detector_with_detections;
     use crate::rule::{ClassRule, DefaultRule};
     use crate::session::{Scope, Session};
+    use std::fs;
     use std::sync::Mutex;
     use tempfile::tempdir;
 
@@ -476,7 +478,11 @@ mod tests {
         assert_eq!(out, "[REDACTED] works here");
 
         let entries = entries.lock().unwrap();
-        assert_eq!(entries.len(), 2, "expected one winner + one loser: {entries:?}");
+        assert_eq!(
+            entries.len(),
+            2,
+            "expected one winner + one loser: {entries:?}"
+        );
         let winner = entries.iter().find(|e| !e.conflict_loser).expect("winner");
         let loser = entries.iter().find(|e| e.conflict_loser).expect("loser");
         assert_eq!(winner.source, "ner/gliner", "longer span should win");

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -77,6 +77,8 @@ pub enum PolicyError {
     NoRules,
     #[error("policy must define at least one detector")]
     NoDetectors,
+    #[error("ner load error: {0}")]
+    NerLoad(#[source] crate::ner::NerLoadError),
 }
 
 impl Policy {
@@ -169,7 +171,11 @@ fn parse_session(raw: RawSessionPolicy) -> Result<SessionPolicy, PolicyError> {
         "ephemeral" => SessionScope::Ephemeral,
         "conversation" => SessionScope::Conversation,
         "persistent" => SessionScope::Persistent,
-        other => return Err(PolicyError::BadTtl(format!("unknown session.scope '{other}'"))),
+        other => {
+            return Err(PolicyError::BadTtl(format!(
+                "unknown session.scope '{other}'"
+            )))
+        }
     };
 
     match scope {
@@ -278,7 +284,9 @@ fn parse_action(input: &str) -> Result<Action, PolicyError> {
         "format_preserve" => Ok(Action::FormatPreserve),
         "generalize" => Ok(Action::Generalize),
         "preserve" => Ok(Action::Preserve),
-        other => Err(PolicyError::BadTtl(format!("unknown rule.action '{other}'"))),
+        other => Err(PolicyError::BadTtl(format!(
+            "unknown rule.action '{other}'"
+        ))),
     }
 }
 
@@ -365,6 +373,9 @@ action = "preserve"
         )
         .unwrap();
 
-        assert!(matches!(Policy::load(&path), Err(PolicyError::TomlParse(_))));
+        assert!(matches!(
+            Policy::load(&path),
+            Err(PolicyError::TomlParse(_))
+        ));
     }
 }

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -79,6 +79,8 @@ pub enum PolicyError {
     NoDetectors,
     #[error("ner load error: {0}")]
     NerLoad(#[source] crate::ner::NerLoadError),
+    #[error("{0}")]
+    UnsupportedRuleKind(String),
 }
 
 impl Policy {
@@ -86,6 +88,20 @@ impl Policy {
         let raw = fs::read_to_string(path).map_err(PolicyError::Io)?;
         let raw: RawPolicy = toml::from_str(&raw).map_err(PolicyError::TomlParse)?;
         raw.try_into()
+    }
+
+    pub fn load_for_cli(path: &Path) -> Result<Policy, PolicyError> {
+        let policy = Self::load(path)?;
+        if policy
+            .rules
+            .iter()
+            .any(|rule| matches!(rule, RuleSpec::Column { .. }))
+        {
+            return Err(PolicyError::UnsupportedRuleKind(
+                "column rules not supported in CLI mode".to_string(),
+            ));
+        }
+        Ok(policy)
     }
 }
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -8,7 +8,10 @@ use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 
 use crate::detector::PiiClass;
+use crate::policy::{Policy, SessionScope};
 use crate::{Error, Result};
+
+const DEFAULT_PERSISTENT_TTL_SECS: u64 = 86_400;
 
 #[derive(Debug, Clone)]
 pub enum Scope {
@@ -81,8 +84,34 @@ impl Session {
         })
     }
 
+    pub fn from_policy(policy: &Policy) -> Result<Self> {
+        Self::from_policy_with_ttl_override(policy, None)
+    }
+
+    pub fn from_policy_with_ttl_override(
+        policy: &Policy,
+        ttl_secs_override: Option<u64>,
+    ) -> Result<Self> {
+        let scope = match policy.session.scope {
+            SessionScope::Ephemeral => Scope::Ephemeral,
+            SessionScope::Conversation => Scope::Conversation("cli".to_string()),
+            SessionScope::Persistent => {
+                let ttl_secs = ttl_secs_override
+                    .or(policy.session.ttl_secs)
+                    .unwrap_or(DEFAULT_PERSISTENT_TTL_SECS);
+                Scope::Persistent {
+                    ttl: Duration::from_secs(ttl_secs),
+                }
+            }
+        };
+
+        Self::new(scope)
+    }
+
     pub fn tokenize(&self, class: &PiiClass, raw: &str) -> Result<String> {
-        self.intern_mapping(class, raw, |index| format!("<{}_{}>", class.class_name(), index))
+        self.intern_mapping(class, raw, |index| {
+            format!("<{}_{}>", class.class_name(), index)
+        })
     }
 
     pub fn format_preserving_fake(&self, class: &PiiClass, raw: &str) -> Result<String> {
@@ -388,7 +417,11 @@ fn scope_from_snapshot(scope: SnapshotScope) -> Scope {
 }
 
 fn parse_token_index(token: &str) -> Option<usize> {
-    let suffix = token.rsplit_once('_')?.1.strip_suffix('>').unwrap_or(token.rsplit_once('_')?.1);
+    let suffix = token
+        .rsplit_once('_')?
+        .1
+        .strip_suffix('>')
+        .unwrap_or(token.rsplit_once('_')?.1);
     suffix.parse().ok()
 }
 

--- a/crates/gaze/tests/cli_pipe.rs
+++ b/crates/gaze/tests/cli_pipe.rs
@@ -626,6 +626,55 @@ action = "preserve"
 }
 
 #[test]
+fn broken_ner_model_dir_exits_policy_config() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    let missing_model = dir.path().join("missing-model");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 3600
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{{2,}}\b'
+class = "email"
+
+[ner]
+model_dir = "{}"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            missing_model.display()
+        ),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", path.display())])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
+}
+
+#[test]
 fn t19_restore_custom_token_round_trip_ok() {
     let blob = build_blob_with(|s| {
         s.tokenize(&PiiClass::custom("order_id"), "42").unwrap();

--- a/crates/gaze/tests/cli_pipe.rs
+++ b/crates/gaze/tests/cli_pipe.rs
@@ -675,6 +675,52 @@ action = "preserve"
 }
 
 #[test]
+fn column_rule_policy_exits_policy_config_in_cli_mode() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 3600
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "column"
+column = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", path.display())])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("column rules not supported in CLI mode"),
+        "stderr did not mention column rejection: {stderr}"
+    );
+    let value = parse_stderr_variant(&out.stderr);
+    assert_eq!(value["error"], "PolicyConfig");
+    assert_eq!(value["exit"], 2);
+}
+
+#[test]
 fn t19_restore_custom_token_round_trip_ok() {
     let blob = build_blob_with(|s| {
         s.tokenize(&PiiClass::custom("order_id"), "42").unwrap();

--- a/crates/gaze/tests/cli_pipe.rs
+++ b/crates/gaze/tests/cli_pipe.rs
@@ -97,6 +97,12 @@ action = "preserve"
     (dir, path)
 }
 
+fn session_blob_ttl_secs(blob: &str) -> u64 {
+    let raw = BASE64.decode(blob.as_bytes()).unwrap();
+    let payload: Value = serde_json::from_slice(&raw[97..]).unwrap();
+    payload["scope"]["Persistent"]["ttl_secs"].as_u64().unwrap()
+}
+
 /// Build a session blob by hand via the library. Used where the stub CLI
 /// pipeline cannot emit the token shape under test (`<Name_1>`, lowercase
 /// FormatPreserve, etc.) until solo #3 ships the real policy loader.
@@ -123,13 +129,24 @@ fn t01_roundtrip_email_tokenized_then_restored() {
     let (clean_text, blob, detections) = clean_ok(input);
 
     assert_eq!(detections, 1, "stub pipeline tokenizes one email");
-    assert!(!clean_text.contains("alice@example.com"), "raw email leaked");
-    assert!(clean_text.contains("<Email_1>"), "expected <Email_1> token: {clean_text}");
+    assert!(
+        !clean_text.contains("alice@example.com"),
+        "raw email leaked"
+    );
+    assert!(
+        clean_text.contains("<Email_1>"),
+        "expected <Email_1> token: {clean_text}"
+    );
 
     // LLM reply reuses the tokens.
     let llm_reply = clean_text.replace("Contact", "Reply to");
     let (code, stdout, stderr) = restore_json(&blob, &llm_reply);
-    assert_eq!(code, Some(0), "restore should succeed, stderr={}", String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        code,
+        Some(0),
+        "restore should succeed, stderr={}",
+        String::from_utf8_lossy(&stderr)
+    );
     assert!(stderr.is_empty(), "expected empty stderr");
     let resp: Value = serde_json::from_slice(&stdout).unwrap();
     assert_eq!(
@@ -148,12 +165,18 @@ fn t02_canary_absent_in_clean_reappears_in_restore() {
     let input = format!("Ping {canary} before noon.");
 
     let (clean_text, blob, _) = clean_ok(&input);
-    assert!(!clean_text.contains(canary), "canary leaked into clean_text: {clean_text}");
+    assert!(
+        !clean_text.contains(canary),
+        "canary leaked into clean_text: {clean_text}"
+    );
 
     let (code, stdout, _) = restore_json(&blob, &clean_text);
     assert_eq!(code, Some(0));
     let resp: Value = serde_json::from_slice(&stdout).unwrap();
-    assert!(resp["text"].as_str().unwrap().contains(canary), "canary did not round-trip");
+    assert!(
+        resp["text"].as_str().unwrap().contains(canary),
+        "canary did not round-trip"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -165,8 +188,13 @@ fn t03_unknown_token_pascalcase_shape() {
     let (_, blob, _) = clean_ok("Email is alice@example.com please.");
     // Session has <Email_1>. LLM invents <Email_999>.
     let (code, stdout, stderr) = restore_json(&blob, "Your <Email_999> is queued.");
-    assert_eq!(code, Some(3), "expected exit 3, stdout={} stderr={}",
-        String::from_utf8_lossy(&stdout), String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        code,
+        Some(3),
+        "expected exit 3, stdout={} stderr={}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
     assert_eq!(
         parse_stderr_variant(&stderr),
         json!({ "error": "UnknownToken", "exit": 3 })
@@ -185,8 +213,13 @@ fn t04_unknown_token_lowercase_formatpreserve_shape() {
     // arm catches the LLM hallucination.
     let (_, blob, _) = clean_ok("No PII here.");
     let (code, stdout, stderr) = restore_json(&blob, "Your location_7 order arrives soon.");
-    assert_eq!(code, Some(3), "expected exit 3, stdout={} stderr={}",
-        String::from_utf8_lossy(&stdout), String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        code,
+        Some(3),
+        "expected exit 3, stdout={} stderr={}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
     assert_eq!(
         parse_stderr_variant(&stderr),
         json!({ "error": "UnknownToken", "exit": 3 })
@@ -208,9 +241,18 @@ fn t05_adjacency_corruption_name_inside_larger_word() {
 
     let reply = "User-Name_1s-record is internal.";
     let (code, stdout, stderr) = restore_json(&blob, reply);
-    assert_eq!(code, Some(0), "expected success, stderr={}", String::from_utf8_lossy(&stderr));
+    assert_eq!(
+        code,
+        Some(0),
+        "expected success, stderr={}",
+        String::from_utf8_lossy(&stderr)
+    );
     let resp: Value = serde_json::from_slice(&stdout).unwrap();
-    assert_eq!(resp["text"].as_str().unwrap(), reply, "Pass 1 must not eat Name_1 substring");
+    assert_eq!(
+        resp["text"].as_str().unwrap(),
+        reply,
+        "Pass 1 must not eat Name_1 substring"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -307,8 +349,14 @@ fn t09_bad_flag_emits_sanitized_json_not_clap_usage() {
     );
     // No clap usage banner, no "Usage:" string.
     let stderr_str = String::from_utf8_lossy(&out.stderr);
-    assert!(!stderr_str.contains("Usage"), "clap usage leaked: {stderr_str}");
-    assert!(!stderr_str.contains("--help"), "clap help leaked: {stderr_str}");
+    assert!(
+        !stderr_str.contains("Usage"),
+        "clap usage leaked: {stderr_str}"
+    );
+    assert!(
+        !stderr_str.contains("--help"),
+        "clap help leaked: {stderr_str}"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -409,7 +457,11 @@ fn t14_silence_on_success_across_subcommands() {
         .output()
         .unwrap();
     assert!(out.status.success());
-    assert!(out.stderr.is_empty(), "clean stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.stderr.is_empty(),
+        "clean stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 
     // Re-use the emitted blob for `restore`.
     let v: Value = serde_json::from_slice(&out.stdout).unwrap();
@@ -417,7 +469,11 @@ fn t14_silence_on_success_across_subcommands() {
 
     let (code, _, stderr) = restore_json(&blob, "plain text reply");
     assert_eq!(code, Some(0));
-    assert!(stderr.is_empty(), "restore stderr: {}", String::from_utf8_lossy(&stderr));
+    assert!(
+        stderr.is_empty(),
+        "restore stderr: {}",
+        String::from_utf8_lossy(&stderr)
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -451,7 +507,10 @@ fn t15_stats_detections_excludes_preserve() {
 #[ignore = "requires policy loader (solo #3) to drive an Organization detector with Preserve"]
 fn t15b_stats_detections_excludes_preserve_verbatim_spec() {
     let (_, _, detections) = clean_ok("Alice at alice@example.com works at Acme Corp.");
-    assert_eq!(detections, 1, "tokenized email counts; preserved Organization does not");
+    assert_eq!(
+        detections, 1,
+        "tokenized email counts; preserved Organization does not"
+    );
 }
 
 #[test]
@@ -463,9 +522,107 @@ fn t16_clean_with_policy_tokenizes_email() {
         .write_stdin(b"Email alice@example.com now".to_vec())
         .output()
         .unwrap();
-    assert!(out.status.success(), "stderr={}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let value: Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(value["clean_text"].as_str().unwrap(), "Email <Email_1> now");
+}
+
+#[test]
+fn policy_session_ttl_is_honored() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 3600
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", path.display())])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let value: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let blob = value["session_blob"].as_str().unwrap();
+    assert_eq!(session_blob_ttl_secs(blob), 3600);
+}
+
+#[test]
+fn cli_session_ttl_overrides_policy() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 3600
+
+[[detector]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "clean",
+            &format!("--policy={}", path.display()),
+            "--session-ttl=1800",
+        ])
+        .write_stdin(b"Email alice@example.com now".to_vec())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let value: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let blob = value["session_blob"].as_str().unwrap();
+    assert_eq!(session_blob_ttl_secs(blob), 1800);
 }
 
 #[test]
@@ -474,8 +631,7 @@ fn t19_restore_custom_token_round_trip_ok() {
         s.tokenize(&PiiClass::custom("order_id"), "42").unwrap();
     });
 
-    let (code, stdout, stderr) =
-        restore_json(&blob, "Order <Custom:order_id_1> is shipped.");
+    let (code, stdout, stderr) = restore_json(&blob, "Order <Custom:order_id_1> is shipped.");
     assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
     let resp: Value = serde_json::from_slice(&stdout).unwrap();
     assert_eq!(resp["text"].as_str().unwrap(), "Order 42 is shipped.");
@@ -511,8 +667,7 @@ fn t21_restore_wrapped_token_in_prose() {
         s.tokenize(&PiiClass::Email, "bob@example.com").unwrap();
     });
 
-    let (code, stdout, stderr) =
-        restore_json(&blob, "See <Email_1>. Reply <Email_2>");
+    let (code, stdout, stderr) = restore_json(&blob, "See <Email_1>. Reply <Email_2>");
     assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
     let resp: Value = serde_json::from_slice(&stdout).unwrap();
     assert_eq!(

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -139,10 +139,11 @@ action = "preserve"
 - **`kind = "class"`** — fires when a detection's class equals `class`. The
   most common rule shape.
 - **`kind = "column"`** — fires when the document being redacted is a
-  structured value and the current field name equals `column`. **From
-  `gaze clean` today, this never fires:** the CLI only accepts text on
-  stdin, so there is no field name. `column` rules are useful only when
-  driving the library directly with `RawDocument::Structured`.
+  structured value and the current field name equals `column`. Resolved in
+  v0.3.1: `gaze clean` rejects policies containing `column` rules with
+  `PolicyConfig`, because the CLI only accepts text on stdin and has no field
+  name. `column` rules are useful only when driving the library directly with
+  `RawDocument::Structured`.
 - **`kind = "default"`** — always fires. Place last as a catch-all. If
   omitted, unmatched detections fall through to `Preserve` automatically,
   but an explicit `default` makes the policy intent visible.
@@ -470,6 +471,7 @@ and is summarised here.
 | `{"error":"PolicyConfig","exit":2}`     | `NoRules`                  | 2    | Zero `[[rule]]` blocks. At least one is required.                            |
 | `{"error":"PolicyConfig","exit":2}`     | `BadTtl("unknown detector.kind …")` | 2 | `kind` was not `"regex"`. Surfaced from `Pipeline::from_policy`, not the parser. |
 | `{"error":"PolicyConfig","exit":2}`     | `NerLoad`                  | 2    | `[ner] model_dir` resolves but the model bundle is missing or corrupt. Verify the install path against the README. |
+| `{"error":"PolicyConfig","exit":2,"detail":"column rules not supported in CLI mode"}` | `UnsupportedRuleKind` | 2 | `gaze clean` received a policy containing `kind = "column"`. Use library structured input for column rules. |
 
 ## See also
 
@@ -492,8 +494,6 @@ gaps land on the engineering board:
 2. **Resolved in v0.3.1: `[ner]` load failures exit `2` `PolicyConfig`.**
    `PolicyError::NerLoad` keeps missing or corrupt model bundles in the
    policy/configuration failure class.
-3. **`kind = "column"` rules never fire from `gaze clean`.** The CLI only
-   submits `RawDocument::Text`, so `Context::field_name` is always `None`
-   and `ColumnRule` cannot match. Either document this as library-only or
-   plumb a field-name hint through stdin (e.g. accept JSON `{field, text}`
-   on stdin under an opt-in flag).
+3. **Resolved in v0.3.1: `kind = "column"` rules are rejected in CLI mode.**
+   `gaze clean` now fails policy load with exit `2` `PolicyConfig` and a
+   detail string, avoiding silent no-op column rules for text stdin.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -81,13 +81,9 @@ ttl_secs = 86400       # required when scope = "persistent"; optional otherwise
 | `scope`    | string   | yes                          | One of `"ephemeral"`, `"conversation"`, `"persistent"`. |
 | `ttl_secs` | integer  | yes if `scope = "persistent"`| Must be `> 0`. Zero is rejected.                |
 
-> **Caveat — `gaze clean` does not yet honour `policy.session`.** The CLI
-> currently constructs its session from `--session-ttl` (default 86 400 s)
-> using `Scope::Persistent`, regardless of what `[session]` says. The block
-> is parsed (and its presence is required) but the values are not yet routed
-> into `Session::new`. Tracked via solo todo (see "Known spec drift" below).
-> Until that lands, treat `[session]` as a forward-looking reservation:
-> declare it correctly so a future binary picks it up automatically.
+> Resolved in v0.3.1: `gaze clean` now constructs its session from
+> `[session]`. `--session-ttl` is an explicit CLI override for persistent
+> session TTL; when the flag is omitted, `ttl_secs` from policy is used.
 
 ### `[[detector]]`
 
@@ -298,9 +294,9 @@ exports a `SensitiveSnapshot` (the `session_blob` field of stdout) so that
 - `scope = "persistent"` — the only scope `gaze clean` produces. Requires
   `ttl_secs > 0`.
 
-The `--session-ttl=<secs>` CLI flag (default `86400`) is the value `gaze
-clean` actually uses today. See the caveat in [`[session]`](#session)
-above.
+The `--session-ttl=<secs>` CLI flag overrides the policy TTL for persistent
+sessions. If the flag is omitted, `gaze clean` uses `[session].ttl_secs`;
+policy-less stub mode falls back to `86400`.
 
 TTL enforcement on `gaze restore`: when the imported snapshot's `issued_at +
 ttl_secs` has passed, restore fails with **exit `3` `BlobExpired`**. (The
@@ -492,10 +488,9 @@ and is summarised here.
 Documented here so users get the truth, with corresponding solo todos so the
 gaps land on the engineering board:
 
-1. **`policy.session` is parsed but ignored by `gaze clean`.** The CLI
-   forces `Scope::Persistent { ttl: --session-ttl }` regardless of what the
-   policy declares. Fix: thread `policy.session` into `Session::new` and
-   document `--session-ttl` as an override, not the source of truth.
+1. **Resolved in v0.3.1: `policy.session` is honoured by `gaze clean`.**
+   The CLI constructs sessions from `[session]`; `--session-ttl` is now only
+   an explicit persistent-TTL override.
 2. **`[ner]` load failures exit `3` `Pipeline`, not `2` `PolicyConfig`.**
    Users editing `model_dir` get a runtime variant for what is morally a
    config error. Fix: map `Error::NerLoad` to `PolicyConfig` (or introduce a

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -161,11 +161,9 @@ locale = "de"
 | `locale`    | string | no       | Locale hint passed to the NER detector (e.g. `"de"`).          |
 
 If `model_dir` is set but the model fails to load (missing files, bad
-manifest), the pipeline build fails with `Error::NerLoad`, which the CLI
-maps to **exit `3` `Pipeline`** — not exit `2` `PolicyConfig`. Treat NER
-load errors as a runtime failure, not a config failure. See
-[README §"NER Model Runtime"](../README.md#ner-model-runtime) for the
-expected directory layout.
+manifest), the CLI maps the failure to **exit `2` `PolicyConfig`**. Treat
+NER load errors as policy configuration failures: verify the install path
+against [README §"NER Model Runtime"](../README.md#ner-model-runtime).
 
 ## Classes
 
@@ -471,7 +469,7 @@ and is summarised here.
 | `{"error":"PolicyConfig","exit":2}`     | `NoDetectors`              | 2    | Zero `[[detector]]` blocks. At least one is required.                        |
 | `{"error":"PolicyConfig","exit":2}`     | `NoRules`                  | 2    | Zero `[[rule]]` blocks. At least one is required.                            |
 | `{"error":"PolicyConfig","exit":2}`     | `BadTtl("unknown detector.kind …")` | 2 | `kind` was not `"regex"`. Surfaced from `Pipeline::from_policy`, not the parser. |
-| `{"error":"Pipeline","exit":3}`         | (NER load failure)         | 3    | `[ner] model_dir` resolves but the model bundle is missing or corrupt. Verify the install path against the README. |
+| `{"error":"PolicyConfig","exit":2}`     | `NerLoad`                  | 2    | `[ner] model_dir` resolves but the model bundle is missing or corrupt. Verify the install path against the README. |
 
 ## See also
 
@@ -491,11 +489,9 @@ gaps land on the engineering board:
 1. **Resolved in v0.3.1: `policy.session` is honoured by `gaze clean`.**
    The CLI constructs sessions from `[session]`; `--session-ttl` is now only
    an explicit persistent-TTL override.
-2. **`[ner]` load failures exit `3` `Pipeline`, not `2` `PolicyConfig`.**
-   Users editing `model_dir` get a runtime variant for what is morally a
-   config error. Fix: map `Error::NerLoad` to `PolicyConfig` (or introduce a
-   `NerConfig` variant) so failure mode lines up with where the user can
-   make the change.
+2. **Resolved in v0.3.1: `[ner]` load failures exit `2` `PolicyConfig`.**
+   `PolicyError::NerLoad` keeps missing or corrupt model bundles in the
+   policy/configuration failure class.
 3. **`kind = "column"` rules never fire from `gaze clean`.** The CLI only
    submits `RawDocument::Text`, so `Context::field_name` is always `None`
    and `ColumnRule` cannot match. Either document this as library-only or


### PR DESCRIPTION
## Summary
- Honor policy.session in gaze clean; --session-ttl is now an explicit persistent TTL override.
- Route broken [ner] model_dir load failures to PolicyConfig exit 2.
- Reject kind = "column" rules during CLI policy load with a PolicyConfig detail instead of silently accepting inert rules.
- Add v0.3.1 unreleased changelog entry and update docs/policy.md spec-drift notes.

## Test plan
- cargo test -p gaze

## Commits
- 3ee5fd7 [agent] fix(session): honor policy.session block in gaze clean (#41)
- c60f226 [agent] fix(policy): route NER load failure to PolicyConfig exit 2 (#42)
- 0941aa4 [agent] fix(policy): reject kind=column rules in CLI mode (#43)
- d5a0770 [agent] docs(changelog): v0.3.1 spec-drift fixes entry