### PR TITLE
docs: refresh for v0.4.0-rc.1 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,4 +24,15 @@ Verbatim user directive (2026-04-24): *"set a north star to be focused on never 
 
 All design, implementation, and review decisions in this repo must be evaluated against these axes. If a decision weakens any axis, call it out in the PR description and justify the tradeoff. Correctness axes 1–4 always beat performance.
 
-Full rationale (including what the north star rejects and how drift is measured) lives in [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24) and in MemPalace drawer `drawer_gaze_decisions_ba559e1cf1fbca5c1098b12f` (wing=gaze, room=decisions).
+Full rationale (including what the north star rejects and how drift is measured) lives in [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24).
+
+## v0.4 architecture primer
+
+As of v0.4.0-rc.1 the repo is split into four crates and uses a recognizer-native detection path. Future Claude sessions should keep the deltas below in mind before touching code.
+
+- **Crates:** `gaze` (core: pipeline, session, policy, registry, locale, rulepack), `gaze-recognizers` (regex/dictionary/NER backends + embedded rulepacks + locale bundles), `gaze-cli` (standalone `gaze` binary, the `map_policy_error` surface, `--locale`/`--context-json` flags), `debug-proxy` (MCP consumer). Always `cargo test --workspace`, never per-crate, unless you're narrowing a single failure.
+- **Detection is recognizer-native.** Every detector runs through `gaze::RecognizerRegistry` with a typed `DetectContext` envelope. The legacy standalone `Detector` path was removed. New detection features should land as a `Recognizer` impl in `gaze-recognizers`, not as a bespoke pipeline hook.
+- **Policy surface:** `[policy.rulepacks]` (bundled + path) + `[[policy.custom_recognizers]]`. Top-level `[[detector]]` is rejected. When editing `crates/gaze/src/policy.rs`, cross-check [docs/policy.md](docs/policy.md) and the `gaze-cli` integration suite in `crates/gaze-cli/tests/cli_pipe.rs`.
+- **Locale chain is 4-tier** (CLI > policy > rulepack default > system default) with strict `LocaleTag::Other(_)` matching. Recognizers gate on `locales = [...]`.
+- **Conflict resolution:** class-priority > rule-priority > score > span-length > recognizer-id with multi-overlap fixed point. Losers are logged with `decided_by: ConflictTier` in the redaction log.
+- **Rulepack fields parsed but gated** (v0.4.1-pending): `token.family`, `token.format`, `context.hotwords`, `context.boost`, `context.window`. If a design needs these, unblock them deliberately rather than editing around the `UnsupportedFieldInB1` guard.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ It does not merely redact. It replaces PII with stable, reversible tokens, so th
 
 Gaze is a reversible PII pseudonymization runtime that lets AI agents work with production data without ever seeing the real personal data.
 
-The workspace has two crates:
+The workspace has four crates:
 
-- `crates/gaze` — shared redaction core library and the standalone `gaze clean` / `gaze restore` CLI
-- `crates/debug-proxy` — MCP debug server for MySQL + Laravel logs
+- `crates/gaze` — core library: pipeline, sessions, policy loader, recognizer registry, locale chain, rulepack schema, token grammar.
+- `crates/gaze-recognizers` — detection backends plugged into the registry (regex, dictionary, NER) and bundled rulepacks.
+- `crates/gaze-cli` — the `gaze clean` / `gaze restore` binary adopters invoke from language adapters.
+- `crates/debug-proxy` — MCP debug server for MySQL + Laravel logs, built on top of `gaze`.
 
 ## Project north star
 
@@ -33,7 +35,9 @@ Every design, implementation, and review decision is evaluated against these fiv
 4. **Trust (auditable + deterministic).** Rule-based detectors preferred; every token emission traceable to a rule or recognizer.
 5. **Adopter ergonomics.** Low-friction framework adapters; adopter picks Gaze up in under a day without deep PII expertise.
 
-## Install (v0.3.0)
+## Install (v0.4.0-rc.1)
+
+v0.4.0-rc.1 is a release candidate — pin it explicitly while dogfooding.
 
 Apple Silicon macOS via Homebrew (tap):
 
