### PR TITLE
v0.4.2 P3.S3: fixture sweep — tenant-pattern strings → neutral placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.1`.
 - Snapshot envelope version bumped from 2 to 3; v0.4.1 imports v2 snapshots with default `counter` family, while v0.4.0 rejects v3 snapshots instead of silently collapsing family metadata.
 - Dictionary recognizer audit sources now include per-term traceability as `dictionary:{name}[#term_index]`.
+- v0.4.2 fixture sweep renamed tenant-pattern test and benchmark strings to neutral placeholders, with `CONTRIBUTING.md` documenting tenant class naming policy.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+## Tenant class names in tests
+
+Test fixtures and benchmark labels MUST use neutral class names (e.g. `class_alpha`, `tenant_class_a`, `dict_alpha`), never tenant-specific patterns like `order_id`, `Order_42`, `Song_42`, `User_7`. Rationale: drawer `eac549ae` — gaze core has no built-in tenant knowledge.
+
+Forward-reference: a future `// gaze-allow-tenant-knowledge: <reason>` comment marker may be introduced for legitimate cases (drawer `eac549ae` + planned v0.4.3 lint gate). Use neutral placeholders by default.

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -767,24 +767,24 @@ fn t04c_tolerant_restore_omits_empty_warning_array() {
 }
 
 #[test]
-fn cascade_restored_order_id_not_trapped() {
+fn cascade_restored_class_alpha_not_trapped() {
     let (blob, tokens) = build_blob_and_tokens(|s| {
         vec![s
-            .tokenize(&PiiClass::custom("order_ref"), "Order_42")
+            .tokenize(&PiiClass::custom("order_ref"), "tenant_class_a")
             .unwrap()]
     });
     assert_session_scoped_custom_token(&tokens[0]);
 
     let restored = restore_success_text(&blob, &format!("Reference {} is ready.", tokens[0]));
 
-    assert_eq!(restored, "Reference Order_42 is ready.");
+    assert_eq!(restored, "Reference tenant_class_a is ready.");
 }
 
 #[test]
 fn cascade_restored_song_user_artist_tenant() {
     let cases = [
-        ("song_ref", "Song_42"),
-        ("user_ref", "User_7"),
+        ("song_ref", "tenant_class_b"),
+        ("user_ref", "tenant_class_c"),
         ("artist_ref", "Artist_1"),
         ("tenant_ref", "Tenant_5"),
     ];
@@ -804,13 +804,13 @@ fn cascade_restored_song_user_artist_tenant() {
     );
     let restored = restore_success_text(&blob, &reply);
 
-    assert_eq!(restored, "Song_42 / User_7 / Artist_1 / Tenant_5");
+    assert_eq!(restored, "tenant_class_b / tenant_class_c / Artist_1 / Tenant_5");
 }
 
 #[test]
 fn cascade_restored_snake_case() {
     let cases = [
-        ("order_raw", "order_id_7"),
+        ("order_raw", "class_alpha_7"),
         ("tenant_raw", "tenant_5"),
         ("class_raw", "class_1"),
         ("song_title_raw", "song_title_3"),
@@ -828,14 +828,14 @@ fn cascade_restored_snake_case() {
     let reply = format!("{} {} {} {}", tokens[0], tokens[1], tokens[2], tokens[3]);
     let restored = restore_success_text(&blob, &reply);
 
-    assert_eq!(restored, "order_id_7 tenant_5 class_1 song_title_3");
+    assert_eq!(restored, "class_alpha_7 tenant_5 class_1 song_title_3");
 }
 
 #[test]
 fn cascade_llm_hallucination_still_trapped() {
     let (blob, tokens) = build_blob_and_tokens(|s| {
         vec![s
-            .tokenize(&PiiClass::custom("order_ref"), "Order_42")
+            .tokenize(&PiiClass::custom("order_ref"), "tenant_class_a")
             .unwrap()]
     });
     assert_session_scoped_custom_token(&tokens[0]);
@@ -2319,7 +2319,7 @@ action = "preserve"
 #[test]
 fn t19_restore_custom_token_round_trip_ok() {
     let (blob, tokens) =
-        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]);
+        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("class_alpha"), "42").unwrap()]);
     let text = format!("Order {} is shipped.", tokens[0]);
 
     let (code, stdout, stderr) = restore_json(&blob, &text);
@@ -2331,7 +2331,7 @@ fn t19_restore_custom_token_round_trip_ok() {
 #[test]
 fn t20_restore_custom_hallucination_exits_3() {
     let (blob, tokens) =
-        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("order_id"), "42").unwrap()]);
+        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("class_alpha"), "42").unwrap()]);
 
     let text = format!("Order {} and <Custom:fake_id_99> are shipped.", tokens[0]);
     let (code, stdout, stderr) = restore_json(&blob, &text);

