### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1] - unreleased
+## [v0.3.1] — 2026-04-24
 
 ### Fixed
 
-- `gaze clean` now honors `[session]` from `policy.toml`; `--session-ttl`
-  is an explicit persistent-TTL override instead of the source of truth.
-- Broken `[ner] model_dir` configuration now exits as `PolicyConfig`
-  with exit code 2.
-- `gaze clean` now rejects `kind = "column"` rules during CLI policy load
-  instead of silently accepting rules that cannot fire for text stdin.
+- **NER silent no-op with BIO-prefixed labels.json.** `LabelMap::resolve`
+  now accepts both BIO-prefixed (`B-PER`, `B-LOC`) and bare (`PER`, `LOC`)
+  label keys. Previously, bundles shipping BIO-prefixed labels (the standard
+  Davlan/HuggingFace format) produced zero detections silently. Adopters on
+  aarch64-apple-darwin were particularly affected. (#19)
+- Spec-drift: `[session]` policy.toml key now authoritative over
+  `--session-ttl`. (#16)
+- Spec-drift: Broken `[ner] model_dir` exits `PolicyConfig` (exit code 2)
+  instead of silently degrading. (#16)
+- Spec-drift: `kind = "column"` policy rules rejected by `gaze clean` CLI
+  load. (#16)
+
+### Added
+
+- `tracing::info!("ner detector registered, N backends")` on NER bootstrap -
+  adopters can now confirm whether [ner] block is being picked up. (#19)
+- `tracing::warn!` on zero-overlap (NER inference ran but emitted 0 entities
+  for input class) - surfaces silent detection failures. (#19)
+
+### Changed
+
+- README hero copy + project north star documentation refresh. (#15)
+- Roadmap documentation for v0.4 / v0.4.1 / v0.5. (docs-only,
+  offsite-readable)
 
 ## [0.3.0] — 2026-04-24
 
@@ -128,7 +146,8 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/Naoray/gaze/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Naoray/gaze/compare/v0.3.1...HEAD
+[v0.3.1]: https://github.com/Naoray/gaze/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Naoray/gaze/releases/tag/v0.3.0
 [0.3.0-rc.2]: https://github.com/Naoray/gaze/releases/tag/v0.3.0-rc.2
 [0.3.0-rc.1]: https://github.com/Naoray/gaze/releases/tag/v0.3.0-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "debug-proxy"
-version = "0.3.0-rc.3"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "gaze"
-version = "0.3.0-rc.3"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/debug-proxy/Cargo.toml
+++ b/crates/debug-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "debug-proxy"
-version = "0.3.0-rc.3"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.3.0-rc.3"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"


### PR DESCRIPTION
## Summary
- Adopter-critical NER label-map fix (Markus/Dashboard gaze-laravel report).
- Spec-drift closeouts already on main (from b70947d).
- Docs updates (north star, roadmap, README hero).

## Binaries
Post-merge CI/build produces aarch64-apple-darwin + x86_64-apple-darwin + linux-x86_64 + linux-aarch64.

## Test plan
- [x] cargo test -p gaze passes (NER + regression)
- [x] NER example bundle (BIO-prefixed labels.json) produces detections via regression coverage
- [ ] Adopter smoke test (Markus can verify post-release)

## Adopter ref
- Solo todo #73 (NER silent no-op)
- Solo todo #74 (stale v0.3.0 asset)