@@ -44,35 +48,52 @@ brew install Naoray/gaze/gaze
 Direct binary download from the release assets:
 
 ```bash
-curl -LO https://github.com/Naoray/gaze/releases/download/v0.3.0/gaze-aarch64-apple-darwin
-chmod +x gaze-aarch64-apple-darwin
-mv gaze-aarch64-apple-darwin /usr/local/bin/gaze
+curl -LO https://github.com/Naoray/gaze/releases/download/v0.4.0-rc.1/gaze-v0.4.0-rc.1-aarch64-apple-darwin.tar.gz
+tar -xzf gaze-v0.4.0-rc.1-aarch64-apple-darwin.tar.gz
+mv gaze /usr/local/bin/gaze
 ```
 
-Linux and Intel macOS binaries are not published in v0.3.0; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release` in the meantime.
+Linux and Intel macOS binaries are not published in v0.4.0-rc.1; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release -p gaze-cli` in the meantime.
 
 ## Workspace Layout
 
 ```text
 crates/
-  gaze/         core library + standalone CLI
-  debug-proxy/  MCP debug server consumer
+  gaze/               core library (pipeline, sessions, policy, registry, locale, rulepack)
+  gaze-recognizers/   detection backends (regex, dictionary, NER) + bundled rulepacks
+  gaze-cli/           standalone `gaze` binary for LLM pipe-mode integrations
+  debug-proxy/        MCP debug server consumer for MySQL + Laravel logs
 ```
 
 ## Crate Guide
 
 ### `gaze`
 
-Pure Rust library for:
+Pure Rust library. Owns:
 
-- detector composition
-- rule-based redaction
-- session-scoped tokenization
-- signed sensitive snapshots
-- redaction logging
+- pipeline + rule evaluation
+- session-scoped tokenization (`<{session_hex}:Class_N>` grammar)
+- signed sensitive snapshots with TTL enforcement
+- `RecognizerRegistry` trait + `DetectContext` envelope (the recognizer-native detection path; the legacy standalone `Detector` path was removed in v0.4.0-rc.1)
+- class/rule/score/length/id conflict resolver
+- locale chain (CLI > policy > rulepack default > system default) with strict opaque-tag matching
+- TOML rulepack schema loader (`[policy.rulepacks]`, `[[policy.custom_recognizers]]`)
+- redaction logger + audit symmetry (`decided_by` + merge-loser entries)
 - pluggable sandbox trait shape for future action-side work
 
-The standalone CLI consumes the library for LLM pipe-mode integration (Laravel wrapper ships out-of-tree via `gaze/laravel`). See `docs/roadmap/v0.3/cli.md` for the surface and `docs/roadmap/v0.3/laravel.md` for the host integration.
+### `gaze-recognizers`
+
+Detection backends registered through `gaze::RecognizerRegistry`:
+
+- `RegexDetector` — named regex recognizer with optional validator (Luhn, IBAN MOD-97, IPv4/IPv6, VIN) and normalizer kinds.
+- `DictionaryRecognizer` — Aho-Corasick multi-term recognizer for tenant-specific PII (order IDs, song titles, artist names). Terms flow in through `[[policy.custom_recognizers]]`, `terms_file`, or `--context-json`.
+- `NerDetector` — optional transformer NER backend (ONNX + Davlan mBERT). Off unless `[ner] model_dir` resolves a valid bundle.
+
+The crate also ships the embedded `core` rulepack (`gaze-recognizers/embedded/core.toml`) plus DACH/EN locale bundles.
+
+### `gaze-cli`
+
+Standalone `gaze` binary for LLM pipe-mode integration. Language-specific adapters (e.g. `gaze-laravel`) shell out to it rather than linking the library. See `docs/roadmap/v0.3/cli.md` for the full CLI contract and `docs/roadmap/v0.3/laravel.md` for the host-side integration. v0.4 flag additions: `--locale` (comma-separated priority chain) and `--context-json` (typed `DetectContext` envelope with tenant fields + dictionaries + class map).
 
 #### CLI Example
 
