### PR TITLE
v0.4.2 P3.5 #114: generic placeholder vocab — drop codified email_headers concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-in `core-extended` bundled rulepack with Phase 1 shape-only recognizers for E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes.
 - v0.5 design doc for open-key `PiiClass` and decision-deferred crate-shape Option B sketch.
 - Three-surfaces parity audit table for every `policy.toml` field, classifying runtime knobs with CLI/TOML/default coverage and policy-document fields that intentionally remain TOML-only.
+- Rulepack locale `pattern_template` placeholders now support generic `{locale.<bucket>}` expansion from adopter-defined `[locale.<bucket>] names = [...]` tables.
 
 ### Changed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snapshot envelope version bumped from 2 to 3; v0.4.1 imports v2 snapshots with default `counter` family, while v0.4.0 rejects v3 snapshots instead of silently collapsing family metadata.
 - Dictionary recognizer audit sources now include per-term traceability as `dictionary:{name}[#term_index]`.
 - v0.4.2 fixture sweep renamed tenant-pattern test and benchmark strings to neutral placeholders, with `CONTRIBUTING.md` documenting tenant class naming policy.
+- `{locale_email_headers}` remains supported as a v0.4.2 compatibility alias for `{locale.email_headers}` and is deprecated for removal in the v0.5 cycle.
 
 ### Fixed
 

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -112,11 +112,13 @@ runtime context together.
 
 Rulepack regex recognizers may use supported pattern-template placeholders.
 `gaze-assembly` lowers those placeholders after the active locale chain is
-known. For example, `{locale_email_headers}` lowers from the loaded rulepack
-locale metadata, falling back to the default English header list when no
-loaded locale metadata matches.
+known. Generic placeholders use `{locale.<bucket>}` and lower from loaded
+rulepack locale metadata such as `[locale.salutations] names = [...]`.
+`{locale_email_headers}` remains a v0.4.2 compatibility alias for
+`{locale.email_headers}` and is deprecated for removal in the v0.5 cycle.
 
