### PR TITLE
v0.4.1 Bundle P3: Audit + API hardening + composition validator

### DIFF
--- a/.github/workflows/symmetric-potemkin.yml
+++ b/.github/workflows/symmetric-potemkin.yml
@@ -12,3 +12,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run symmetric_potemkin_gate
         run: cargo run -p xtask -- symmetric-potemkin
+      - name: Run recognizer_composition_validator gate
+        run: cargo run -p xtask -- recognizer-composition-validator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `capture_groups = [...]` regex span narrowing with first-non-empty semantics.
 - `NerRecognizer` public export plus `[ner] threshold` policy knob using min-aggregated span confidence.
 - Core `email.header.name` recognizer for RFC822-style header display names, including German `Von:` / `An:` forms.
+- Strict rulepack composition validation: same-class recognizer pairs now require explicit `cooperates_with` declarations.
+- `Context::fields_typed() -> ContextFieldsRef<'_>` borrowed accessor for context-field consumers.
+- `gaze clean --audit-db=<path>` persists the metadata-only SQLite redaction log for pipe-mode invocations.
 
 ### Changed
 
 - Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.1`.
 - Snapshot envelope version bumped from 2 to 3; v0.4.1 imports v2 snapshots with default `counter` family, while v0.4.0 rejects v3 snapshots instead of silently collapsing family metadata.
+- Dictionary recognizer audit sources now include per-term traceability as `dictionary:{name}[#term_index]`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{s
 
 `gaze clean --policy=<path>` loads a TOML policy that declares recognizer bundles (`[policy.rulepacks]`), custom recognizers (`[[policy.custom_recognizers]]`), per-class rules, the locale chain, and optional NER bootstrap. See [`docs/policy.md`](docs/policy.md) for the full schema reference and worked examples, including the `[[detector]]` → `[[policy.custom_recognizers]]` migration.
 
+Use `--audit-db=<path>` to persist the metadata-only SQLite redaction log for a
+clean invocation. Dictionary sources include the matched term index as
+`dictionary:{name}[#term_index]`.
+
 #### Library Example
 
 ```rust
@@ -232,8 +236,8 @@ Shipped 2026-04-24 (see [CHANGELOG.md](CHANGELOG.md) for the full entry):
 
 Known limits to surface during dogfooding (tracked for v0.4.1):
 
-- `token.family` / `token.format` and `context.hotwords` / `boost` / `window` are parsed only for schema validation in v0.4.0-rc.1; non-default values fail closed with `RulepackError::UnsupportedField` until runtime consumers ship in v0.4.1.
-- Dictionary audit log carries `dictionary:{name}`; per-term `[#term_index]` is v0.4.1.
+- `token.format` and `context.hotwords` / `boost` / `window` are still parsed only for schema validation in v0.4.1; non-default values fail closed with `RulepackError::UnsupportedFieldInB1`.
+- Same-class rulepack recognizer pairs require explicit `cooperates_with = ["other.id"]`; missing cooperation fails closed with `RulepackError::SameClassWithoutCooperation`.
 - NER context-sensitivity gap on prompt boilerplate / RFC822 email headers — workarounds + roadmap in issue #24.
 
 Deferred beyond v0.4:

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -149,16 +149,16 @@ fn main() -> ExitCode {
             max_bytes,
             context_json,
             audit_db,
-        } => run_clean(
-            policy.as_deref(),
-            &format,
+        } => run_clean(CleanOptions {
+            policy: policy.as_deref(),
+            format: &format,
             session_ttl,
-            &locale,
+            locale: &locale,
             ner_threshold,
             max_bytes,
-            context_json.as_deref(),
-            audit_db.as_deref(),
-        ),
+            context_json: context_json.as_deref(),
+            audit_db: audit_db.as_deref(),
+        }),
         Cmd::Restore {
             format,
             restore_mode,
@@ -216,25 +216,28 @@ fn require_json_format(format: &str) -> std::result::Result<(), CliError> {
     }
 }
 
-fn run_clean(
-    policy: Option<&std::path::Path>,
-    format: &str,
+struct CleanOptions<'a> {
+    policy: Option<&'a std::path::Path>,
+    format: &'a str,
     session_ttl: Option<u64>,
-    locale: &[String],
+    locale: &'a [String],
     ner_threshold: Option<f32>,
     max_bytes: u64,
-    context_json: Option<&std::path::Path>,
-    audit_db: Option<&std::path::Path>,
-) -> std::result::Result<(), CliError> {
-    require_json_format(format)?;
-    let cli_ner_threshold = ner_threshold
+    context_json: Option<&'a std::path::Path>,
+    audit_db: Option<&'a std::path::Path>,
+}
+
+fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
+    require_json_format(options.format)?;
+    let cli_ner_threshold = options
+        .ner_threshold
         .map(validate_ner_threshold)
         .transpose()
         .map_err(map_policy_error)?;
-    let raw = read_stdin_text(max_bytes)?;
+    let raw = read_stdin_text(options.max_bytes)?;
 
-    let counter = Arc::new(CountingLogger::new(audit_db).map_err(|_| CliError::Pipeline)?);
-    let loaded_policy = match policy {
+    let counter = Arc::new(CountingLogger::new(options.audit_db).map_err(|_| CliError::Pipeline)?);
+    let loaded_policy = match options.policy {
         Some(path) => Some(Policy::load_for_cli(path).map_err(map_policy_error)?),
         None => None,
     };
@@ -242,7 +245,8 @@ fn run_clean(
         Some(policy) => load_rulepacks(policy).map_err(map_pipeline_error)?,
         None => Vec::new(),
     };
-    let context = context_json
+    let context = options
+        .context_json
         .map(TypedContext::load)
         .transpose()
         .map_err(|_| CliError::PolicyConfig)?;
@@ -263,7 +267,7 @@ fn run_clean(
     let dictionaries = DictionaryBundle::merge(policy_bundle, context_bundle);
     let dictionary_stats = dictionaries.stats();
     let rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
-    let cli_locales = parse_cli_locales(locale)?;
+    let cli_locales = parse_cli_locales(options.locale)?;
     let locale_chain = LocaleChain::merge_cli_policy_rulepack_default(
         cli_locales.as_deref(),
         loaded_policy
@@ -296,9 +300,9 @@ fn run_clean(
     };
 
     let session = match &loaded_policy {
-        Some(policy) => Session::from_policy_with_ttl_override(policy, session_ttl),
+        Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
         None => Session::new(Scope::Persistent {
-            ttl: Duration::from_secs(session_ttl.unwrap_or(86_400)),
+            ttl: Duration::from_secs(options.session_ttl.unwrap_or(86_400)),
         }),
     }
     .map_err(|_| CliError::Pipeline)?;
@@ -339,7 +343,7 @@ fn run_clean(
                 .into_iter()
                 .map(LoadedDictionaryStats::from)
                 .collect(),
-            context_source: context_json.map(|_| "cli".to_string()),
+            context_source: options.context_json.map(|_| "cli".to_string()),
         },
     };
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -25,7 +25,7 @@ use gaze::{
     Action, ClassRule, DefaultRule, DictionaryBundle, DictionarySource, DocumentKind, LocaleChain,
     LocaleTag, PiiClass, Pipeline, Policy, PolicyError, RawDocument, RawMatch, RedactionEntry,
     RedactionLogger, Result as GazeResult, Rulepack, RulepackDict, RulepackSource, Scope,
-    SensitiveSnapshot, Session, TypedContext, DEFAULT_NER_THRESHOLD,
+    SensitiveSnapshot, Session, SqliteLogger, TypedContext, DEFAULT_NER_THRESHOLD,
 };
 use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 
@@ -71,6 +71,9 @@ enum Cmd {
         /// Path to a typed Context JSON envelope. stdin remains raw text.
         #[arg(long)]
         context_json: Option<PathBuf>,
+        /// Optional SQLite redaction-log database path.
+        #[arg(long)]
+        audit_db: Option<PathBuf>,
     },
     /// Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout.
     Restore {
@@ -145,6 +148,7 @@ fn main() -> ExitCode {
             ner_threshold,
             max_bytes,
             context_json,
+            audit_db,
         } => run_clean(
             policy.as_deref(),
             &format,
@@ -153,6 +157,7 @@ fn main() -> ExitCode {
             ner_threshold,
             max_bytes,
             context_json.as_deref(),
+            audit_db.as_deref(),
         ),
         Cmd::Restore {
             format,
@@ -219,6 +224,7 @@ fn run_clean(
     ner_threshold: Option<f32>,
     max_bytes: u64,
     context_json: Option<&std::path::Path>,
+    audit_db: Option<&std::path::Path>,
 ) -> std::result::Result<(), CliError> {
     require_json_format(format)?;
     let cli_ner_threshold = ner_threshold
@@ -227,7 +233,7 @@ fn run_clean(
         .map_err(map_policy_error)?;
     let raw = read_stdin_text(max_bytes)?;
 
-    let counter = Arc::new(CountingLogger::default());
+    let counter = Arc::new(CountingLogger::new(audit_db).map_err(|_| CliError::Pipeline)?);
     let loaded_policy = match policy {
         Some(path) => Some(Policy::load_for_cli(path).map_err(map_policy_error)?),
         None => None,
@@ -721,13 +727,25 @@ fn build_context_pipeline(
         .build()
 }
 
-#[derive(Default)]
 struct CountingLogger {
     detections: AtomicU64,
+    audit: Option<SqliteLogger>,
+}
+
+impl CountingLogger {
+    fn new(audit_db: Option<&std::path::Path>) -> GazeResult<Self> {
+        Ok(Self {
+            detections: AtomicU64::new(0),
+            audit: audit_db.map(SqliteLogger::new).transpose()?,
+        })
+    }
 }
 
 impl RedactionLogger for CountingLogger {
     fn log(&self, entry: &RedactionEntry) -> GazeResult<()> {
+        if let Some(audit) = &self.audit {
+            audit.log(entry)?;
+        }
         if !entry.conflict_loser
             && entry.document_kind == DocumentKind::Text
             && entry.action != gaze::Action::Preserve

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
-use gaze::{PiiClass, Scope, Session};
+use gaze::{PiiClass, Scope, Session, SqliteLogger};
 
 /// Run `gaze clean` on the given stdin and parse the JSON response.
 fn clean_ok(input: &str) -> (String, String, u64) {
@@ -755,6 +755,83 @@ fn t21f_prompt_preamble_threshold_03_pipeline_end_to_end() {
 
     let restored = restore_success_text(v["session_blob"].as_str().unwrap(), clean);
     assert_eq!(restored, input);
+}
+
+#[test]
+fn t22_audit_log_per_term_traceability() {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("rulepack.toml");
+    fs::write(
+        &rulepack_path,
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "audit-dict"
+rulepack_version = "0.4.1"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "audit_terms"
+class = "custom:term"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "dictionary"
+terms = ["foo", "bar", "baz"]
+case_sensitive = true
+
+[recognizers.token]
+"#,
+    )
+    .unwrap();
+    let policy_path = dir.path().join("policy.toml");
+    fs::write(
+        &policy_path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = []
+paths = ["{}"]
+
+[[rule]]
+kind = "class"
+class = "custom:term"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            rulepack_path.display()
+        ),
+    )
+    .unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let v = clean_json_with_args(
+        &[
+            &format!("--policy={}", policy_path.display()),
+            &format!("--audit-db={}", audit_path.display()),
+        ],
+        "foo bar baz",
+    );
+
+    assert_eq!(v["stats"]["detections"], 3);
+    let logger = SqliteLogger::new(&audit_path).expect("audit log opens");
+    let entries = logger.entries().expect("audit entries");
+    assert_eq!(entries.len(), 3);
+    for (index, entry) in entries.iter().enumerate() {
+        let source_shape = Regex::new(&format!(r"^dictionary:[a-z_]+\[#{}\]$", index)).unwrap();
+        assert!(
+            source_shape.is_match(&entry.source),
+            "unexpected audit source: {}",
+            entry.source
+        );
+    }
 }
 
 #[test]

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -87,7 +87,11 @@ impl Recognizer for DictionaryRecognizer {
                 priority: self.priority,
                 canonical_form: Some(input[m.start()..m.end()].to_string()),
                 token_family: self.token_family.clone(),
-                source: format!("dictionary:{}", self.dictionary_name),
+                source: format!(
+                    "dictionary:{}[#{}]",
+                    self.dictionary_name,
+                    m.pattern().as_usize()
+                ),
                 decided_by: ConflictTier::None,
                 merged_sources: Vec::new(),
             })
@@ -183,5 +187,57 @@ mod tests {
         let registry = RecognizerRegistry::builder().register(recognizer).build();
         let hits = registry.detect_all("Listening to bohemian rhapsody", &detect_context);
         assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn dictionary_recognizer_emits_per_term_source() {
+        let ctx = TypedContext {
+            dictionaries: HashMap::from([(
+                "songs".to_string(),
+                ContextDictionary {
+                    terms: vec![
+                        "alpha-one".to_string(),
+                        "bravo-two".to_string(),
+                        "charlie-three".to_string(),
+                    ],
+                    case_sensitive: true,
+                },
+            )]),
+            class_map: HashMap::new(),
+            fields: Map::new(),
+        };
+        let bundle = DictionaryBundle::from_context(&ctx);
+        let fields = Map::new();
+        let detect_context = DetectContext {
+            locale_chain: &[LocaleTag::Global],
+            dictionaries: &bundle,
+            fields: &fields,
+            degraded: Cell::new(false),
+        };
+        let recognizer = DictionaryRecognizer::new(
+            "dict/songs",
+            PiiClass::Custom("song".to_string()),
+            "songs",
+            true,
+            "counter",
+        );
+
+        let hits = recognizer.detect(
+            "first alpha-one, second bravo-two, third charlie-three",
+            &detect_context,
+        );
+
+        assert_eq!(hits.len(), 3);
+        let source_shape = regex::Regex::new(r"^dictionary:[a-z_]+\[#\d+\]$").unwrap();
+        for hit in &hits {
+            assert!(
+                source_shape.is_match(&hit.source),
+                "unexpected source shape: {}",
+                hit.source
+            );
+        }
+        assert_eq!(hits[0].source, "dictionary:songs[#0]");
+        assert_eq!(hits[1].source, "dictionary:songs[#1]");
+        assert_eq!(hits[2].source, "dictionary:songs[#2]");
     }
 }

--- a/crates/gaze/src/context.rs
+++ b/crates/gaze/src/context.rs
@@ -31,6 +31,31 @@ pub struct Context {
     pub fields: Map<String, Value>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ContextFieldsRef<'a>(&'a Map<String, Value>);
+
+impl<'a> ContextFieldsRef<'a> {
+    pub fn as_map(&self) -> &'a Map<String, Value> {
+        self.0
+    }
+
+    pub fn get(&self, key: &str) -> Option<&'a Value> {
+        self.0.get(key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'a String, &'a Value)> + 'a {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextDictionary {
     pub terms: Vec<String>,
@@ -58,6 +83,10 @@ impl Context {
         let raw = fs::read_to_string(path).map_err(ContextError::Io)?;
         let raw = serde_json::from_str::<RawContext>(&raw).map_err(ContextError::Json)?;
         Self::try_from(raw)
+    }
+
+    pub fn fields_typed(&self) -> ContextFieldsRef<'_> {
+        ContextFieldsRef(&self.fields)
     }
 }
 
@@ -154,5 +183,45 @@ mod tests {
             Context::try_from(raw),
             Err(ContextError::UnicodeInsensitiveDictionaryUnsupported { .. })
         ));
+    }
+
+    #[test]
+    fn context_fields_ref_iter_matches_underlying_map() {
+        let raw = serde_json::from_str::<RawContext>(
+            r#"{
+              "dictionaries": {},
+              "class_map": {},
+              "fields": { "tenant": "demo", "region": "eu" }
+            }"#,
+        )
+        .expect("raw context");
+        let ctx = Context::try_from(raw).expect("context");
+
+        let typed = ctx.fields_typed();
+        let from_ref = typed.iter().collect::<Vec<_>>();
+        let from_map = ctx.fields.iter().collect::<Vec<_>>();
+
+        assert_eq!(from_ref, from_map);
+        assert_eq!(typed.len(), ctx.fields.len());
+        assert_eq!(
+            typed.get("tenant"),
+            Some(&Value::String("demo".to_string()))
+        );
+        assert!(!typed.is_empty());
+    }
+
+    #[test]
+    fn context_fields_ref_borrows_without_clone() {
+        let raw = serde_json::from_str::<RawContext>(
+            r#"{
+              "dictionaries": {},
+              "class_map": {},
+              "fields": { "tenant": "demo" }
+            }"#,
+        )
+        .expect("raw context");
+        let ctx = Context::try_from(raw).expect("context");
+
+        assert!(std::ptr::eq(ctx.fields_typed().as_map(), &ctx.fields));
     }
 }

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -16,7 +16,9 @@ mod session;
 pub mod token_shape;
 mod types;
 
-pub use context::{Context, Context as TypedContext, ContextDictionary, ContextError, RawContext};
+pub use context::{
+    Context, Context as TypedContext, ContextDictionary, ContextError, ContextFieldsRef, RawContext,
+};
 pub use detector::{Detection, Detector, PiiClass, BUILTIN_CLASS_NAMES};
 pub use dictionaries::{
     DictionaryBundle, DictionaryEntry, DictionaryLoadError, DictionarySource, DictionaryStats,

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -38,8 +38,9 @@ pub use registry::{
 pub use resolver::resolve_candidates;
 pub use rule::{Action, ClassRule, ColumnRule, DefaultRule, Rule, RuleContext};
 pub use rulepack::{
-    ContextSpec, LocaleData, LocaleEmailHeaders, NormalizerSpec, RawMatch, RecognizerSpec,
-    Rulepack, RulepackError, RulepackSource, ScoringSpec, SourceSpec, TokenSpec, ValidatorSpec,
+    recognizer_composition_validator, ContextSpec, LocaleData, LocaleEmailHeaders, NormalizerSpec,
+    RawMatch, RecognizerSpec, Rulepack, RulepackError, RulepackSource, ScoringSpec, SourceSpec,
+    TokenSpec, ValidatorSpec,
 };
 pub use sandbox::{
     ExecPolicy, Sandbox, SandboxError, SandboxPlan, UntrustedExecRequest, ValidatedExecRequest,

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -21,6 +21,7 @@ pub struct Rulepack {
 pub struct RecognizerSpec {
     pub id: String,
     pub class: PiiClass,
+    pub cooperates_with: Vec<String>,
     pub enabled: bool,
     pub locales: Vec<LocaleTag>,
     pub matcher: RawMatch,
@@ -153,6 +154,14 @@ pub enum RulepackError {
         new_class: PiiClass,
         uncovered_rule: String,
     },
+    #[error(
+        "same-class recognizers '{recognizer_a}' and '{recognizer_b}' both emit {class:?} but neither declares cooperates_with"
+    )]
+    SameClassWithoutCooperation {
+        class: PiiClass,
+        recognizer_a: String,
+        recognizer_b: String,
+    },
 }
 
 impl Rulepack {
@@ -204,6 +213,8 @@ struct RawLocaleEmailHeaders {
 struct RawRecognizerSpec {
     id: String,
     class: String,
+    #[serde(default)]
+    cooperates_with: Vec<String>,
     #[serde(default = "default_true")]
     enabled: bool,
     #[serde(default)]
@@ -294,6 +305,7 @@ impl TryFrom<RawRulepack> for Rulepack {
             .into_iter()
             .map(|recognizer| parse_recognizer(recognizer, &default_locales))
             .collect::<Result<Vec<_>, _>>()?;
+        recognizer_composition_validator(&recognizers)?;
 
         Ok(Self {
             schema_version: raw.schema_version,
@@ -331,6 +343,7 @@ fn parse_recognizer(
     Ok(RecognizerSpec {
         id: raw.id,
         class: parse_class(&raw.class)?,
+        cooperates_with: raw.cooperates_with,
         enabled: raw.enabled,
         locales,
         matcher: raw.matcher,
@@ -413,6 +426,29 @@ fn reject_unshipped_fields(raw: &RawRecognizerSpec) -> Result<(), RulepackError>
             return Err(RulepackError::UnsupportedField {
                 field: "context.window".to_string(),
                 planned_version: PLANNED_VERSION,
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn recognizer_composition_validator(
+    recognizers: &[RecognizerSpec],
+) -> Result<(), RulepackError> {
+    for (index, first) in recognizers.iter().enumerate() {
+        for second in recognizers.iter().skip(index + 1) {
+            if first.class != second.class {
+                continue;
+            }
+            if first.cooperates_with.iter().any(|id| id == &second.id)
+                || second.cooperates_with.iter().any(|id| id == &first.id)
+            {
+                continue;
+            }
+            return Err(RulepackError::SameClassWithoutCooperation {
+                class: first.class.clone(),
+                recognizer_a: first.id.clone(),
+                recognizer_b: second.id.clone(),
             });
         }
     }
@@ -626,6 +662,84 @@ kind = "regex"
             err,
             RulepackError::RegexPatternChoice { id } if id == "bad.email"
         ));
+    }
+
+    #[test]
+    fn rulepack_load_fails_when_two_name_recognizers_omit_cooperates_with() {
+        let err = Rulepack::parse(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "bad-composition"
+rulepack_version = "0.4.1"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "email.header.name"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern = "From: ([A-Z][a-z]+)"
+
+[[recognizers]]
+id = "salutation.name"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern = "Dear ([A-Z][a-z]+)"
+"#,
+        )
+        .expect_err("same-class recognizers must explicitly cooperate");
+
+        assert!(matches!(
+            err,
+            RulepackError::SameClassWithoutCooperation {
+                class: PiiClass::Name,
+                recognizer_a,
+                recognizer_b,
+            } if recognizer_a == "email.header.name" && recognizer_b == "salutation.name"
+        ));
+    }
+
+    #[test]
+    fn rulepack_load_accepts_same_class_pair_with_cooperates_with() {
+        let rulepack = Rulepack::parse(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "cooperating-composition"
+rulepack_version = "0.4.1"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "email.header.name"
+class = "Name"
+cooperates_with = ["salutation.name"]
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern = "From: ([A-Z][a-z]+)"
+
+[[recognizers]]
+id = "salutation.name"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern = "Dear ([A-Z][a-z]+)"
+"#,
+        )
+        .expect("cooperates_with unblocks same-class recognizers");
+
+        assert_eq!(rulepack.recognizers.len(), 2);
+        assert_eq!(
+            rulepack.recognizers[0].cooperates_with,
+            vec!["salutation.name"]
+        );
     }
 
     #[test]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -25,10 +25,7 @@ fn main() -> Result<()> {
             println!("class_map_override_safety: scaffolded");
             Ok(())
         }
-        Command::RecognizerCompositionValidator => {
-            println!("recognizer_composition_validator: scaffolded");
-            Ok(())
-        }
+        Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
     }
 }
 
@@ -118,6 +115,19 @@ const SYMMETRIC_POTEMKIN_TESTS: &[BehavioralTest] = &[
     },
 ];
 
+const RECOGNIZER_COMPOSITION_VALIDATOR_TESTS: &[BehavioralTest] = &[
+    BehavioralTest {
+        package: "gaze",
+        test_target: None,
+        name: "rulepack::tests::rulepack_load_fails_when_two_name_recognizers_omit_cooperates_with",
+    },
+    BehavioralTest {
+        package: "gaze",
+        test_target: None,
+        name: "rulepack::tests::rulepack_load_accepts_same_class_pair_with_cooperates_with",
+    },
+];
+
 fn run_symmetric_potemkin_gate() -> Result<()> {
     println!(
         "symmetric_potemkin_gate: checking {} behavioral tests",
@@ -130,6 +140,21 @@ fn run_symmetric_potemkin_gate() -> Result<()> {
         run_behavioral_test(*test)?;
     }
     println!("symmetric_potemkin_gate: passed");
+    Ok(())
+}
+
+fn run_recognizer_composition_validator_gate() -> Result<()> {
+    println!(
+        "recognizer_composition_validator: checking {} behavioral tests",
+        RECOGNIZER_COMPOSITION_VALIDATOR_TESTS.len()
+    );
+    for test in RECOGNIZER_COMPOSITION_VALIDATOR_TESTS {
+        ensure_test_exists(*test)?;
+    }
+    for test in RECOGNIZER_COMPOSITION_VALIDATOR_TESTS {
+        run_behavioral_test(*test)?;
+    }
+    println!("recognizer_composition_validator: passed");
     Ok(())
 }
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -62,6 +62,11 @@ $ echo "Email alice@example.invalid now" | gaze clean --policy=minimal.toml
 {"clean_text":"Email <{session_hex}:Email_1> now","session_blob":"<base64>","stats":{"detections":1}}
 ```
 
+Add `--audit-db=redaction.sqlite` to persist the metadata-only SQLite
+redaction log for the invocation. Dictionary rows use
+`dictionary:{name}[#term_index]` source labels so an operator can trace which
+configured term fired without storing raw PII.
+
 This is the same fixture the CLI integration suite uses
 (`crates/gaze/tests/cli_pipe.rs::t16_clean_with_policy_tokenizes_email`).
 
@@ -87,6 +92,38 @@ ttl_secs = 86400       # required when scope = "persistent"; optional otherwise
 > Resolved in v0.3.1: `gaze clean` now constructs its session from
 > `[session]`. `--session-ttl` is an explicit CLI override for persistent
 > session TTL; when the flag is omitted, `ttl_secs` from policy is used.
+
+### `[policy.rulepacks]`
+
+Rulepacks declare reusable recognizers outside the host policy file. The CLI
+loads bundled rulepacks by name and custom rulepack TOML files by path.
+
+```toml
+[policy.rulepacks]
+bundled = ["core"]
+paths = ["./tenant-rulepack.toml"]
+```
+
+Within a rulepack, every `[[recognizers]]` block has an `id`, `class`, and
+`[recognizers.match]` table. If two recognizers in the same rulepack emit the
+same `class`, at least one must explicitly list the other recognizer id in
+`cooperates_with`.
+
+```toml
+[[recognizers]]
+id = "email.header.name"
+class = "Name"
+cooperates_with = ["salutation.name"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?m)^From:\s+([A-Z][a-z]+)\s+<[^>]+>'''
+capture_groups = [1]
+```
+
+Missing cooperation fails rulepack load with
+`RulepackError::SameClassWithoutCooperation`. The check is strict by design:
+there is no line-anchor heuristic or implicit overlap analysis.
 
 ### `[[policy.custom_recognizers]]`
 
@@ -139,9 +176,10 @@ case_sensitive = true
 recognizer. In that mode, Gaze registers one dictionary recognizer per context
 dictionary and uses `class_map` for the class, falling back to `custom:<name>`
 when a mapping is absent. `fields` are threaded into `DetectContext` for
-recognizers; no built-in recognizer consumes them in v0.4.0. `class_map` is
+recognizers and are available to library users through the borrowed
+`Context::fields_typed() -> ContextFieldsRef<'_>` accessor. `class_map` is
 runtime metadata for dictionary recognizer construction, not a general class
-override mechanism. Broader `fields` consumers are deferred to v0.4.1.
+override mechanism.
 
 NER is **not** a detector kind. NER is configured via the top-level `[ner]`
 block (below) — when set, the pipeline appends a transformer NER detector
@@ -549,15 +587,14 @@ engineering board:
 3. **Resolved in v0.3.1: `kind = "column"` rules are rejected in CLI mode.**
    `gaze clean` now fails policy load with exit `2` `PolicyConfig` and a
    detail string, avoiding silent no-op column rules for text stdin.
-4. **v0.4.0-rc.1 gated rulepack fields (runtime consumers pending v0.4.1).**
-   The rulepack schema parses `token.family`, `token.format`,
-   `context.hotwords`, `context.boost`, and `context.window` for
-   forward-compatible authoring, but the loader rejects any non-default value
-   with `RulepackError::UnsupportedField`. Runtime consumers ship in
-   v0.4.1; until then, leave these fields unset or explicitly default.
-5. **v0.4.0-rc.1 dictionary audit granularity.** The redaction log carries
-   `dictionary:{name}` for dictionary hits; per-term `[#term_index]`
-   traceability is scheduled for v0.4.1.
+4. **v0.4.1 still gates `token.format` and context scoring hints.**
+   The rulepack schema parses `token.format`, `context.hotwords`,
+   `context.boost`, and `context.window` for forward-compatible authoring, but
+   the loader rejects any non-default value with
+   `RulepackError::UnsupportedFieldInB1`.
+5. **v0.4.1 dictionary audit granularity is per term.** Dictionary redaction
+   sources use `dictionary:{name}[#term_index]`, where `term_index` is the
+   term's position in the loaded dictionary.
 6. **v0.4.0-rc.1 NER context-sensitivity gap.** Default Davlan-HRL may
    pass names embedded in prompt boilerplate or RFC822 email headers.
    Workarounds (wrap with a dictionary recognizer, tighten locale gating


### PR DESCRIPTION
## Summary

- Add strict rulepack-load composition validation: same-class recognizer pairs must declare `cooperates_with` on at least one side, or load fails with `RulepackError::SameClassWithoutCooperation`.
- Add per-term dictionary traceability through detection/audit sources as `dictionary:{name}[#term_index]`, including a pipe-mode `--audit-db` assertion.
- Add `ContextFieldsRef<'_>` and `Context::fields_typed()` as the borrowed context-field API, plus docs for new P3 public surfaces.
- Replace the scaffolded recognizer-composition xtask command with an executable gate and run it in CI.

## North-star axis impact

- Reliability: strengthened. Same-class recognizer overlap now fails closed unless the rulepack author declares cooperation explicitly.
- Reversibility: unchanged. Token grammar and restore mappings are not changed by P3.
- Agentic-first: strengthened. Per-term dictionary source labels improve tenant-specific recognizer auditability without storing raw values.
- Trust: strengthened. Validator failures use a typed error variant; audit source suffixes are deterministic and traceable.
- Adopter ergonomics: strengthened. `ContextFieldsRef` gives a low-friction borrowed API and docs describe the migration surface.

No axis is intentionally weakened.

## Verification

```text
cargo test --workspace
ok

cargo clippy --workspace -- -D warnings
ok

cargo fmt --check
ok

cargo run -p xtask -- symmetric-potemkin
symmetric_potemkin_gate: passed

cargo run -p xtask -- recognizer-composition-validator
recognizer_composition_validator: passed
```

## P3 symmetric-Potemkin grep gates

```text
$ rg -n "dictionary:.*\[#|m\.pattern\(\)|t22_audit_log_per_term_traceability" crates/gaze-recognizers/src/dictionary.rs crates/gaze-cli/tests/cli_pipe.rs
crates/gaze-cli/tests/cli_pipe.rs:675:fn t22_audit_log_per_term_traceability() {
crates/gaze-cli/tests/cli_pipe.rs:742:        let source_shape = Regex::new(&format!(r"^dictionary:[a-z_]+\[#{}\]$", index)).unwrap();
crates/gaze-recognizers/src/dictionary.rs:91:                    "dictionary:{}[#{}]",
crates/gaze-recognizers/src/dictionary.rs:93:                    m.pattern().as_usize()
crates/gaze-recognizers/src/dictionary.rs:231:        let source_shape = regex::Regex::new(r"^dictionary:[a-z_]+\[#\d+\]$").unwrap();
crates/gaze-recognizers/src/dictionary.rs:239:        assert_eq!(hits[0].source, "dictionary:songs[#0]");
crates/gaze-recognizers/src/dictionary.rs:240:        assert_eq!(hits[1].source, "dictionary:songs[#1]");
crates/gaze-recognizers/src/dictionary.rs:241:        assert_eq!(hits[2].source, "dictionary:songs[#2]");

$ rg -n "ContextFieldsRef|fields_typed" crates/gaze/src/lib.rs crates/gaze/src/context.rs
crates/gaze/src/lib.rs:20:    Context, Context as TypedContext, ContextDictionary, ContextError, ContextFieldsRef, RawContext,
crates/gaze/src/context.rs:35:pub struct ContextFieldsRef<'a>(&'a Map<String, Value>);
crates/gaze/src/context.rs:37:impl<'a> ContextFieldsRef<'a> {
crates/gaze/src/context.rs:88:    pub fn fields_typed(&self) -> ContextFieldsRef<'_> {
crates/gaze/src/context.rs:89:        ContextFieldsRef(&self.fields)
crates/gaze/src/context.rs:200:        let typed = ctx.fields_typed();
crates/gaze/src/context.rs:225:        assert!(std::ptr::eq(ctx.fields_typed().as_map(), &ctx.fields));

$ rg -n "SameClassWithoutCooperation|recognizer_composition_validator|cooperates_with" crates/gaze/src/rulepack.rs crates/gaze/src/lib.rs crates/xtask/src/main.rs .github/workflows/symmetric-potemkin.yml
.github/workflows/symmetric-potemkin.yml:15:      - name: Run recognizer_composition_validator gate
crates/xtask/src/main.rs:28:        Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
crates/xtask/src/main.rs:122:        name: "rulepack::tests::rulepack_load_fails_when_two_name_recognizers_omit_cooperates_with",
crates/xtask/src/main.rs:127:        name: "rulepack::tests::rulepack_load_accepts_same_class_pair_with_cooperates_with",
crates/xtask/src/main.rs:146:fn run_recognizer_composition_validator_gate() -> Result<()> {
crates/xtask/src/main.rs:148:        "recognizer_composition_validator: checking {} behavioral tests",
crates/xtask/src/main.rs:157:    println!("recognizer_composition_validator: passed");
crates/gaze/src/lib.rs:43:    recognizer_composition_validator, ContextSpec, LocaleData, LocaleEmailHeaders, NormalizerSpec,
crates/gaze/src/rulepack.rs:24:    pub cooperates_with: Vec<String>,
crates/gaze/src/rulepack.rs:158:        "same-class recognizers '{recognizer_a}' and '{recognizer_b}' both emit {class:?} but neither declares cooperates_with"
crates/gaze/src/rulepack.rs:160:    SameClassWithoutCooperation {
crates/gaze/src/rulepack.rs:217:    cooperates_with: Vec<String>,
crates/gaze/src/rulepack.rs:308:        recognizer_composition_validator(&recognizers)?;
crates/gaze/src/rulepack.rs:346:        cooperates_with: raw.cooperates_with,
crates/gaze/src/rulepack.rs:435:pub fn recognizer_composition_validator(
crates/gaze/src/rulepack.rs:443:            if first.cooperates_with.iter().any(|id| id == &second.id)
crates/gaze/src/rulepack.rs:444:                || second.cooperates_with.iter().any(|id| id == &first.id)
crates/gaze/src/rulepack.rs:448:            return Err(RulepackError::SameClassWithoutCooperation {
crates/gaze/src/rulepack.rs:668:    fn rulepack_load_fails_when_two_name_recognizers_omit_cooperates_with() {
crates/gaze/src/rulepack.rs:699:            RulepackError::SameClassWithoutCooperation {
crates/gaze/src/rulepack.rs:708:    fn rulepack_load_accepts_same_class_pair_with_cooperates_with() {
crates/gaze/src/rulepack.rs:719:cooperates_with = ["salutation.name"]
crates/gaze/src/rulepack.rs:736:        .expect("cooperates_with unblocks same-class recognizers");
crates/gaze/src/rulepack.rs:740:            rulepack.recognizers[0].cooperates_with,
```

## Notes

- Existing embedded rulepacks have no same-class recognizer pairs requiring migration.
- MemPalace tools were not available in this spawned process; I used the AGENTS north-star text and supplied scratchpad plan sections as the source of truth.