@@ -85,24 +106,23 @@ Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{s
 
 #### Policy Configuration
 
-`gaze clean --policy=<path>` loads a TOML policy that declares detectors, classes, and per-class actions. See [`docs/policy.md`](docs/policy.md) for the full schema reference and worked examples.
+`gaze clean --policy=<path>` loads a TOML policy that declares recognizer bundles (`[policy.rulepacks]`), custom recognizers (`[[policy.custom_recognizers]]`), per-class rules, the locale chain, and optional NER bootstrap. See [`docs/policy.md`](docs/policy.md) for the full schema reference and worked examples, including the `[[detector]]` → `[[policy.custom_recognizers]]` migration.
 
 #### Library Example
 
 ```rust
-use gaze::{
-    Action, ClassRule, Pipeline, RawDocument, RegexDetector, Scope, Session, PiiClass,
-};
+use gaze::{Action, ClassRule, Pipeline, PiiClass, RawDocument, Scope, Session};
+use gaze_recognizers::RegexDetector;
 
 let pipeline = Pipeline::builder()
-    .detector(RegexDetector::emails()?)
+    .recognizer(RegexDetector::emails()?)
     .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
     .build()?;
 
 let session = Session::new(Scope::Conversation("msg-42".into()))?;
 let clean = pipeline.redact(
     &session,
-    RawDocument::Text("alice@example.com".to_string()),
+    RawDocument::Text("alice@example.invalid".to_string()),
 )?;
 ```
 
@@ -179,51 +199,50 @@ cargo run -p debug-proxy -- serve policy.toml
 ## Build
 
 ```bash
-cargo build
+cargo build --workspace
 ```
 
 Release:
 
 ```bash
-cargo build --release
+cargo build --release --workspace
 ```
 
 ## Verification
 
 ```bash
-cargo test -p gaze -p debug-proxy
-cargo clippy -p gaze -p debug-proxy --all-targets --all-features -- -D warnings
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-## Status
+## What's new in v0.4.0-rc.1
 
-Shipped in v0.3.0 (2026-04-24):
+Shipped 2026-04-24 (see [CHANGELOG.md](CHANGELOG.md) for the full entry):
 
-- shared `gaze` core library
-- `debug-proxy` MCP consumer
-- standalone `gaze clean` / `gaze restore` CLI (see `docs/roadmap/v0.3/cli.md`)
-- `policy.toml` loader + `Pipeline::from_policy(...)` helper
-- angle-bracket-wrapped counter tokens + `gaze::token_shape` grammar
-- two-pass restore (exact token match + shape-validator) with `UnknownToken` fail-closed signal
-- session TTL enforcement (`issued_at` on snapshot payload, `BlobExpired` exit bucket)
-- structured stderr JSON with stable exit buckets
-- Apple Silicon macOS binary + Homebrew tap formula
+- **Crate split** — `gaze` (core) + `gaze-recognizers` (detection backends) + `gaze-cli` (binary) + `debug-proxy` (MCP consumer). Debug-proxy canary test tightened to assert the 8-hex `{session_hex}` shape.
+- **`RecognizerRegistry` is the detection path.** The legacy standalone `Detector` trait path was removed; every detection routes through the registry with a typed `DetectContext` envelope.
+- **F3 rulepack schema** — TOML-defined recognizer bundles (`[policy.rulepacks]`) with a closed validator/normalizer kind registry. Unknown matchers fail closed.
+- **F4 locale chain** — 4-tier: CLI > policy > rulepack default > system default. Per-recognizer locale gating via `locales = [...]`; `LocaleTag::Other(_)` matches strict-equal only.
+- **F2-full resolver** — class-priority > rule-priority > score > span-length > recognizer-id, with a multi-overlap fixed-point pass. Audit entries carry `decided_by: ConflictTier` + merge-loser rows.
+- **F5 `.invalid` domain** — format-preserving email fakes now use `email{N}.{session_hex}@gaze-fake.invalid`. The legacy `example.test` Pass 2 trap arm is retained for v0.3 manifest restore compatibility.
+- **F6 Dictionary recognizer** — Aho-Corasick multi-term detector for tenant PII, registered through the `Recognizer` trait. Adopter-tunable via `[[policy.custom_recognizers]]`, `terms_file`, or `--context-json`.
+- **Typed `Context` envelope** — `--context-json` carries tenant `fields` / `dictionaries` / `class_map` through `DetectContext` instead of being parsed-and-dropped.
+- **F7.5 byte-range-skip** — Pass 1 substitution spans are tracked; Pass 2 trap scan skips fully-contained matches. Closes the cascade false-positive where adopter raw values matching trap arms (`Order_42`, `Song_42`, `User_7`) were rejected in strict mode (PR #22).
+- **Migration:** legacy top-level `[[detector]]` is rejected with `LegacyDetectorUnsupported`. Move blocks to `[[policy.custom_recognizers]]` — see [docs/policy.md](docs/policy.md#migrating-detector).
 
-v0.4 (in flight, plan under review — not imminent):
+Known limits to surface during dogfooding (tracked for v0.4.1):
 
-- engine / corpus crate split
-- `RecognizerRegistry` trait for stackable detectors
-- full TOML rulepack schema
-- DACH + EN locale infrastructure
-- `.invalid` domain switch for format-preserving fakes
-- dictionary detector + typed `Context` envelope
-- text-provenance fingerprint (library-side blob↔text scope isolation)
+- `token.family` / `token.format` and `context.hotwords` / `boost` / `window` are parsed but gated — runtime consumers ship in v0.4.1.
+- Dictionary audit log carries `dictionary:{name}`; per-term `[#term_index]` is v0.4.1.
+- NER context-sensitivity gap on prompt boilerplate / RFC822 email headers — workarounds + roadmap in issue #24.
 
 Deferred beyond v0.4:
 
 - real sandbox backend implementations
 - k-anonymity / query-budget controls
 - full format-preserving fake generation
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for v0.4.1 and v0.5 directions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Shipped 2026-04-24 (see [CHANGELOG.md](CHANGELOG.md) for the full entry):
 
 Known limits to surface during dogfooding (tracked for v0.4.1):
 
-- `token.family` / `token.format` and `context.hotwords` / `boost` / `window` are parsed but gated — runtime consumers ship in v0.4.1.
+- `token.family` / `token.format` and `context.hotwords` / `boost` / `window` are parsed only for schema validation in v0.4.0-rc.1; non-default values fail closed with `RulepackError::UnsupportedFieldInB1` until runtime consumers ship in v0.4.1.
 - Dictionary audit log carries `dictionary:{name}`; per-term `[#term_index]` is v0.4.1.
 - NER context-sensitivity gap on prompt boilerplate / RFC822 email headers — workarounds + roadmap in issue #24.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,32 +31,52 @@ alternatives live in `docs/research/gaze-first-principles-vision.md` and
 
 ---
 
-## Current state — v0.3.0 shipped 2026-04-24
+## Current state — v0.4.0-rc.1 shipped 2026-04-24
 
-v0.3.0 delivers the first adopter-ready Gaze runtime: `gaze clean` and
-`gaze restore` CLI with two-pass restore (Pass 1 manifest lookup plus Pass 2
-hallucination trap), angle-bracket counter-family tokens (`<{session_hex}:Email_1>`,
-`<{session_hex}:Custom:order_id_1>`) with format-preserving bare emails, `policy.toml`
-configuration surface, SQLite redaction log, and the Laravel adapter
-(`gaze-laravel`) that pipes requests through the binary. The homebrew
-formula `Naoray/gaze/gaze` resolves to the real release artifact, and the
-drift-gate fixture compile-errors if `PiiClass` grows without a matching
-grammar update.
+v0.4.0-rc.1 lands the engine/corpus separation planned for v0.4 Phase 1 and
+cuts over the detection path to recognizers. The workspace is now four
+crates (`gaze`, `gaze-recognizers`, `gaze-cli`, `debug-proxy`). Detection
+runs through `gaze::RecognizerRegistry` with a typed `DetectContext`; the
+legacy standalone `Detector` path is gone. The TOML rulepack schema
+(`[policy.rulepacks]`, `[[policy.custom_recognizers]]`) plus the 4-tier
+locale chain (CLI > policy > rulepack default > system default) with strict
+`LocaleTag::Other(_)` matching are live. Format-preserving emails now use
+`.invalid`, the Aho-Corasick dictionary recognizer ships for tenant PII,
+and the F7.5 byte-range-skip closes the Pass 1 → Pass 2 cascade false
+positive under strict restore mode. Audit entries carry `decided_by:
+ConflictTier` plus merge-loser rows. Full entry in
+[CHANGELOG.md](../CHANGELOG.md).
 
-Known spec-drift scheduled for the v0.3.1 patch (already landed on main as
-of 2026-04-24 — see `b70947d`):
+Shipped earlier on the v0.3 line and still live:
 
-- `[session]` policy.toml key now authoritative over `--session-ttl`
-- Broken `[ner] model_dir` exits `PolicyConfig` (exit code 2) instead of
-  silently degrading
-- `kind = "column"` policy rules rejected by `gaze clean` CLI load
+- `gaze clean` / `gaze restore` CLI with two-pass restore (manifest
+  lookup + hallucination trap), angle-bracket counter-family tokens
+  (`<{session_hex}:Email_1>`, `<{session_hex}:Custom:order_id_1>`),
+  format-preserving bare emails, SQLite redaction log, drift-gate fixture
+  that compile-errors if `PiiClass` grows without a matching grammar
+  update, Apple Silicon macOS binary + homebrew formula, `gaze-laravel`
+  adapter.
+- v0.3.1 spec-drift patches: `[session]` authoritative over
+  `--session-ttl`; broken `[ner] model_dir` exits `PolicyConfig`;
+  `kind = "column"` policy rules rejected by the CLI loader; NER BIO-prefix
+  `labels.json` resolved.
 
-Live binary + homebrew formula + adopter deployment (gaze-laravel) are
-production. Next focus is v0.4 engine/corpus separation.
+Known limits logged for the v0.4.1 patch (see
+[CHANGELOG.md](../CHANGELOG.md) "Known limits"):
+
+- `token.family` / `token.format` and `context.hotwords` / `boost` /
+  `window` are parsed but gated with `UnsupportedFieldInB1`.
+- Dictionary audit log carries `dictionary:{name}` only; per-term
+  traceability pending.
+- NER context-sensitivity gap on prompt boilerplate + RFC822 headers
+  (issue #24).
+
+Next focus is closing the v0.4.1 list plus the Tier 1 structured recognizer
+set.
 
 ---
 
-## v0.4 — engine/corpus split + tenant PII (target: weeks)
+## v0.4 — engine/corpus split + tenant PII (Phase 1 shipped in rc.1)
 
 ### Why
 
@@ -75,12 +95,16 @@ production. Next focus is v0.4 engine/corpus separation.
 (`gaze` / `gaze-recognizers` / `gaze-cli`). F2 `RecognizerRegistry` trait.
 F3 TOML rulepack schema. F4 locale infra (DACH + EN). F5 `.invalid`
 domain handling. F6 Dictionary detector. Typed `Context` envelope. Token
-grammar becomes session-scoped: `<{session_hex}:Email_1>` where
+grammar is session-scoped: `<{session_hex}:Email_1>` where
 `{session_hex}` is 8 lowercase hex chars per session. Pass 2 regex
 splits into a two-branch form (prefixed manifest-lookup + unprefixed trap
 for fail-closed). `SnapshotPayload` envelope byte bumps 1 → 2.
-**Status:** multi-review loop; Layer A implementation auto-fires on
-review clear.
+**Status:** shipped in v0.4.0-rc.1 — crate split, `RecognizerRegistry`
+(legacy `Detector` path removed), rulepack schema with closed
+validator/normalizer registry + `UnsupportedFieldInB1` gating, 4-tier
+locale chain, `.invalid` FPE emails, Aho-Corasick dictionary recognizer,
+typed `DetectContext` envelope via `--context-json`, F7.5 Pass 1 → Pass 2
+byte-range-skip. PRs #21, #22, #23, #25, #26.
 
 **Phase 2 — Engine.** Overlap resolver, context-aware enhancer,
 validator trait, in-house validator implementations (Luhn, IBAN MOD-97,

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -544,15 +544,11 @@ engineering board:
    `gaze clean` now fails policy load with exit `2` `PolicyConfig` and a
    detail string, avoiding silent no-op column rules for text stdin.
 4. **v0.4.0-rc.1 gated rulepack fields (runtime consumers pending v0.4.1).**
-   The rulepack schema parses these fields but rejects non-default values
-   with `RulepackError::UnsupportedFieldInB1`:
-   - `token.family` / `token.format` — counter-family is the only wired
-     family today.
-   - `context.hotwords` / `context.boost` / `context.window` — parsed and
-     threaded through `DetectContext` but not consumed by shipped
-     recognizers.
-   Keep them at defaults until the v0.4.1 consumers land; today any
-   non-default value exits `2` `PolicyConfig` at load time.
+   The rulepack schema parses `token.family`, `token.format`,
+   `context.hotwords`, `context.boost`, and `context.window` for
+   forward-compatible authoring, but the loader rejects any non-default value
+   with `RulepackError::UnsupportedFieldInB1`. Runtime consumers ship in
+   v0.4.1; until then, leave these fields unset or explicitly default.
 5. **v0.4.0-rc.1 dictionary audit granularity.** The redaction log carries
    `dictionary:{name}` for dictionary hits; per-term `[#term_index]`
    traceability is scheduled for v0.4.1.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -5,10 +5,13 @@ build its detection-and-redaction pipeline. It declares which detectors run,
 which PII classes they emit, and what action the pipeline takes when each class
 is found.
 
-This document describes the schema as shipped in v0.4.0. The canonical
+This document describes the schema as shipped in v0.4.0-rc.1. The canonical
 parser lives at [`crates/gaze/src/policy.rs`](../crates/gaze/src/policy.rs);
-the CLI wiring is in [`crates/gaze-cli/src/main.rs`](../crates/gaze-cli/src/main.rs).
-For the full CLI contract — exit codes, stderr discipline, blob format — see
+the CLI wiring (argument parsing, context envelope assembly, policy-error
+mapping) is in [`crates/gaze-cli/src/main.rs`](../crates/gaze-cli/src/main.rs).
+Recognizer backends (regex, dictionary, NER) live in
+[`crates/gaze-recognizers`](../crates/gaze-recognizers). For the full CLI
+contract — exit codes, stderr discipline, blob format — see
 [`docs/roadmap/v0.3/cli.md`](roadmap/v0.3/cli.md).
 
 ## What `policy.toml` is for
@@ -407,7 +410,7 @@ kind = "default"
 action = "preserve"
 ```
 
-`Order ORD-123456 is queued.` → `Order <Custom:order_id_1> is queued.`
+`Order ORD-123456 is queued.` → `Order <{session_hex}:Custom:order_id_1> is queued.`
 
 ### Example C — Format-preserving emails for downstream parsers
 
@@ -499,7 +502,7 @@ through while `name = tokenize` swaps person names for restorable tokens.
 ## Troubleshooting
 
 Each `PolicyError` variant maps to one exit code via `gaze clean`. The
-mapping lives at [`main.rs::map_policy_error`](../crates/gaze/src/main.rs)
+mapping lives at [`gaze-cli/src/main.rs::map_policy_error`](../crates/gaze-cli/src/main.rs)
 and is summarised here.
 
 | Symptom (stderr variant)                | `PolicyError`              | Exit | Common cause                                                                 |
@@ -528,8 +531,8 @@ and is summarised here.
 
 ## Known spec drift
 
-Documented here so users get the truth, with corresponding solo todos so the
-gaps land on the engineering board:
+Documented here so users get the truth while the gaps land on the
+engineering board:
 
 1. **Resolved in v0.3.1: `policy.session` is honoured by `gaze clean`.**
    The CLI constructs sessions from `[session]`; `--session-ttl` is now only
@@ -540,3 +543,20 @@ gaps land on the engineering board:
 3. **Resolved in v0.3.1: `kind = "column"` rules are rejected in CLI mode.**
    `gaze clean` now fails policy load with exit `2` `PolicyConfig` and a
    detail string, avoiding silent no-op column rules for text stdin.
+4. **v0.4.0-rc.1 gated rulepack fields (runtime consumers pending v0.4.1).**
+   The rulepack schema parses these fields but rejects non-default values
+   with `RulepackError::UnsupportedFieldInB1`:
+   - `token.family` / `token.format` — counter-family is the only wired
+     family today.
+   - `context.hotwords` / `context.boost` / `context.window` — parsed and
+     threaded through `DetectContext` but not consumed by shipped
+     recognizers.
+   Keep them at defaults until the v0.4.1 consumers land; today any
+   non-default value exits `2` `PolicyConfig` at load time.
+5. **v0.4.0-rc.1 dictionary audit granularity.** The redaction log carries
+   `dictionary:{name}` for dictionary hits; per-term `[#term_index]`
+   traceability is scheduled for v0.4.1.
+6. **v0.4.0-rc.1 NER context-sensitivity gap.** Default Davlan-HRL may
+   pass names embedded in prompt boilerplate or RFC822 email headers.
+   Workarounds (wrap with a dictionary recognizer, tighten locale gating
+   via `[ner] locale`) and roadmap in GitHub issue #24.


### PR DESCRIPTION
## Summary

Repo-level docs refresh after v0.4.0-rc.1 ships. Reflects:
- 3-crate split (gaze + gaze-recognizers + gaze-cli) + debug-proxy canary
- F3 rulepack schema (TOML) + F4 locale chain + F2-full resolver
- F5 .invalid domain + F6 Dictionary detector + typed Context
- F7.5 byte-range-skip cascade fix
- Recognizer-native pipeline (legacy Detector path removed)
- [[detector]] → [[policy.custom_recognizers]] migration

Deferrals captured for v0.4.1: token.family/format, context.hotwords/boost/window, NER context-sensitivity (#24).

## Documentation

- `README.md`: workspace layout updated to four crates; install snippet pinned to v0.4.0-rc.1 tarball shape; crate guide split (gaze / gaze-recognizers / gaze-cli) with recognizer-native pipeline, locale chain, and `--locale` / `--context-json` flags called out; library example migrated to `gaze_recognizers::RegexDetector` + `.recognizer(..)`; "Status" section replaced with "What's new in v0.4.0-rc.1" covering every shipped F-series feature and the v0.4.1-pending known limits; `cargo test` / `clippy` switched to `--workspace`.
- `CLAUDE.md`: added a "v0.4 architecture primer" so future Claude Code sessions pick up the crate split, recognizer-native pipeline, `[policy.rulepacks]` + `[[policy.custom_recognizers]]` surface, 4-tier locale chain, conflict resolver, and the `UnsupportedFieldInB1`-gated rulepack fields.
- `docs/policy.md`: schema header bumped to v0.4.0-rc.1; `map_policy_error` source path fixed to `crates/gaze-cli/src/main.rs` after the crate split; Example B output now carries the `{session_hex}` prefix; "Known spec drift" gains v0.4.0-rc.1 entries for gated rulepack fields (`token.family/format`, `context.hotwords/boost/window`), dictionary audit granularity, and the NER context-sensitivity gap (#24).
- `docs/ROADMAP.md`: "Current state" now leads with v0.4.0-rc.1 shipped and preserves v0.3 contents as history; v0.4 Phase 1 status flipped from "multi-review loop" to shipped with PR references (#21, #22, #23, #25, #26).

## Test plan

- [x] cargo test --workspace green (baseline from v0.4.0-rc.1 tag)
- [x] All doc cross-references resolve (README <-> docs/policy.md <-> docs/ROADMAP.md <-> CHANGELOG.md)
- [x] No internal-state references (no MemPalace drawer IDs, no solo todo / scratchpad IDs, no process PIDs, no solo:// links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)