### PR TITLE
v0.4.2 P1: S1 three-surfaces backfill (CLI flags for session/NER/rulepacks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strict rulepack composition validation: same-class recognizer pairs now require explicit `cooperates_with` declarations.
 - `Context::fields_typed() -> ContextFieldsRef<'_>` borrowed accessor for context-field consumers.
 - `gaze clean --audit-db=<path>` persists the metadata-only SQLite redaction log for pipe-mode invocations.
+- `gaze clean` now exposes three-surfaces CLI overrides for existing policy runtime knobs: `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path`.
 
 ### Changed
 

--- a/crates/gaze-cli/src/clean_overrides.rs
+++ b/crates/gaze-cli/src/clean_overrides.rs
@@ -51,7 +51,7 @@ impl CleanOverrides {
                 .or(Some(policy.rulepacks.bundled.clone()))
                 .unwrap_or_else(|| vec!["core".to_string()]),
             paths: if self.rulepack_paths.is_empty() {
-                Some(policy.rulepacks.paths.clone()).unwrap_or_default()
+                policy.rulepacks.paths.clone()
             } else {
                 self.rulepack_paths.clone()
             },

--- a/crates/gaze-cli/src/clean_overrides.rs
+++ b/crates/gaze-cli/src/clean_overrides.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use gaze::{NerPolicy, Policy, RulepackPolicy, SessionScope, DEFAULT_NER_THRESHOLD};
 
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct CleanOverrides {
     pub session_scope: Option<SessionScope>,
     pub ner_model_dir: Option<PathBuf>,
@@ -13,7 +12,6 @@ pub struct CleanOverrides {
 }
 
 impl CleanOverrides {
-    #[allow(dead_code)]
     pub fn apply_to(&self, policy: &Policy) -> Policy {
         let mut resolved = policy.clone();
         resolved.session.scope = self

--- a/crates/gaze-cli/src/clean_overrides.rs
+++ b/crates/gaze-cli/src/clean_overrides.rs
@@ -1,0 +1,212 @@
+use std::path::PathBuf;
+
+use gaze::{NerPolicy, Policy, RulepackPolicy, SessionScope, DEFAULT_NER_THRESHOLD};
+
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct CleanOverrides {
+    pub session_scope: Option<SessionScope>,
+    pub ner_model_dir: Option<PathBuf>,
+    pub ner_locale: Option<String>,
+    pub rulepack_bundled: Option<Vec<String>>,
+    pub rulepack_paths: Vec<PathBuf>,
+}
+
+impl CleanOverrides {
+    #[allow(dead_code)]
+    pub fn apply_to(&self, policy: &Policy) -> Policy {
+        let mut resolved = policy.clone();
+        resolved.session.scope = self
+            .session_scope
+            .clone()
+            .or(Some(policy.session.scope.clone()))
+            .unwrap_or(SessionScope::Persistent);
+
+        let policy_ner = policy.ner.as_ref();
+        let ner_model_dir = self
+            .ner_model_dir
+            .clone()
+            .or_else(|| policy_ner.and_then(|ner| ner.model_dir.clone()))
+            .or(None);
+        let ner_locale = self
+            .ner_locale
+            .clone()
+            .or_else(|| policy_ner.and_then(|ner| ner.locale.clone()))
+            .or(None);
+        let ner_threshold = policy_ner
+            .map(|ner| ner.threshold)
+            .unwrap_or(DEFAULT_NER_THRESHOLD);
+        resolved.ner = if policy_ner.is_some() || ner_model_dir.is_some() || ner_locale.is_some() {
+            Some(NerPolicy {
+                model_dir: ner_model_dir,
+                locale: ner_locale,
+                threshold: ner_threshold,
+            })
+        } else {
+            None
+        };
+
+        resolved.rulepacks = RulepackPolicy {
+            bundled: self
+                .rulepack_bundled
+                .clone()
+                .or(Some(policy.rulepacks.bundled.clone()))
+                .unwrap_or_else(|| vec!["core".to_string()]),
+            paths: if self.rulepack_paths.is_empty() {
+                Some(policy.rulepacks.paths.clone()).unwrap_or_default()
+            } else {
+                self.rulepack_paths.clone()
+            },
+        };
+        resolved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gaze::{Action, RuleSpec, SessionPolicy};
+
+    fn policy() -> Policy {
+        Policy {
+            session: SessionPolicy {
+                scope: SessionScope::Conversation,
+                ttl_secs: None,
+            },
+            detectors: Vec::new(),
+            dictionaries: Vec::new(),
+            rules: vec![RuleSpec::Default {
+                action: Action::Preserve,
+            }],
+            ner: Some(NerPolicy {
+                model_dir: Some(PathBuf::from("/policy/model")),
+                locale: Some("de-DE".to_string()),
+                threshold: 0.7,
+            }),
+            rulepacks: RulepackPolicy {
+                bundled: vec!["locale-de".to_string()],
+                paths: vec![PathBuf::from("/policy/rulepack.toml")],
+            },
+            locale: None,
+        }
+    }
+
+    #[test]
+    fn session_scope_resolves_cli_policy_then_default() {
+        let policy = policy();
+        let cli = CleanOverrides {
+            session_scope: Some(SessionScope::Ephemeral),
+            ..Default::default()
+        };
+        assert_eq!(cli.apply_to(&policy).session.scope, SessionScope::Ephemeral);
+        assert_eq!(
+            CleanOverrides::default().apply_to(&policy).session.scope,
+            SessionScope::Conversation
+        );
+    }
+
+    #[test]
+    fn ner_model_dir_resolves_cli_policy_then_absent_default() {
+        let policy = policy();
+        let cli = CleanOverrides {
+            ner_model_dir: Some(PathBuf::from("/cli/model")),
+            ..Default::default()
+        };
+        assert_eq!(
+            cli.apply_to(&policy)
+                .ner
+                .as_ref()
+                .and_then(|ner| ner.model_dir.as_deref()),
+            Some(std::path::Path::new("/cli/model"))
+        );
+        assert_eq!(
+            CleanOverrides::default()
+                .apply_to(&policy)
+                .ner
+                .as_ref()
+                .and_then(|ner| ner.model_dir.as_deref()),
+            Some(std::path::Path::new("/policy/model"))
+        );
+
+        let mut no_ner_policy = policy;
+        no_ner_policy.ner = None;
+        assert!(
+            CleanOverrides::default()
+                .apply_to(&no_ner_policy)
+                .ner
+                .is_none(),
+            "absent NER defaults must not register a detector"
+        );
+    }
+
+    #[test]
+    fn ner_locale_resolves_cli_policy_then_absent_default() {
+        let policy = policy();
+        let cli = CleanOverrides {
+            ner_locale: Some("en-US".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            cli.apply_to(&policy)
+                .ner
+                .as_ref()
+                .and_then(|ner| ner.locale.as_deref()),
+            Some("en-US")
+        );
+        assert_eq!(
+            CleanOverrides::default()
+                .apply_to(&policy)
+                .ner
+                .as_ref()
+                .and_then(|ner| ner.locale.as_deref()),
+            Some("de-DE")
+        );
+
+        let mut no_ner_policy = policy;
+        no_ner_policy.ner = None;
+        assert!(
+            CleanOverrides::default()
+                .apply_to(&no_ner_policy)
+                .ner
+                .is_none(),
+            "absent NER defaults must not register a detector"
+        );
+    }
+
+    #[test]
+    fn bundled_rulepacks_resolve_cli_policy_then_default() {
+        let policy = policy();
+        let cli = CleanOverrides {
+            rulepack_bundled: Some(vec!["core".to_string(), "locale-en".to_string()]),
+            ..Default::default()
+        };
+        assert_eq!(
+            cli.apply_to(&policy).rulepacks.bundled,
+            vec!["core", "locale-en"]
+        );
+        assert_eq!(
+            CleanOverrides::default()
+                .apply_to(&policy)
+                .rulepacks
+                .bundled,
+            vec!["locale-de"]
+        );
+    }
+
+    #[test]
+    fn rulepack_paths_resolve_cli_policy_then_default() {
+        let policy = policy();
+        let cli = CleanOverrides {
+            rulepack_paths: vec![PathBuf::from("/cli/rulepack.toml")],
+            ..Default::default()
+        };
+        assert_eq!(
+            cli.apply_to(&policy).rulepacks.paths,
+            vec![PathBuf::from("/cli/rulepack.toml")]
+        );
+        assert_eq!(
+            CleanOverrides::default().apply_to(&policy).rulepacks.paths,
+            vec![PathBuf::from("/policy/rulepack.toml")]
+        );
+    }
+}

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -396,7 +396,14 @@ fn clean_overrides_from_options(
         .map(SessionScope::parse)
         .transpose()
         .map_err(map_policy_error)?;
-    let ner_locale = options.ner_locale.map(ToString::to_string);
+    let ner_locale = options
+        .ner_locale
+        .map(|locale| {
+            gaze::validate_ner_locale(locale)
+                .map(|_| locale.to_string())
+                .map_err(map_policy_error)
+        })
+        .transpose()?;
     let rulepack_bundled = if options.rulepack_bundled.is_empty() {
         None
     } else {
@@ -534,17 +541,21 @@ fn resolve_ner_threshold(cli_threshold: Option<f32>, policy: Option<&Policy>) ->
 fn load_rulepacks(policy: &Policy) -> GazeResult<Vec<Rulepack>> {
     let mut rulepacks = Vec::new();
     for bundled in &policy.rulepacks.bundled {
-        let contents = gaze_recognizers::embedded(bundled).ok_or_else(|| {
-            gaze::Error::Policy(PolicyError::BundledRulepackUnknown {
-                value: bundled.clone(),
-            })
-        })?;
+        let contents = load_embedded_rulepack_contents(bundled)?;
         rulepacks.push(Rulepack::load(RulepackSource::Embedded(contents))?);
     }
     for path in &policy.rulepacks.paths {
         rulepacks.push(Rulepack::load(RulepackSource::Path(path.clone()))?);
     }
     Ok(rulepacks)
+}
+
+fn load_embedded_rulepack_contents(id: &str) -> GazeResult<&'static str> {
+    gaze_recognizers::embedded(id).ok_or_else(|| {
+        gaze::Error::Policy(PolicyError::BundledRulepackUnknown {
+            value: id.to_string(),
+        })
+    })
 }
 
 fn dictionary_terms_from_rulepacks(rulepacks: &[Rulepack]) -> GazeResult<Vec<RulepackDict>> {

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+mod clean_overrides;
 mod error;
 
 use clap::{Parser, Subcommand};

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -49,6 +49,7 @@ struct Cli {
 const DEFAULT_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Cmd {
     /// Read raw text from stdin; emit `{clean_text, session_blob, stats}` JSON to stdout.
     Clean {

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -26,10 +26,11 @@ use gaze::{
     Action, ClassRule, DefaultRule, DictionaryBundle, DictionarySource, DocumentKind, LocaleChain,
     LocaleTag, PiiClass, Pipeline, Policy, PolicyError, RawDocument, RawMatch, RedactionEntry,
     RedactionLogger, Result as GazeResult, Rulepack, RulepackDict, RulepackSource, Scope,
-    SensitiveSnapshot, Session, SqliteLogger, TypedContext, DEFAULT_NER_THRESHOLD,
+    SensitiveSnapshot, Session, SessionScope, SqliteLogger, TypedContext, DEFAULT_NER_THRESHOLD,
 };
 use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 
+use crate::clean_overrides::CleanOverrides;
 use crate::error::{CliError, RestoreMode, RestoreWarning};
 
 #[derive(Parser, Debug)]
@@ -60,12 +61,27 @@ enum Cmd {
         /// Override the persistent session TTL in seconds.
         #[arg(long)]
         session_ttl: Option<u64>,
+        /// Override policy [session].scope.
+        #[arg(long)]
+        session_scope: Option<String>,
         /// Active locale fallback chain, comma separated and priority ordered.
         #[arg(long, value_delimiter = ',')]
         locale: Vec<String>,
         /// Override policy [ner] threshold. Must be between 0.0 and 1.0 inclusive.
         #[arg(long)]
         ner_threshold: Option<f32>,
+        /// Override policy [ner].model_dir.
+        #[arg(long)]
+        ner_model_dir: Option<PathBuf>,
+        /// Override policy [ner].locale.
+        #[arg(long)]
+        ner_locale: Option<String>,
+        /// Override policy.rulepacks.bundled. Comma-separated and repeatable.
+        #[arg(long, value_delimiter = ',')]
+        rulepack_bundled: Vec<String>,
+        /// Override policy.rulepacks.paths. Repeatable.
+        #[arg(long = "rulepack-path")]
+        rulepack_paths: Vec<PathBuf>,
         /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
@@ -145,8 +161,13 @@ fn main() -> ExitCode {
             policy,
             format,
             session_ttl,
+            session_scope,
             locale,
             ner_threshold,
+            ner_model_dir,
+            ner_locale,
+            rulepack_bundled,
+            rulepack_paths,
             max_bytes,
             context_json,
             audit_db,
@@ -154,8 +175,13 @@ fn main() -> ExitCode {
             policy: policy.as_deref(),
             format: &format,
             session_ttl,
+            session_scope: session_scope.as_deref(),
             locale: &locale,
             ner_threshold,
+            ner_model_dir,
+            ner_locale: ner_locale.as_deref(),
+            rulepack_bundled: &rulepack_bundled,
+            rulepack_paths,
             max_bytes,
             context_json: context_json.as_deref(),
             audit_db: audit_db.as_deref(),
@@ -221,8 +247,13 @@ struct CleanOptions<'a> {
     policy: Option<&'a std::path::Path>,
     format: &'a str,
     session_ttl: Option<u64>,
+    session_scope: Option<&'a str>,
     locale: &'a [String],
     ner_threshold: Option<f32>,
+    ner_model_dir: Option<PathBuf>,
+    ner_locale: Option<&'a str>,
+    rulepack_bundled: &'a [String],
+    rulepack_paths: Vec<PathBuf>,
     max_bytes: u64,
     context_json: Option<&'a std::path::Path>,
     audit_db: Option<&'a std::path::Path>,
@@ -235,11 +266,15 @@ fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
         .map(validate_ner_threshold)
         .transpose()
         .map_err(map_policy_error)?;
+    let clean_overrides = clean_overrides_from_options(&options)?;
     let raw = read_stdin_text(options.max_bytes)?;
 
     let counter = Arc::new(CountingLogger::new(options.audit_db).map_err(|_| CliError::Pipeline)?);
     let loaded_policy = match options.policy {
-        Some(path) => Some(Policy::load_for_cli(path).map_err(map_policy_error)?),
+        Some(path) => {
+            let policy = Policy::load_for_cli(path).map_err(map_policy_error)?;
+            Some(clean_overrides.apply_to(&policy))
+        }
         None => None,
     };
     let loaded_rulepacks = match &loaded_policy {
@@ -302,9 +337,10 @@ fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
 
     let session = match &loaded_policy {
         Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
-        None => Session::new(Scope::Persistent {
-            ttl: Duration::from_secs(options.session_ttl.unwrap_or(86_400)),
-        }),
+        None => Session::new(scope_for_cli_without_policy(
+            clean_overrides.session_scope.as_ref(),
+            options.session_ttl,
+        )),
     }
     .map_err(|_| CliError::Pipeline)?;
 
@@ -350,6 +386,40 @@ fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
     println!("{json}");
     Ok(())
+}
+
+fn clean_overrides_from_options(
+    options: &CleanOptions<'_>,
+) -> std::result::Result<CleanOverrides, CliError> {
+    let session_scope = options
+        .session_scope
+        .map(SessionScope::parse)
+        .transpose()
+        .map_err(map_policy_error)?;
+    let ner_locale = options.ner_locale.map(ToString::to_string);
+    let rulepack_bundled = if options.rulepack_bundled.is_empty() {
+        None
+    } else {
+        Some(options.rulepack_bundled.to_vec())
+    };
+
+    Ok(CleanOverrides {
+        session_scope,
+        ner_model_dir: options.ner_model_dir.clone(),
+        ner_locale,
+        rulepack_bundled,
+        rulepack_paths: options.rulepack_paths.clone(),
+    })
+}
+
+fn scope_for_cli_without_policy(scope: Option<&SessionScope>, ttl_secs: Option<u64>) -> Scope {
+    match scope.unwrap_or(&SessionScope::Persistent) {
+        SessionScope::Ephemeral => Scope::Ephemeral,
+        SessionScope::Conversation => Scope::Conversation("cli".to_string()),
+        SessionScope::Persistent => Scope::Persistent {
+            ttl: Duration::from_secs(ttl_secs.unwrap_or(86_400)),
+        },
+    }
 }
 
 fn parse_cli_locales(raw: &[String]) -> std::result::Result<Option<Vec<LocaleTag>>, CliError> {
@@ -465,9 +535,9 @@ fn load_rulepacks(policy: &Policy) -> GazeResult<Vec<Rulepack>> {
     let mut rulepacks = Vec::new();
     for bundled in &policy.rulepacks.bundled {
         let contents = gaze_recognizers::embedded(bundled).ok_or_else(|| {
-            gaze::Error::Policy(PolicyError::BadTtl(format!(
-                "unknown bundled rulepack '{bundled}'"
-            )))
+            gaze::Error::Policy(PolicyError::BundledRulepackUnknown {
+                value: bundled.clone(),
+            })
         })?;
         rulepacks.push(Rulepack::load(RulepackSource::Embedded(contents))?);
     }

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -25,8 +25,9 @@ use serde::{Deserialize, Serialize};
 use gaze::{
     Action, ClassRule, DefaultRule, DictionaryBundle, DictionarySource, DocumentKind, LocaleChain,
     LocaleTag, PiiClass, Pipeline, Policy, PolicyError, RawDocument, RawMatch, RedactionEntry,
-    RedactionLogger, Result as GazeResult, Rulepack, RulepackDict, RulepackSource, Scope,
-    SensitiveSnapshot, Session, SessionScope, SqliteLogger, TypedContext, DEFAULT_NER_THRESHOLD,
+    RedactionLogger, Result as GazeResult, RuleSpec, Rulepack, RulepackDict, RulepackPolicy,
+    RulepackSource, Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope, SqliteLogger,
+    TypedContext, DEFAULT_NER_THRESHOLD,
 };
 use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 
@@ -278,9 +279,16 @@ fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
         }
         None => None,
     };
-    let loaded_rulepacks = match &loaded_policy {
-        Some(policy) => load_rulepacks(policy).map_err(map_pipeline_error)?,
-        None => Vec::new(),
+    let cli_rulepack_policy = if loaded_policy.is_none() && has_rulepack_overrides(&options) {
+        Some(policy_for_rulepack_overrides(&clean_overrides))
+    } else {
+        None
+    };
+    let loaded_rulepacks = match (&loaded_policy, &cli_rulepack_policy) {
+        (Some(policy), _) | (None, Some(policy)) => {
+            load_rulepacks(policy).map_err(map_pipeline_error)?
+        }
+        (None, None) => Vec::new(),
     };
     let context = options
         .context_json
@@ -418,6 +426,31 @@ fn clean_overrides_from_options(
         rulepack_bundled,
         rulepack_paths: options.rulepack_paths.clone(),
     })
+}
+
+fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
+    !options.rulepack_bundled.is_empty() || !options.rulepack_paths.is_empty()
+}
+
+fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
+    let base = Policy {
+        session: SessionPolicy {
+            scope: SessionScope::Persistent,
+            ttl_secs: Some(86_400),
+        },
+        detectors: Vec::new(),
+        dictionaries: Vec::new(),
+        rules: vec![RuleSpec::Default {
+            action: Action::Preserve,
+        }],
+        ner: None,
+        rulepacks: RulepackPolicy {
+            bundled: Vec::new(),
+            paths: Vec::new(),
+        },
+        locale: None,
+    };
+    clean_overrides.apply_to(&base)
 }
 
 fn scope_for_cli_without_policy(scope: Option<&SessionScope>, ttl_secs: Option<u64>) -> Scope {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -152,6 +152,117 @@ action = "preserve"
     (dir, path)
 }
 
+fn write_policy_with_session_scope(scope: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "{scope}"
+ttl_secs = 86400
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "class_alpha"
+pattern = 'class-alpha-[0-9]+'
+class = "custom:class_alpha"
+
+[[rule]]
+kind = "class"
+class = "custom:class_alpha"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
+fn write_policy_with_bundled_id(rulepack_id: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = ["{rulepack_id}"]
+
+[[rule]]
+kind = "class"
+class = "custom:class_alpha"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
+fn write_policy_with_ner_locale(locale: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[ner]
+locale = "{locale}"
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "class_alpha"
+pattern = 'class-alpha-[0-9]+'
+class = "custom:class_alpha"
+
+[[rule]]
+kind = "class"
+class = "custom:class_alpha"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
+fn assert_symmetric_policy_config(cli_out: std::process::Output, toml_out: std::process::Output) {
+    assert_eq!(cli_out.status.code(), Some(2));
+    assert_eq!(toml_out.status.code(), Some(2));
+    assert!(cli_out.stdout.is_empty(), "CLI stdout must stay empty");
+    assert!(toml_out.stdout.is_empty(), "TOML stdout must stay empty");
+    assert_eq!(
+        cli_out.stderr, toml_out.stderr,
+        "CLI and TOML policy errors must be byte-identical"
+    );
+    assert_eq!(
+        parse_stderr_variant(&cli_out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
+}
+
 fn write_policy_with_rulepack(
     rulepack: &str,
     locale_active: Option<&str>,
@@ -879,6 +990,66 @@ fn t_cli_ner_threshold_out_of_range_fails_closed() {
         parse_stderr_variant(&out.stderr),
         json!({ "error": "PolicyConfig", "exit": 2 })
     );
+}
+
+#[test]
+fn s1_invalid_session_scope_is_symmetric_between_cli_and_toml() {
+    let (_valid_dir, valid_policy) = write_policy_with_session_scope("persistent");
+    let (_invalid_dir, invalid_policy) = write_policy_with_session_scope("forever");
+
+    let cli_out = clean_raw_with_args(
+        &[
+            &format!("--policy={}", valid_policy.display()),
+            "--session-scope=forever",
+        ],
+        "class-alpha-123",
+    );
+    let toml_out = clean_raw_with_args(
+        &[&format!("--policy={}", invalid_policy.display())],
+        "class-alpha-123",
+    );
+
+    assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s1_invalid_bundled_rulepack_is_symmetric_between_cli_and_toml() {
+    let (_valid_dir, valid_policy) = write_policy_with_bundled_id("core");
+    let (_invalid_dir, invalid_policy) = write_policy_with_bundled_id("garbage");
+
+    let cli_out = clean_raw_with_args(
+        &[
+            &format!("--policy={}", valid_policy.display()),
+            "--rulepack-bundled=garbage",
+        ],
+        "class-alpha-123",
+    );
+    let toml_out = clean_raw_with_args(
+        &[&format!("--policy={}", invalid_policy.display())],
+        "class-alpha-123",
+    );
+
+    assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s1_invalid_ner_locale_is_symmetric_between_cli_and_toml() {
+    let (_valid_dir, valid_policy) = write_policy_with_ner_locale("en-US");
+    let (_invalid_dir, invalid_policy) = write_policy_with_ner_locale("bad_locale_!");
+
+    let cli_out = clean_raw_with_args(
+        &[
+            &format!("--policy={}", valid_policy.display()),
+            "--ner-locale=bad_locale_!",
+        ],
+        "class-alpha-123",
+    );
+    let toml_out = clean_raw_with_args(
+        &[&format!("--policy={}", invalid_policy.display())],
+        "class-alpha-123",
+    );
+
+    assert_symmetric_policy_config(cli_out, toml_out);
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -248,6 +248,102 @@ action = "preserve"
     (dir, path)
 }
 
+fn write_policy_with_ner_model_dir(
+    policy_model_dir: &std::path::Path,
+    locale_active: &str,
+    ner_locale: &str,
+    threshold: f32,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[locale]
+active = ["{locale_active}"]
+
+[ner]
+model_dir = "{}"
+locale = "{ner_locale}"
+threshold = {threshold}
+
+[policy.rulepacks]
+bundled = ["core"]
+
+[[rule]]
+kind = "class"
+class = "name"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            policy_model_dir.display()
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
+fn class_alpha_rulepack() -> String {
+    r#"
+schema_version = "0.1.0"
+rulepack_id = "class-alpha"
+rulepack_version = "0.4.2"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "class-alpha.regex"
+class = "custom:class_alpha"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = 'class-alpha-[0-9]+'
+
+[recognizers.scoring]
+base = 0.42
+priority = 77
+
+[recognizers.token]
+"#
+    .to_string()
+}
+
+fn write_policy_for_class_alpha_rulepack() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = ["core"]
+
+[[rule]]
+kind = "class"
+class = "custom:class_alpha"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+    (dir, path)
+}
+
 fn assert_symmetric_policy_config(cli_out: std::process::Output, toml_out: std::process::Output) {
     assert_eq!(cli_out.status.code(), Some(2));
     assert_eq!(toml_out.status.code(), Some(2));
@@ -433,6 +529,12 @@ fn session_blob_ttl_secs(blob: &str) -> u64 {
     let raw = BASE64.decode(blob.as_bytes()).unwrap();
     let payload: Value = serde_json::from_slice(&raw[97..]).unwrap();
     payload["scope"]["Persistent"]["ttl_secs"].as_u64().unwrap()
+}
+
+fn session_blob_scope(blob: &str) -> Value {
+    let raw = BASE64.decode(blob.as_bytes()).unwrap();
+    let payload: Value = serde_json::from_slice(&raw[97..]).unwrap();
+    payload["scope"].clone()
 }
 
 /// Build a session blob by hand via the library. Used where the stub CLI
@@ -1050,6 +1152,173 @@ fn s1_invalid_ner_locale_is_symmetric_between_cli_and_toml() {
     );
 
     assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s1_session_scope_override_changes_observed_session_semantics() {
+    let (_dir, policy) = write_policy_with_session_scope("persistent");
+    let persistent = clean_json_with_args(
+        &[&format!("--policy={}", policy.display())],
+        "class-alpha-123",
+    );
+    assert_eq!(
+        session_blob_scope(persistent["session_blob"].as_str().unwrap()),
+        json!({ "Persistent": { "ttl_secs": 86400 } })
+    );
+
+    let conversation = clean_json_with_args(
+        &[
+            &format!("--policy={}", policy.display()),
+            "--session-scope=conversation",
+        ],
+        "class-alpha-123",
+    );
+    assert_eq!(
+        session_blob_scope(conversation["session_blob"].as_str().unwrap()),
+        json!({ "Conversation": "cli" })
+    );
+
+    let ephemeral = clean_raw_with_args(
+        &[
+            &format!("--policy={}", policy.display()),
+            "--session-scope=ephemeral",
+        ],
+        "class-alpha-123",
+    );
+    assert_eq!(
+        ephemeral.status.code(),
+        Some(3),
+        "ephemeral sessions must retain export-forbidden semantics"
+    );
+    assert_eq!(
+        parse_stderr_variant(&ephemeral.stderr),
+        json!({ "error": "Pipeline", "exit": 3 })
+    );
+}
+
+#[test]
+fn s1_rulepack_bundled_override_changes_bundled_recognizer_availability() {
+    let (_dir, policy) = write_policy_with_bundled_rulepacks(&["core"], "de-DE");
+    let input = "Von: Alice Example <alice@example.invalid>";
+
+    let without_locale_pack =
+        clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+    let baseline_clean = without_locale_pack["clean_text"].as_str().unwrap();
+    assert!(baseline_clean.starts_with("Von: Alice Example <<"));
+    assert!(baseline_clean.ends_with(":Email_1>>"));
+    assert_eq!(without_locale_pack["stats"]["detections"], 1);
+
+    let with_locale_pack = clean_json_with_args(
+        &[
+            &format!("--policy={}", policy.display()),
+            "--rulepack-bundled=core,locale-de,locale-en",
+        ],
+        input,
+    );
+    let clean = with_locale_pack["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Von: <[0-9a-f]{8}:Name_\d+> <<[0-9a-f]{8}:Email_\d+>>$")
+            .unwrap()
+            .is_match(clean),
+        "unexpected clean text: {clean}"
+    );
+    assert_eq!(with_locale_pack["stats"]["detections"], 2);
+}
+
+#[test]
+fn s1_rulepack_path_override_loads_fixture_rulepack_and_round_trips() {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("class-alpha.toml");
+    fs::write(&rulepack_path, class_alpha_rulepack()).unwrap();
+    let (_policy_dir, policy) = write_policy_for_class_alpha_rulepack();
+    let input = "ticket class-alpha-123";
+
+    let without_path = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+    assert_eq!(without_path["clean_text"], input);
+    assert_eq!(without_path["stats"]["detections"], 0);
+
+    let with_path = clean_json_with_args(
+        &[
+            &format!("--policy={}", policy.display()),
+            &format!("--rulepack-path={}", rulepack_path.display()),
+        ],
+        input,
+    );
+    let clean = with_path["clean_text"].as_str().unwrap();
+    assert!(clean.starts_with("ticket <"));
+    assert!(clean.ends_with(":Custom:class_alpha_1>"));
+    assert_eq!(with_path["stats"]["detections"], 1);
+    assert_eq!(
+        restore_success_text(with_path["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+}
+
+#[test]
+fn s1_ner_model_dir_and_locale_override_toml_and_detect_with_test_backend() {
+    let model_dir_holder = tempdir().unwrap();
+    let good_model_dir = model_dir_holder.path().join("__gaze_test_fixed_ner");
+    fs::create_dir(&good_model_dir).unwrap();
+    let missing_model_dir = model_dir_holder.path().join("missing-model");
+    let (_policy_dir, policy) =
+        write_policy_with_ner_model_dir(&missing_model_dir, "de-DE", "en-US", 0.3);
+    let input = "Du antwortest als Support an Alice Example.";
+
+    let out = clean_raw_with_args(&[&format!("--policy={}", policy.display())], input);
+    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
+
+    let value = clean_json_with_args(
+        &[
+            &format!("--policy={}", policy.display()),
+            &format!("--ner-model-dir={}", good_model_dir.display()),
+            "--ner-locale=de",
+        ],
+        input,
+    );
+    let clean = value["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Du antwortest als Support an <[0-9a-f]{8}:Name_\d+>\.$")
+            .unwrap()
+            .is_match(clean),
+        "unexpected clean text: {clean}"
+    );
+    assert_eq!(value["stats"]["detections"], 1);
+    assert_eq!(
+        restore_success_text(value["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+}
+
+#[test]
+fn s1_three_surfaces_flags_are_exposed_and_bundled_ids_unchanged() {
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", "--help"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let help = String::from_utf8(out.stdout).unwrap();
+    for flag in [
+        "--session-scope",
+        "--ner-model-dir",
+        "--ner-locale",
+        "--rulepack-bundled",
+        "--rulepack-path",
+        "--session-ttl",
+        "--ner-threshold",
+        "--locale",
+    ] {
+        assert!(help.contains(flag), "missing CLI flag in help: {flag}");
+    }
+
+    assert!(gaze_recognizers::embedded("core").is_some());
+    assert!(gaze_recognizers::embedded("locale-de").is_some());
+    assert!(gaze_recognizers::embedded("locale-en").is_some());
+    assert!(gaze_recognizers::embedded("class_alpha").is_none());
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1135,6 +1135,57 @@ fn s1_invalid_bundled_rulepack_is_symmetric_between_cli_and_toml() {
 }
 
 #[test]
+fn s1_rulepack_bundled_garbage_no_policy_rejects() {
+    let (_invalid_dir, invalid_policy) = write_policy_with_bundled_id("garbage");
+
+    let cli_out = clean_raw_with_args(&["--rulepack-bundled=garbage"], "alice@example.invalid");
+    let toml_out = clean_raw_with_args(
+        &[&format!("--policy={}", invalid_policy.display())],
+        "alice@example.invalid",
+    );
+
+    assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s1_rulepack_path_missing_no_policy_rejects() {
+    let dir = tempdir().unwrap();
+    let missing_rulepack = dir.path().join("missing-rulepack.toml");
+    let policy = dir.path().join("policy.toml");
+    fs::write(
+        &policy,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = []
+paths = ["{}"]
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            missing_rulepack.display()
+        ),
+    )
+    .unwrap();
+
+    let cli_out = clean_raw_with_args(
+        &[&format!("--rulepack-path={}", missing_rulepack.display())],
+        "alice@example.invalid",
+    );
+    let toml_out = clean_raw_with_args(
+        &[&format!("--policy={}", policy.display())],
+        "alice@example.invalid",
+    );
+
+    assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
 fn s1_invalid_ner_locale_is_symmetric_between_cli_and_toml() {
     let (_valid_dir, valid_policy) = write_policy_with_ner_locale("en-US");
     let (_invalid_dir, invalid_policy) = write_policy_with_ner_locale("bad_locale_!");

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -27,8 +27,8 @@ pub use dictionaries::{
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{Error, Pipeline, PipelineBuilder, Result};
 pub use policy::{
-    DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec, RulepackPolicy,
-    SessionPolicy, SessionScope, DEFAULT_NER_THRESHOLD,
+    validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,
+    RulepackPolicy, SessionPolicy, SessionScope, DEFAULT_NER_THRESHOLD,
 };
 pub use redaction_log::{
     ConflictTier, DocumentKind, RedactionEntry, RedactionLogger, SqliteLogger,

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -659,6 +659,21 @@ action = "preserve"
     }
 
     #[test]
+    fn accepts_bcp47_ner_locale_hints() {
+        for locale in ["de", "en-US", "pt-BR", "zh-Hant"] {
+            assert!(
+                validate_ner_locale(locale).is_ok(),
+                "NER locale hints should accept BCP47-shaped tag {locale}"
+            );
+        }
+
+        assert!(matches!(
+            validate_ner_locale("bad locale!"),
+            Err(PolicyError::NerLocaleUnsupported { value }) if value == "bad locale!"
+        ));
+    }
+
+    #[test]
     fn rejects_unknown_session_scope_with_typed_error() {
         let raw = r#"
 [session]

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -127,6 +127,8 @@ pub enum PolicyError {
     NerThresholdOutOfRange { value: f32 },
     #[error("session.scope must be one of ephemeral, conversation, persistent, got {value}")]
     SessionScopeUnknown { value: String },
+    #[error("ner.locale must be a BCP47 locale tag, got {value}")]
+    NerLocaleUnsupported { value: String },
     #[error("unknown bundled rulepack: {value}")]
     BundledRulepackUnknown { value: String },
     #[error("{0}")]
@@ -479,11 +481,22 @@ fn parse_ner(raw: RawNerPolicy) -> Result<NerPolicy, PolicyError> {
     if !(0.0..=1.0).contains(&threshold) {
         return Err(PolicyError::NerThresholdOutOfRange { value: threshold });
     }
+    if let Some(locale) = &raw.locale {
+        validate_ner_locale(locale)?;
+    }
     Ok(NerPolicy {
         model_dir: raw.model_dir.map(expand_home).transpose()?,
         locale: raw.locale,
         threshold,
     })
+}
+
+pub fn validate_ner_locale(locale: &str) -> Result<(), PolicyError> {
+    LocaleTag::parse(locale)
+        .map(|_| ())
+        .map_err(|_| PolicyError::NerLocaleUnsupported {
+            value: locale.to_string(),
+        })
 }
 
 fn parse_locale_policy(raw: RawLocalePolicy) -> Result<Option<Vec<LocaleTag>>, PolicyError> {

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use serde::Deserialize;
 use thiserror::Error;
@@ -31,6 +32,27 @@ pub enum SessionScope {
     Ephemeral,
     Conversation,
     Persistent,
+}
+
+impl SessionScope {
+    pub fn parse(value: &str) -> Result<Self, PolicyError> {
+        match value {
+            "ephemeral" => Ok(SessionScope::Ephemeral),
+            "conversation" => Ok(SessionScope::Conversation),
+            "persistent" => Ok(SessionScope::Persistent),
+            other => Err(PolicyError::SessionScopeUnknown {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+impl FromStr for SessionScope {
+    type Err = PolicyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,6 +125,10 @@ pub enum PolicyError {
     NerLoad(String),
     #[error("ner.threshold must be between 0.0 and 1.0 inclusive, got {value}")]
     NerThresholdOutOfRange { value: f32 },
+    #[error("session.scope must be one of ephemeral, conversation, persistent, got {value}")]
+    SessionScopeUnknown { value: String },
+    #[error("unknown bundled rulepack: {value}")]
+    BundledRulepackUnknown { value: String },
     #[error("{0}")]
     UnsupportedRuleKind(String),
 }
@@ -275,16 +301,7 @@ impl TryFrom<RawPolicy> for Policy {
 }
 
 fn parse_session(raw: RawSessionPolicy) -> Result<SessionPolicy, PolicyError> {
-    let scope = match raw.scope.as_str() {
-        "ephemeral" => SessionScope::Ephemeral,
-        "conversation" => SessionScope::Conversation,
-        "persistent" => SessionScope::Persistent,
-        other => {
-            return Err(PolicyError::BadTtl(format!(
-                "unknown session.scope '{other}'"
-            )))
-        }
-    };
+    let scope = SessionScope::parse(&raw.scope)?;
 
     match scope {
         SessionScope::Persistent => match raw.ttl_secs {
@@ -625,6 +642,32 @@ action = "preserve"
         assert!(matches!(
             Policy::try_from(raw),
             Err(PolicyError::NerThresholdOutOfRange { value }) if value == 1.1
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_session_scope_with_typed_error() {
+        let raw = r#"
+[session]
+scope = "forever"
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = ".+"
+class = "email"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#;
+
+        let raw = toml::from_str::<RawPolicy>(raw).unwrap();
+        let err = Policy::try_from(raw).unwrap_err();
+
+        assert!(matches!(
+            err,
+            PolicyError::SessionScopeUnknown { value } if value == "forever"
         ));
     }
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -30,6 +30,50 @@ If `--policy` is omitted, `gaze clean` falls back to a hard-coded stub pipeline
 (email regex + tokenize). The stub exists only so the CLI surface can be
 exercised before a policy is written; **production use requires `--policy`**.
 
+## CLI overrides for runtime knobs
+
+`policy.toml` is the durable source of truth. `gaze clean` also exposes
+runtime-only overrides for knobs operators commonly vary between invocations.
+Resolution is always:
+
+```text
+CLI flag > policy.toml > Gaze default
+```
+
+| Policy field | CLI flag | Notes |
+|--------------|----------|-------|
+| `[session].scope` | `--session-scope <ephemeral|conversation|persistent>` | Overrides session lifetime for the current clean run. `ephemeral` keeps export-forbidden semantics, so pipe-mode clean exits `Pipeline` if a session blob would be required. |
+| `[session].ttl_secs` | `--session-ttl <SECONDS>` | Existing override for persistent session TTL. |
+| `[ner].model_dir` | `--ner-model-dir <PATH>` | Overrides the NER model directory. If neither CLI nor TOML sets a model directory, no NER detector is registered. |
+| `[ner].locale` | `--ner-locale <BCP47>` | Overrides the NER locale hint. Invalid tags fail closed with `PolicyConfig`. |
+| `[ner].threshold` | `--ner-threshold <FLOAT>` | Existing override for NER confidence threshold; must be `0.0..=1.0`. |
+| `[locale].active` | `--locale <BCP47,...>` | Existing override for the active locale fallback chain. |
+| `[policy.rulepacks].bundled` | `--rulepack-bundled <ID,...>` | Comma-separated and repeatable. Replaces TOML bundled rulepack IDs for the current run. |
+| `[policy.rulepacks].paths` | `--rulepack-path <PATH>` | Repeatable. Replaces TOML rulepack paths for the current run. |
+
+Example:
+
+```sh
+gaze clean \
+  --policy=policy.toml \
+  --session-scope=conversation \
+  --ner-model-dir="$HOME/.local/share/gaze/models/davlan-mbert-ner-hrl" \
+  --ner-locale=de \
+  --rulepack-bundled=core,locale-de \
+  --rulepack-path=./workspace-rulepack.toml
+```
+
+If `policy.toml` sets `[session].scope = "persistent"` and the command passes
+`--session-scope=conversation`, the exported `session_blob` records a
+conversation-scoped session. If neither source mentions `[ner].model_dir`, Gaze
+keeps NER disabled rather than registering a placeholder detector.
+
+Policy-document fields have no CLI override by design. Examples include
+recognizer definitions (`[[policy.custom_recognizers]]`), rule definitions
+(`[[rule]]`), rulepack internals, and policy-document metadata. Those fields
+define the auditable contract; changing them requires changing the policy or
+rulepack document itself.
+
 ## Classes
 
 A `class` identifies what kind of PII a recognizer detects. Every recognizer


### PR DESCRIPTION
## Summary
v0.4.2 plan rev 3 §S1 (scratchpad 258). Adds 5 new CLI flags backing existing TOML policy fields per three-surfaces principle (drawer e8b5c041). Runtime knobs only — policy documents excluded.

New flags:
- \`--session-scope <ephemeral|conversation|persistent>\`
- \`--ner-model-dir <PATH>\`
- \`--ner-locale <BCP47>\`
- \`--rulepack-bundled <ID,...>\` (comma list, repeatable)
- \`--rulepack-path <PATH>\` (repeatable)

CleanOverrides resolver: CLI > TOML > default. Symmetric error messages between CLI + TOML surfaces.

## Test plan
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets\` zero warnings
- [x] All 8 S1.test rows present + passing
- [x] Recursive-Potemkin adversarial test: flip --session-scope=ephemeral against policy=persistent observes ephemeral semantics
- [x] Symmetric rejection diff: CLI invalid value matches TOML invalid value byte-for-byte
- [x] Round-trip: S1 fixtures restore identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)