### PR TITLE
docs: workspace crates + per-crate READMEs (#118)

### DIFF
--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -1,0 +1,132 @@
+# gaze-assembly
+
+Policy-to-pipeline assembly for Gaze.
+
+This crate joins the core `gaze` policy model with the built-in recognizers
+from `gaze-recognizers`. It exists to keep the dependency direction clean:
+`gaze` defines the core contracts, `gaze-recognizers` implements shipped
+backends, and `gaze-assembly` wires them together for CLI-style policy
+execution.
+
+Without this crate, either `gaze` would need to depend on
+`gaze-recognizers`, creating an unnecessary backend dependency for every core
+adopter, or every consumer would need to duplicate policy assembly logic.
+
+## Cargo
+
+```toml
+[dependencies]
+gaze = "0.4.1"
+gaze-assembly = "0.4.1"
+gaze-recognizers = "0.4.1"
+serde_json = "1"
+```
+
+Inside the workspace:
+
+```toml
+[dependencies]
+gaze = { path = "../gaze" }
+gaze-assembly = { path = "../gaze-assembly" }
+gaze-recognizers = { path = "../gaze-recognizers" }
+serde_json = "1"
+```
+
+## Public entry points
+
+[`src/lib.rs`](src/lib.rs) exposes:
+
+- `build_pipeline(policy, context, rulepacks, active_locales, ner_threshold)`
+- `BuildError`
+
+`build_pipeline` accepts:
+
+| Argument | Type | Purpose |
+|----------|------|---------|
+| `policy` | `&gaze::Policy` | Parsed policy with detector specs, rule specs, rulepack config, and optional NER config. |
+| `context` | `&gaze::Context` | Runtime dictionaries, class-map overrides, and fields. |
+| `rulepacks` | `&[gaze::Rulepack]` | Loaded bundled or path rulepacks. |
+| `active_locales` | `&gaze::LocaleChain` | Locale chain used to lower locale templates and constrain recognizers. |
+| `ner_threshold` | `Option<f32>` | Caller override for policy NER threshold. |
+
+It returns a fully built `gaze::Pipeline`.
+
+## What it assembles
+
+`build_pipeline` currently wires:
+
+- policy regex detectors into `gaze_recognizers::RegexDetector`
+- policy dictionary detectors into `gaze_recognizers::DictionaryRecognizer`
+- rulepack regex recognizers, including locale pattern-template lowering
+- rulepack dictionary recognizers
+- context-only dictionaries that are not already registered by policy or
+  rulepack recognizers
+- policy `RuleSpec` values into `ClassRule`, `ColumnRule`, and `DefaultRule`
+- optional NER model loading through `gaze_recognizers::NerRecognizer`
+
+The function fails closed with `BuildError` when policy, rulepack, recognizer,
+or pipeline construction fails.
+
+## Minimal flow
+
+```rust
+use std::collections::HashMap;
+
+use gaze::{Context, LocaleChain, Policy, Rulepack};
+
+let policy: Policy = Policy::load_for_cli(policy_path)?;
+let context = Context {
+    dictionaries: HashMap::new(),
+    class_map: HashMap::new(),
+    fields: serde_json::Map::new(),
+};
+let rulepacks: Vec<Rulepack> = Vec::new();
+let active_locales = LocaleChain::merge_policy_and_cli(None, None);
+
+let pipeline = gaze_assembly::build_pipeline(
+    &policy,
+    &context,
+    &rulepacks,
+    &active_locales,
+    None,
+)?;
+```
+
+Consumers that need CLI-equivalent behavior must still load bundled/path
+rulepacks, build `DictionaryBundle` values, resolve locale precedence, and
+choose a session. See `crates/gaze-cli/src/main.rs` for that process-boundary
+work.
+
+## Class-map safety
+
+Context `class_map` entries may override a dictionary recognizer's class. The
+assembly layer only accepts that override when the resulting class is covered
+by a tokenize-or-stricter rule (`Tokenize`, `Redact`, `FormatPreserve`, or
+`Generalize`). Otherwise assembly fails closed with
+`RulepackError::ClassMapOverrideClash`.
+
+This check belongs here because it depends on the final policy rules and the
+runtime context together.
+
+## Locale template lowering
+
+Rulepack regex recognizers may use supported pattern-template placeholders.
+`gaze-assembly` lowers those placeholders after the active locale chain is
+known. For example, `{locale_email_headers}` lowers from the loaded rulepack
+locale metadata, falling back to the default English header list when no
+loaded locale metadata matches.
+
+Unknown placeholders fail closed with `RulepackError`.
+
+## What belongs here
+
+Put code in this crate when it is assembly glue between:
+
+- `gaze::Policy`
+- `gaze::Context`
+- `gaze::Rulepack`
+- `gaze::LocaleChain`
+- recognizers from `gaze-recognizers`
+
+Do not put core contracts here. Those belong in `gaze`. Do not put backend
+implementation here. Those belong in `gaze-recognizers`.

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -1,0 +1,109 @@
+# gaze-cli
+
+Command-line interface for Gaze.
+
+This crate publishes the `gaze` binary. It is the process boundary used by
+shell integrations and language adapters that should not link the Rust library
+directly.
+
+The CLI reads from stdin, writes JSON to stdout, and emits sanitized structured
+errors to stderr. Panic handling is overridden so dependency panics do not dump
+raw input or backtraces into caller logs.
+
+## Cargo
+
+Build from the workspace root:
+
+```console
+$ cargo build -p gaze-cli
+```
+
+Run from the workspace root:
+
+```console
+$ cargo run -p gaze-cli -- clean --policy policy.toml
+```
+
+The installed binary name is `gaze`.
+
+## Subcommands
+
+Current subcommands in [`src/main.rs`](src/main.rs):
+
+| Subcommand | Purpose |
+|------------|---------|
+| `clean` | Reads raw UTF-8 text from stdin and emits `{"clean_text","session_blob","stats"}` JSON. |
+| `restore` | Reads `{"session_blob","text"}` JSON from stdin and emits restored `{"text"}` JSON, plus `restore_warning` when tolerant restore allows an unknown token. |
+
+There is no separate `audit` subcommand in the current binary. Audit logging is
+enabled on `clean` with `--audit-db <path>`.
+
+## `clean`
+
+```console
+$ printf '%s' 'Email alice@example.invalid now' \
+  | gaze clean --policy policy.toml
+```
+
+Flags:
+
+| Flag | Meaning |
+|------|---------|
+| `--policy <path>` | Optional `policy.toml` path. Production integrations should pass one. |
+| `--format <json>` | Output format. Only `json` is accepted. Defaults to `json`. |
+| `--session-ttl <secs>` | Override persistent session TTL from policy. |
+| `--locale <tag[,tag...]>` | Active locale fallback chain, comma separated and priority ordered. |
+| `--ner-threshold <float>` | Override policy `[ner]` threshold. Must be between `0.0` and `1.0` inclusive. |
+| `--max-bytes <bytes>` | Stdin byte cap. Defaults to `10485760`. |
+| `--context-json <path>` | Typed context envelope with dictionaries, class map, and fields. |
+| `--audit-db <path>` | Optional SQLite redaction-log database path for metadata-only audit entries. |
+
+When `--policy` is omitted, the CLI runs a stub email pipeline so the process
+surface can be exercised. Production use should pass `--policy`.
+
+## `restore`
+
+```console
+$ printf '%s' '{"session_blob":"<base64>","text":"Email <token> now"}' \
+  | gaze restore
+```
+
+Flags:
+
+| Flag | Meaning |
+|------|---------|
+| `--format <json>` | Output format. Only `json` is accepted. Defaults to `json`. |
+| `--restore-mode <strict\|tolerant>` | Unknown-token handling. Defaults to `strict`. |
+| `--max-bytes <bytes>` | Stdin byte cap. Defaults to `10485760`. |
+
+`strict` restore fails on unknown tokens. `tolerant` restore preserves unknown
+tokens and returns a warning in the JSON response.
+
+## Exit codes
+
+Exit codes are defined by `CliError` in [`src/error.rs`](src/error.rs).
+
+| Exit | Variants |
+|------|----------|
+| `0` | Success, help, or version output. |
+| `1` | `StdinParse`, `EmptyInput`, `InputTooLarge`, `InvalidEncoding`. |
+| `2` | `PolicyConfig`, including unsupported format, invalid policy, invalid locale, invalid NER threshold, unknown rulepack, or unsupported CLI column rules. |
+| `3` | `UnknownToken`, `InvalidSignature`, `InvalidBlobVersion`, `BlobExpired`, `Pipeline`, and sanitized panic path. |
+| `4` | `Io`, `PolicyOpen`. |
+
+Stderr is JSON with the error variant and exit code, for example:
+
+```json
+{"error":"PolicyConfig","exit":2}
+```
+
+`UnknownToken` includes the unknown token string because the token is already a
+pseudonym emitted by Gaze, not raw PII.
+
+## Policy path
+
+`clean --policy <path>` loads the TOML policy through `gaze::Policy`, loads
+bundled/path rulepacks, resolves locale precedence, builds a pipeline with
+`gaze-assembly`, then exports the session as `session_blob`.
+
+For policy schema details, see [docs/policy.md](../../docs/policy.md).

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -1,0 +1,124 @@
+# gaze-recognizers
+
+Built-in recognizer backends and bundled rulepacks for Gaze.
+
+This crate depends on `gaze` and implements concrete `gaze::Recognizer`
+backends. Keeping it separate lets the core crate expose a small, stable
+contract without forcing every adopter to compile regex, dictionary, ONNX, and
+tokenizer dependencies.
+
+## Cargo
+
+```toml
+[dependencies]
+gaze = "0.4.1"
+gaze-recognizers = "0.4.1"
+```
+
+Inside the workspace:
+
+```toml
+[dependencies]
+gaze = { path = "../gaze" }
+gaze-recognizers = { path = "../gaze-recognizers" }
+```
+
+## Public entry points
+
+The public surface is re-exported from [`src/lib.rs`](src/lib.rs).
+
+| Backend | Public types |
+|---------|--------------|
+| Regex | `RegexDetector`, `NormalizerKind`, `ValidatorKind` |
+| Dictionary | `DictionaryRecognizer` |
+| NER | `NerRecognizer`, `NerDetector`, `NerOptions`, `NerLoadError`, `NerBackendKind`, `LabelMap`, `VerifiedArtifacts` |
+| Rulepacks | `embedded(name)` |
+
+## Regex backend
+
+`RegexDetector` can be constructed directly:
+
+```rust
+use gaze::PiiClass;
+use gaze_recognizers::RegexDetector;
+
+let recognizer = RegexDetector::new(
+    r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b",
+    PiiClass::Email,
+)?;
+```
+
+Use `RegexDetector::emails()` for the built-in email recognizer. Rulepack
+assembly uses `RegexDetector::with_rulepack_fields` so locale tags, scores,
+priorities, token families, capture groups, exclusions, validators, and
+normalizers can flow from TOML rulepacks into the registry.
+
+Current validator and normalizer enums:
+
+- `ValidatorKind::EmailRfc`
+- `NormalizerKind::EmailCanonical`
+
+## Dictionary backend
+
+`DictionaryRecognizer` detects tenant or rulepack dictionaries supplied through
+`gaze::DictionaryBundle` and `gaze::DetectContext`.
+
+Use it for bounded adopter-specific PII such as order IDs, account handles,
+internal project names, song titles, or artist names. The recognizer stores a
+dictionary name and reads the actual terms from runtime context, policy, or
+rulepack assembly.
+
+Use adopter custom recognizers instead when the detector needs external
+services, private model code, or domain-specific scoring that should not ship
+as a built-in backend.
+
+## NER backend
+
+The NER backend is optional at runtime. `NerRecognizer` loads a verified ONNX
+model bundle with `NerOptions`; `NerDetector` is part of the public surface for
+the backend implementation.
+
+Current dependencies include:
+
+- `ort` for ONNX Runtime
+- `tokenizers` for tokenizer execution
+- `ndarray` for model tensors
+
+The expected production model family is Davlan mBERT NER, configured through
+policy `[ner]` and loaded by `gaze-assembly` when `model_dir` is present.
+Loading failures are policy configuration failures in the CLI path.
+
+## Embedded rulepacks
+
+`embedded(name)` returns bundled TOML contents for known rulepack names:
+
+| Name | File | Purpose |
+|------|------|---------|
+| `core` | [`embedded/core.toml`](embedded/core.toml) | Global core recognizers, including email address and email-header name detection. |
+| `locale-de` | [`embedded/locale-de.toml`](embedded/locale-de.toml) | DACH locale metadata such as German email headers. |
+| `locale-en` | [`embedded/locale-en.toml`](embedded/locale-en.toml) | English locale metadata such as English email headers. |
+
+The loader returns `None` for unknown names. Policy/CLI callers should treat
+unknown bundled names as configuration errors.
+
+## Adding recognizers here
+
+Add a recognizer to this crate when it is a built-in backend Gaze should ship
+for many adopters. The recognizer should implement `gaze::Recognizer` and
+provide deterministic metadata:
+
+- stable `id`
+- supported `PiiClass`
+- locale eligibility
+- score and priority
+- token family
+- canonical form when a validator proves one
+- source labels suitable for audit logs
+
+Add adopter-specific recognizers outside this crate when the behavior is tied
+to one tenant, one private schema, or one proprietary data source.
+
+## Test support
+
+The crate has a `test-support` feature for tests that need additional support
+surface without making it part of the default public runtime.

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -1,0 +1,128 @@
+# gaze
+
+Core reversible PII pseudonymization library for Gaze.
+
+This crate owns the contracts that must remain stable for adopters:
+`Pipeline`, `Session`, `Policy`, `RecognizerRegistry`, `LocaleChain`, the
+rulepack schema, token shapes, restore, and audit logging. It deliberately
+does not depend on `gaze-recognizers`; concrete recognizer backends live in a
+separate crate and plug into the core `Recognizer` surface.
+
+## Cargo
+
+```toml
+[dependencies]
+gaze = "0.4.1"
+```
+
+When developing inside the workspace, use the path dependency:
+
+```toml
+[dependencies]
+gaze = { path = "../gaze" }
+```
+
+## Public entry points
+
+The public surface is re-exported from [`src/lib.rs`](src/lib.rs).
+
+| Area | Types |
+|------|-------|
+| Pipeline execution | `Pipeline`, `PipelineBuilder`, `Error`, `Result` |
+| Sessions and restore | `Session`, `Scope`, `SensitiveSnapshot` |
+| Policy model | `Policy`, `PolicyError`, `DetectorSpec`, `DetectorKind`, `RuleSpec`, `RulepackPolicy`, `NerPolicy`, `SessionPolicy`, `SessionScope`, `DEFAULT_NER_THRESHOLD` |
+| Recognizer API | `Recognizer`, `RecognizerRegistry`, `RecognizerRegistryBuilder`, `DetectContext`, `Candidate`, `Validator`, `ValidationResult`, `Canonicalizer` |
+| Locale chain | `LocaleChain`, `LocaleTag`, `LocaleError` |
+| Rulepacks | `Rulepack`, `RulepackSource`, `RulepackError`, `RecognizerSpec`, `RawMatch`, `ContextSpec`, `TokenSpec`, `LocaleData`, `recognizer_composition_validator` |
+| Rules and classes | `PiiClass`, `BUILTIN_CLASS_NAMES`, `Action`, `ClassRule`, `ColumnRule`, `DefaultRule`, `Rule`, `RuleContext` |
+| Documents | `RawDocument`, `CleanDocument`, `Value` |
+| Context dictionaries | `Context`, `TypedContext`, `RawContext`, `ContextDictionary`, `ContextFieldsRef`, `DictionaryBundle`, `DictionaryEntry`, `DictionarySource`, `RulepackDict` |
+| Audit logging | `RedactionLogger`, `RedactionEntry`, `SqliteLogger`, `ConflictTier`, `DocumentKind` |
+| Sandbox contracts | `Sandbox`, `SandboxPlan`, `ExecPolicy`, `UntrustedExecRequest`, `ValidatedExecRequest`, `SandboxError` |
+
+## Minimal library flow
+
+```rust
+use gaze::{Action, ClassRule, PiiClass, Pipeline, RawDocument, Scope, Session};
+use gaze_recognizers::RegexDetector;
+
+let pipeline = Pipeline::builder()
+    .recognizer(RegexDetector::emails()?)
+    .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+    .build()?;
+
+let session = Session::new(Scope::Conversation("example-session".to_string()))?;
+let clean = pipeline.redact(
+    &session,
+    RawDocument::Text("alice@example.invalid".to_string()),
+)?;
+```
+
+The example uses `gaze-recognizers` for a built-in recognizer. The core crate
+only requires an implementation of `gaze::Recognizer` or the legacy
+`gaze::Detector` adapter accepted by `PipelineBuilder::detector`.
+
+## Policy and sessions
+
+`Policy::load_for_cli(path)` parses `policy.toml` with fail-closed validation.
+`Session::from_policy(policy)` and `Session::from_policy_with_ttl_override`
+construct the corresponding `Scope`.
+
+The session owns the reversible mapping between raw values and emitted tokens.
+Use `Session::export()` to create a signed `SensitiveSnapshot`, and
+`Session::import(snapshot)` to restore it later. Ephemeral sessions cannot be
+exported.
+
+## Pipeline execution
+
+Use `Pipeline::builder()` to register recognizers, rules, and optional
+redaction loggers:
+
+```rust
+let pipeline = Pipeline::builder()
+    .recognizer(my_recognizer)
+    .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+    .redaction_logger(my_logger)
+    .build()?;
+```
+
+Execution entry points:
+
+- `Pipeline::redact(session, raw)` uses the default `global` locale chain.
+- `Pipeline::redact_with_context(session, raw, locale_chain)` adds locale
+  selection.
+- `Pipeline::redact_with_detect_context(session, raw, locale_chain,
+  dictionaries, detect_fields)` adds tenant dictionaries and structured
+  context fields.
+
+## LocaleChain
+
+`LocaleChain` resolves recognizer eligibility from ordered locale tags. The
+CLI path merges CLI, policy, rulepack default, and system default in that
+precedence order. See [docs/architecture/locale-chain.md](../../docs/architecture/locale-chain.md).
+
+## RecognizerRegistry
+
+`RecognizerRegistry` runs recognizers through `DetectContext` and resolves
+candidate conflicts before redaction. Implement `Recognizer` directly when a
+backend needs locale eligibility, scores, priorities, token families, or
+context dictionaries. Use `PipelineBuilder::recognizer` for the modern path.
+
+Use `PipelineBuilder::detector` only for simple detector implementations that
+emit `Detection` values without the full recognizer metadata.
+
+## What belongs here
+
+Put code in this crate when it is part of the reversible core contract:
+
+- token grammar and restore
+- session scope and snapshot validation
+- policy parsing and typed policy errors
+- recognizer traits and registry behavior
+- locale matching
+- rulepack schema and validation
+- redaction-log contracts
+- sandbox contracts
+
+Concrete built-in backends belong in `gaze-recognizers`, and policy-to-pipeline
+assembly that imports those backends belongs in `gaze-assembly`.

--- a/crates/xtask/README.md
+++ b/crates/xtask/README.md
@@ -1,0 +1,82 @@
+# xtask
+
+Internal gate runner for the Gaze repository.
+
+This crate is not published (`publish = false`). It gives maintainers and CI a
+stable place to run repository-specific checks that do not belong in the
+library or CLI binaries.
+
+## Run locally
+
+From the workspace root:
+
+```console
+$ cargo run -p xtask -- symmetric-potemkin
+$ cargo run -p xtask -- class-map-override-safety
+$ cargo run -p xtask -- recognizer-composition-validator
+```
+
+Clap converts enum variants to kebab-case command names.
+
+## Gates
+
+| Gate | Command | Behavior |
+|------|---------|----------|
+| `SymmetricPotemkin` | `symmetric-potemkin` | Checks that every named behavioral test in `SYMMETRIC_POTEMKIN_TESTS` exists, then runs each exact test. |
+| `ClassMapOverrideSafety` | `class-map-override-safety` | Scaffolded placeholder. It prints `class_map_override_safety: scaffolded` and exits successfully. |
+| `RecognizerCompositionValidator` | `recognizer-composition-validator` | Checks that every named behavioral test in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS` exists, then runs each exact test. |
+
+The implementation lives in [`src/main.rs`](src/main.rs). The broader gate
+catalog and gate-authoring rules are in
+[docs/architecture/xtask.md](../../docs/architecture/xtask.md).
+
+## CI integration
+
+CI can call gates directly:
+
+```console
+$ cargo run -p xtask -- symmetric-potemkin
+```
+
+Each gate exits non-zero when:
+
+- a protected test cannot be listed
+- a protected test has been renamed or removed
+- a protected test fails
+- the underlying `cargo test` command cannot be started
+
+The current `class-map-override-safety` command is a placeholder and should not
+be treated as proof until it runs named behavioral tests.
+
+## Adding a gate
+
+Every gate must invoke behavioral tests. Do not add a gate that only checks for
+symbols, files, or strings.
+
+The current helper type is:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+struct BehavioralTest {
+    package: &'static str,
+    test_target: Option<&'static str>,
+    name: &'static str,
+}
+```
+
+A new gate should:
+
+1. add a `Command` enum variant
+2. add a `const` slice of `BehavioralTest`
+3. call `ensure_test_exists` for every entry
+4. call `run_behavioral_test` for every entry
+5. print a clear passed line only after all tests pass
+
+For integration tests, set `test_target: Some("target_name")`; for unit tests,
+set `test_target: None`.
+
+## Failure rehearsal
+
+Before merging a new gate, temporarily rename one protected test and run the
+gate. It should fail during the list phase before any passing subset can hide
+the missing behavioral contract. Revert the temporary rename before commit.

--- a/docs/architecture/crates.md
+++ b/docs/architecture/crates.md
@@ -1,0 +1,85 @@
+# Crates
+
+Gaze is a Rust workspace split around the boundary between the reversible
+pseudonymization core, recognizer backends, CLI assembly, and internal tooling.
+The root [`Cargo.toml`](../../Cargo.toml) is the workspace source of truth.
+
+## Workspace map
+
+| Crate | Role | Key types / entry points | Depends on | Depended on by | When to use |
+|-------|------|--------------------------|------------|----------------|-------------|
+| [`gaze`](../../crates/gaze) | Core reversible pseudonymization library. Owns policies, sessions, token restore, locale chains, rulepacks, registries, and redaction logging. | `Pipeline`, `PipelineBuilder`, `Session`, `Policy`, `RecognizerRegistry`, `LocaleChain`, `Rulepack`, `PiiClass`, `Action`, `RawDocument`, `CleanDocument`, `SensitiveSnapshot`. | External crates only. `gaze-recognizers` is a dev-dependency for tests. | `gaze-assembly`, `gaze-recognizers`, `gaze-cli`, `debug-proxy`. | Use from adapters or applications that want to construct pipelines directly and keep control over recognizer registration, session lifetime, restore, and audit behavior. |
+| [`gaze-assembly`](../../crates/gaze-assembly) | Policy-to-pipeline builder. Converts loaded policy, context, rulepacks, active locales, and NER threshold into a core `Pipeline`. | `build_pipeline(policy, context, rulepacks, active_locales, ner_threshold)`, `BuildError`. | `gaze`, `gaze-recognizers`. | `gaze-cli`. | Use when you want the same policy/rulepack assembly path as the CLI without copying CLI code. This crate exists so `gaze` does not depend on built-in recognizers. |
+| [`gaze-recognizers`](../../crates/gaze-recognizers) | Built-in recognizer backends and embedded rulepacks. | `RegexDetector`, `DictionaryRecognizer`, `NerRecognizer`, `NerDetector`, `NerOptions`, `NormalizerKind`, `ValidatorKind`, `embedded(name)`. | `gaze` plus backend dependencies such as `regex`, `aho-corasick`, `ort`, and `tokenizers`. | `gaze-assembly`, `gaze-cli`, `debug-proxy`; `gaze` tests use it as a dev-dependency. | Use when an adopter wants the shipped regex, dictionary, or ONNX NER recognizers instead of implementing `gaze::Recognizer` directly. |
+| [`gaze-cli`](../../crates/gaze-cli) | Published `gaze` binary for pipe-mode integrations. | Binary `gaze`; subcommands `clean` and `restore`; flags such as `--policy`, `--locale`, `--context-json`, `--audit-db`, `--restore-mode`. | `gaze`, `gaze-assembly`, `gaze-recognizers`. | External host adapters and shell integrations. | Use from language adapters or scripts that need a stable process boundary rather than linking Rust. |
+| [`xtask`](../../crates/xtask) | Internal gate runner. Not published. | Binary `xtask`; gates `symmetric-potemkin`, `class-map-override-safety`, `recognizer-composition-validator`. | `anyhow`, `clap`; shells out to `cargo test`. | CI and maintainers. | Use when adding or verifying regression gates that must run real behavioral tests. |
+| [`debug-proxy`](../../crates/debug-proxy) | Internal MCP consumer for debugging MySQL and Laravel-log data through Gaze. | Library modules `adapter`, `cli`, `mcp`, `policy`; binary `debug-proxy` with `init`, `check`, `serve`. | `gaze`, `gaze-recognizers`, `rmcp`, `sqlx`, `tokio`, `toml`. | Operators running the debug MCP server. | Use to expose allowlisted DB/log tools to an MCP client while routing sampled data through Gaze pseudonymization. |
+
+## Dependency direction
+
+```text
+gaze
+  ^  ^
+  |  |
+  |  +-- gaze-recognizers
+  |         ^
+  |         |
+  +-- gaze-assembly
+          ^
+          |
+       gaze-cli
+
+gaze + gaze-recognizers -> debug-proxy
+xtask -> cargo test subprocesses
+```
+
+The important boundary is that `gaze` does not depend on
+`gaze-recognizers`. The core crate defines the recognizer trait, registry,
+policy model, rulepack schema, session store, token grammar, and restore path.
+The recognizer crate implements concrete backends against that surface.
+`gaze-assembly` is the joining layer for CLI-style policy execution.
+
+## Published vs internal
+
+Published crates:
+
+- `gaze`
+- `gaze-assembly`
+- `gaze-recognizers`
+- `gaze-cli`
+
+Internal crates:
+
+- `xtask`
+- `debug-proxy`
+
+Internal crates can depend on the published crates, but published crates should
+not grow dependencies on internal tooling. If a feature needs to be reusable by
+adopters, put the contract in `gaze`, the built-in backend in
+`gaze-recognizers`, and the policy assembly glue in `gaze-assembly`.
+
+## Choosing a crate for new work
+
+Put code in `gaze` when it is part of the core contract: reversible sessions,
+restore, policy parsing, rule evaluation, locale resolution, rulepack loading,
+recognizer traits, validation contracts, sandbox contracts, or redaction-log
+interfaces.
+
+Put code in `gaze-recognizers` when it implements a concrete detector backend
+or bundled rulepack data. Built-in regex, dictionary, and NER behavior belongs
+there because those backends depend on implementation crates that the core
+contract should not force onto every adopter.
+
+Put code in `gaze-assembly` when it wires `Policy`, `Context`, `Rulepack`,
+`LocaleChain`, and built-in recognizers into a `Pipeline`. This is where
+CLI-equivalent policy execution should live.
+
+Put code in `gaze-cli` when it is process-boundary behavior: argv parsing,
+stdin/stdout JSON, sanitized stderr, exit codes, policy-file loading,
+context-file loading, audit database path handling, or restore-mode handling.
+
+Put code in `xtask` when it is a repository gate. Gates must prove behavior by
+running named tests; see [xtask](xtask.md).
+
+Put code in `debug-proxy` when it is specific to the MCP debug consumer,
+database/log adapters, or its policy wrapper.

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -1,0 +1,102 @@
+# Xtask
+
+`crates/xtask` is Gaze's internal gate runner. It is not published; it exists
+to make repository checks explicit and repeatable.
+
+Run gates from the workspace root:
+
+```console
+$ cargo run -p xtask -- symmetric-potemkin
+$ cargo run -p xtask -- class-map-override-safety
+$ cargo run -p xtask -- recognizer-composition-validator
+```
+
+The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.rs).
+
+## Current gates
+
+| Gate | Command | Current behavior |
+|------|---------|------------------|
+| `SymmetricPotemkin` | `cargo run -p xtask -- symmetric-potemkin` | Lists and runs the behavioral tests in `SYMMETRIC_POTEMKIN_TESTS`. The gate fails if any named test is missing or fails. |
+| `ClassMapOverrideSafety` | `cargo run -p xtask -- class-map-override-safety` | Scaffolded placeholder that prints `class_map_override_safety: scaffolded` and exits successfully. The related class-map behavioral tests currently run under `SymmetricPotemkin`. |
+| `RecognizerCompositionValidator` | `cargo run -p xtask -- recognizer-composition-validator` | Lists and runs the behavioral tests in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS`. The gate fails if the rulepack composition validator tests are missing or failing. |
+
+## Recursive-Potemkin discipline
+
+Every gate must invoke a behavioral test. A gate may check that a test exists,
+but the final proof must be a real `cargo test` invocation of behavior that
+would fail if the protected contract regressed.
+
+Do not write gates that only assert symbol presence, file presence, or string
+presence. Those checks can pass while the behavior is broken.
+
+The current helper shape is:
+
+- add one or more `BehavioralTest` entries with package, optional integration
+  test target, and exact test name
+- call `ensure_test_exists(test)` before running it
+- call `run_behavioral_test(test)` to execute the exact test
+
+This makes the gate recursive-Potemkin resistant: deleting or renaming the
+test fails during the list phase, and breaking the contract fails during the
+execution phase.
+
+## Adding a gate
+
+Add the gate in four places:
+
+```rust
+#[derive(Debug, Subcommand)]
+enum Command {
+    SymmetricPotemkin,
+    ClassMapOverrideSafety,
+    RecognizerCompositionValidator,
+    NewBehaviorGate,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::SymmetricPotemkin => run_symmetric_potemkin_gate(),
+        Command::ClassMapOverrideSafety => {
+            println!("class_map_override_safety: scaffolded");
+            Ok(())
+        }
+        Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
+        Command::NewBehaviorGate => run_new_behavior_gate(),
+    }
+}
+
+const NEW_BEHAVIOR_TESTS: &[BehavioralTest] = &[
+    BehavioralTest {
+        package: "gaze",
+        test_target: None,
+        name: "module::tests::specific_contract_test",
+    },
+];
+
+fn run_new_behavior_gate() -> Result<()> {
+    println!(
+        "new_behavior_gate: checking {} behavioral tests",
+        NEW_BEHAVIOR_TESTS.len()
+    );
+    for test in NEW_BEHAVIOR_TESTS {
+        ensure_test_exists(*test)?;
+    }
+    for test in NEW_BEHAVIOR_TESTS {
+        run_behavioral_test(*test)?;
+    }
+    println!("new_behavior_gate: passed");
+    Ok(())
+}
+```
+
+Then run the gate and at least one failure rehearsal before opening a PR:
+
+```console
+$ cargo run -p xtask -- new-behavior-gate
+```
+
+Failure rehearsal means temporarily renaming the protected test, running the
+gate, confirming it exits non-zero during the list phase, and reverting the
+rename before commit.


### PR DESCRIPTION
## Summary
Closes adopter-discoverability gap flagged during v0.4.2 handoff (todo #118): no docs about xtask, gaze-assembly, or gaze-recognizers crates. Adopters reading source figure out crate boundaries from Cargo.toml.

Adds:
- \`docs/architecture/crates.md\` — workspace overview + role/dep table per crate
- \`docs/architecture/xtask.md\` — gate catalog + how to add gates (recursive-Potemkin discipline reminder)
- 5 per-crate READMEs: gaze, gaze-recognizers, gaze-assembly, gaze-cli, xtask

Reflects current crate shape (Option A from todo #117). If #117 brainstorm picks Option B (extract gaze-types, collapse gaze-assembly), follow-up doc churn ~1pt rebase.

## Test plan
- [ ] \`docs/architecture/crates.md\` table cites accurate crate deps (verify vs Cargo.toml)
- [ ] Public API examples in each README compile against current main
- [ ] Internal links resolve
- [ ] No source code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)