### PR TITLE
v0.4.2 P4: release plumbing — version bump + CHANGELOG + roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-25
+
 ### Added
 
-- v0.4.2 P3.S4 release CI now publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-22.04` runner, alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts.
+- **S4 Linux release artifact:** release CI now publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-22.04` runner, alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts.
 - Release artifact smoke now executes the packaged binary for `--version`, `alice@example.invalid` clean/restore reversibility, S1 runtime knob help flags (`--session-scope`, NER, and rulepack surfaces), and `core-extended` bundled rulepack loading with neutral non-real fixture data.
 - v0.4.1 Bundle P1 foundation: `gaze-assembly` library entrypoint, `xtask` scaffold, and the `symmetric_potemkin_gate` workflow.
 - `token.family` now threads from recognizers into session snapshot entries while preserving the existing emitted token grammar.
@@ -20,21 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strict rulepack composition validation: same-class recognizer pairs now require explicit `cooperates_with` declarations.
 - `Context::fields_typed() -> ContextFieldsRef<'_>` borrowed accessor for context-field consumers.
 - `gaze clean --audit-db=<path>` persists the metadata-only SQLite redaction log for pipe-mode invocations.
-- `gaze clean` now exposes three-surfaces CLI overrides for existing policy runtime knobs: `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path`.
-- Opt-in `core-extended` bundled rulepack with Phase 1 shape-only recognizers for E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes.
-- v0.5 design doc for open-key `PiiClass` and decision-deferred crate-shape Option B sketch.
-- Three-surfaces parity audit table for every `policy.toml` field, classifying runtime knobs with CLI/TOML/default coverage and policy-document fields that intentionally remain TOML-only.
-- Rulepack locale `pattern_template` placeholders now support generic `{locale.<bucket>}` expansion from adopter-defined `[locale.<bucket>] names = [...]` tables.
+- **S1 three-surfaces backfill:** `gaze clean` now exposes CLI overrides for existing policy runtime knobs: `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path`.
+- **S2 core-extended rulepack:** opt-in bundled rulepack with Phase 1 shape-only recognizers for E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes.
+- **S5 v0.5 design:** design doc for open-key `PiiClass` and decision-deferred crate-shape Option B sketch.
+- **P3.5 #100 parity audit:** three-surfaces parity audit table for every `policy.toml` field, classifying runtime knobs with CLI/TOML/default coverage and policy-document fields that intentionally remain TOML-only.
+- **P3.5 #114 generic placeholder vocab:** rulepack locale `pattern_template` placeholders now support generic `{locale.<bucket>}` expansion from adopter-defined `[locale.<bucket>] names = [...]` tables.
 
 ### Changed
 
-- Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.1`.
-- Split `gaze-cli/src/main.rs` into focused `commands`, `pipeline`, `restore`, `io`, `error`, and `logger` modules with responsibility-based names and no CLI behavior change.
+- Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.2`.
+- **P3.5 #115 CLI split:** split `gaze-cli/src/main.rs` into focused `commands`, `pipeline`, `restore`, `io`, `error`, and `logger` modules with responsibility-based names and no CLI behavior change.
 - Snapshot envelope version bumped from 2 to 3; v0.4.1 imports v2 snapshots with default `counter` family, while v0.4.0 rejects v3 snapshots instead of silently collapsing family metadata.
 - Dictionary recognizer audit sources now include per-term traceability as `dictionary:{name}[#term_index]`.
-- v0.4.2 fixture sweep renamed tenant-pattern test and benchmark strings to neutral placeholders, with `CONTRIBUTING.md` documenting tenant class naming policy.
+- **S3 fixture sweep:** renamed tenant-pattern test and benchmark strings to neutral placeholders, with `CONTRIBUTING.md` documenting tenant class naming policy.
 - `{locale_email_headers}` remains supported as a v0.4.2 compatibility alias for `{locale.email_headers}` and is deprecated for removal in the v0.5 cycle.