-Unknown placeholders fail closed with `RulepackError`.
+Unknown placeholders fail closed with `RulepackError`; unknown locale buckets
+fail closed with `PolicyError::UnknownLocaleBucket`.
 
 ## What belongs here
 

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -96,12 +96,8 @@ pub fn build_pipeline(
                 pattern_template,
                 capture_groups,
             } => {
-                let pattern = lower_regex_pattern(
-                    &recognizer.id,
-                    pattern,
-                    pattern_template,
-                    &locale_vocab,
-                )?;
+                let pattern =
+                    lower_regex_pattern(&recognizer.id, pattern, pattern_template, &locale_vocab)?;
                 let exclusions = recognizer
                     .context
                     .as_ref()

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -642,6 +642,118 @@ mod tests {
     }
 
     #[test]
+    fn locale_email_headers_legacy_alias_matches_bucket_syntax() {
+        let locale_vocab = std::collections::HashMap::from([(
+            "email_headers".to_string(),
+            vec!["From".to_string(), "Reply-To".to_string()],
+        )]);
+
+        let legacy = lower_pattern_template(
+            "email.header.name",
+            r"^(?:{locale_email_headers}):\s+(.+)$",
+            &locale_vocab,
+        )
+        .expect("legacy placeholder");
+        let bucket = lower_pattern_template(
+            "email.header.name",
+            r"^(?:{locale.email_headers}):\s+(.+)$",
+            &locale_vocab,
+        )
+        .expect("bucket placeholder");
+
+        assert_eq!(legacy, bucket);
+    }
+
+    #[test]
+    fn locale_bucket_placeholder_lowers_neutral_bucket() {
+        let rulepack = Rulepack::parse(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "neutral-template"
+rulepack_version = "0.4.2"
+default_locales = ["global"]
+
+[locale.salutations]
+names = ["Mx", "Dr"]
+
+[[recognizers]]
+id = "neutral.salutation.name"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern_template = '''(?m)^(?:{locale.salutations}):\s+([A-Z][a-z]+)$'''
+capture_groups = [1]
+"#,
+        )
+        .expect("parse");
+
+        let policy = policy();
+        let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+        let pipeline = build_pipeline(
+            &policy,
+            &empty_context(),
+            &[rulepack],
+            &active_locales,
+            None,
+        )
+        .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = pipeline
+            .redact(&session, RawDocument::Text("Mx: Schmidt".to_string()))
+            .expect("redact");
+
+        let CleanDocument::Text(text) = clean else {
+            panic!("expected text");
+        };
+        assert!(regex::Regex::new(r"^Mx: <[0-9a-f]{8}:Name_\d+>$")
+            .unwrap()
+            .is_match(&text));
+    }
+
+    #[test]
+    fn locale_bucket_placeholder_unknown_bucket_fails_closed() {
+        let rulepack = Rulepack::parse(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "bad-locale-bucket"
+rulepack_version = "0.4.2"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "bad.locale.bucket"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern_template = '''{locale.missing_bucket}: (.+)'''
+"#,
+        )
+        .expect("parse");
+
+        let policy = policy();
+        let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+        let err = match build_pipeline(
+            &policy,
+            &empty_context(),
+            &[rulepack],
+            &active_locales,
+            None,
+        ) {
+            Ok(_) => panic!("unknown locale bucket must fail"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            BuildError::Policy(PolicyError::UnknownLocaleBucket { name })
+                if name == "missing_bucket"
+        ));
+    }
+
+    #[test]
     fn pattern_template_unknown_placeholder_fails_closed() {
         let rulepack = Rulepack::parse(
             r#"

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -383,9 +383,7 @@ fn merged_locale_vocab(
                 let bucket_values = buckets
                     .entry(bucket_name.clone())
                     .or_insert_with(Vec::<String>::new);
-                let bucket_seen = seen
-                    .entry(bucket_name.clone())
-                    .or_insert_with(BTreeSet::<String>::new);
+                let bucket_seen = seen.entry(bucket_name.clone()).or_default();
                 for name in &bucket.names {
                     if bucket_seen.insert(name.clone()) {
                         bucket_values.push(name.clone());

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use gaze::{
     Action, ClassRule, ColumnRule, Context, DefaultRule, DetectorKind, LocaleChain, PiiClass,
@@ -28,7 +28,7 @@ pub fn build_pipeline(
 ) -> Result<Pipeline, BuildError> {
     let mut builder = Pipeline::builder();
     let mut registered_dictionaries = BTreeSet::<String>::new();
-    let locale_headers = merged_locale_email_headers(rulepacks, active_locales);
+    let locale_vocab = merged_locale_vocab(rulepacks, active_locales);
 
     for detector in &policy.detectors {
         builder = match &detector.kind {
@@ -100,7 +100,7 @@ pub fn build_pipeline(
                     &recognizer.id,
                     pattern,
                     pattern_template,
-                    &locale_headers,
+                    &locale_vocab,
                 )?;
                 let exclusions = recognizer
                     .context
@@ -271,20 +271,20 @@ fn lower_regex_pattern(
     id: &str,
     pattern: Option<String>,
     pattern_template: Option<String>,
-    locale_headers: &[String],
-) -> Result<String, RulepackError> {
+    locale_vocab: &HashMap<String, Vec<String>>,
+) -> Result<String, BuildError> {
     match (pattern, pattern_template) {
         (Some(pattern), None) => Ok(pattern),
-        (None, Some(template)) => lower_pattern_template(id, &template, locale_headers),
-        _ => Err(RulepackError::RegexPatternChoice { id: id.to_string() }),
+        (None, Some(template)) => lower_pattern_template(id, &template, locale_vocab),
+        _ => Err(RulepackError::RegexPatternChoice { id: id.to_string() }.into()),
     }
 }
 
 fn lower_pattern_template(
     id: &str,
     template: &str,
-    locale_headers: &[String],
-) -> Result<String, RulepackError> {
+    locale_vocab: &HashMap<String, Vec<String>>,
+) -> Result<String, BuildError> {
     let mut lowered = String::with_capacity(template.len());
     let mut rest = template;
     while let Some(start) = rest.find('{') {
@@ -294,7 +294,8 @@ fn lower_pattern_template(
             return Err(RulepackError::UnknownPatternTemplatePlaceholder {
                 id: id.to_string(),
                 placeholder: after.to_string(),
-            });
+            }
+            .into());
         };
         let placeholder = &after[..end];
         if !is_template_placeholder(placeholder) {
@@ -304,21 +305,27 @@ fn lower_pattern_template(
             rest = &after[end + 1..];
             continue;
         }
-        match placeholder {
-            "locale_email_headers" => lowered.push_str(&format!(
+        if let Some(bucket_name) = locale_bucket_name(placeholder) {
+            let Some(names) = locale_vocab.get(bucket_name) else {
+                return Err(PolicyError::UnknownLocaleBucket {
+                    name: bucket_name.to_string(),
+                }
+                .into());
+            };
+            lowered.push_str(&format!(
                 "(?:{})",
-                locale_headers
+                names
                     .iter()
                     .map(|name| regex::escape(name))
                     .collect::<Vec<_>>()
                     .join("|")
-            )),
-            other => {
-                return Err(RulepackError::UnknownPatternTemplatePlaceholder {
-                    id: id.to_string(),
-                    placeholder: other.to_string(),
-                })
+            ));
+        } else {
+            return Err(RulepackError::UnknownPatternTemplatePlaceholder {
+                id: id.to_string(),
+                placeholder: placeholder.to_string(),
             }
+            .into());
         }
         rest = &after[end + 1..];
     }
@@ -327,6 +334,10 @@ fn lower_pattern_template(
 }
 
 fn is_template_placeholder(value: &str) -> bool {
+    is_legacy_template_placeholder(value) || locale_bucket_name(value).is_some()
+}
+
+fn is_legacy_template_placeholder(value: &str) -> bool {
     !value.is_empty()
         && value
             .bytes()
@@ -337,49 +348,58 @@ fn is_template_placeholder(value: &str) -> bool {
             .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
 }
 
-fn merged_locale_email_headers(
+fn locale_bucket_name(placeholder: &str) -> Option<&str> {
+    const LEGACY_EMAIL_HEADERS_ALIAS: &str = "locale_email_headers";
+    const LEGACY_EMAIL_HEADERS_BUCKET: &str = "email_headers";
+
+    if placeholder == LEGACY_EMAIL_HEADERS_ALIAS {
+        return Some(LEGACY_EMAIL_HEADERS_BUCKET);
+    }
+
+    let bucket_name = placeholder.strip_prefix("locale.")?;
+    if !bucket_name.is_empty()
+        && bucket_name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        Some(bucket_name)
+    } else {
+        None
+    }
+}
+
+fn merged_locale_vocab(
     rulepacks: &[Rulepack],
     active_locales: &LocaleChain,
-) -> Vec<String> {
-    let mut names = Vec::new();
-    let mut seen = BTreeSet::new();
+) -> HashMap<String, Vec<String>> {
+    let mut buckets = HashMap::new();
+    let mut seen = HashMap::<String, BTreeSet<String>>::new();
 
     for active_locale in active_locales.as_slice() {
         for rulepack in rulepacks {
             if !rulepack.default_locales.contains(active_locale) {
                 continue;
             }
-            let Some(headers) = rulepack
-                .locale
-                .as_ref()
-                .and_then(|locale| locale.email_headers.as_ref())
-            else {
+            let Some(locale) = rulepack.locale.as_ref() else {
                 continue;
             };
-            for name in &headers.names {
-                if seen.insert(name.clone()) {
-                    names.push(name.clone());
+            for (bucket_name, bucket) in &locale.buckets {
+                let bucket_values = buckets
+                    .entry(bucket_name.clone())
+                    .or_insert_with(Vec::<String>::new);
+                let bucket_seen = seen
+                    .entry(bucket_name.clone())
+                    .or_insert_with(BTreeSet::<String>::new);
+                for name in &bucket.names {
+                    if bucket_seen.insert(name.clone()) {
+                        bucket_values.push(name.clone());
+                    }
                 }
             }
         }
     }
 
-    if names.is_empty() {
-        default_email_headers()
-    } else {
-        names
-    }
-}
-
-fn default_email_headers() -> Vec<String> {
-    vec![
-        "From".to_string(),
-        "To".to_string(),
-        "Cc".to_string(),
-        "Bcc".to_string(),
-        "Reply-To".to_string(),
-        "Sender".to_string(),
-    ]
+    buckets
 }
 
 #[cfg(test)]
@@ -575,10 +595,14 @@ mod tests {
 
     #[test]
     fn pattern_template_preserves_regex_quantifiers() {
+        let locale_vocab = std::collections::HashMap::from([(
+            "email_headers".to_string(),
+            vec!["From".to_string()],
+        )]);
         let pattern = lower_pattern_template(
             "email.header.name",
             r"^(?:{locale_email_headers}): ([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3})$",
-            &["From".to_string()],
+            &locale_vocab,
         )
         .expect("lowered pattern");
 
@@ -592,10 +616,14 @@ mod tests {
 
     #[test]
     fn locale_email_headers_placeholder_is_non_capturing() {
+        let locale_vocab = std::collections::HashMap::from([(
+            "email_headers".to_string(),
+            vec!["Von".to_string()],
+        )]);
         let pattern = lower_pattern_template(
             "email.header.name",
             r#"^(?:{locale_email_headers}):\s*(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+<[^>]+>"#,
-            &["Von".to_string()],
+            &locale_vocab,
         )
         .expect("lowered pattern");
         let regex = regex::Regex::new(&pattern).expect("compiled regex");

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -40,7 +40,7 @@ pub use registry::{
 pub use resolver::resolve_candidates;
 pub use rule::{Action, ClassRule, ColumnRule, DefaultRule, Rule, RuleContext};
 pub use rulepack::{
-    recognizer_composition_validator, ContextSpec, LocaleData, LocaleEmailHeaders, NormalizerSpec,
+    recognizer_composition_validator, ContextSpec, LocaleBucket, LocaleData, NormalizerSpec,
     RawMatch, RecognizerSpec, Rulepack, RulepackError, RulepackSource, ScoringSpec, SourceSpec,
     TokenSpec, ValidatorSpec,
 };

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -131,6 +131,8 @@ pub enum PolicyError {
     NerLocaleUnsupported { value: String },
     #[error("unknown bundled rulepack: {value}")]
     BundledRulepackUnknown { value: String },
+    #[error("unknown locale bucket: {name}")]
+    UnknownLocaleBucket { name: String },
     #[error("{0}")]
     UnsupportedRuleKind(String),
 }

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -98,11 +99,11 @@ pub struct SourceSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LocaleData {
-    pub email_headers: Option<LocaleEmailHeaders>,
+    pub buckets: HashMap<String, LocaleBucket>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LocaleEmailHeaders {
+pub struct LocaleBucket {
     pub names: Vec<String>,
 }
 
@@ -196,15 +197,14 @@ struct RawRulepack {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct RawLocaleData {
-    #[serde(default)]
-    email_headers: Option<RawLocaleEmailHeaders>,
+    #[serde(flatten)]
+    buckets: HashMap<String, RawLocaleBucket>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawLocaleEmailHeaders {
+struct RawLocaleBucket {
     names: Vec<String>,
 }
 
@@ -321,9 +321,18 @@ impl TryFrom<RawRulepack> for Rulepack {
 impl From<RawLocaleData> for LocaleData {
     fn from(raw: RawLocaleData) -> Self {
         Self {
-            email_headers: raw.email_headers.map(|headers| LocaleEmailHeaders {
-                names: headers.names,
-            }),
+            buckets: raw
+                .buckets
+                .into_iter()
+                .map(|(name, bucket)| {
+                    (
+                        name,
+                        LocaleBucket {
+                            names: bucket.names,
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 }
@@ -547,7 +556,7 @@ license = "Apache-2.0"
         let header_names = &rulepack
             .locale
             .as_ref()
-            .and_then(|locale| locale.email_headers.as_ref())
+            .and_then(|locale| locale.buckets.get("email_headers"))
             .expect("email headers")
             .names;
         assert_eq!(

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -264,9 +264,10 @@ This is the same fixture the CLI integration suite uses
 
 ## Schema reference
 
-All TOML tables use `deny_unknown_fields` — any key the parser does not
-recognise is a hard error. v0.4 adds `[policy.rulepacks]` and
-`[[policy.custom_recognizers]]`; legacy top-level `[[detector]]` is rejected.
+TOML tables use closed schemas unless explicitly documented otherwise — any key
+the parser does not recognise is a hard error. v0.4 adds
+`[policy.rulepacks]` and `[[policy.custom_recognizers]]`; legacy top-level
+`[[detector]]` is rejected.
 
 ### `[session]`
 
@@ -349,6 +350,32 @@ capture_groups = [1]
 Missing cooperation fails rulepack load with
 `RulepackError::SameClassWithoutCooperation`. The check is strict by design:
 there is no line-anchor heuristic or implicit overlap analysis.
+
+Rulepack locale metadata can define adopter-specific vocabulary buckets under
+`[locale.<bucket>]`. Bucket tables are intentionally open by name; each bucket
+contains `names = [...]`. Regex `pattern_template` values may reference those
+buckets with `{locale.<bucket>}`. Assembly lowers the placeholder after the
+active locale chain is known.
+
+```toml
+[locale.salutations]
+names = ["Dr", "Mx"]
+
+[[recognizers]]
+id = "salutation.name"
+class = "Name"
+
+[recognizers.match]
+kind = "regex"
+pattern_template = '''(?m)^(?:{locale.salutations}):\s+([A-Z][a-z]+)$'''
+capture_groups = [1]
+```
+
+If a template references an unknown locale bucket, assembly fails closed with
+`PolicyError::UnknownLocaleBucket`. The legacy `{locale_email_headers}`
+placeholder remains a v0.4.2 compatibility alias for
+`{locale.email_headers}`; prefer the generic syntax in new rulepacks. The alias
+is deprecated for removal in the v0.5 cycle.
 
 ### `[[policy.custom_recognizers]]`
 


### PR DESCRIPTION
Closes #114. Per drawer 4d298230. Replaces hardcoded {locale_email_headers} with generic {locale.<bucket>} syntax over RawLocaleData buckets map. Back-compat alias preserves rulepack TOML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)