### PR TITLE
v0.4 Phase 1 Layer B Bundle B3: F7.5 byte-range-skip (cascade false-positive fix)

### DIFF
--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -4,6 +4,7 @@
 //! `docs/roadmap/v0.3/laravel.md` for the host-side integration contract.
 
 use std::io::{self, Read};
+use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::{
@@ -276,10 +277,15 @@ fn run_restore(
         })?;
 
     let pass1 = restore_pass1(&session, &request.text)?;
-    let restore_warning = restore_pass2_validate(&pass1, &session, restore_mode)?;
+    let restore_warning = restore_pass2_validate(
+        &pass1.text,
+        &pass1.substitution_spans,
+        &session,
+        restore_mode,
+    )?;
 
     let response = RestoreResponse {
-        text: pass1,
+        text: pass1.text,
         restore_warning,
     };
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
@@ -359,10 +365,18 @@ fn build_pipeline_from_policy(policy: &Policy) -> GazeResult<Pipeline> {
 /// `>` are explicit delimiters, and `\b` would miss `See <Email_1>.` because
 /// it does not fire across non-word characters. Empty session map is a no-op:
 /// `Regex::new("")` would match everywhere, so short-circuit.
-fn restore_pass1(session: &Session, text: &str) -> std::result::Result<String, CliError> {
+struct RestorePass1 {
+    text: String,
+    substitution_spans: Vec<Range<usize>>,
+}
+
+fn restore_pass1(session: &Session, text: &str) -> std::result::Result<RestorePass1, CliError> {
     let mut tokens = session.tokens();
     if tokens.is_empty() {
-        return Ok(text.to_string());
+        return Ok(RestorePass1 {
+            text: text.to_string(),
+            substitution_spans: Vec::new(),
+        });
     }
     tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
 
@@ -381,17 +395,23 @@ fn restore_pass1(session: &Session, text: &str) -> std::result::Result<String, C
     let re = Regex::new(&pattern).map_err(|_| CliError::Pipeline)?;
 
     let mut out = String::with_capacity(text.len());
+    let mut substitution_spans = Vec::new();
     let mut last = 0usize;
     for m in re.find_iter(text) {
         out.push_str(&text[last..m.start()]);
         let real = session
             .restore_strict(m.as_str())
             .map_err(|_| CliError::Pipeline)?;
+        let substitution_start = out.len();
         out.push_str(&real);
+        substitution_spans.push(substitution_start..out.len());
         last = m.end();
     }
     out.push_str(&text[last..]);
-    Ok(out)
+    Ok(RestorePass1 {
+        text: out,
+        substitution_spans,
+    })
 }
 
 /// Pass 2 — shape-validator over Pass-1 output.
@@ -401,41 +421,52 @@ fn restore_pass1(session: &Session, text: &str) -> std::result::Result<String, C
 /// `gaze::token_shape`, so the CLI no longer re-encodes token shapes locally.
 fn restore_pass2_validate(
     text: &str,
+    substitution_spans: &[Range<usize>],
     session: &Session,
     mode: RestoreMode,
 ) -> std::result::Result<Vec<RestoreWarning>, CliError> {
     let mut warnings = Vec::new();
-    for matched in gaze::token_shape::find_tokens(text) {
-        if gaze::token_shape::is_trap(matched) {
+    for matched in gaze::token_shape::pattern().find_iter(text) {
+        if is_inside_substitution_span(matched.start(), matched.end(), substitution_spans) {
+            continue;
+        }
+        let matched_text = matched.as_str();
+        if gaze::token_shape::is_trap(matched_text) {
             match mode {
                 RestoreMode::Strict => {
                     return Err(CliError::UnknownToken {
-                        token: matched.to_string(),
+                        token: matched_text.to_string(),
                     })
                 }
                 RestoreMode::Tolerant => warnings.push(RestoreWarning {
                     variant: "UnknownToken".to_string(),
-                    token: matched.to_string(),
+                    token: matched_text.to_string(),
                 }),
             }
             continue;
         }
-        if session.contains_token(matched) {
+        if session.contains_token(matched_text) {
             continue;
         }
         match mode {
             RestoreMode::Strict => {
                 return Err(CliError::UnknownToken {
-                    token: matched.to_string(),
+                    token: matched_text.to_string(),
                 })
             }
             RestoreMode::Tolerant => warnings.push(RestoreWarning {
                 variant: "UnknownToken".to_string(),
-                token: matched.to_string(),
+                token: matched_text.to_string(),
             }),
         }
     }
     Ok(warnings)
+}
+
+fn is_inside_substitution_span(start: usize, end: usize, spans: &[Range<usize>]) -> bool {
+    spans
+        .iter()
+        .any(|span| span.start <= start && end <= span.end)
 }
 
 #[derive(Deserialize)]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use regex::Regex;
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
@@ -79,6 +80,19 @@ fn restore_json_with_args(
 
 fn parse_stderr_variant(stderr: &[u8]) -> Value {
     serde_json::from_slice(stderr).expect("stderr is one-line JSON")
+}
+
+fn assert_session_scoped_custom_token(token: &str) {
+    let re = Regex::new(r"^<[0-9a-f]{8}:Custom:[a-z0-9_]+_\d+>$").unwrap();
+    assert!(re.is_match(token), "unexpected custom token shape: {token}");
+}
+
+fn restore_success_text(blob: &str, text: &str) -> String {
+    let (code, stdout, stderr) = restore_json(blob, text);
+    assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
+    assert!(stderr.is_empty(), "expected empty stderr");
+    let resp: Value = serde_json::from_slice(&stdout).unwrap();
+    resp["text"].as_str().unwrap().to_string()
 }
 
 fn write_minimal_policy() -> (tempfile::TempDir, std::path::PathBuf) {
@@ -257,8 +271,7 @@ fn t04_unknown_token_lowercase_formatpreserve_shape() {
 fn t04b_tolerant_restore_reports_warning_and_preserves_text() {
     let (_, blob, _) = clean_ok("No PII here.");
     let text = "Your location_7 order arrives soon.";
-    let (code, stdout, stderr) =
-        restore_json_with_args(&["--restore-mode=tolerant"], &blob, text);
+    let (code, stdout, stderr) = restore_json_with_args(&["--restore-mode=tolerant"], &blob, text);
 
     assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
     assert!(stderr.is_empty(), "expected empty stderr");
@@ -282,6 +295,96 @@ fn t04c_tolerant_restore_omits_empty_warning_array() {
     assert!(
         resp.get("restore_warning").is_none(),
         "empty restore_warning must be omitted: {resp}"
+    );
+}
+
+#[test]
+fn cascade_restored_order_id_not_trapped() {
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        vec![s
+            .tokenize(&PiiClass::custom("order_ref"), "Order_42")
+            .unwrap()]
+    });
+    assert_session_scoped_custom_token(&tokens[0]);
+
+    let restored = restore_success_text(&blob, &format!("Reference {} is ready.", tokens[0]));
+
+    assert_eq!(restored, "Reference Order_42 is ready.");
+}
+
+#[test]
+fn cascade_restored_song_user_artist_tenant() {
+    let cases = [
+        ("song_ref", "Song_42"),
+        ("user_ref", "User_7"),
+        ("artist_ref", "Artist_1"),
+        ("tenant_ref", "Tenant_5"),
+    ];
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        cases
+            .iter()
+            .map(|(class, raw)| s.tokenize(&PiiClass::custom(*class), raw).unwrap())
+            .collect()
+    });
+    for token in &tokens {
+        assert_session_scoped_custom_token(token);
+    }
+
+    let reply = format!(
+        "{} / {} / {} / {}",
+        tokens[0], tokens[1], tokens[2], tokens[3]
+    );
+    let restored = restore_success_text(&blob, &reply);
+
+    assert_eq!(restored, "Song_42 / User_7 / Artist_1 / Tenant_5");
+}
+
+#[test]
+fn cascade_restored_snake_case() {
+    let cases = [
+        ("order_raw", "order_id_7"),
+        ("tenant_raw", "tenant_5"),
+        ("class_raw", "class_1"),
+        ("song_title_raw", "song_title_3"),
+    ];
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        cases
+            .iter()
+            .map(|(class, raw)| s.tokenize(&PiiClass::custom(*class), raw).unwrap())
+            .collect()
+    });
+    for token in &tokens {
+        assert_session_scoped_custom_token(token);
+    }
+
+    let reply = format!("{} {} {} {}", tokens[0], tokens[1], tokens[2], tokens[3]);
+    let restored = restore_success_text(&blob, &reply);
+
+    assert_eq!(restored, "order_id_7 tenant_5 class_1 song_title_3");
+}
+
+#[test]
+fn cascade_llm_hallucination_still_trapped() {
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        vec![s
+            .tokenize(&PiiClass::custom("order_ref"), "Order_42")
+            .unwrap()]
+    });
+    assert_session_scoped_custom_token(&tokens[0]);
+
+    let text = format!("Known {} and unknown <unknown:Email_99>.", tokens[0]);
+    let (code, stdout, stderr) = restore_json(&blob, &text);
+
+    assert_eq!(
+        code,
+        Some(3),
+        "expected exit 3, stdout={} stderr={}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(
+        parse_stderr_variant(&stderr),
+        json!({ "error": "UnknownToken", "exit": 3, "token": "Email_99" })
     );
 }
 
@@ -783,9 +886,8 @@ action = "preserve"
 
 #[test]
 fn t19_restore_custom_token_round_trip_ok() {
-    let (blob, tokens) = build_blob_and_tokens(|s| {
-        vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]
-    });
+    let (blob, tokens) =
+        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]);
     let text = format!("Order {} is shipped.", tokens[0]);
 
     let (code, stdout, stderr) = restore_json(&blob, &text);
