### PR TITLE
v0.4.2 P3.S4: Linux x86_64 release artifact (ubuntu-22.04 native runner)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: gaze-aarch64-apple-darwin
+          - os: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            artifact: gaze-x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +34,47 @@ jobs:
           cp target/${{ matrix.target }}/release/gaze dist/${{ matrix.artifact }}
           chmod +x dist/${{ matrix.artifact }}
           (cd dist && shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256)
+      - name: Smoke artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="dist/${{ matrix.artifact }}"
+
+          "$bin" --version
+          "$bin" clean --help | grep -q -- '--session-scope'
+          "$bin" clean --help | grep -q -- '--ner-model-dir'
+          "$bin" clean --help | grep -q -- '--ner-locale'
+          "$bin" clean --help | grep -q -- '--rulepack-bundled'
+          "$bin" clean --help | grep -q -- '--rulepack-path'
+
+          clean_json="$(printf 'alice@example.invalid' | "$bin" clean)"
+          clean_text="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["clean_text"])' <<< "$clean_json")"
+          grep -q '<' <<< "$clean_text" || (echo "smoke failed: no token in output"; exit 1)
+          restore_request="$(python3 -c 'import json,sys; v=json.load(sys.stdin); print(json.dumps({"session_blob": v["session_blob"], "text": v["clean_text"]}))' <<< "$clean_json")"
+          restored_json="$(printf '%s' "$restore_request" | "$bin" restore)"
+          python3 -c 'import json,sys; assert json.load(sys.stdin)["text"] == "alice@example.invalid"' <<< "$restored_json"
+
+          policy="$(mktemp)"
+          cat > "$policy" <<'POLICY'
+          [session]
+          scope = "persistent"
+          ttl_secs = 86400
+
+          [policy.rulepacks]
+          bundled = ["core", "core-extended"]
+
+          [[rule]]
+          kind = "class"
+          class = "custom:ip_address"
+          action = "tokenize"
+
+          [[rule]]
+          kind = "default"
+          action = "preserve"
+          POLICY
+          extended_json="$(printf 'host 192.0.2.1' | "$bin" clean --policy="$policy")"
+          extended_text="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["clean_text"])' <<< "$extended_json")"
+          grep -q 'Custom:ip_address' <<< "$extended_text" || (echo "smoke failed: core-extended did not tokenize IP fixture"; exit 1)
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,20 @@ jobs:
           cp target/${{ matrix.target }}/release/gaze dist/${{ matrix.artifact }}
           chmod +x dist/${{ matrix.artifact }}
           (cd dist && shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/*
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: smoke
       - name: Smoke artifact
         shell: bash
         run: |
           set -euo pipefail
-          bin="dist/${{ matrix.artifact }}"
+          bin="smoke/${{ matrix.artifact }}"
+          chmod +x "$bin"
 
           "$bin" --version
           "$bin" clean --help | grep -q -- '--session-scope'
@@ -75,10 +84,6 @@ jobs:
           extended_json="$(printf 'host 192.0.2.1' | "$bin" clean --policy="$policy")"
           extended_text="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["clean_text"])' <<< "$extended_json")"
           grep -q 'Custom:ip_address' <<< "$extended_text" || (echo "smoke failed: core-extended did not tokenize IP fixture"; exit 1)
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact }}
-          path: dist/*
 
   release:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- v0.4.2 P3.S4 release CI now publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-22.04` runner, alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts.
+- Release artifact smoke now executes the packaged binary for `--version`, `alice@example.invalid` clean/restore reversibility, S1 runtime knob help flags (`--session-scope`, NER, and rulepack surfaces), and `core-extended` bundled rulepack loading with neutral non-real fixture data.
 - v0.4.1 Bundle P1 foundation: `gaze-assembly` library entrypoint, `xtask` scaffold, and the `symmetric_potemkin_gate` workflow.
 - `token.family` now threads from recognizers into session snapshot entries while preserving the existing emitted token grammar.
 - Locale-aware regex `pattern_template` lowering for `{locale_email_headers}` with English and German defaults.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ tar -xzf gaze-v0.4.0-rc.1-aarch64-apple-darwin.tar.gz
 mv gaze /usr/local/bin/gaze
 ```
 
-Linux and Intel macOS binaries are not published in v0.4.0-rc.1; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release -p gaze-cli` in the meantime.
+Linux x86_64 release asset pattern for v0.4.2 release candidates and later:
+
+```bash
+curl -L -o gaze https://github.com/Naoray/gaze/releases/download/v0.4.2-rc.1/gaze-x86_64-unknown-linux-gnu
+chmod +x gaze
+mv gaze /usr/local/bin/gaze
+```
+
+Intel macOS binaries are not published in v0.4.0-rc.1; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release -p gaze-cli` in the meantime.
 
 ## Workspace Layout
 

--- a/crates/gaze/build.rs
+++ b/crates/gaze/build.rs
@@ -1,7 +1,11 @@
+#[cfg(target_os = "macos")]
 use std::env;
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::process::Command;
 
+#[cfg(target_os = "macos")]
 fn main() {
     let Ok(target) = env::var("TARGET") else {
         return;
@@ -15,6 +19,10 @@ fn main() {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+fn main() {}
+
+#[cfg(target_os = "macos")]
 fn clang_runtime_dir() -> Option<PathBuf> {
     let output = Command::new("xcrun")
         .args(["clang", "--print-resource-dir"])


### PR DESCRIPTION
Closes #76 v0.4.2 portion. Native ubuntu-22.04 runner per rev 3 §S4. Smoke step downloads + runs --version + clean fixture. macOS host cross-build dies in onig_sys (Codex verified) — native runner is the fix.

Full S4.test matrix runs at v0.4.2-rc.1 tag (P4 wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)