--- a/crates/gaze-recognizers/benches/dictionary.rs
+++ b/crates/gaze-recognizers/benches/dictionary.rs
@@ -24,7 +24,7 @@ fn build_recognizer(term_count: usize) -> (DictionaryRecognizer, DictionaryBundl
     (
         DictionaryRecognizer::new(
             "dict/orders",
-            PiiClass::Custom("order_id".to_string()),
+            PiiClass::Custom("class_alpha".to_string()),
             "orders",
             true,
             "counter",

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -121,9 +121,9 @@ mod tests {
     fn recognizer_detects_dictionary_hits_from_context_bundle() {
         let ctx = TypedContext {
             dictionaries: HashMap::from([(
-                "order_ids".to_string(),
+                "dict_alpha".to_string(),
                 ContextDictionary {
-                    terms: vec!["ORD-12345".to_string()],
+                    terms: vec!["AAA-12345".to_string()],
                     case_sensitive: true,
                 },
             )]),
@@ -139,17 +139,17 @@ mod tests {
             degraded: Cell::new(false),
         };
         let recognizer = DictionaryRecognizer::new(
-            "dict/order_ids",
-            PiiClass::Custom("order_id".to_string()),
-            "order_ids",
+            "dict/dict_alpha",
+            PiiClass::Custom("class_alpha".to_string()),
+            "dict_alpha",
             true,
             "counter",
         );
 
-        let hits = recognizer.detect("Customer bought ORD-12345", &detect_context);
+        let hits = recognizer.detect("Customer bought AAA-12345", &detect_context);
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].span, 16..25);
-        assert_eq!(hits[0].class, PiiClass::Custom("order_id".to_string()));
+        assert_eq!(hits[0].class, PiiClass::Custom("class_alpha".to_string()));
     }
 
     #[test]

--- a/crates/gaze/src/context.rs
+++ b/crates/gaze/src/context.rs
@@ -135,19 +135,19 @@ mod tests {
         let raw = serde_json::from_str::<RawContext>(
             r#"{
               "dictionaries": {
-                "order_ids": { "terms": ["ORD-12345"], "case_sensitive": true }
+                "dict_alpha": { "terms": ["AAA-12345"], "case_sensitive": true }
               },
-              "class_map": { "order_ids": "custom:order_id" },
+              "class_map": { "dict_alpha": "custom:class_alpha" },
               "fields": { "tenant": "demo" }
             }"#,
         )
         .expect("raw context");
 
         let ctx = Context::try_from(raw).expect("context");
-        assert_eq!(ctx.dictionaries["order_ids"].terms, vec!["ORD-12345"]);
+        assert_eq!(ctx.dictionaries["dict_alpha"].terms, vec!["AAA-12345"]);
         assert_eq!(
-            ctx.class_map["order_ids"],
-            PiiClass::Custom("order_id".to_string())
+            ctx.class_map["dict_alpha"],
+            PiiClass::Custom("class_alpha".to_string())
         );
         assert_eq!(ctx.fields["tenant"], Value::String("demo".to_string()));
     }

--- a/crates/gaze/src/dictionaries.rs
+++ b/crates/gaze/src/dictionaries.rs
@@ -165,23 +165,23 @@ mod tests {
     fn context_bundle_builds_automata_per_request() {
         let ctx = Context {
             dictionaries: HashMap::from([(
-                "order_ids".to_string(),
+                "dict_alpha".to_string(),
                 ContextDictionary {
-                    terms: vec!["ORD-12345".to_string()],
+                    terms: vec!["AAA-12345".to_string()],
                     case_sensitive: true,
                 },
             )]),
             class_map: HashMap::from([(
-                "order_ids".to_string(),
-                PiiClass::Custom("order_id".to_string()),
+                "dict_alpha".to_string(),
+                PiiClass::Custom("class_alpha".to_string()),
             )]),
             fields: Map::new(),
         };
 
         let bundle = DictionaryBundle::from_context(&ctx);
-        let entry = bundle.get("order_ids").expect("entry");
-        assert!(entry.automaton().find("ORD-12345").is_some());
-        assert!(entry.automaton().find("ord-12345").is_none());
+        let entry = bundle.get("dict_alpha").expect("entry");
+        assert!(entry.automaton().find("AAA-12345").is_some());
+        assert!(entry.automaton().find("aaa-12345").is_none());
     }
 
     #[test]

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -777,8 +777,8 @@ rulepack_version = "0.4.0"
     fn class_spelling_accepts_pascal_case_and_custom_names() {
         assert_eq!(parse_class("Email").unwrap(), PiiClass::Email);
         assert_eq!(
-            parse_class("custom:Order_ID").unwrap(),
-            PiiClass::Custom("order_id".to_string())
+            parse_class("custom:Class_Alpha").unwrap(),
+            PiiClass::Custom("class_alpha".to_string())
         );
     }
 

--- a/crates/gaze/src/token_shape.rs
+++ b/crates/gaze/src/token_shape.rs
@@ -112,7 +112,7 @@ mod tests {
         for class in PiiClass::builtin_variants()
             .iter()
             .cloned()
-            .chain(std::iter::once(PiiClass::custom("order_id")))
+            .chain(std::iter::once(PiiClass::custom("class_alpha")))
         {
             assert!(contains_token(&tokenized_for(class.clone())));
             assert!(contains_token(&format_preserving_for(class)));
@@ -172,11 +172,11 @@ mod tests {
 
     #[test]
     fn custom_token_matches_as_single_span() {
-        let haystack = format!("before <Custom:{}> after", ["order_id", "1"].join("_"));
+        let haystack = format!("before <Custom:{}> after", ["class_alpha", "1"].join("_"));
         let matched = pattern().find(&haystack).expect("custom token match");
         assert_eq!(
             matched.as_str(),
-            format!("<Custom:{}>", ["order_id", "1"].join("_"))
+            format!("<Custom:{}>", ["class_alpha", "1"].join("_"))
         );
     }
 
@@ -188,7 +188,7 @@ mod tests {
         )));
         assert!(contains_token(&format!(
             "See <Custom:{}>.",
-            ["order_id", "1"].join("_")
+            ["class_alpha", "1"].join("_")
         )));
         assert!(contains_token("Reply to name_1."));
         assert!(contains_token("Email email1@example.test later."));
@@ -198,7 +198,7 @@ mod tests {
     fn legacy_shape_parity_traps_all_known_v03_forms() {
         for shape in [
             format!("<{}>", ["Email", "1"].join("_")),
-            format!("<Custom:{}>", ["order_id", "1"].join("_")),
+            format!("<Custom:{}>", ["class_alpha", "1"].join("_")),
             format!("<{}>", ["Foo", "5"].join("_")),
             format!("<{}>", ["foo", "1"].join("_")),
             ["Email", "7"].join("_"),
@@ -206,7 +206,7 @@ mod tests {
             ["name", "1"].join("_"),
             ["organization", "1"].join("_"),
             ["email", "1"].join("_"),
-            format!("custom:{}", ["order_id", "1"].join("_")),
+            format!("custom:{}", ["class_alpha", "1"].join("_")),
             "email3@example.test".to_string(),
             "email3@gaze-fake.invalid".to_string(),
         ] {

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -381,8 +381,8 @@ fn tokenize_assigns_indices_left_to_right() {
 #[test]
 fn custom_pii_class_normalizes_name() {
     assert_eq!(
-        PiiClass::custom(" Order-ID ").as_custom_name(),
-        Some("order_id")
+        PiiClass::custom(" Class-Alpha ").as_custom_name(),
+        Some("class_alpha")
     );
 }
 


### PR DESCRIPTION
Closes part of #95. Mechanical rename per rev 3 §S3. Excludes main.rs (coordinated with #115 split via worker 585). CONTRIBUTING gets tenant-naming policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)