@@ -796,15 +898,11 @@ fn t19_restore_custom_token_round_trip_ok() {
 
 #[test]
 fn t20_restore_custom_hallucination_exits_3() {
-    let (blob, tokens) = build_blob_and_tokens(|s| {
-        vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]
-    });
+    let (blob, tokens) =
+        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]);
 
     let text = format!("Order {} and <Custom:fake_id_99> are shipped.", tokens[0]);
-    let (code, stdout, stderr) = restore_json(
-        &blob,
-        &text,
-    );
+    let (code, stdout, stderr) = restore_json(&blob, &text);
     assert_eq!(
         code,
         Some(3),

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -388,6 +388,29 @@ fn cascade_llm_hallucination_still_trapped() {
     );
 }
 
+#[test]
+fn cascade_trap_boundary_crossing_not_exempted() {
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        vec![s.tokenize(&PiiClass::custom("name_ref"), "Foo").unwrap()]
+    });
+    assert_session_scoped_custom_token(&tokens[0]);
+
+    let text = format!("{}_7", tokens[0]);
+    let (code, stdout, stderr) = restore_json(&blob, &text);
+
+    assert_eq!(
+        code,
+        Some(3),
+        "expected exit 3, stdout={} stderr={}",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+    );
+    assert_eq!(
+        parse_stderr_variant(&stderr),
+        json!({ "error": "UnknownToken", "exit": 3, "token": "Foo_7" })
+    );
+}
+
 // -----------------------------------------------------------------------
 // 5. Adjacency corruption regression
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Track Pass 1 substitution byte spans on output text
- Pass 2 trap scan skips matches inside recorded spans
- Preserves strict-mode fail-closed for LLM-raw residue

Resolves Pass 1 → Pass 2 cascade false-positive documented in plan rev 5.

## Context

Promoted from Phase 5 A3 to v0.4.0 per north-star decision 2026-04-24. Flagship adopter Markus's tenant identifiers (`Order_42`/`Song_42`/`User_7`) match trap arms by construction; strict-mode restore was rejecting legitimate restored values.

## Test plan

- [x] cargo test --workspace green
- [x] New regression tests cover `Order_42`, `Song_42`, `User_7`, `Artist_1`, `Tenant_5`, `order_id_7`, snake-case variants
- [x] `t04_unknown_token_lowercase_formatpreserve_shape` still passes (real v0.3 residue still trapped)
- [x] Unknown LLM-hallucination tokens still trapped (fail-closed preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)