### PR TITLE
v0.4 Phase 1 Layer B Bundle B2: F5 .invalid + F6 Dictionary + typed Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Counter-family tokens now wrap in angle brackets.** `<Email_1>`,
-  `<Name_1>`, `<Custom:order_id_1>`. Format-preserving email tokens
-  (`email1@example.test`) stay bare — angle brackets defeat the
+- **Counter-family tokens now wrap in angle brackets.** `<{session_hex}:Email_1>`,
+  `<{session_hex}:Name_1>`, `<{session_hex}:Custom:order_id_1>`. Format-preserving email tokens
+  (`email1.{session_hex}@gaze-fake.invalid`) stay bare — angle brackets defeat the
   format-preserving purpose.
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +418,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -525,6 +564,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +632,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1088,6 +1169,7 @@ dependencies = [
 name = "gaze"
 version = "0.4.0-rc.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "base64 0.22.1",
  "dashmap",
@@ -1132,6 +1214,8 @@ dependencies = [
 name = "gaze-recognizers"
 version = "0.4.0-rc.0"
 dependencies = [
+ "aho-corasick",
+ "criterion",
  "gaze",
  "hex",
  "ndarray 0.16.1",
@@ -1219,6 +1303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1368,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1621,10 +1722,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1998,6 +2119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2289,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,7 +2418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2381,7 +2536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -2630,6 +2785,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3300,7 +3464,7 @@ dependencies = [
  "ferroid",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -3406,6 +3570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,7 +3607,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -3866,6 +4040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,6 +4165,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ The standalone CLI consumes the library for LLM pipe-mode integration (Laravel w
 #### CLI Example
 
 ```bash
-echo "Email alice@example.com now" | gaze clean --policy=policy.toml
-# {"clean_text":"Email <Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
+echo "Email alice@example.invalid now" | gaze clean --policy=policy.toml
+# {"clean_text":"Email <{session_hex}:Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
 ```
 
-Counter-family tokens (`<Email_N>`, `<Name_N>`, `<Location_N>`, `<Organization_N>`, `<Custom:name_N>`) are wrapped in angle brackets so the LLM cannot silently dissolve them into adjacent words. Format-preserving email tokens (`email1@example.test`) intentionally stay bare — the whole point is to look like a real email.
+Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{session_hex}:Location_N>`, `<{session_hex}:Organization_N>`, `<{session_hex}:Custom:name_N>`) are wrapped in angle brackets so the LLM cannot silently dissolve them into adjacent words. Format-preserving email tokens (`email1.{session_hex}@gaze-fake.invalid`) intentionally stay bare — the whole point is to look like a real email.
 
 #### Policy Configuration
 

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Arc,
+    Arc, OnceLock,
 };
 use std::time::Duration;
 
@@ -22,11 +22,14 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use gaze::{
-    Action, ClassRule, ColumnRule, DefaultRule, DocumentKind, LocaleChain, LocaleTag, PiiClass,
-    Pipeline, Policy, PolicyError, RawDocument, RawMatch, RedactionEntry, RedactionLogger,
-    Result as GazeResult, RuleSpec, Rulepack, RulepackSource, Scope, SensitiveSnapshot, Session,
+    Action, ClassRule, ColumnRule, DefaultRule, DictionaryBundle, DictionarySource, DocumentKind,
+    LocaleChain, LocaleTag, PiiClass, Pipeline, Policy, PolicyError, RawDocument, RawMatch,
+    RedactionEntry, RedactionLogger, Result as GazeResult, RuleSpec, Rulepack, RulepackDict,
+    RulepackSource, Scope, SensitiveSnapshot, Session, TypedContext,
 };
-use gaze_recognizers::{NerDetector, NerOptions, NormalizerKind, RegexDetector, ValidatorKind};
+use gaze_recognizers::{
+    DictionaryRecognizer, NerDetector, NerOptions, NormalizerKind, RegexDetector, ValidatorKind,
+};
 
 use crate::error::{CliError, RestoreMode, RestoreWarning};
 
@@ -64,6 +67,9 @@ enum Cmd {
         /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
+        /// Path to a typed Context JSON envelope. stdin remains raw text.
+        #[arg(long)]
+        context_json: Option<PathBuf>,
     },
     /// Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout.
     Restore {
@@ -136,7 +142,15 @@ fn main() -> ExitCode {
             session_ttl,
             locale,
             max_bytes,
-        } => run_clean(policy.as_deref(), &format, session_ttl, &locale, max_bytes),
+            context_json,
+        } => run_clean(
+            policy.as_deref(),
+            &format,
+            session_ttl,
+            &locale,
+            max_bytes,
+            context_json.as_deref(),
+        ),
         Cmd::Restore {
             format,
             restore_mode,
@@ -200,6 +214,7 @@ fn run_clean(
     session_ttl: Option<u64>,
     locale: &[String],
     max_bytes: u64,
+    context_json: Option<&std::path::Path>,
 ) -> std::result::Result<(), CliError> {
     require_json_format(format)?;
     let raw = read_stdin_text(max_bytes)?;
@@ -213,6 +228,26 @@ fn run_clean(
         Some(policy) => load_rulepacks(policy).map_err(map_pipeline_error)?,
         None => Vec::new(),
     };
+    let context = context_json
+        .map(TypedContext::load)
+        .transpose()
+        .map_err(|_| CliError::PolicyConfig)?;
+    let context_bundle = context
+        .as_ref()
+        .map(DictionaryBundle::from_context)
+        .unwrap_or_default();
+    let rulepack_dictionaries =
+        dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
+    let policy_bundle = loaded_policy
+        .as_ref()
+        .map(|policy| {
+            let mut dictionaries = policy.dictionaries.clone();
+            dictionaries.extend(rulepack_dictionaries);
+            DictionaryBundle::from_rulepack_terms(&dictionaries)
+        })
+        .unwrap_or_default();
+    let dictionaries = DictionaryBundle::merge(policy_bundle, context_bundle);
+    let dictionary_stats = dictionaries.stats();
     let rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
     let cli_locales = parse_cli_locales(locale)?;
     let locale_chain = LocaleChain::merge_cli_policy_rulepack_default(
@@ -224,9 +259,14 @@ fn run_clean(
     );
 
     let pipeline = match &loaded_policy {
-        Some(policy) => build_pipeline_from_policy(policy, loaded_rulepacks)
+        Some(policy) => build_pipeline_from_policy(policy, &loaded_rulepacks, context.as_ref())
             .map_err(map_pipeline_error)?
             .with_redaction_logger(ArcLogger(Arc::clone(&counter) as Arc<dyn RedactionLogger>)),
+        None if context.is_some() => build_context_pipeline(
+            context.as_ref().expect("checked context"),
+            Arc::clone(&counter) as Arc<dyn RedactionLogger>,
+        )
+        .map_err(|_| CliError::PolicyConfig)?,
         None => {
             tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
             build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>)
@@ -242,8 +282,18 @@ fn run_clean(
     }
     .map_err(|_| CliError::Pipeline)?;
 
+    let detect_fields = match &context {
+        Some(context) => &context.fields,
+        None => empty_fields(),
+    };
     let clean_doc = pipeline
-        .redact_with_context(&session, RawDocument::Text(raw), locale_chain.as_slice())
+        .redact_with_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            locale_chain.as_slice(),
+            &dictionaries,
+            detect_fields,
+        )
         .map_err(|_| CliError::Pipeline)?;
 
     let clean_text = match clean_doc {
@@ -264,6 +314,11 @@ fn run_clean(
         stats: Stats {
             detections: counter.detections.load(Ordering::Relaxed),
             locale_chain: locale_chain.to_strings(),
+            dictionaries_loaded: dictionary_stats
+                .into_iter()
+                .map(LoadedDictionaryStats::from)
+                .collect(),
+            context_source: context_json.map(|_| "cli".to_string()),
         },
     };
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
@@ -340,16 +395,42 @@ fn map_pipeline_error(err: gaze::Error) -> CliError {
     }
 }
 
-fn build_pipeline_from_policy(policy: &Policy, rulepacks: Vec<Rulepack>) -> GazeResult<Pipeline> {
+fn build_pipeline_from_policy(
+    policy: &Policy,
+    rulepacks: &[Rulepack],
+    context: Option<&TypedContext>,
+) -> GazeResult<Pipeline> {
     let mut builder = Pipeline::builder();
+    let mut registered_dictionaries = std::collections::BTreeSet::<String>::new();
 
     for detector in &policy.detectors {
         builder = match &detector.kind {
             gaze::DetectorKind::Regex => builder.detector(RegexDetector::with_source(
-                &detector.pattern,
+                detector.pattern.as_deref().ok_or_else(|| {
+                    gaze::Error::Policy(PolicyError::BadDictionary {
+                        name: detector.name.clone(),
+                        reason: "regex recognizer missing pattern".to_string(),
+                    })
+                })?,
                 detector.class.clone(),
                 &detector.name,
             )?),
+            gaze::DetectorKind::Dictionary => {
+                let dictionary_name = detector.dictionary_name.as_deref().ok_or_else(|| {
+                    gaze::Error::Policy(PolicyError::BadDictionary {
+                        name: detector.name.clone(),
+                        reason: "dictionary recognizer missing dictionary name".to_string(),
+                    })
+                })?;
+                registered_dictionaries.insert(dictionary_name.to_string());
+                builder.recognizer(DictionaryRecognizer::new(
+                    format!("dict/{}", detector.name),
+                    detector.class.clone(),
+                    dictionary_name,
+                    detector.case_sensitive,
+                    detector.token_family.clone(),
+                ))
+            }
             gaze::DetectorKind::Unknown(kind) => {
                 return Err(gaze::Error::Policy(PolicyError::BadTtl(format!(
                     "unknown detector.kind '{kind}'"
@@ -361,18 +442,18 @@ fn build_pipeline_from_policy(policy: &Policy, rulepacks: Vec<Rulepack>) -> Gaze
     let mut rulepack_recognizers =
         std::collections::BTreeMap::<String, (String, gaze::RecognizerSpec)>::new();
     for rulepack in rulepacks {
-        for recognizer in rulepack.recognizers {
+        for recognizer in &rulepack.recognizers {
             tracing::info!(recognizer_id = %recognizer.id, "loaded rulepack recognizer");
             if let Some((first_pack, _)) = rulepack_recognizers.get(&recognizer.id) {
                 return Err(gaze::Error::Rulepack(gaze::RulepackError::DuplicateId {
-                    id: recognizer.id,
+                    id: recognizer.id.clone(),
                     first_pack: first_pack.clone(),
                     second_pack: rulepack.rulepack_id.clone(),
                 }));
             }
             rulepack_recognizers.insert(
                 recognizer.id.clone(),
-                (rulepack.rulepack_id.clone(), recognizer),
+                (rulepack.rulepack_id.clone(), recognizer.clone()),
             );
         }
     }
@@ -411,16 +492,71 @@ fn build_pipeline_from_policy(policy: &Policy, rulepacks: Vec<Rulepack>) -> Gaze
                     normalizer_kind,
                 )?);
             }
-            RawMatch::Dictionary { .. } => {
-                return Err(gaze::Error::Rulepack(
-                    gaze::RulepackError::UnsupportedMatcher("Dictionary".to_string()),
-                ))
+            RawMatch::Dictionary {
+                terms,
+                terms_file,
+                terms_from_context,
+                case_sensitive,
+            } => {
+                let dictionary_name = terms_from_context
+                    .as_deref()
+                    .unwrap_or(recognizer.id.as_str())
+                    .to_string();
+                let dictionary_has_inline_terms = !terms.is_empty() || terms_file.is_some();
+                if !dictionary_has_inline_terms && terms_from_context.is_none() {
+                    return Err(gaze::Error::Policy(PolicyError::BadDictionary {
+                        name: recognizer.id.clone(),
+                        reason:
+                            "dictionary matcher requires terms, terms_file, or terms_from_context"
+                                .to_string(),
+                    }));
+                }
+                let id = recognizer.id;
+                let class = recognizer.class;
+                let token_family = recognizer
+                    .token
+                    .family
+                    .unwrap_or_else(|| "counter".to_string());
+                let locales = recognizer.locales;
+                let base_score = recognizer.scoring.base;
+                let priority = recognizer.scoring.priority;
+                registered_dictionaries.insert(dictionary_name.clone());
+                builder = builder.recognizer(DictionaryRecognizer::with_rulepack_fields(
+                    id,
+                    class,
+                    dictionary_name,
+                    case_sensitive,
+                    token_family,
+                    locales,
+                    base_score,
+                    priority,
+                ));
             }
             RawMatch::Ner { .. } => {
                 return Err(gaze::Error::Rulepack(
                     gaze::RulepackError::UnsupportedMatcher("Ner".to_string()),
                 ))
             }
+        }
+    }
+
+    if let Some(context) = context {
+        for name in context.dictionaries.keys() {
+            if registered_dictionaries.contains(name) {
+                continue;
+            }
+            let class = context
+                .class_map
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| PiiClass::custom(name));
+            builder = builder.recognizer(DictionaryRecognizer::new(
+                format!("context/{name}"),
+                class,
+                name,
+                context.dictionaries[name].case_sensitive,
+                "counter",
+            ));
         }
     }
 
@@ -464,6 +600,67 @@ fn load_rulepacks(policy: &Policy) -> GazeResult<Vec<Rulepack>> {
         rulepacks.push(Rulepack::load(RulepackSource::Path(path.clone()))?);
     }
     Ok(rulepacks)
+}
+
+fn dictionary_terms_from_rulepacks(rulepacks: &[Rulepack]) -> GazeResult<Vec<RulepackDict>> {
+    let mut dictionaries = Vec::new();
+    for rulepack in rulepacks {
+        for recognizer in &rulepack.recognizers {
+            let RawMatch::Dictionary {
+                terms,
+                terms_file,
+                terms_from_context,
+                case_sensitive,
+            } = &recognizer.matcher
+            else {
+                continue;
+            };
+            if terms_from_context.is_some() {
+                continue;
+            }
+            let mut all_terms = terms.clone();
+            if let Some(path) = terms_file {
+                let file = std::fs::read_to_string(path).map_err(|err| {
+                    gaze::Error::Policy(PolicyError::BadDictionary {
+                        name: recognizer.id.clone(),
+                        reason: format!("failed to read terms_file: {err}"),
+                    })
+                })?;
+                all_terms.extend(
+                    file.lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                        .map(str::to_string),
+                );
+            }
+            if all_terms.is_empty() {
+                return Err(gaze::Error::Policy(PolicyError::BadDictionary {
+                    name: recognizer.id.clone(),
+                    reason: "dictionary matcher requires terms, terms_file, or terms_from_context"
+                        .to_string(),
+                }));
+            }
+            if !case_sensitive && all_terms.iter().any(|term| !term.is_ascii()) {
+                return Err(gaze::Error::Policy(PolicyError::BadDictionary {
+                    name: recognizer.id.clone(),
+                    reason:
+                        "unicode dictionary insensitive matching unsupported in v0.4.0, use case_sensitive = true"
+                            .to_string(),
+                }));
+            }
+            dictionaries.push(RulepackDict {
+                name: recognizer.id.clone(),
+                terms: all_terms,
+                case_sensitive: *case_sensitive,
+            });
+        }
+    }
+    Ok(dictionaries)
+}
+
+fn empty_fields() -> &'static serde_json::Map<String, serde_json::Value> {
+    static EMPTY_FIELDS: OnceLock<serde_json::Map<String, serde_json::Value>> = OnceLock::new();
+    EMPTY_FIELDS.get_or_init(serde_json::Map::new)
 }
 
 fn merged_rulepack_default_locales(rulepacks: &[Rulepack]) -> Vec<LocaleTag> {
@@ -618,6 +815,33 @@ fn build_stub_pipeline(logger: Arc<dyn RedactionLogger>) -> GazeResult<Pipeline>
         .build()
 }
 
+fn build_context_pipeline(
+    context: &TypedContext,
+    logger: Arc<dyn RedactionLogger>,
+) -> GazeResult<Pipeline> {
+    let mut builder = Pipeline::builder();
+    for name in context.dictionaries.keys() {
+        let class = context
+            .class_map
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| PiiClass::custom(name));
+        builder = builder
+            .recognizer(DictionaryRecognizer::new(
+                format!("context/{name}"),
+                class.clone(),
+                name,
+                context.dictionaries[name].case_sensitive,
+                "counter",
+            ))
+            .rule(ClassRule::new(class, Action::Tokenize));
+    }
+    builder
+        .rule(DefaultRule::new(Action::Preserve))
+        .redaction_logger(ArcLogger(logger))
+        .build()
+}
+
 #[derive(Default)]
 struct CountingLogger {
     detections: AtomicU64,
@@ -657,4 +881,28 @@ struct CleanResponse {
 struct Stats {
     detections: u64,
     locale_chain: Vec<String>,
+    dictionaries_loaded: Vec<LoadedDictionaryStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_source: Option<String>,
+}
+
+#[derive(Serialize)]
+struct LoadedDictionaryStats {
+    name: String,
+    term_count: usize,
+    source: String,
+}
+
+impl From<gaze::DictionaryStats> for LoadedDictionaryStats {
+    fn from(stats: gaze::DictionaryStats) -> Self {
+        let source = match stats.source {
+            DictionarySource::Cli => "cli",
+            DictionarySource::Rulepack => "rulepack",
+        };
+        Self {
+            name: stats.name,
+            term_count: stats.term_count,
+            source: source.to_string(),
+        }
+    }
 }

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -481,7 +481,7 @@ fn merged_rulepack_default_locales(rulepacks: &[Rulepack]) -> Vec<LocaleTag> {
 /// Pass 1 — exact-literal alternation built from `session.tokens()`.
 ///
 /// Sorts tokens longest-first so a format-preserved email like
-/// `email1@example.test` wins over a substring match like `<Email_1>`. Bare
+/// `email1.<session>@gaze-fake.invalid` wins over a substring match like `<Email_1>`. Bare
 /// format-preserving tokens stay wrapped in `\b` word boundaries so a token
 /// cannot be swallowed inside an adjacent identifier (the
 /// `hostName_1s-record` regression in `docs/roadmap/v0.3/cli.md` §"Test

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -483,9 +483,8 @@ fn cascade_llm_hallucination_still_trapped() {
 
 #[test]
 fn cascade_trap_boundary_crossing_not_exempted() {
-    let (blob, tokens) = build_blob_and_tokens(|s| {
-        vec![s.tokenize(&PiiClass::custom("name_ref"), "Foo").unwrap()]
-    });
+    let (blob, tokens) =
+        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("name_ref"), "Foo").unwrap()]);
     assert_session_scoped_custom_token(&tokens[0]);
 
     let text = format!("{}_7", tokens[0]);
@@ -556,34 +555,73 @@ fn rulepack_recognizer_fr_fr_not_gated_by_en_us() {
 }
 
 #[test]
-fn rulepack_dictionary_matcher_fails_closed_until_dictionary_runtime_lands() {
+fn rulepack_dictionary_matcher_detects_when_locale_matches() {
     let rulepack = r#"
 schema_version = "0.1.0"
 rulepack_id = "test-dict"
 rulepack_version = "0.4.0"
-default_locales = ["global"]
+default_locales = ["de-DE"]
 
 [[recognizers]]
-id = "email.dict"
+id = "email.de"
 class = "Email"
 enabled = true
+locales = ["de-DE"]
 
 [recognizers.match]
 kind = "dictionary"
-terms = ["kundennummer-123"]
+terms = ["Sonnenlied"]
 
 [recognizers.token]
 "#;
-    let (_dir, path) = write_policy_with_rulepack(rulepack, None);
-    let out = clean_raw_with_args(
+    let (_dir, path) = write_policy_with_rulepack(rulepack, Some("\"en-US\""));
+    let v = clean_json_with_args(
         &[&format!("--policy={}", path.display())],
-        "kennung kundennummer-123",
+        "track Sonnenlied",
     );
+    assert_eq!(v["clean_text"], "track Sonnenlied");
+    assert_eq!(v["stats"]["detections"], 0);
 
-    assert_eq!(out.status.code(), Some(2));
+    let (_dir, path) = write_policy_with_rulepack(rulepack, Some("\"de-DE\""));
+    let v = clean_json_with_args(
+        &[&format!("--policy={}", path.display())],
+        "track Sonnenlied",
+    );
+    let clean = v["clean_text"].as_str().unwrap();
+    assert!(clean.starts_with("track <"));
+    assert!(clean.ends_with(":Email_1>"));
+    assert_eq!(v["stats"]["detections"], 1);
+    assert_eq!(v["stats"]["locale_chain"], json!(["de-DE", "global"]));
+}
+
+#[test]
+fn context_json_standalone_dictionary_detects_without_policy_entry() {
+    let dir = tempdir().unwrap();
+    let context_path = dir.path().join("context.json");
+    fs::write(
+        &context_path,
+        r#"{
+          "dictionaries": {
+            "songs": { "terms": ["context-song-123"], "case_sensitive": true }
+          },
+          "class_map": { "songs": "custom:song" },
+          "fields": { "tenant": "demo" }
+        }"#,
+    )
+    .unwrap();
+
+    let v = clean_json_with_args(
+        &[&format!("--context-json={}", context_path.display())],
+        "track context-song-123",
+    );
+    let clean = v["clean_text"].as_str().unwrap();
+    assert!(clean.starts_with("track <"));
+    assert!(clean.ends_with(":Custom:song_1>"));
+    assert_eq!(v["stats"]["detections"], 1);
+    assert_eq!(v["stats"]["context_source"], "cli");
     assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
+        v["stats"]["dictionaries_loaded"],
+        json!([{ "name": "songs", "term_count": 1, "source": "cli" }])
     );
 }
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 description = "Built-in recognizers for Gaze"
 
 [dependencies]
+aho-corasick = "1"
 gaze = { path = "../gaze" }
 hex = "0.4"
 ndarray = "0.16"
@@ -21,4 +22,9 @@ tracing = "0.1"
 unicode-normalization = "0.1"
 
 [dev-dependencies]
+criterion = "0.5"
 tempfile = "3"
+
+[[bench]]
+name = "dictionary"
+harness = false

--- a/crates/gaze-recognizers/benches/dictionary.rs
+++ b/crates/gaze-recognizers/benches/dictionary.rs
@@ -1,0 +1,64 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gaze::{
+    ContextDictionary, DetectContext, DictionaryBundle, PiiClass, Recognizer, TypedContext,
+};
+use gaze_recognizers::DictionaryRecognizer;
+use std::collections::HashMap;
+
+fn build_recognizer(term_count: usize) -> (DictionaryRecognizer, DictionaryBundle) {
+    let terms = (0..term_count)
+        .map(|index| format!("TERM-{index:05}"))
+        .collect::<Vec<_>>();
+    let ctx = TypedContext {
+        dictionaries: HashMap::from([(
+            "orders".to_string(),
+            ContextDictionary {
+                terms,
+                case_sensitive: true,
+            },
+        )]),
+        class_map: HashMap::new(),
+        fields: serde_json::Map::new(),
+    };
+    let bundle = DictionaryBundle::from_context(&ctx);
+    (
+        DictionaryRecognizer::new(
+            "dict/orders",
+            PiiClass::Custom("order_id".to_string()),
+            "orders",
+            true,
+            "counter",
+        ),
+        bundle,
+    )
+}
+
+fn dictionary_baseline(c: &mut Criterion) {
+    let (recognizer_15k, bundle_15k) = build_recognizer(15_000);
+    let fields = serde_json::Map::new();
+    let ctx_15k = DetectContext {
+        locale_chain: &[gaze::LocaleTag::Global],
+        dictionaries: &bundle_15k,
+        fields: &fields,
+        degraded: std::cell::Cell::new(false),
+    };
+    let input_1kb = "Customer referenced TERM-14999. ".repeat(32);
+    c.bench_function("dictionary_15k_terms_1kb", |b| {
+        b.iter(|| recognizer_15k.detect(black_box(&input_1kb), &ctx_15k))
+    });
+
+    let (recognizer_50k, bundle_50k) = build_recognizer(50_000);
+    let ctx_50k = DetectContext {
+        locale_chain: &[gaze::LocaleTag::Global],
+        dictionaries: &bundle_50k,
+        fields: &fields,
+        degraded: std::cell::Cell::new(false),
+    };
+    let input_10kb = "Customer referenced TERM-49999. ".repeat(320);
+    c.bench_function("dictionary_50k_terms_10kb", |b| {
+        b.iter(|| recognizer_50k.detect(black_box(&input_10kb), &ctx_50k))
+    });
+}
+
+criterion_group!(benches, dictionary_baseline);
+criterion_main!(benches);

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -1,0 +1,187 @@
+use gaze::{Candidate, ConflictTier, DetectContext, LocaleTag, PiiClass, Recognizer};
+
+pub struct DictionaryRecognizer {
+    id: String,
+    class: PiiClass,
+    dictionary_name: String,
+    case_sensitive: bool,
+    token_family: String,
+    locales: Vec<LocaleTag>,
+    score: f32,
+    priority: i32,
+}
+
+impl DictionaryRecognizer {
+    pub fn new(
+        id: impl Into<String>,
+        class: PiiClass,
+        dictionary_name: impl Into<String>,
+        case_sensitive: bool,
+        token_family: impl Into<String>,
+    ) -> Self {
+        Self::with_rulepack_fields(
+            id,
+            class,
+            dictionary_name,
+            case_sensitive,
+            token_family,
+            vec![LocaleTag::Global],
+            1.0,
+            0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_rulepack_fields(
+        id: impl Into<String>,
+        class: PiiClass,
+        dictionary_name: impl Into<String>,
+        case_sensitive: bool,
+        token_family: impl Into<String>,
+        locales: Vec<LocaleTag>,
+        score: f32,
+        priority: i32,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            class,
+            dictionary_name: dictionary_name.into(),
+            case_sensitive,
+            token_family: token_family.into(),
+            locales,
+            score,
+            priority,
+        }
+    }
+
+    pub fn dictionary_name(&self) -> &str {
+        &self.dictionary_name
+    }
+
+    pub fn case_sensitive(&self) -> bool {
+        self.case_sensitive
+    }
+}
+
+impl Recognizer for DictionaryRecognizer {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn supported_class(&self) -> &PiiClass {
+        &self.class
+    }
+
+    fn detect(&self, input: &str, ctx: &DetectContext<'_>) -> Vec<Candidate> {
+        let Some(entry) = ctx.dictionaries.get(&self.dictionary_name) else {
+            return Vec::new();
+        };
+        entry
+            .automaton()
+            .find_iter(input)
+            .map(|m| Candidate {
+                span: m.start()..m.end(),
+                class: self.class.clone(),
+                recognizer_id: self.id.clone(),
+                score: self.score,
+                priority: self.priority,
+                canonical_form: Some(input[m.start()..m.end()].to_string()),
+                token_family: self.token_family.clone(),
+                source: format!("dictionary:{}", self.dictionary_name),
+                decided_by: ConflictTier::None,
+                merged_sources: Vec::new(),
+            })
+            .collect()
+    }
+
+    fn token_family(&self) -> &str {
+        &self.token_family
+    }
+
+    fn locales(&self) -> &[LocaleTag] {
+        &self.locales
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::collections::HashMap;
+
+    use gaze::{ContextDictionary, DictionaryBundle, RecognizerRegistry, TypedContext};
+    use serde_json::Map;
+
+    use super::*;
+
+    #[test]
+    fn recognizer_detects_dictionary_hits_from_context_bundle() {
+        let ctx = TypedContext {
+            dictionaries: HashMap::from([(
+                "order_ids".to_string(),
+                ContextDictionary {
+                    terms: vec!["ORD-12345".to_string()],
+                    case_sensitive: true,
+                },
+            )]),
+            class_map: HashMap::new(),
+            fields: Map::new(),
+        };
+        let bundle = DictionaryBundle::from_context(&ctx);
+        let fields = Map::new();
+        let detect_context = DetectContext {
+            locale_chain: &[LocaleTag::Global],
+            dictionaries: &bundle,
+            fields: &fields,
+            degraded: Cell::new(false),
+        };
+        let recognizer = DictionaryRecognizer::new(
+            "dict/order_ids",
+            PiiClass::Custom("order_id".to_string()),
+            "order_ids",
+            true,
+            "counter",
+        );
+
+        let hits = recognizer.detect("Customer bought ORD-12345", &detect_context);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].span, 16..25);
+        assert_eq!(hits[0].class, PiiClass::Custom("order_id".to_string()));
+    }
+
+    #[test]
+    fn recognizer_locale_gates_dictionary_hits() {
+        let ctx = TypedContext {
+            dictionaries: HashMap::from([(
+                "songs".to_string(),
+                ContextDictionary {
+                    terms: vec!["Bohemian Rhapsody".to_string()],
+                    case_sensitive: false,
+                },
+            )]),
+            class_map: HashMap::new(),
+            fields: Map::new(),
+        };
+        let bundle = DictionaryBundle::from_context(&ctx);
+        let fields = Map::new();
+        let detect_context = DetectContext {
+            locale_chain: &[LocaleTag::EnUs],
+            dictionaries: &bundle,
+            fields: &fields,
+            degraded: Cell::new(false),
+        };
+        let recognizer = DictionaryRecognizer::with_rulepack_fields(
+            "dict/songs",
+            PiiClass::Custom("song".to_string()),
+            "songs",
+            false,
+            "counter",
+            vec![LocaleTag::DeDe],
+            1.0,
+            0,
+        );
+
+        let registry = RecognizerRegistry::builder().register(recognizer).build();
+        let hits = registry.detect_all("Listening to bohemian rhapsody", &detect_context);
+        assert!(hits.is_empty());
+    }
+}

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -1,6 +1,8 @@
+mod dictionary;
 mod ner;
 mod regex;
 
+pub use dictionary::DictionaryRecognizer;
 pub use ner::{LabelMap, NerBackendKind, NerDetector, NerLoadError, NerOptions, VerifiedArtifacts};
 pub use regex::{NormalizerKind, RegexDetector, ValidatorKind};
 

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -212,7 +212,7 @@ mod tests {
         )
         .expect("regex detector");
         let fields = serde_json::Map::new();
-        let dictionaries = gaze::DictionaryBundle;
+        let dictionaries = gaze::DictionaryBundle::default();
         let ctx = DetectContext {
             locale_chain: &[LocaleTag::Global],
             dictionaries: &dictionaries,

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1"
+aho-corasick = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"

--- a/crates/gaze/src/context.rs
+++ b/crates/gaze/src/context.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+use crate::PiiClass;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawContext {
+    pub dictionaries: HashMap<String, RawContextDictionary>,
+    pub class_map: HashMap<String, String>,
+    pub fields: Map<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawContextDictionary {
+    pub terms: Vec<String>,
+    #[serde(default)]
+    pub case_sensitive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Context {
+    pub dictionaries: HashMap<String, ContextDictionary>,
+    pub class_map: HashMap<String, PiiClass>,
+    pub fields: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextDictionary {
+    pub terms: Vec<String>,
+    pub case_sensitive: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ContextError {
+    #[error("failed to read context JSON: {0}")]
+    Io(#[source] std::io::Error),
+    #[error("failed to parse context JSON: {0}")]
+    Json(#[source] serde_json::Error),
+    #[error("unknown pii class in context class_map: {0}")]
+    UnknownClass(String),
+    #[error("context dictionary '{name}' has no terms")]
+    EmptyDictionary { name: String },
+    #[error(
+        "unicode dictionary insensitive matching unsupported in v0.4.0, use case_sensitive = true"
+    )]
+    UnicodeInsensitiveDictionaryUnsupported { name: String },
+}
+
+impl Context {
+    pub fn load(path: &Path) -> Result<Self, ContextError> {
+        let raw = fs::read_to_string(path).map_err(ContextError::Io)?;
+        let raw = serde_json::from_str::<RawContext>(&raw).map_err(ContextError::Json)?;
+        Self::try_from(raw)
+    }
+}
+
+impl TryFrom<RawContext> for Context {
+    type Error = ContextError;
+
+    fn try_from(raw: RawContext) -> Result<Self, Self::Error> {
+        let mut class_map = HashMap::with_capacity(raw.class_map.len());
+        for (name, class) in raw.class_map {
+            let parsed = PiiClass::from_policy_name(&class)
+                .ok_or_else(|| ContextError::UnknownClass(class.clone()))?;
+            class_map.insert(name, parsed);
+        }
+
+        let mut dictionaries = HashMap::with_capacity(raw.dictionaries.len());
+        for (name, dictionary) in raw.dictionaries {
+            if dictionary.terms.is_empty() {
+                return Err(ContextError::EmptyDictionary { name });
+            }
+            if !dictionary.case_sensitive && dictionary.terms.iter().any(|term| !term.is_ascii()) {
+                return Err(ContextError::UnicodeInsensitiveDictionaryUnsupported { name });
+            }
+            dictionaries.insert(
+                name,
+                ContextDictionary {
+                    terms: dictionary.terms,
+                    case_sensitive: dictionary.case_sensitive,
+                },
+            );
+        }
+
+        Ok(Self {
+            dictionaries,
+            class_map,
+            fields: raw.fields,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_typed_context_envelope() {
+        let raw = serde_json::from_str::<RawContext>(
+            r#"{
+              "dictionaries": {
+                "order_ids": { "terms": ["ORD-12345"], "case_sensitive": true }
+              },
+              "class_map": { "order_ids": "custom:order_id" },
+              "fields": { "tenant": "demo" }
+            }"#,
+        )
+        .expect("raw context");
+
+        let ctx = Context::try_from(raw).expect("context");
+        assert_eq!(ctx.dictionaries["order_ids"].terms, vec!["ORD-12345"]);
+        assert_eq!(
+            ctx.class_map["order_ids"],
+            PiiClass::Custom("order_id".to_string())
+        );
+        assert_eq!(ctx.fields["tenant"], Value::String("demo".to_string()));
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_context_keys() {
+        let err = serde_json::from_str::<RawContext>(
+            r#"{
+              "dictionaries": {},
+              "class_map": {},
+              "fields": {},
+              "extra": true
+            }"#,
+        )
+        .expect_err("unknown key must fail");
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unicode_case_insensitive_terms() {
+        let raw = serde_json::from_str::<RawContext>(
+            r#"{
+              "dictionaries": {
+                "songs": { "terms": ["Beyoncé"], "case_sensitive": false }
+              },
+              "class_map": { "songs": "custom:song" },
+              "fields": {}
+            }"#,
+        )
+        .expect("raw context");
+
+        assert!(matches!(
+            Context::try_from(raw),
+            Err(ContextError::UnicodeInsensitiveDictionaryUnsupported { .. })
+        ));
+    }
+}

--- a/crates/gaze/src/detector.rs
+++ b/crates/gaze/src/detector.rs
@@ -18,6 +18,20 @@ pub enum PiiClass {
 pub const BUILTIN_CLASS_NAMES: &[&str] = &["Email", "Name", "Location", "Organization"];
 
 impl PiiClass {
+    pub fn from_policy_name(input: &str) -> Option<Self> {
+        match input {
+            "email" => Some(Self::Email),
+            "name" => Some(Self::Name),
+            "location" => Some(Self::Location),
+            "organization" => Some(Self::Organization),
+            custom if custom.starts_with("custom:") => {
+                let name = custom.trim_start_matches("custom:");
+                (!name.trim().is_empty()).then(|| Self::custom(name))
+            }
+            _ => None,
+        }
+    }
+
     pub fn builtin_variants() -> &'static [PiiClass] {
         const _EXHAUSTIVE: fn(&PiiClass) = |c| match c {
             PiiClass::Email

--- a/crates/gaze/src/dictionaries.rs
+++ b/crates/gaze/src/dictionaries.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
+use thiserror::Error;
+
+use crate::context::Context;
+
+#[derive(Debug, Default)]
+pub struct DictionaryBundle {
+    entries: HashMap<String, DictionaryEntry>,
+}
+
+#[derive(Debug)]
+pub struct DictionaryEntry {
+    terms: Vec<String>,
+    case_sensitive: bool,
+    automaton: AhoCorasick,
+    source: DictionarySource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DictionarySource {
+    Cli,
+    Rulepack,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DictionaryStats {
+    pub name: String,
+    pub term_count: usize,
+    pub source: DictionarySource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RulepackDict {
+    pub name: String,
+    pub terms: Vec<String>,
+    pub case_sensitive: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum DictionaryLoadError {
+    #[error("dictionary '{name}' has no terms")]
+    Empty { name: String },
+    #[error(
+        "unicode dictionary insensitive matching unsupported in v0.4.0, use case_sensitive = true"
+    )]
+    UnicodeInsensitiveUnsupported { name: String },
+    #[error("failed to build dictionary '{name}' automaton: {source}")]
+    Automaton {
+        name: String,
+        #[source]
+        source: aho_corasick::BuildError,
+    },
+}
+
+impl DictionaryBundle {
+    pub fn from_context(ctx: &Context) -> Self {
+        let mut entries = HashMap::with_capacity(ctx.dictionaries.len());
+        for (name, dictionary) in &ctx.dictionaries {
+            let entry = DictionaryEntry::new(
+                name,
+                dictionary.terms.clone(),
+                dictionary.case_sensitive,
+                DictionarySource::Cli,
+            )
+            .expect("Context validates dictionary terms before bundle construction");
+            entries.insert(name.clone(), entry);
+        }
+        Self { entries }
+    }
+
+    pub fn from_rulepack_terms(terms: &[RulepackDict]) -> Self {
+        let mut entries = HashMap::with_capacity(terms.len());
+        for dictionary in terms {
+            let entry = DictionaryEntry::new(
+                &dictionary.name,
+                dictionary.terms.clone(),
+                dictionary.case_sensitive,
+                DictionarySource::Rulepack,
+            )
+            .expect("Policy validates dictionary terms before bundle construction");
+            entries.insert(dictionary.name.clone(), entry);
+        }
+        Self { entries }
+    }
+
+    pub fn merge(a: Self, b: Self) -> Self {
+        let mut entries = a.entries;
+        entries.extend(b.entries);
+        Self { entries }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&DictionaryEntry> {
+        self.entries.get(name)
+    }
+
+    pub fn stats(&self) -> Vec<DictionaryStats> {
+        let mut stats = self
+            .entries
+            .iter()
+            .map(|(name, entry)| DictionaryStats {
+                name: name.clone(),
+                term_count: entry.terms.len(),
+                source: entry.source,
+            })
+            .collect::<Vec<_>>();
+        stats.sort_by(|a, b| a.name.cmp(&b.name));
+        stats
+    }
+}
+
+impl DictionaryEntry {
+    pub fn new(
+        name: &str,
+        terms: Vec<String>,
+        case_sensitive: bool,
+        source: DictionarySource,
+    ) -> Result<Self, DictionaryLoadError> {
+        if terms.is_empty() {
+            return Err(DictionaryLoadError::Empty {
+                name: name.to_string(),
+            });
+        }
+        if !case_sensitive && terms.iter().any(|term| !term.is_ascii()) {
+            return Err(DictionaryLoadError::UnicodeInsensitiveUnsupported {
+                name: name.to_string(),
+            });
+        }
+        let automaton = AhoCorasickBuilder::new()
+            .ascii_case_insensitive(!case_sensitive)
+            .build(&terms)
+            .map_err(|source| DictionaryLoadError::Automaton {
+                name: name.to_string(),
+                source,
+            })?;
+        Ok(Self {
+            terms,
+            case_sensitive,
+            automaton,
+            source,
+        })
+    }
+
+    pub fn automaton(&self) -> &AhoCorasick {
+        &self.automaton
+    }
+
+    pub fn case_sensitive(&self) -> bool {
+        self.case_sensitive
+    }
+
+    pub fn terms(&self) -> &[String] {
+        &self.terms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContextDictionary, PiiClass};
+    use serde_json::Map;
+
+    #[test]
+    fn context_bundle_builds_automata_per_request() {
+        let ctx = Context {
+            dictionaries: HashMap::from([(
+                "order_ids".to_string(),
+                ContextDictionary {
+                    terms: vec!["ORD-12345".to_string()],
+                    case_sensitive: true,
+                },
+            )]),
+            class_map: HashMap::from([(
+                "order_ids".to_string(),
+                PiiClass::Custom("order_id".to_string()),
+            )]),
+            fields: Map::new(),
+        };
+
+        let bundle = DictionaryBundle::from_context(&ctx);
+        let entry = bundle.get("order_ids").expect("entry");
+        assert!(entry.automaton().find("ORD-12345").is_some());
+        assert!(entry.automaton().find("ord-12345").is_none());
+    }
+
+    #[test]
+    fn merge_prefers_second_bundle_for_same_name() {
+        let a = DictionaryBundle::from_rulepack_terms(&[RulepackDict {
+            name: "songs".to_string(),
+            terms: vec!["Song A".to_string()],
+            case_sensitive: true,
+        }]);
+        let b = DictionaryBundle::from_rulepack_terms(&[RulepackDict {
+            name: "songs".to_string(),
+            terms: vec!["Song B".to_string()],
+            case_sensitive: true,
+        }]);
+
+        let merged = DictionaryBundle::merge(a, b);
+        let entry = merged.get("songs").expect("entry");
+        assert!(entry.automaton().find("Song B").is_some());
+        assert!(entry.automaton().find("Song A").is_none());
+    }
+}

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -1,4 +1,6 @@
+mod context;
 mod detector;
+mod dictionaries;
 pub mod locale;
 mod normalize;
 mod pipeline;
@@ -14,7 +16,12 @@ mod session;
 pub mod token_shape;
 mod types;
 
+pub use context::{Context as TypedContext, ContextDictionary, ContextError, RawContext};
 pub use detector::{Detection, Detector, PiiClass, BUILTIN_CLASS_NAMES};
+pub use dictionaries::{
+    DictionaryBundle, DictionaryEntry, DictionaryLoadError, DictionarySource, DictionaryStats,
+    RulepackDict,
+};
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{Error, Pipeline, PipelineBuilder, Result};
 pub use policy::{
@@ -25,11 +32,11 @@ pub use redaction_log::{
     ConflictTier, DocumentKind, RedactionEntry, RedactionLogger, SqliteLogger,
 };
 pub use registry::{
-    Candidate, Canonicalizer, DetectContext, DictionaryBundle, Recognizer, RecognizerRegistry,
+    Candidate, Canonicalizer, DetectContext, Recognizer, RecognizerRegistry,
     RecognizerRegistryBuilder, ValidationResult, Validator,
 };
 pub use resolver::resolve_candidates;
-pub use rule::{Action, ClassRule, ColumnRule, Context, DefaultRule, Rule};
+pub use rule::{Action, ClassRule, ColumnRule, DefaultRule, Rule, RuleContext};
 pub use rulepack::{
     ContextSpec, NormalizerSpec, RawMatch, RecognizerSpec, Rulepack, RulepackError, RulepackSource,
     ScoringSpec, SourceSpec, TokenSpec, ValidatorSpec,

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use thiserror::Error;
 
@@ -7,11 +7,12 @@ use crate::detector::{Detection, Detector};
 use crate::normalize::normalize;
 use crate::policy::PolicyError;
 use crate::redaction_log::{ConflictTier, DocumentKind, RedactionEntry, RedactionLogger};
-use crate::registry::{Candidate, DetectContext, DictionaryBundle, Recognizer, RecognizerRegistry};
-use crate::rule::{Action, Context, Rule};
+use crate::registry::{Candidate, DetectContext, Recognizer, RecognizerRegistry};
+use crate::rule::{Action, Rule, RuleContext};
 use crate::rulepack::RulepackError;
 use crate::session::Session;
 use crate::types::{CleanDocument, RawDocument, Value};
+use crate::DictionaryBundle;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -76,13 +77,33 @@ impl Pipeline {
         raw: RawDocument,
         locale_chain: &[crate::LocaleTag],
     ) -> Result<CleanDocument> {
+        let dictionaries = DictionaryBundle::default();
+        self.redact_with_detect_context(
+            session,
+            raw,
+            locale_chain,
+            &dictionaries,
+            empty_detect_fields(),
+        )
+    }
+
+    pub fn redact_with_detect_context(
+        &self,
+        session: &Session,
+        raw: RawDocument,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+        detect_fields: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<CleanDocument> {
         match raw {
-            RawDocument::Structured(fields) => redact_structured(
+            RawDocument::Structured(structured_fields) => redact_structured(
                 self,
                 session,
-                fields,
+                structured_fields,
                 DocumentKind::Structured,
                 locale_chain,
+                dictionaries,
+                detect_fields,
             ),
             RawDocument::Text(text) => Ok(CleanDocument::Text(self.redact_text(
                 session,
@@ -90,6 +111,8 @@ impl Pipeline {
                 None,
                 DocumentKind::Text,
                 locale_chain,
+                dictionaries,
+                detect_fields,
             )?)),
         }
     }
@@ -101,16 +124,16 @@ impl Pipeline {
         field_name: Option<&str>,
         document_kind: DocumentKind,
         locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+        fields: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<String> {
         let mut out = text.to_string();
         let normalized = normalize(text);
         let spans = &normalized.spans;
-        let dictionaries = DictionaryBundle;
-        let fields = serde_json::Map::new();
         let ctx = DetectContext {
             locale_chain,
-            dictionaries: &dictionaries,
-            fields: &fields,
+            dictionaries,
+            fields,
             degraded: std::cell::Cell::new(false),
         };
         let resolved = self
@@ -164,7 +187,7 @@ impl Pipeline {
         Ok(out)
     }
 
-    fn action_for(&self, detection: &Detection, context: &Context) -> Action {
+    fn action_for(&self, detection: &Detection, context: &RuleContext) -> Action {
         self.rules
             .iter()
             .find_map(|rule| rule.action(&detection.class, context))
@@ -263,6 +286,8 @@ fn redact_structured(
     fields: BTreeMap<String, Value>,
     document_kind: DocumentKind,
     locale_chain: &[crate::LocaleTag],
+    dictionaries: &DictionaryBundle,
+    detect_fields: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<CleanDocument> {
     let mut clean = BTreeMap::new();
     for (key, value) in fields {
@@ -273,6 +298,8 @@ fn redact_structured(
                 Some(&key),
                 document_kind.clone(),
                 locale_chain,
+                dictionaries,
+                detect_fields,
             )?),
             Value::I64(value) => serde_json::Value::Number(value.into()),
         };
@@ -394,10 +421,15 @@ fn generalize_token(class: &crate::detector::PiiClass) -> String {
     }
 }
 
-fn build_context(field_name: Option<&str>) -> Context {
-    Context {
+fn build_context(field_name: Option<&str>) -> RuleContext {
+    RuleContext {
         field_name: field_name.map(str::to_string),
     }
+}
+
+fn empty_detect_fields() -> &'static serde_json::Map<String, serde_json::Value> {
+    static EMPTY_FIELDS: OnceLock<serde_json::Map<String, serde_json::Value>> = OnceLock::new();
+    EMPTY_FIELDS.get_or_init(serde_json::Map::new)
 }
 
 #[cfg(test)]

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -5,12 +5,13 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::{Action, LocaleTag, PiiClass};
+use crate::{Action, LocaleTag, PiiClass, RulepackDict};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Policy {
     pub session: SessionPolicy,
     pub detectors: Vec<DetectorSpec>,
+    pub dictionaries: Vec<RulepackDict>,
     pub rules: Vec<RuleSpec>,
     pub ner: Option<NerPolicy>,
     pub rulepacks: RulepackPolicy,
@@ -34,13 +35,17 @@ pub enum SessionScope {
 pub struct DetectorSpec {
     pub kind: DetectorKind,
     pub name: String,
-    pub pattern: String,
+    pub pattern: Option<String>,
     pub class: PiiClass,
+    pub dictionary_name: Option<String>,
+    pub case_sensitive: bool,
+    pub token_family: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DetectorKind {
     Regex,
+    Dictionary,
     Unknown(String),
 }
 
@@ -77,6 +82,8 @@ pub enum PolicyError {
         #[source]
         source: regex::Error,
     },
+    #[error("invalid dictionary detector '{name}': {reason}")]
+    BadDictionary { name: String, reason: String },
     #[error("session.ttl_secs is required when session.scope = \"persistent\"")]
     MissingTtl,
     #[error("invalid session.ttl_secs: {0}")]
@@ -145,8 +152,16 @@ struct RawSessionPolicy {
 struct RawDetectorSpec {
     kind: String,
     name: String,
-    pattern: String,
+    pattern: Option<String>,
     class: String,
+    dictionary: Option<String>,
+    #[serde(default)]
+    terms: Vec<String>,
+    terms_file: Option<String>,
+    terms_from_context: Option<String>,
+    #[serde(default)]
+    case_sensitive: bool,
+    token_family: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -209,8 +224,13 @@ impl TryFrom<RawPolicy> for Policy {
         } = policy_tables;
 
         let mut detectors = Vec::with_capacity(custom_recognizers.len());
+        let mut dictionaries = Vec::new();
         for detector in custom_recognizers {
-            detectors.push(parse_detector(detector)?);
+            let (detector, dictionary) = parse_detector(detector)?;
+            if let Some(dictionary) = dictionary {
+                dictionaries.push(dictionary);
+            }
+            detectors.push(detector);
         }
         let rulepacks = raw_rulepacks
             .map(parse_rulepack_policy)
@@ -238,6 +258,7 @@ impl TryFrom<RawPolicy> for Policy {
         Ok(Self {
             session,
             detectors,
+            dictionaries,
             rules,
             ner,
             rulepacks,
@@ -283,21 +304,127 @@ fn parse_session(raw: RawSessionPolicy) -> Result<SessionPolicy, PolicyError> {
     }
 }
 
-fn parse_detector(raw: RawDetectorSpec) -> Result<DetectorSpec, PolicyError> {
-    regex::Regex::new(&raw.pattern).map_err(|source| PolicyError::BadRegex {
+fn parse_detector(
+    raw: RawDetectorSpec,
+) -> Result<(DetectorSpec, Option<RulepackDict>), PolicyError> {
+    let class = parse_class(&raw.class)?;
+    match raw.kind.as_str() {
+        "regex" => parse_regex_detector(raw, class),
+        "dictionary" => parse_dictionary_detector(raw, class),
+        other => Ok((
+            DetectorSpec {
+                kind: DetectorKind::Unknown(other.to_string()),
+                name: raw.name,
+                pattern: raw.pattern,
+                class,
+                dictionary_name: None,
+                case_sensitive: raw.case_sensitive,
+                token_family: raw.token_family.unwrap_or_else(|| "counter".to_string()),
+            },
+            None,
+        )),
+    }
+}
+
+fn parse_regex_detector(
+    raw: RawDetectorSpec,
+    class: PiiClass,
+) -> Result<(DetectorSpec, Option<RulepackDict>), PolicyError> {
+    let pattern = raw.pattern.ok_or_else(|| PolicyError::BadDictionary {
+        name: raw.name.clone(),
+        reason: "regex recognizers require pattern".to_string(),
+    })?;
+    regex::Regex::new(&pattern).map_err(|source| PolicyError::BadRegex {
         name: raw.name.clone(),
         source,
     })?;
 
-    Ok(DetectorSpec {
-        kind: match raw.kind.as_str() {
-            "regex" => DetectorKind::Regex,
-            other => DetectorKind::Unknown(other.to_string()),
+    Ok((
+        DetectorSpec {
+            kind: DetectorKind::Regex,
+            name: raw.name,
+            pattern: Some(pattern),
+            class,
+            dictionary_name: None,
+            case_sensitive: false,
+            token_family: raw.token_family.unwrap_or_else(|| "counter".to_string()),
         },
-        name: raw.name,
-        pattern: raw.pattern,
-        class: parse_class(&raw.class)?,
-    })
+        None,
+    ))
+}
+
+fn parse_dictionary_detector(
+    raw: RawDetectorSpec,
+    class: PiiClass,
+) -> Result<(DetectorSpec, Option<RulepackDict>), PolicyError> {
+    if raw.pattern.is_some() {
+        return Err(PolicyError::BadDictionary {
+            name: raw.name,
+            reason: "dictionary recognizers must not set pattern".to_string(),
+        });
+    }
+
+    let dictionary_name = raw
+        .terms_from_context
+        .clone()
+        .or(raw.dictionary.clone())
+        .unwrap_or_else(|| raw.name.clone());
+    let mut terms = raw.terms;
+    if let Some(path) = raw.terms_file {
+        let path = expand_home(path)?;
+        let file = fs::read_to_string(&path).map_err(PolicyError::Io)?;
+        terms.extend(
+            file.lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(str::to_string),
+        );
+    }
+
+    let dictionary = if raw.terms_from_context.is_some() {
+        if !terms.is_empty() {
+            return Err(PolicyError::BadDictionary {
+                name: raw.name.clone(),
+                reason: "terms_from_context cannot be combined with terms or terms_file"
+                    .to_string(),
+            });
+        }
+        None
+    } else {
+        if terms.is_empty() {
+            return Err(PolicyError::BadDictionary {
+                name: raw.name.clone(),
+                reason: "dictionary recognizers require terms, terms_file, or terms_from_context"
+                    .to_string(),
+            });
+        }
+        if !raw.case_sensitive && terms.iter().any(|term| !term.is_ascii()) {
+            return Err(PolicyError::BadDictionary {
+                name: raw.name.clone(),
+                reason:
+                    "unicode dictionary insensitive matching unsupported in v0.4.0, use case_sensitive = true"
+                        .to_string(),
+            });
+        }
+        Some(RulepackDict {
+            name: dictionary_name.clone(),
+            terms,
+            case_sensitive: raw.case_sensitive,
+        })
+    };
+
+    Ok((
+        DetectorSpec {
+            kind: DetectorKind::Dictionary,
+            name: raw.name,
+            pattern: None,
+            class,
+            dictionary_name: Some(dictionary_name),
+            case_sensitive: raw.case_sensitive,
+            token_family: raw.token_family.unwrap_or_else(|| "counter".to_string()),
+        },
+        dictionary,
+    ))
 }
 
 fn parse_rule(raw: RawRuleSpec) -> Result<RuleSpec, PolicyError> {
@@ -487,5 +614,43 @@ action = "preserve"
             Policy::load(&path),
             Err(PolicyError::TomlParse(_))
         ));
+    }
+
+    #[test]
+    fn loads_dictionary_custom_recognizer_terms() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("policy.toml");
+        fs::write(
+            &path,
+            r#"
+[session]
+scope = "ephemeral"
+
+[[policy.custom_recognizers]]
+kind = "dictionary"
+name = "songs"
+class = "custom:song"
+terms = ["Song A"]
+case_sensitive = true
+
+[[rule]]
+kind = "class"
+class = "custom:song"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+        )
+        .unwrap();
+
+        let policy = Policy::load(&path).unwrap();
+        assert_eq!(policy.detectors[0].kind, DetectorKind::Dictionary);
+        assert_eq!(
+            policy.detectors[0].dictionary_name.as_deref(),
+            Some("songs")
+        );
+        assert_eq!(policy.dictionaries[0].terms, vec!["Song A"]);
     }
 }

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -8,7 +8,7 @@ use serde_json::{Map, Value};
 use crate::locale::{LocaleChain, LocaleTag};
 use crate::redaction_log::ConflictTier;
 use crate::resolver::resolve_candidates;
-use crate::PiiClass;
+use crate::{DictionaryBundle, PiiClass};
 
 static GLOBAL_LOCALE: [LocaleTag; 1] = [LocaleTag::Global];
 
@@ -58,9 +58,6 @@ pub struct DetectContext<'a> {
     pub fields: &'a Map<String, Value>,
     pub degraded: Cell<bool>,
 }
-
-#[derive(Debug, Default)]
-pub struct DictionaryBundle;
 
 pub struct RecognizerRegistry {
     entries: Vec<Arc<dyn Recognizer>>,
@@ -113,7 +110,7 @@ mod tests {
                 class: PiiClass::Email,
             })
             .build();
-        let dictionaries = DictionaryBundle;
+        let dictionaries = DictionaryBundle::default();
         let fields = Map::new();
         let ctx = DetectContext {
             locale_chain: &[LocaleTag::Global],
@@ -185,7 +182,7 @@ mod tests {
                 locale: LocaleTag::DeDe,
             })
             .build();
-        let dictionaries = DictionaryBundle;
+        let dictionaries = DictionaryBundle::default();
         let fields = Map::new();
         let ctx = DetectContext {
             locale_chain: &[LocaleTag::EnUs, LocaleTag::Global],

--- a/crates/gaze/src/rule.rs
+++ b/crates/gaze/src/rule.rs
@@ -10,12 +10,12 @@ pub enum Action {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Context {
+pub struct RuleContext {
     pub field_name: Option<String>,
 }
 
 pub trait Rule: Send + Sync {
-    fn action(&self, class: &PiiClass, context: &Context) -> Option<Action>;
+    fn action(&self, class: &PiiClass, context: &RuleContext) -> Option<Action>;
 }
 
 pub struct ClassRule {
@@ -30,7 +30,7 @@ impl ClassRule {
 }
 
 impl Rule for ClassRule {
-    fn action(&self, class: &PiiClass, _context: &Context) -> Option<Action> {
+    fn action(&self, class: &PiiClass, _context: &RuleContext) -> Option<Action> {
         (self.class == *class).then_some(self.action)
     }
 }
@@ -50,7 +50,7 @@ impl ColumnRule {
 }
 
 impl Rule for ColumnRule {
-    fn action(&self, _class: &PiiClass, context: &Context) -> Option<Action> {
+    fn action(&self, _class: &PiiClass, context: &RuleContext) -> Option<Action> {
         (context.field_name.as_deref() == Some(self.field_name.as_str())).then_some(self.action)
     }
 }
@@ -66,7 +66,7 @@ impl DefaultRule {
 }
 
 impl Rule for DefaultRule {
-    fn action(&self, _class: &PiiClass, _context: &Context) -> Option<Action> {
+    fn action(&self, _class: &PiiClass, _context: &RuleContext) -> Option<Action> {
         Some(self.action)
     }
 }

--- a/crates/gaze/src/sandbox.rs
+++ b/crates/gaze/src/sandbox.rs
@@ -175,7 +175,10 @@ mod tests {
                 "send-email".to_string(),
                 format!("<{}>", ["Email", "1"].join("_")),
             ],
-            env: BTreeMap::from([("MAIL_FROM".to_string(), "bot@example.test".to_string())]),
+            env: BTreeMap::from([(
+                "MAIL_FROM".to_string(),
+                "bot@example.invalid".to_string(),
+            )]),
             cwd: Some(PathBuf::from("/tmp")),
         };
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -320,7 +320,7 @@ impl Session {
         }
         // Authoritative counter state from the exporter. Overrides any
         // index we reconstructed from parseable token suffixes above so
-        // that format-preserving tokens (e.g. `email1@example.test`)
+        // that format-preserving tokens (e.g. `email1.<session>@gaze-fake.invalid`)
         // also round-trip safely.
         for (class, index) in payload.next_by_class {
             let mut next = session.next_by_class.entry(class).or_insert(0);

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -433,7 +433,10 @@ fn exec_policy_validates_untrusted_input_before_sandbox_prepare() {
             "send-email".to_string(),
             format!("<{}>", ["Email", "1"].join("_")),
         ],
-        env: BTreeMap::from([("MAIL_FROM".to_string(), "bot@example.test".to_string())]),
+        env: BTreeMap::from([(
+            "MAIL_FROM".to_string(),
+            "bot@example.invalid".to_string(),
+        )]),
         cwd: Some("/tmp".into()),
     };
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,8 +35,8 @@ alternatives live in `docs/research/gaze-first-principles-vision.md` and
 
 v0.3.0 delivers the first adopter-ready Gaze runtime: `gaze clean` and
 `gaze restore` CLI with two-pass restore (Pass 1 manifest lookup plus Pass 2
-hallucination trap), angle-bracket counter-family tokens (`<Email_1>`,
-`<Custom:order_id_1>`) with format-preserving bare emails, `policy.toml`
+hallucination trap), angle-bracket counter-family tokens (`<{session_hex}:Email_1>`,
+`<{session_hex}:Custom:order_id_1>`) with format-preserving bare emails, `policy.toml`
 configuration surface, SQLite redaction log, and the Laravel adapter
 (`gaze-laravel`) that pipes requests through the binary. The homebrew
 formula `Naoray/gaze/gaze` resolves to the real release artifact, and the
@@ -75,7 +75,8 @@ production. Next focus is v0.4 engine/corpus separation.
 (`gaze` / `gaze-recognizers` / `gaze-cli`). F2 `RecognizerRegistry` trait.
 F3 TOML rulepack schema. F4 locale infra (DACH + EN). F5 `.invalid`
 domain handling. F6 Dictionary detector. Typed `Context` envelope. Token
-grammar becomes session-scoped: `<{8-hex}:{Class}_{N}>`. Pass 2 regex
+grammar becomes session-scoped: `<{session_hex}:Email_1>` where
+`{session_hex}` is 8 lowercase hex chars per session. Pass 2 regex
 splits into a two-branch form (prefixed manifest-lookup + unprefixed trap
 for fail-closed). `SnapshotPayload` envelope byte bumps 1 → 2.
 **Status:** multi-review loop; Layer A implementation auto-fires on

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -55,8 +55,8 @@ action = "preserve"
 Run it:
 
 ```console
-$ echo "Email alice@example.com now" | gaze clean --policy=minimal.toml
-{"clean_text":"Email <Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
+$ echo "Email alice@example.invalid now" | gaze clean --policy=minimal.toml
+{"clean_text":"Email <{session_hex}:Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
 ```
 
 This is the same fixture the CLI integration suite uses
@@ -183,10 +183,10 @@ prefix for user-defined classes.
 
 | `class` value     | `PiiClass` variant       | Default token shape (`tokenize`)     | Format-preserve shape    | Generalize shape   |
 |-------------------|--------------------------|--------------------------------------|--------------------------|--------------------|
-| `"email"`         | `PiiClass::Email`        | `<Email_1>`, `<Email_2>`, …          | `email1@example.test`    | `[EMAIL]`          |
-| `"name"`          | `PiiClass::Name`         | `<Name_1>`, `<Name_2>`, …            | `name_1`, `name_2`, …    | `[NAME]`           |
-| `"location"`      | `PiiClass::Location`     | `<Location_1>`, …                    | `location_1`, …          | `[LOCATION]`       |
-| `"organization"`  | `PiiClass::Organization` | `<Organization_1>`, …                | `organization_1`, …      | `[ORGANIZATION]`   |
+| `"email"`         | `PiiClass::Email`        | `<{session_hex}:Email_1>`, `<{session_hex}:Email_2>`, …          | `email1.{session_hex}@gaze-fake.invalid`    | `[EMAIL]`          |
+| `"name"`          | `PiiClass::Name`         | `<{session_hex}:Name_1>`, `<{session_hex}:Name_2>`, …            | `{session_hex}:name_1`, `{session_hex}:name_2`, …    | `[NAME]`           |
+| `"location"`      | `PiiClass::Location`     | `<{session_hex}:Location_1>`, …                    | `{session_hex}:location_1`, …          | `[LOCATION]`       |
+| `"organization"`  | `PiiClass::Organization` | `<{session_hex}:Organization_1>`, …                | `{session_hex}:organization_1`, …      | `[ORGANIZATION]`   |
 
 Counter-family `tokenize` shapes wrap in angle brackets as of v0.3.0 so the LLM cannot dissolve them into adjacent words. Format-preserve shapes stay bare — the whole point of format-preserve is to look like a real value of that type.
 
@@ -224,16 +224,16 @@ built-ins or with each other:
 
 | Policy `class`           | Normalised name | `tokenize` token         | `format_preserve` token | `generalize` token |
 |--------------------------|-----------------|--------------------------|-------------------------|--------------------|
-| `"custom:order_id"`      | `order_id`      | `<Custom:order_id_1>`    | `custom:order_id_1`     | `[ORDER_ID]`       |
-| `"custom:tenant_slug"`   | `tenant_slug`   | `<Custom:tenant_slug_1>` | `custom:tenant_slug_1`  | `[TENANT_SLUG]`    |
-| `"custom:song"`          | `song`          | `<Custom:song_1>`        | `custom:song_1`         | `[SONG]`           |
+| `"custom:order_id"`      | `order_id`      | `<{session_hex}:Custom:order_id_1>`    | `{session_hex}:custom:order_id_1`     | `[ORDER_ID]`       |
+| `"custom:tenant_slug"`   | `tenant_slug`   | `<{session_hex}:Custom:tenant_slug_1>` | `{session_hex}:custom:tenant_slug_1`  | `[TENANT_SLUG]`    |
+| `"custom:song"`          | `song`          | `<{session_hex}:Custom:song_1>`        | `{session_hex}:custom:song_1`         | `[SONG]`           |
 
 A class string of `"custom:"` (empty name) is rejected with `PolicyConfig`.
 
 `custom:email` and other names that mirror built-ins are safe to use — the
 `Custom:` prefix keeps them in their own counter family, so `custom:email`
-emits `<Custom:email_1>` while built-in email detections continue to emit
-`<Email_1>`.
+emits `<{session_hex}:Custom:email_1>` while built-in email detections continue to emit
+`<{session_hex}:Email_1>`.
 
 ## Detectors
 
@@ -277,9 +277,9 @@ then act on the classes the model produces.
 
 | `action` value      | What it does                                                                                                       |
 |---------------------|--------------------------------------------------------------------------------------------------------------------|
-| `"tokenize"`        | Replace the matched span with an angle-bracketed counter-family token (`<Email_1>`, `<Name_2>`, `<Custom:order_id_3>`, …). Restorable via the session blob. |
+| `"tokenize"`        | Replace the matched span with an angle-bracketed counter-family token (`<{session_hex}:Email_1>`, `<{session_hex}:Name_2>`, `<{session_hex}:Custom:order_id_3>`, …). Restorable via the session blob. |
 | `"redact"`          | Replace the matched span with the literal string `[REDACTED]`. Not restorable — the original value is dropped from the session map. |
-| `"format_preserve"` | Replace with a fake value that preserves the surface shape (`email1@example.test` for emails; `name_1`, `location_1`, `custom:order_id_1` for everything else). Restorable. |
+| `"format_preserve"` | Replace with a fake value that preserves the surface shape (`email1.{session_hex}@gaze-fake.invalid` for emails; `{session_hex}:name_1`, `{session_hex}:location_1`, `{session_hex}:custom:order_id_1` for everything else). Restorable. |
 | `"generalize"`      | Replace with a bracketed class label: `[EMAIL]`, `[NAME]`, `[LOCATION]`, `[ORGANIZATION]`, or `[CUSTOM_NAME]` (uppercased custom name with underscores preserved). Restoration returns the label, not the original value. |
 | `"preserve"`        | Leave the matched span unchanged. The detection is still logged, but no replacement happens. |
 
@@ -348,8 +348,8 @@ kind = "default"
 action = "preserve"
 ```
 
-Input `Reach Alice at alice@example.com or +49 30 1234567` produces
-`Reach Alice at <Email_1> or [REDACTED]`.
+Input `Reach Alice at alice@example.invalid or +49 30 1234567` produces
+`Reach Alice at <{session_hex}:Email_1> or [REDACTED]`.
 
 ### Example B — Custom class for tenant order IDs
 
@@ -402,7 +402,7 @@ kind = "default"
 action = "preserve"
 ```
 
-`Mail alice@example.com` → `Mail email1@example.test`. Restoration returns
+`Mail alice@example.invalid` → `Mail email1.{session_hex}@gaze-fake.invalid`. Restoration returns
 the real address.
 
 ### Example D — Mixed regex + NER + custom class

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -100,12 +100,45 @@ pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
 class = "email"
 ```
 
-| Field     | Type   | Required | Notes                                                     |
-|-----------|--------|----------|-----------------------------------------------------------|
-| `kind`    | string | yes      | Today only `"regex"` is supported. Other values parse but fail at pipeline build with `PolicyConfig`. |
-| `name`    | string | yes      | Used as the `source` label on every `Detection` for debugging and conflict-loser logs. |
-| `pattern` | string | yes      | Compiled with the [`regex`](https://docs.rs/regex) crate at policy load. Bad patterns → `PolicyConfig`. |
-| `class`   | string | yes      | A class name (see [Classes](#classes)). Unknown classes → `PolicyConfig`. |
+| Field                | Type      | Required | Notes                                                     |
+|----------------------|-----------|----------|-----------------------------------------------------------|
+| `kind`               | string    | yes      | `"regex"` or `"dictionary"`. Other values parse but fail at pipeline build with `PolicyConfig`. |
+| `name`               | string    | yes      | Used as the recognizer id/source label for debugging and conflict-loser logs. |
+| `pattern`            | string    | regex    | Compiled with the [`regex`](https://docs.rs/regex) crate at policy load. Bad patterns → `PolicyConfig`. |
+| `class`              | string    | yes      | A class name (see [Classes](#classes)). Unknown classes → `PolicyConfig`. |
+| `terms`              | array     | dictionary | Inline dictionary terms. Use only with `kind = "dictionary"`. |
+| `terms_file`         | string    | dictionary | Newline-delimited dictionary terms. Blank lines and `#` comments are ignored. |
+| `terms_from_context` | string    | dictionary | Reads the named dictionary from `--context-json`; cannot be combined with `terms` or `terms_file`. |
+| `case_sensitive`     | boolean   | no       | Dictionary only. Defaults to `false`; non-ASCII insensitive dictionaries fail closed in v0.4.0. |
+| `token_family`       | string    | no       | Defaults to `"counter"`. |
+
+Dictionary recognizers are registered through the same recognizer registry as
+rulepack recognizers and are gated by the active locale chain when they come
+from a rulepack. The CLI passes the merged dictionary bundle from rulepacks,
+policy inline terms, and `--context-json` into the runtime `DetectContext`.
+
+```toml
+[[policy.custom_recognizers]]
+kind = "dictionary"
+name = "songs"
+class = "custom:song"
+terms = ["Song A", "Song B"]
+
+[[policy.custom_recognizers]]
+kind = "dictionary"
+name = "tenant_order_ids"
+class = "custom:order_id"
+terms_from_context = "order_ids"
+case_sensitive = true
+```
+
+`--context-json` can also supply dictionaries without a matching policy
+recognizer. In that mode, Gaze registers one dictionary recognizer per context
+dictionary and uses `class_map` for the class, falling back to `custom:<name>`
+when a mapping is absent. `fields` are threaded into `DetectContext` for
+recognizers; no built-in recognizer consumes them in v0.4.0. `class_map` is
+runtime metadata for dictionary recognizer construction, not a general class
+override mechanism. Broader `fields` consumers are deferred to v0.4.1.
 
 NER is **not** a detector kind. NER is configured via the top-level `[ner]`
 block (below) — when set, the pipeline appends a transformer NER detector


### PR DESCRIPTION
## Summary

Rebased PR #25 onto post-PR23 `main` (`b2fa55d`) and reworked B2 onto the recognizer-native path.

- Kept the F5 `.invalid` token grammar/domain migration.
- Deleted the legacy `DictionaryDetector` wrapper and removed it from the public recognizer exports/bench path.
- Registered `DictionaryRecognizer` directly through `PipelineBuilder::recognizer` / `RecognizerRegistry` for policy, rulepack, and context dictionaries.
- Replaced the B1-era `UnsupportedMatcher("Dictionary")` gate with real dictionary matcher construction. `RawMatch::Ner` remains fail-closed with `UnsupportedMatcher("Ner")` for v0.5 scope.
- Threaded the real runtime `DetectContext`: merged locale chain, merged `DictionaryBundle`, and typed context fields now flow into `Pipeline::redact_with_detect_context`.
- `stats.locale_chain` now reflects the merged chain actually passed to redaction.
- `--context-json` can now detect dictionaries without a matching `[[policy.custom_recognizers]]` entry; `class_map` supplies the class and falls back to `custom:<dictionary_name>` if absent.
- Preserved candidate metadata through the recognizer-native resolution path instead of truncating through the old Detector adapter.

## Review Follow-ups

Addressed:
- Claude N-1: no per-detector dictionary automaton clone; one merged bundle is built and shared through `DetectContext`.
- Claude N-2: context-only dictionary detection works without dual policy wiring.
- Claude N-4: dictionary candidates stay on the Candidate path through resolver/pipeline conversion.

Deferred with Solo todos:
- N-5 per-term dictionary traceability: todo #92 for `dictionary:{name}[#term_index]`-style audit sources.
- N-6 `Context.fields` public serde_json map wrapper: todo #93 for a v0.4.1 `ContextFields` newtype/API cleanup.

`Context.class_map` decision: it is now consumed for context-only dictionary recognizer construction. It is not a general runtime class override mechanism; docs call that out.

## Tests

- `cargo test --workspace` green across all workspace crates.
- Static gate checked: no `DictionaryDetector` references remain; dictionary `UnsupportedMatcher` is removed; only `UnsupportedMatcher("Ner")` remains.
- Added/updated regressions for dictionary locale gating and `--context-json` standalone dictionary detection.