### PR TITLE
v0.4.1 Bundle P2: Adopter NER fix (Markus dogfood — locale-aware email-header recognizer + threshold knob acceptance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Locale-aware regex `pattern_template` lowering for `{locale_email_headers}` with English and German defaults.
 - `capture_groups = [...]` regex span narrowing with first-non-empty semantics.
 - `NerRecognizer` public export plus `[ner] threshold` policy knob using min-aggregated span confidence.
+- Core `email.header.name` recognizer for RFC822-style header display names, including German `Von:` / `An:` forms.
 
 ### Changed
 
@@ -22,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Markus adopter dogfood gap closed at the foundation layer: locale-aware email-header schema supports `Von:` / `An:` plus English defaults for the upcoming header recognizer.
+- Markus adopter dogfood gap closed: locale-aware email-header recognizer (`Von:` / `An:` plus English defaults) tokenizes header display names and restores them round-trip. See GH #24.
 - `[ner] threshold` knob un-deferred from v0.4.2 so adopters can tune the NER confidence floor for prompt-preamble PII.
+- Template lowering now preserves regex quantifiers such as `{0,3}` and keeps locale-header alternation non-capturing, so capture-group span narrowing remains stable.
 
 ## [0.4.0-rc.1] - 2026-04-24
 

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -573,6 +573,46 @@ mod tests {
     }
 
     #[test]
+    fn pattern_template_preserves_regex_quantifiers() {
+        let pattern = lower_pattern_template(
+            "email.header.name",
+            r"^(?:{locale_email_headers}): ([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})$",
+            &["From".to_string()],
+        )
+        .expect("lowered pattern");
+
+        assert!(pattern.contains(r"{0,3}"));
+        let regex = regex::Regex::new(&pattern).expect("compiled regex");
+        let captures = regex
+            .captures("From: Alice Example")
+            .expect("email header captures");
+        assert_eq!(captures.get(1).map(|m| m.as_str()), Some("Alice Example"));
+    }
+
+    #[test]
+    fn locale_email_headers_placeholder_is_non_capturing() {
+        let pattern = lower_pattern_template(
+            "email.header.name",
+            r#"^(?:{locale_email_headers}):\s*(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+<[^>]+>"#,
+            &["Von".to_string()],
+        )
+        .expect("lowered pattern");
+        let regex = regex::Regex::new(&pattern).expect("compiled regex");
+
+        let quoted = regex
+            .captures(r#"Von: "Doe, Jane" <jane@example.invalid>"#)
+            .expect("quoted capture");
+        assert_eq!(quoted.get(1).map(|m| m.as_str()), Some("Doe, Jane"));
+        assert!(quoted.get(2).is_none());
+
+        let bare = regex
+            .captures("Von: Alice Example <alice@example.invalid>")
+            .expect("bare capture");
+        assert!(bare.get(1).is_none());
+        assert_eq!(bare.get(2).map(|m| m.as_str()), Some("Alice Example"));
+    }
+
+    #[test]
     fn pattern_template_unknown_placeholder_fails_closed() {
         let rulepack = Rulepack::parse(
             r#"

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -297,9 +297,16 @@ fn lower_pattern_template(
             });
         };
         let placeholder = &after[..end];
+        if !is_template_placeholder(placeholder) {
+            lowered.push('{');
+            lowered.push_str(placeholder);
+            lowered.push('}');
+            rest = &after[end + 1..];
+            continue;
+        }
         match placeholder {
             "locale_email_headers" => lowered.push_str(&format!(
-                "({})",
+                "(?:{})",
                 locale_headers
                     .iter()
                     .map(|name| regex::escape(name))
@@ -317,6 +324,16 @@ fn lower_pattern_template(
     }
     lowered.push_str(rest);
     Ok(lowered)
+}
+
+fn is_template_placeholder(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        && value.bytes().next().is_some_and(|byte| {
+            byte.is_ascii_alphabetic() || byte == b'_'
+        })
 }
 
 fn merged_locale_email_headers(
@@ -526,40 +543,13 @@ mod tests {
             gaze_recognizers::embedded("locale-de").expect("locale-de"),
         ))
         .expect("de");
-        let email_header = Rulepack::parse(
-            r#"
-schema_version = "0.1.0"
-rulepack_id = "email-header"
-rulepack_version = "0.4.1"
-default_locales = ["global"]
-
-[[recognizers]]
-id = "email.header.name"
-class = "Name"
-enabled = true
-locales = ["global"]
-
-[recognizers.match]
-kind = "regex"
-pattern_template = '''(?m)^{locale_email_headers}:\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+<[^>]+>'''
-capture_groups = [2]
-
-[recognizers.scoring]
-base = 0.90
-priority = 100
-
-[recognizers.token]
-family = "email.header.name"
-"#,
-        )
-        .expect("email header rulepack");
         let policy = policy();
         let active_locales =
             LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), Some(&[LocaleTag::DeDe]));
         let pipeline = build_pipeline(
             &policy,
             &empty_context(),
-            &[core, de, email_header],
+            &[core, de],
             &active_locales,
             None,
         )

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -331,9 +331,10 @@ fn is_template_placeholder(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-        && value.bytes().next().is_some_and(|byte| {
-            byte.is_ascii_alphabetic() || byte == b'_'
-        })
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
 }
 
 fn merged_locale_email_headers(

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -24,5 +24,6 @@ tracing = "0.1"
 [dev-dependencies]
 assert_cmd = "2"
 base64 = "0.22"
+gaze-recognizers = { path = "../gaze-recognizers", features = ["test-support"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -256,7 +256,8 @@ action = "tokenize"
 [[rule]]
 kind = "default"
 action = "preserve"
-"#),
+"#
+        ),
     )
     .unwrap();
     (dir, path)
@@ -663,10 +664,7 @@ fn t21e_email_header_de_locale() {
     let (_dir, path) =
         write_policy_with_bundled_rulepacks(&["core", "locale-de", "locale-en"], "de-DE");
     let input = "Von: Alice Example <alice@example.invalid>";
-    let v = clean_json_with_args(
-        &[&format!("--policy={}", path.display())],
-        input,
-    );
+    let v = clean_json_with_args(&[&format!("--policy={}", path.display())], input);
     let clean = v["clean_text"].as_str().unwrap();
 
     assert!(

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -639,6 +639,49 @@ terms = ["Sonnenlied"]
 }
 
 #[test]
+fn t21a_email_header_does_not_fire_on_inline_titlecase() {
+    let (_dir, path) = write_policy_with_bundled_rulepacks(&["core"], "en-US");
+    let input = "I love using Microsoft Word and React Components in New York";
+    let v = clean_json_with_args(&[&format!("--policy={}", path.display())], input);
+
+    assert_eq!(v["clean_text"], input);
+    assert_eq!(v["stats"]["detections"], 0);
+}
+
+#[test]
+fn t21c_email_header_rejects_body_from_without_bracket() {
+    let (_dir, path) = write_policy_with_bundled_rulepacks(&["core"], "en-US");
+    let input = "\nReply from From: React Component for context.\n";
+    let v = clean_json_with_args(&[&format!("--policy={}", path.display())], input);
+
+    assert_eq!(v["clean_text"], input);
+    assert_eq!(v["stats"]["detections"], 0);
+}
+
+#[test]
+fn t21e_email_header_de_locale() {
+    let (_dir, path) =
+        write_policy_with_bundled_rulepacks(&["core", "locale-de", "locale-en"], "de-DE");
+    let input = "Von: Alice Example <alice@example.invalid>";
+    let v = clean_json_with_args(
+        &[&format!("--policy={}", path.display())],
+        input,
+    );
+    let clean = v["clean_text"].as_str().unwrap();
+
+    assert!(
+        Regex::new(r"^Von: <[0-9a-f]{8}:Name_\d+> <<[0-9a-f]{8}:Email_\d+>>$")
+            .unwrap()
+            .is_match(clean)
+    );
+    assert_eq!(v["stats"]["detections"], 2);
+    assert_eq!(v["stats"]["locale_chain"], json!(["de-DE", "global"]));
+
+    let restored = restore_success_text(v["session_blob"].as_str().unwrap(), clean);
+    assert_eq!(restored, input);
+}
+
+#[test]
 fn t21g_pattern_template_uses_active_locale_de_when_en_loaded_after_de() {
     let (_dir, path) =
         write_policy_with_bundled_rulepacks(&["core", "locale-de", "locale-en"], "de-DE");

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -461,7 +461,7 @@ fn cascade_restored_song_user_artist_tenant() {
     let (blob, tokens) = build_blob_and_tokens(|s| {
         cases
             .iter()
-            .map(|(class, raw)| s.tokenize(&PiiClass::custom(*class), raw).unwrap())
+            .map(|(class, raw)| s.tokenize(&PiiClass::custom(class), raw).unwrap())
             .collect()
     });
     for token in &tokens {
@@ -488,7 +488,7 @@ fn cascade_restored_snake_case() {
     let (blob, tokens) = build_blob_and_tokens(|s| {
         cases
             .iter()
-            .map(|(class, raw)| s.tokenize(&PiiClass::custom(*class), raw).unwrap())
+            .map(|(class, raw)| s.tokenize(&PiiClass::custom(class), raw).unwrap())
             .collect()
     });
     for token in &tokens {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -263,6 +263,61 @@ action = "preserve"
     (dir, path)
 }
 
+fn write_policy_with_test_ner(
+    bundled_rulepacks: &[&str],
+    locale_active: &str,
+    ner_locale: &str,
+    threshold: f32,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let model_dir = dir.path().join("__gaze_test_fixed_ner");
+    fs::create_dir(&model_dir).unwrap();
+    let path = dir.path().join("policy.toml");
+    let bundled = bundled_rulepacks
+        .iter()
+        .map(|rulepack| format!("\"{rulepack}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[locale]
+active = ["{locale_active}"]
+
+[ner]
+model_dir = "{}"
+locale = "{ner_locale}"
+threshold = {threshold}
+
+[policy.rulepacks]
+bundled = [{bundled}]
+
+[[rule]]
+kind = "class"
+class = "name"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            model_dir.display()
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
 fn session_blob_ttl_secs(blob: &str) -> u64 {
     let raw = BASE64.decode(blob.as_bytes()).unwrap();
     let payload: Value = serde_json::from_slice(&raw[97..]).unwrap();
@@ -673,6 +728,29 @@ fn t21e_email_header_de_locale() {
             .is_match(clean)
     );
     assert_eq!(v["stats"]["detections"], 2);
+    assert_eq!(v["stats"]["locale_chain"], json!(["de-DE", "global"]));
+
+    let restored = restore_success_text(v["session_blob"].as_str().unwrap(), clean);
+    assert_eq!(restored, input);
+}
+
+#[test]
+fn t21f_prompt_preamble_threshold_03_pipeline_end_to_end() {
+    let (_dir, path) =
+        write_policy_with_test_ner(&["core", "locale-de", "locale-en"], "de-DE", "de", 0.3);
+    let input = "Du antwortest als Artistfy-Support an Alice Example.";
+    let v = clean_json_with_args(&[&format!("--policy={}", path.display())], input);
+    let clean = v["clean_text"].as_str().unwrap();
+
+    assert!(
+        Regex::new(
+            r"^Du antwortest als Artistfy-Support an <[0-9a-f]{8}:Name_\d+>\.$"
+        )
+        .unwrap()
+        .is_match(clean),
+        "unexpected clean text: {clean}"
+    );
+    assert_eq!(v["stats"]["detections"], 1);
     assert_eq!(v["stats"]["locale_chain"], json!(["de-DE", "global"]));
 
     let restored = restore_success_text(v["session_blob"].as_str().unwrap(), clean);

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -707,7 +707,7 @@ fn t21a_email_header_does_not_fire_on_inline_titlecase() {
 #[test]
 fn t21c_email_header_rejects_body_from_without_bracket() {
     let (_dir, path) = write_policy_with_bundled_rulepacks(&["core"], "en-US");
-    let input = "\nReply from From: React Component for context.\n";
+    let input = "From: React Component for context.\n";
     let v = clean_json_with_args(&[&format!("--policy={}", path.display())], input);
 
     assert_eq!(v["clean_text"], input);

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -218,41 +218,11 @@ priority = 77
     )
 }
 
-fn email_header_rulepack() -> String {
-    r#"
-schema_version = "0.1.0"
-rulepack_id = "email-header"
-rulepack_version = "0.4.1"
-default_locales = ["global"]
-
-[[recognizers]]
-id = "email.header.name"
-class = "Name"
-enabled = true
-locales = ["global"]
-
-[recognizers.match]
-kind = "regex"
-pattern_template = '''(?m)^{locale_email_headers}:\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\s+<[^>]+>'''
-capture_groups = [2]
-
-[recognizers.scoring]
-base = 0.90
-priority = 100
-
-[recognizers.token]
-family = "email.header.name"
-"#
-    .to_string()
-}
-
-fn write_policy_with_email_header_rulepack(
+fn write_policy_with_bundled_rulepacks(
     bundled_rulepacks: &[&str],
     locale_active: &str,
 ) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempdir().unwrap();
-    let rulepack_path = dir.path().join("email-header.toml");
-    fs::write(&rulepack_path, email_header_rulepack()).unwrap();
     let path = dir.path().join("policy.toml");
     let bundled = bundled_rulepacks
         .iter()
@@ -272,7 +242,6 @@ active = ["{locale_active}"]
 
 [policy.rulepacks]
 bundled = [{bundled}]
-paths = ["{}"]
 
 [[rule]]
 kind = "class"
@@ -287,9 +256,7 @@ action = "tokenize"
 [[rule]]
 kind = "default"
 action = "preserve"
-"#,
-            rulepack_path.display()
-        ),
+"#),
     )
     .unwrap();
     (dir, path)
@@ -674,7 +641,7 @@ terms = ["Sonnenlied"]
 #[test]
 fn t21g_pattern_template_uses_active_locale_de_when_en_loaded_after_de() {
     let (_dir, path) =
-        write_policy_with_email_header_rulepack(&["core", "locale-de", "locale-en"], "de-DE");
+        write_policy_with_bundled_rulepacks(&["core", "locale-de", "locale-en"], "de-DE");
     let v = clean_json_with_args(
         &[&format!("--policy={}", path.display())],
         "Von: Alice Example <alice@example.invalid>",
@@ -692,7 +659,7 @@ fn t21g_pattern_template_uses_active_locale_de_when_en_loaded_after_de() {
 
 #[test]
 fn t21h_pattern_template_falls_back_to_global_when_locale_not_loaded() {
-    let (_dir, path) = write_policy_with_email_header_rulepack(&["core"], "fr-FR");
+    let (_dir, path) = write_policy_with_bundled_rulepacks(&["core"], "fr-FR");
     let v = clean_json_with_args(
         &[&format!("--policy={}", path.display())],
         "From: Alice Example <alice@example.invalid>",

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Built-in recognizers for Gaze"
 
+[features]
+default = []
+test-support = []
+
 [dependencies]
 aho-corasick = "1"
 gaze = { path = "../gaze" }

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -43,3 +43,18 @@ priority = 90
 origin = "ported"
 from = "presidio"
 license = "Apache-2.0"
+
+[[recognizers]]
+id = "email.header.name"
+class = "Name"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern_template = '''(?m)^(?:{locale_email_headers}):\s*(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+<[^>]+>'''
+capture_groups = [1, 2]
+
+[recognizers.scoring]
+base = 0.85
+priority = 100

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -28,10 +28,15 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 1);
+        assert_eq!(rulepack.recognizers.len(), 2);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
+        assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert!(matches!(
             rulepack.recognizers[0].matcher,
+            RawMatch::Regex { .. }
+        ));
+        assert!(matches!(
+            rulepack.recognizers[1].matcher,
             RawMatch::Regex { .. }
         ));
     }

--- a/crates/gaze-recognizers/src/ner.rs
+++ b/crates/gaze-recognizers/src/ner.rs
@@ -1181,4 +1181,63 @@ mod tests {
         assert_eq!(candidates[0].span, 6..11);
         assert_eq!(candidates[0].score, 0.50);
     }
+
+    #[test]
+    fn t21f_prompt_preamble_threshold_03() {
+        struct FixedBackend {
+            spans: Vec<NerSpanResult>,
+        }
+
+        impl NerBackend for FixedBackend {
+            fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+                Ok(self.spans.clone())
+            }
+        }
+
+        let input = "Du antwortest als Artistfy-Support an Alice Example.";
+        let name_start = input.find("Alice Example").expect("name span start");
+        let name_end = name_start + "Alice Example".len();
+        let dictionaries = gaze::DictionaryBundle::default();
+        let fields = serde_json::Map::new();
+        let ctx = DetectContext {
+            locale_chain: &[gaze::LocaleTag::DeDe, gaze::LocaleTag::Global],
+            dictionaries: &dictionaries,
+            fields: &fields,
+            degraded: std::cell::Cell::new(false),
+        };
+        let backend = Arc::new(FixedBackend {
+            spans: vec![NerSpanResult {
+                span: name_start..name_end,
+                class: PiiClass::Name,
+                score: 0.40,
+            }],
+        });
+        let default_threshold = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                locale: Some("de".to_string()),
+                threshold: 0.3,
+                backend: backend.clone(),
+            },
+        };
+        let stricter_threshold = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                locale: Some("de".to_string()),
+                threshold: 0.5,
+                backend,
+            },
+        };
+
+        let default_candidates = Recognizer::detect(&default_threshold, input, &ctx);
+        let stricter_candidates = Recognizer::detect(&stricter_threshold, input, &ctx);
+
+        assert_eq!(default_candidates.len(), 1);
+        assert_eq!(default_candidates[0].span, name_start..name_end);
+        assert_eq!(&input[default_candidates[0].span.clone()], "Alice Example");
+        assert_eq!(default_candidates[0].score, 0.40);
+        assert!(stricter_candidates.is_empty());
+    }
 }

--- a/crates/gaze-recognizers/src/ner.rs
+++ b/crates/gaze-recognizers/src/ner.rs
@@ -414,10 +414,50 @@ impl NerDetector {
 
 impl NerRecognizer {
     pub fn load_with_options(model_dir: &Path, options: NerOptions) -> Result<Self, NerLoadError> {
+        #[cfg(feature = "test-support")]
+        if let Some(recognizer) = load_test_support_recognizer(model_dir, &options) {
+            return Ok(recognizer);
+        }
+
         Ok(Self {
             detector: NerDetector::load_with_options(model_dir, options)?,
         })
     }
+}
+
+#[cfg(feature = "test-support")]
+struct TestSupportBackend;
+
+#[cfg(feature = "test-support")]
+impl NerBackend for TestSupportBackend {
+    fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+        Ok(input
+            .find("Alice Example")
+            .map(|start| NerSpanResult {
+                span: start..start + "Alice Example".len(),
+                class: PiiClass::Name,
+                score: 0.40,
+            })
+            .into_iter()
+            .collect())
+    }
+}
+
+#[cfg(feature = "test-support")]
+fn load_test_support_recognizer(model_dir: &Path, options: &NerOptions) -> Option<NerRecognizer> {
+    if model_dir.file_name().and_then(|name| name.to_str()) != Some("__gaze_test_fixed_ner") {
+        return None;
+    }
+
+    Some(NerRecognizer {
+        detector: NerDetector {
+            model_dir: model_dir.to_path_buf(),
+            backend_kind: NerBackendKind::Ort,
+            locale: options.locale.clone(),
+            threshold: options.threshold,
+            backend: Arc::new(TestSupportBackend),
+        },
+    })
 }
 
 impl Detector for NerDetector {
@@ -1137,7 +1177,7 @@ mod tests {
     }
 
     #[test]
-    fn t21f_prompt_preamble_threshold_03() {
+    fn t21f_threshold_filtering_unit() {
         struct FixedBackend {
             spans: Vec<NerSpanResult>,
         }

--- a/crates/gaze-recognizers/src/ner.rs
+++ b/crates/gaze-recognizers/src/ner.rs
@@ -793,52 +793,6 @@ fn config_to_id2label(
     Ok(out)
 }
 
-/// Test-only helpers for stacking multiple `NerDetector` instances with
-/// in-memory fake backends. Lets pipeline tests verify Layer-1 stackability
-/// without real ONNX artifacts.
-#[cfg(test)]
-pub(crate) mod test_support {
-    use super::*;
-
-    struct FixedBackend {
-        detections: Vec<NerSpanResult>,
-    }
-
-    impl NerBackend for FixedBackend {
-        fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
-            Ok(self.detections.clone())
-        }
-    }
-
-    /// Build a `NerDetector` that emits a fixed detection set, bypassing the
-    /// SHA256-pinned artifact contract. For tests only.
-    pub(crate) fn detector_with_detections(
-        source: &str,
-        detections: Vec<Detection>,
-    ) -> NerDetector {
-        let kind = match source {
-            "gliner" => NerBackendKind::Gliner,
-            _ => NerBackendKind::Ort,
-        };
-        NerDetector {
-            model_dir: PathBuf::from("/test/fake"),
-            backend_kind: kind,
-            locale: None,
-            threshold: 0.3,
-            backend: Arc::new(FixedBackend {
-                detections: detections
-                    .into_iter()
-                    .map(|detection| NerSpanResult {
-                        span: detection.span,
-                        class: detection.class,
-                        score: 1.0,
-                    })
-                    .collect(),
-            }),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Implements Gaze v0.4.1 Bundle P2 per scratchpad 144 rev 6 and GH #24.

- Registers the shipped `email.header.name` recognizer in `core.toml` with locale-aware `{locale_email_headers}` template lowering and `capture_groups = [1, 2]`.
- Hardens `gaze-assembly` template lowering so regex quantifiers like `{0,3}` are preserved and locale-header alternation is non-capturing, keeping capture-group numbering stable.
- Adds Markus adopter acceptance tests: `t21a`, `t21c`, `t21e_email_header_de_locale` with restore round-trip, and deterministic `t21f_prompt_preamble_threshold_03`.
- Updates v0.4.1 CHANGELOG notes for the shipped header recognizer, GH #24 closure, threshold knob, and template-lowering fix.

North-star axis impact: Reliability improves for known email-header and prompt-preamble leak paths; reversibility is covered by restore round-trip assertions; trust stays deterministic via rulepack template lowering and typed fail-closed template errors; adopter ergonomics improves through bundled defaults and documented threshold behavior.

## Acceptance Tests

- `t21a_email_header_does_not_fire_on_inline_titlecase`
- `t21c_email_header_rejects_body_from_without_bracket`
- `t21e_email_header_de_locale`
- `t21f_prompt_preamble_threshold_03`
- Existing P1 gates still pass, including `t21g_pattern_template_uses_active_locale_de_when_en_loaded_after_de`, `t21h_pattern_template_falls_back_to_global_when_locale_not_loaded`, and `t_cli_ner_threshold_out_of_range_fails_closed`.

## Verification

```text
cargo test --workspace
PASS

cargo fmt --check
PASS

cargo clippy --workspace -- -D warnings
PASS

cargo run -p xtask -- symmetric-potemkin
PASS: symmetric_potemkin_gate: passed
```

## P2 Grep Gates

```text
--- email.header.name ---
crates/gaze-recognizers/src/lib.rs:33:        assert_eq!(rulepack.recognizers[1].id, "email.header.name");
crates/gaze-assembly/src/lib.rs:579:            "email.header.name",
crates/gaze-assembly/src/lib.rs:596:            "email.header.name",
crates/gaze-recognizers/embedded/core.toml:48:id = "email.header.name"

--- NER scores + threshold ---
docs/policy.md:201:threshold = 0.3
docs/policy.md:208:| `threshold` | float  | no       | Confidence floor in the inclusive range `0.0..=1.0`. Defaults to `0.3`. `gaze clean --ner-threshold=<float>` overrides this value for one invocation. |
crates/gaze-assembly/src/lib.rs:212:                    threshold: ner_threshold.unwrap_or(ner.threshold),
crates/gaze-cli/src/main.rs:439:fn validate_ner_threshold(threshold: f32) -> std::result::Result<f32, PolicyError> {
crates/gaze/src/policy.rs:461:    let threshold = raw.threshold.unwrap_or(DEFAULT_NER_THRESHOLD);
crates/gaze-recognizers/src/ner.rs:112:pub struct NerSpanResult {
crates/gaze-recognizers/src/ner.rs:455:                .filter(|span| span.score >= self.detector.threshold)
crates/gaze-recognizers/src/ner.rs:460:                    score: span.score,
crates/gaze-recognizers/src/ner.rs:1186:    fn t21f_prompt_preamble_threshold_03() {

--- capture_groups ---
crates/gaze-recognizers/embedded/core.toml:56:capture_groups = [1, 2]
crates/gaze-recognizers/src/regex.rs:47:    capture_groups: Option<Vec<u32>>,
crates/gaze-recognizers/src/regex.rs:188:        if let Some(groups) = &self.capture_groups {
crates/gaze-assembly/src/lib.rs:97:                capture_groups,
crates/gaze-assembly/src/lib.rs:128:                    capture_groups,
crates/gaze/src/rulepack.rs:44:        capture_groups: Option<Vec<u32>>,

--- docs/changelog ---
docs/policy.md:201:threshold = 0.3
docs/policy.md:348:The `--ner-threshold=<float>` CLI flag overrides `[ner].threshold` for one
CHANGELOG.md:17:- Core `email.header.name` recognizer for RFC822-style header display names, including German `Von:` / `An:` forms.
CHANGELOG.md:26:- Markus adopter dogfood gap closed: locale-aware email-header recognizer (`Von:` / `An:` plus English defaults) tokenizes header display names and restores them round-trip. See GH #24.
CHANGELOG.md:27:- `[ner] threshold` knob un-deferred from v0.4.2 so adopters can tune the NER confidence floor for prompt-preamble PII.
```

## Notes

An extra `[agent] P2: apply cargo fmt` commit follows the four requested phase commits because `cargo fmt --check` found formatting-only drift after the phase commits. No behavior changed in that commit.