-- Split the NER recognizer implementation into focused `ner/` submodules without changing public exports or runtime behavior. (#116)
+- **P3.5 #116 NER split:** split the NER recognizer implementation into focused `ner/` submodules without changing public exports or runtime behavior.
 
 ### Fixed
 
@@ -215,7 +217,8 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/Naoray/gaze/compare/v0.4.0-rc.1...HEAD
+[Unreleased]: https://github.com/Naoray/gaze/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/Naoray/gaze/compare/v0.4.0-rc.1...v0.4.2
 [0.4.0-rc.1]: https://github.com/Naoray/gaze/releases/tag/v0.4.0-rc.1
 [v0.3.1]: https://github.com/Naoray/gaze/releases/tag/v0.3.1
 [0.3.0]: https://github.com/Naoray/gaze/releases/tag/v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "gaze"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"

--- a/docs/roadmap/v0.4/v0.4.2.md
+++ b/docs/roadmap/v0.4/v0.4.2.md
@@ -1,0 +1,26 @@
+# v0.4.2 Release Notes
+
+Status: release plumbing for 2026-04-25.
+
+v0.4.2 closes the v0.4 hardening wave around the north-star requirement: no PII crosses from data owner to LLM outside the manifest contract. The release keeps the reversible session-token contract intact while improving runtime knob coverage, opt-in recognizer breadth, release artifacts, and auditability.
+
+## Shipped Scope
+
+- **S1 three-surfaces backfill:** `gaze clean` now exposes CLI overrides for the existing runtime knobs `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path`, matching TOML/default behavior without turning policy-document fields into CLI flags.
+- **S2 core-extended Phase 1:** adopters can opt into shape-only recognizers for E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes through the bundled `core-extended` rulepack.
+- **S3 fixture sweep:** tenant-shaped fixture names were replaced with neutral placeholders, and `CONTRIBUTING.md` now documents the neutral fixture naming rule.
+- **S4 Linux artifact:** release CI now builds `gaze-x86_64-unknown-linux-gnu` on native `ubuntu-22.04` alongside `gaze-aarch64-apple-darwin`, with SHA256 files and packaged-binary smoke checks.
+- **S5 v0.5 design:** `docs/design/v0.5-open-piiclass.md` captures the open-key `PiiClass` direction and the deferred crate-shape Option B sketch without changing v0.4.2 runtime behavior.
+- **P3.5 #100:** the three-surfaces parity audit classifies policy fields by CLI/TOML/default coverage.
+- **P3.5 #114:** generic rulepack locale buckets support `{locale.<bucket>}` placeholders while preserving the v0.4.2 `{locale_email_headers}` compatibility alias.
+- **P3.5 #115:** `gaze-cli` was split into focused modules with no behavior change.
+- **P3.5 #116:** the NER recognizer was split into focused submodules with no public export or runtime behavior change.
+
+## Release Checks
+
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets`
+- `cargo fmt --check`
+- `cargo metadata` confirms only `gaze`, `gaze-assembly`, `gaze-recognizers`, and `gaze-cli` are versioned `0.4.2`; `xtask` remains `0.0.1` and `debug-proxy` remains `0.3.1`.
+
+Final tag acceptance requires the `v0.4.2-rc.1` and `v0.4.2` release workflows to publish macOS aarch64 and Linux x86_64 binaries, each with SHA256 files and packaged-binary smoke coverage for `gaze --version`, clean/restore identity, S1 help flags, and `core-extended` loading using neutral non-real fixture data.


### PR DESCRIPTION
Per rev 3 §S6 (scratchpad 258). Bumps 4 release crates to 0.4.2. Aggregates CHANGELOG. Adds v0.4.2 roadmap entry. xtask + debug-proxy untouched per rev 3 lock.

After merge: tag v0.4.2-rc.1 → CI smoke → tag v0.4.2 → release → Homebrew bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)