### PR TITLE
v0.4.2 P2: S2 core-extended.toml Phase 1 (E.164 phone + IPv4/v6 + DE/US postal, opt-in bundle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Context::fields_typed() -> ContextFieldsRef<'_>` borrowed accessor for context-field consumers.
 - `gaze clean --audit-db=<path>` persists the metadata-only SQLite redaction log for pipe-mode invocations.
 - `gaze clean` now exposes three-surfaces CLI overrides for existing policy runtime knobs: `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path`.
+- Opt-in `core-extended` bundled rulepack with Phase 1 shape-only recognizers for E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes.
 
 ### Changed
 

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -359,6 +359,13 @@ fn assert_symmetric_policy_config(cli_out: std::process::Output, toml_out: std::
     );
 }
 
+fn normalize_session_hex(text: &str) -> String {
+    Regex::new(r"<[0-9a-f]{8}:")
+        .unwrap()
+        .replace_all(text, "<SESSION:")
+        .to_string()
+}
+
 fn write_policy_with_rulepack(
     rulepack: &str,
     locale_active: Option<&str>,
@@ -458,6 +465,61 @@ action = "tokenize"
 [[rule]]
 kind = "class"
 class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#
+        ),
+    )
+    .unwrap();
+    (dir, path)
+}
+
+fn write_policy_with_core_extended_rulepacks(
+    bundled_rulepacks: &[&str],
+    locale_active: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    let bundled = bundled_rulepacks
+        .iter()
+        .map(|rulepack| format!("\"{rulepack}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        &path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[locale]
+active = ["{locale_active}"]
+
+[policy.rulepacks]
+bundled = [{bundled}]
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:phone"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:ip_address"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:postal_code"
 action = "tokenize"
 
 [[rule]]
@@ -1274,6 +1336,142 @@ fn s1_rulepack_bundled_override_changes_bundled_recognizer_availability() {
         "unexpected clean text: {clean}"
     );
     assert_eq!(with_locale_pack["stats"]["detections"], 2);
+}
+
+#[test]
+fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
+    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103-1234";
+    let (_core_dir, core_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
+    let core_only = clean_json_with_args(&[&format!("--policy={}", core_policy.display())], input);
+    let core_clean = core_only["clean_text"].as_str().unwrap();
+    assert!(core_clean.contains(":Email_1>"), "{core_clean}");
+    assert!(!core_clean.contains("Custom:phone"), "{core_clean}");
+    assert!(!core_clean.contains("Custom:ip_address"), "{core_clean}");
+    assert!(!core_clean.contains("Custom:postal_code"), "{core_clean}");
+    assert_eq!(core_only["stats"]["detections"], 1);
+
+    let (_extended_dir, extended_policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+    let extended =
+        clean_json_with_args(&[&format!("--policy={}", extended_policy.display())], input);
+    let extended_clean = extended["clean_text"].as_str().unwrap();
+    assert!(extended_clean.contains(":Email_1>"), "{extended_clean}");
+    assert!(
+        extended_clean.contains(":Custom:phone_1>"),
+        "{extended_clean}"
+    );
+    assert!(
+        extended_clean.contains(":Custom:ip_address_1>"),
+        "{extended_clean}"
+    );
+    assert!(
+        extended_clean.contains(":Custom:postal_code_1>"),
+        "{extended_clean}"
+    );
+    assert_eq!(extended["stats"]["detections"], 4);
+    assert_eq!(
+        restore_success_text(extended["session_blob"].as_str().unwrap(), extended_clean),
+        input
+    );
+}
+
+#[test]
+fn s2_core_extended_cli_opt_in_mirrors_toml_and_rejects_garbage_symmetrically() {
+    let input = "phone +4915112345678 host 192.168.1.1 zip 94103";
+    let (_toml_dir, toml_policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+    let toml = clean_json_with_args(&[&format!("--policy={}", toml_policy.display())], input);
+
+    let (_cli_dir, cli_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
+    let cli = clean_json_with_args(
+        &[
+            &format!("--policy={}", cli_policy.display()),
+            "--rulepack-bundled=core,core-extended",
+        ],
+        input,
+    );
+
+    assert_eq!(
+        normalize_session_hex(toml["clean_text"].as_str().unwrap()),
+        normalize_session_hex(cli["clean_text"].as_str().unwrap())
+    );
+    assert_eq!(toml["stats"]["detections"], cli["stats"]["detections"]);
+
+    let (_valid_dir, valid_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
+    let (_invalid_dir, invalid_policy) =
+        write_policy_with_core_extended_rulepacks(&["garbage"], "en-US");
+    let cli_out = clean_raw_with_args(
+        &[
+            &format!("--policy={}", valid_policy.display()),
+            "--rulepack-bundled=garbage",
+        ],
+        input,
+    );
+    let toml_out = clean_raw_with_args(&[&format!("--policy={}", invalid_policy.display())], input);
+    assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s2_core_extended_cli_locale_gating_and_plain_en_negative() {
+    let (_dir, policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+
+    let us = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=en-US"],
+        "ZIP 94103-1234",
+    );
+    let us_clean = us["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^ZIP <[0-9a-f]{8}:Custom:postal_code_1>$")
+            .unwrap()
+            .is_match(us_clean),
+        "unexpected en-US clean text: {us_clean}"
+    );
+
+    let de = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=de-DE"],
+        "Berlin 10115",
+    );
+    let de_clean = de["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Berlin <[0-9a-f]{8}:Custom:postal_code_1>$")
+            .unwrap()
+            .is_match(de_clean),
+        "unexpected de-DE clean text: {de_clean}"
+    );
+
+    let plain_en = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=en"],
+        "ZIP 94103",
+    );
+    assert_eq!(plain_en["clean_text"], "ZIP 94103");
+    assert_eq!(plain_en["stats"]["detections"], 0);
+
+    let de_zip4 = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=de-DE"],
+        "ZIP 94103-1234",
+    );
+    let de_zip4_clean = de_zip4["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^ZIP <[0-9a-f]{8}:Custom:postal_code_1>-1234$")
+            .unwrap()
+            .is_match(de_zip4_clean),
+        "de-DE must not apply postal.us full ZIP+4 shape: {de_zip4_clean}"
+    );
+}
+
+#[test]
+fn s2_core_extended_tenant_like_numeric_ids_are_not_phone_tokens() {
+    let (_dir, policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "de-DE");
+    let input = "Subscriber_0001234567 Order_0815 0123-456789 0815 12345";
+    let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(!clean.contains("Custom:phone"), "{clean}");
+    assert!(clean.contains("Subscriber_0001234567"), "{clean}");
+    assert!(clean.contains("Order_0815"), "{clean}");
+    assert!(clean.contains("0123-456789"), "{clean}");
 }
 
 #[test]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,0 +1,90 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-core-extended"
+rulepack_version = "0.4.2"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "phone.structural"
+class = "custom:phone"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\+\d{6,15}\b'''
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
+id = "ip.v4"
+class = "custom:ip_address"
+cooperates_with = ["ip.v6"]
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?:^|[^A-Za-z0-9_.])((?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d))(?:$|[^A-Za-z0-9_.])'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
+id = "ip.v6"
+class = "custom:ip_address"
+cooperates_with = ["ip.v4"]
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)(?:^|[^0-9a-f:])((?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:){1,7}:|(?:[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}|(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2}|(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3}|(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4}|(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5}|[0-9a-f]{1,4}:(?:(?::[0-9a-f]{1,4}){1,6})|::(?:[0-9a-f]{1,4}:){0,6}[0-9a-f]{1,4}|::)(?:$|[^0-9a-f:])'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
+id = "postal.de"
+class = "custom:postal_code"
+cooperates_with = ["postal.us"]
+enabled = true
+locales = ["de-DE"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b\d{5}\b'''
+
+[recognizers.scoring]
+base = 0.70
+priority = 70
+
+[recognizers.token]
+
+[[recognizers]]
+id = "postal.us"
+class = "custom:postal_code"
+cooperates_with = ["postal.de"]
+enabled = true
+locales = ["en-US"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b\d{5}(-\d{4})?\b'''
+
+[recognizers.scoring]
+base = 0.70
+priority = 70
+
+[recognizers.token]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -28,8 +28,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?:^|[^A-Za-z0-9_.])((?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d))(?:$|[^A-Za-z0-9_.])'''
-capture_groups = [1]
+pattern = '''\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b'''
 
 [recognizers.scoring]
 base = 0.70

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -12,6 +12,7 @@ pub use regex::{NormalizerKind, RegexDetector, ValidatorKind};
 pub fn embedded(name: &str) -> Option<&'static str> {
     match name {
         "core" => Some(include_str!("../embedded/core.toml")),
+        "core-extended" => Some(include_str!("../embedded/core-extended.toml")),
         "locale-de" => Some(include_str!("../embedded/locale-de.toml")),
         "locale-en" => Some(include_str!("../embedded/locale-en.toml")),
         _ => None,
@@ -39,5 +40,23 @@ mod tests {
             rulepack.recognizers[1].matcher,
             RawMatch::Regex { .. }
         ));
+    }
+
+    #[test]
+    fn embedded_core_extended_rulepack_parses_and_contains_phase1_recognizers() {
+        let core_extended = embedded("core-extended").expect("core-extended rulepack");
+        let rulepack =
+            Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
+
+        assert_eq!(rulepack.recognizers.len(), 5);
+        assert_eq!(rulepack.recognizers[0].id, "phone.structural");
+        assert_eq!(rulepack.recognizers[1].id, "ip.v4");
+        assert_eq!(rulepack.recognizers[2].id, "ip.v6");
+        assert_eq!(rulepack.recognizers[3].id, "postal.de");
+        assert_eq!(rulepack.recognizers[4].id, "postal.us");
+        assert!(rulepack
+            .recognizers
+            .iter()
+            .all(|recognizer| matches!(recognizer.matcher, RawMatch::Regex { .. })));
     }
 }

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1,0 +1,290 @@
+use std::cell::Cell;
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, DetectContext, DictionaryBundle, LocaleTag,
+    PiiClass, Pipeline, RawDocument, RawMatch, Recognizer, RecognizerSpec, Rulepack, RulepackError,
+    RulepackSource, Scope, Session,
+};
+use gaze_recognizers::{embedded, RegexDetector};
+use serde_json::Map;
+
+fn core_extended() -> Rulepack {
+    Rulepack::load(RulepackSource::Embedded(
+        embedded("core-extended").expect("core-extended embedded rulepack"),
+    ))
+    .expect("core-extended loads")
+}
+
+fn regex_from_spec(spec: &RecognizerSpec) -> RegexDetector {
+    let RawMatch::Regex {
+        pattern,
+        pattern_template: None,
+        capture_groups,
+    } = &spec.matcher
+    else {
+        panic!("expected plain regex recognizer {}", spec.id);
+    };
+
+    RegexDetector::with_rulepack_fields(
+        pattern.as_deref().expect("regex pattern"),
+        spec.class.clone(),
+        &spec.id,
+        spec.locales.clone(),
+        spec.scoring.base,
+        spec.scoring.priority,
+        spec.token.family.as_deref().unwrap_or("counter"),
+        capture_groups.clone(),
+        spec.context
+            .as_ref()
+            .map(|context| context.exclusions.clone())
+            .unwrap_or_default(),
+        None,
+        None,
+    )
+    .expect("regex detector")
+}
+
+fn detect_recognizer(
+    rulepack: &Rulepack,
+    recognizer_id: &str,
+    input: &str,
+    locale: LocaleTag,
+) -> Vec<String> {
+    let dictionaries = DictionaryBundle::default();
+    let fields = Map::new();
+    let ctx = DetectContext {
+        locale_chain: &[locale, LocaleTag::Global],
+        dictionaries: &dictionaries,
+        fields: &fields,
+        degraded: Cell::new(false),
+    };
+    let spec = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == recognizer_id)
+        .unwrap_or_else(|| panic!("missing recognizer {recognizer_id}"));
+    let detector = regex_from_spec(spec);
+
+    Recognizer::detect(&detector, input, &ctx)
+        .into_iter()
+        .map(|candidate| input[candidate.span].to_string())
+        .collect()
+}
+
+fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
+    let mut builder = Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("phone".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("ip_address".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("postal_code".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve));
+
+    for spec in &rulepack.recognizers {
+        if spec.enabled {
+            builder = builder.recognizer(regex_from_spec(spec));
+        }
+    }
+
+    builder.build().expect("pipeline")
+}
+
+fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: LocaleTag) -> String {
+    let clean = pipeline
+        .redact_with_context(
+            session,
+            RawDocument::Text(input.to_string()),
+            &[locale, LocaleTag::Global],
+        )
+        .expect("clean");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+    text
+}
+
+#[test]
+fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
+    let rulepack = core_extended();
+
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "phone.structural",
+            "Phone +4915112345678",
+            LocaleTag::DeDe
+        ),
+        vec!["+4915112345678".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "ip.v4", "Host 192.168.1.1.", LocaleTag::EnUs),
+        vec!["192.168.1.1".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "ip.v6", "Loopback ::1.", LocaleTag::EnUs),
+        vec!["::1".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "ip.v6", "Host 2001:db8::1.", LocaleTag::EnUs),
+        vec!["2001:db8::1".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "postal.de", "Berlin 10115", LocaleTag::DeDe),
+        vec!["10115".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "postal.us", "ZIP 94103", LocaleTag::EnUs),
+        vec!["94103".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "postal.us", "ZIP 94103-1234", LocaleTag::EnUs),
+        vec!["94103-1234".to_string()]
+    );
+
+    for input in [
+        "1.2.3.4567",
+        "version v1.2.3.4",
+        "2026-04-25",
+        "0815 12345",
+        "0123-456789",
+        "Subscriber_0001234567",
+        "Order_0815",
+    ] {
+        assert!(
+            detect_recognizer(&rulepack, "phone.structural", input, LocaleTag::DeDe).is_empty(),
+            "phone.structural must not fire for {input}"
+        );
+    }
+}
+
+#[test]
+fn core_and_core_extended_compose_without_counter_collision() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+    let extended = core_extended();
+    let mut builder = Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("phone".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve));
+
+    let email_spec = core
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "email.global")
+        .expect("email.global");
+    builder = builder.recognizer(regex_from_spec(email_spec));
+    let phone_spec = extended
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "phone.structural")
+        .expect("phone.structural");
+    builder = builder.recognizer(regex_from_spec(phone_spec));
+
+    let pipeline = builder.build().expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(
+        &pipeline,
+        &session,
+        "Contact alice@example.invalid or +4915112345678",
+        LocaleTag::EnUs,
+    );
+
+    let tokens = clean
+        .split_whitespace()
+        .filter(|part| part.starts_with('<'))
+        .collect::<Vec<_>>();
+    assert_eq!(tokens.len(), 2);
+    assert!(tokens[0].ends_with(":Email_1>"), "{clean}");
+    assert!(tokens[1].ends_with(":Custom:phone_1>"), "{clean}");
+}
+
+#[test]
+fn every_phase1_recognizer_round_trips_through_restore() {
+    let rulepack = core_extended();
+    let pipeline = pipeline_from_rulepack(&rulepack);
+
+    for (input, locale) in [
+        ("Call +4915112345678", LocaleTag::DeDe),
+        ("Host 192.168.1.1", LocaleTag::EnUs),
+        ("Loopback ::1", LocaleTag::EnUs),
+        ("Host 2001:db8::1", LocaleTag::EnUs),
+        ("Berlin 10115", LocaleTag::DeDe),
+        ("ZIP 94103-1234", LocaleTag::EnUs),
+    ] {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, locale);
+        assert_ne!(clean, input, "expected tokenized output for {input}");
+        let restored =
+            gaze::token_shape::pattern().replace_all(&clean, |captures: &regex::Captures<'_>| {
+                session.restore_strict(&captures[0]).expect("known token")
+            });
+        assert_eq!(restored, input);
+    }
+}
+
+#[test]
+fn embedded_core_extended_load_smoke_has_at_least_five_recognizers() {
+    let rulepack = Rulepack::load(RulepackSource::Embedded(
+        embedded("core-extended").expect("core-extended embedded rulepack"),
+    ))
+    .expect("core-extended loads");
+
+    assert!(rulepack.recognizers.len() >= 5);
+}
+
+#[test]
+fn same_class_cooperation_is_data_and_unilateral_failure_behavior() {
+    let raw = embedded("core-extended").unwrap();
+    let rulepack = Rulepack::load(RulepackSource::Embedded(raw)).unwrap();
+    let ip_v4 = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "ip.v4")
+        .unwrap();
+    let ip_v6 = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "ip.v6")
+        .unwrap();
+    assert_eq!(ip_v4.cooperates_with, vec!["ip.v6"]);
+    assert_eq!(ip_v6.cooperates_with, vec!["ip.v4"]);
+
+    let one_side_removed = raw.replace("cooperates_with = [\"ip.v4\"]\n", "");
+    Rulepack::parse(&one_side_removed).expect("one-sided cooperation remains valid");
+
+    let both_sides_removed = one_side_removed.replace("cooperates_with = [\"ip.v6\"]\n", "");
+    let err = Rulepack::parse(&both_sides_removed)
+        .expect_err("both-side cooperation drop must fail closed");
+    assert!(matches!(
+        err,
+        RulepackError::SameClassWithoutCooperation {
+            class: PiiClass::Custom(ref name),
+            ..
+        } if name == "ip_address"
+    ));
+
+    let one_postal_side_removed = raw.replace("cooperates_with = [\"postal.de\"]\n", "");
+    Rulepack::parse(&one_postal_side_removed).expect("one-sided postal cooperation remains valid");
+
+    let both_postal_sides_removed =
+        one_postal_side_removed.replace("cooperates_with = [\"postal.us\"]\n", "");
+    let err = Rulepack::parse(&both_postal_sides_removed)
+        .expect_err("both-side postal cooperation drop must fail closed");
+    assert!(matches!(
+        err,
+        RulepackError::SameClassWithoutCooperation {
+            class: PiiClass::Custom(ref name),
+            ..
+        } if name == "postal_code"
+    ));
+}

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -251,6 +251,39 @@ bundled = ["core"]
 paths = ["./tenant-rulepack.toml"]
 ```
 
+Bundled rulepacks:
+
+| Bundle | Recognizers | Classes | Notes |
+|--------|-------------|---------|-------|
+| `core` | `email.global`, `email.header.name` | `email`, `name` | Default bundle when `[policy.rulepacks]` is omitted. |
+| `core-extended` | `phone.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:ip_address`, `custom:postal_code` | Opt-in Phase 1 bundle. Shape-only recognizers; no validators yet. |
+
+Opt into `core-extended` alongside `core`:
+
+```toml
+[policy.rulepacks]
+bundled = ["core", "core-extended"]
+```
+
+Or override the bundle list for one CLI run:
+
+```bash
+gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
+```
+
+`core-extended` Phase 1 recognizers are intentionally conservative:
+
+- `phone.structural` matches E.164-only `+\d{6,15}` numbers. National phone
+  patterns are not included.
+- `ip.v4` and `ip.v6` emit `custom:ip_address`.
+- `postal.de` emits `custom:postal_code` only under active locale `de-DE`.
+- `postal.us` emits `custom:postal_code` only under active locale `en-US`.
+  Plain `en` does not activate `postal.us`.
+
+Phase 1 is shape-only. IBAN, credit-card, and national-phone recognizers need
+validator support and are planned for v0.4.3 with the `ValidatorKind`
+extension.
+
 Within a rulepack, every `[[recognizers]]` block has an `id`, `class`, and
 `[recognizers.match]` table. If two recognizers in the same rulepack emit the
 same `class`, at least one must explicitly list the other recognizer id in


### PR DESCRIPTION
## Summary
v0.4.2 plan rev 3 §S2 (scratchpad 258). NEW opt-in rulepack \`core-extended\` shipping 5 validator-free universal recognizers. Closes drawer 170d6b18 Part 2 (extensible classes hybrid).

Recognizers (Phase 1, no validators):
- \`phone.structural\` — E.164 only \`\\+\\d{6,15}\\b\`. Drops national patterns to avoid tenant-numeric-ID collision.
- \`ip.v4\` + \`ip.v6\` — same class \`custom:ip_address\`, bidirectional \`cooperates_with\`.
- \`postal.de\` (locale \`de-DE\`) + \`postal.us\` (locale \`en-US\`) — same class \`custom:postal_code\`, bidirectional \`cooperates_with\`.

Opt-in:
- TOML: \`[policy.rulepacks] bundled = ["core", "core-extended"]\`
- CLI: \`gaze clean --rulepack-bundled=core,core-extended ...\`

Phase-1 = shape-only. IBAN/CreditCard/national-phone with validators land in v0.4.3 alongside ValidatorKind extension.

## Test plan
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets\` zero warnings
- [x] All 11 S2.test rows present + passing
- [x] Recursive-Potemkin: \`embedded("core-extended")\` not None; rulepack ≥5 recognizers; both-side cooperation drop fails load
- [x] Round-trip identity per recognizer
- [x] Locale gating: en-US → postal.us, de-DE → postal.de, plain en → no postal

🤖 Generated with [Claude Code](https://claude.com/claude-code)