### PR TITLE
v0.4.2 hotfix: bump release runner to ubuntu-24.04 (glibc 2.39 for ort)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: gaze-aarch64-apple-darwin
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact: gaze-x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **S4 Linux release artifact:** release CI now publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-22.04` runner, alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts.
+- **S4 Linux release artifact:** release CI now publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-24.04` runner, alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts. The Linux artifact requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer); older distros should build from source.
 - Release artifact smoke now executes the packaged binary for `--version`, `alice@example.invalid` clean/restore reversibility, S1 runtime knob help flags (`--session-scope`, NER, and rulepack surfaces), and `core-extended` bundled rulepack loading with neutral non-real fixture data.
 - v0.4.1 Bundle P1 foundation: `gaze-assembly` library entrypoint, `xtask` scaffold, and the `symmetric_potemkin_gate` workflow.
 - `token.family` now threads from recognizers into session snapshot entries while preserving the existing emitted token grammar.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
 
+The Linux x86_64 binary requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer). On older distros, build from source with `cargo build --release -p gaze-cli`.
+
 Intel macOS binaries are not published in v0.4.0-rc.1; they return in a later release once the runner and runtime story is pinned. Build from source with `cargo build --release -p gaze-cli` in the meantime.
 
 ## Workspace Layout


### PR DESCRIPTION
v0.4.2-rc.1 release CI failed on ubuntu-22.04 — ort_sys requires glibc 2.39+ C23 symbols. Bumps Linux runner to ubuntu-24.04. Documents glibc 2.39+ adopter requirement.

After merge: delete failed rc.1 tag, re-tag rc.1, smoke, tag v0.4.2 final, Homebrew bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)