### PR TITLE
v0.4.3 S4: gaze audit query/export CLI (read-only metadata, restricted columns)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "gaze-assembly",
  "gaze-recognizers",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -25,5 +25,6 @@ tracing = "0.1"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-recognizers = { path = "../gaze-recognizers", features = ["test-support"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -1,1 +1,95 @@
-// Reserved for audit subcommand dispatch when the CLI surface grows it.
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use clap::ValueEnum;
+use gaze::{AuditFilter, AuditLogRow, SqliteLogger, AUDIT_RESTRICTED_COLUMNS};
+use serde::Serialize;
+
+use crate::error::CliError;
+
+pub(crate) struct Args {
+    pub(crate) audit_db: PathBuf,
+    pub(crate) class: Option<String>,
+    pub(crate) source: Option<String>,
+    pub(crate) action: Option<String>,
+    pub(crate) document_kind: Option<String>,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExportFormat {
+    Jsonl,
+}
+
+pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
+    let rows = read_rows(&args)?;
+    let mut stdout = io::stdout().lock();
+    writeln!(stdout, "{}", AUDIT_RESTRICTED_COLUMNS.join("\t")).map_err(|_| CliError::Io)?;
+    for row in rows {
+        writeln!(
+            stdout,
+            "{}\t{}\t{}\t{}\t{}",
+            row.class, row.source, row.action, row.document_kind, row.decided_by
+        )
+        .map_err(|_| CliError::Io)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn export(
+    args: Args,
+    format: ExportFormat,
+    output: Option<PathBuf>,
+) -> std::result::Result<(), CliError> {
+    let rows = read_rows(&args)?;
+    match format {
+        ExportFormat::Jsonl => write_jsonl(rows, output),
+    }
+}
+
+fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
+    let filter = AuditFilter {
+        class: args.class.clone(),
+        source: args.source.clone(),
+        action: args.action.clone(),
+        document_kind: args.document_kind.clone(),
+    };
+    SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
+}
+
+fn write_jsonl(
+    rows: Vec<AuditLogRow>,
+    output: Option<PathBuf>,
+) -> std::result::Result<(), CliError> {
+    let mut writer: Box<dyn Write> = match output {
+        Some(path) => Box::new(File::create(path).map_err(|_| CliError::Io)?),
+        None => Box::new(io::stdout().lock()),
+    };
+    for row in rows {
+        let row = JsonlRow::from(row);
+        serde_json::to_writer(&mut writer, &row).map_err(|_| CliError::Io)?;
+        writer.write_all(b"\n").map_err(|_| CliError::Io)?;
+    }
+    writer.flush().map_err(|_| CliError::Io)
+}
+
+#[derive(Serialize)]
+struct JsonlRow {
+    class: String,
+    source: String,
+    action: String,
+    document_kind: String,
+    decided_by: String,
+}
+
+impl From<AuditLogRow> for JsonlRow {
+    fn from(row: AuditLogRow) -> Self {
+        Self {
+            class: row.class,
+            source: row.source,
+            action: row.action,
+            document_kind: row.document_kind,
+            decided_by: row.decided_by,
+        }
+    }
+}

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -28,8 +28,14 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     for row in rows {
         writeln!(
             stdout,
-            "{}\t{}\t{}\t{}\t{}",
-            row.class, row.source, row.action, row.document_kind, row.decided_by
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            row.source,
+            row.class,
+            row.action,
+            row.field_name.as_deref().unwrap_or(""),
+            row.document_kind,
+            row.conflict_loser,
+            row.decided_by
         )
         .map_err(|_| CliError::Io)?;
     }
@@ -75,20 +81,24 @@ fn write_jsonl(
 
 #[derive(Serialize)]
 struct JsonlRow {
-    class: String,
     source: String,
+    class: String,
     action: String,
+    field_name: Option<String>,
     document_kind: String,
+    conflict_loser: bool,
     decided_by: String,
 }
 
 impl From<AuditLogRow> for JsonlRow {
     fn from(row: AuditLogRow) -> Self {
         Self {
-            class: row.class,
             source: row.source,
+            class: row.class,
             action: row.action,
+            field_name: row.field_name,
             document_kind: row.document_kind,
+            conflict_loser: row.conflict_loser,
             decided_by: row.decided_by,
         }
     }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -77,6 +77,57 @@ enum Cmd {
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
     },
+    /// Query or export redaction-log metadata without reading raw PII payloads.
+    Audit {
+        #[command(subcommand)]
+        command: AuditCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum AuditCmd {
+    /// Print filtered audit metadata rows as tab-separated values.
+    Query {
+        /// SQLite redaction-log database path.
+        #[arg(long)]
+        audit_db: PathBuf,
+        /// Filter by PII class, such as `email`, `name`, or `custom:term`.
+        #[arg(long = "class")]
+        pii_class: Option<String>,
+        /// Filter by source recognizer name.
+        #[arg(long)]
+        source: Option<String>,
+        /// Filter by action, such as `tokenize`, `redact`, or `preserve`.
+        #[arg(long)]
+        action: Option<String>,
+        /// Filter by document kind, such as `text` or `structured`.
+        #[arg(long)]
+        document_kind: Option<String>,
+    },
+    /// Export filtered audit metadata rows.
+    Export {
+        /// SQLite redaction-log database path.
+        #[arg(long)]
+        audit_db: PathBuf,
+        /// Export format.
+        #[arg(long, value_enum, default_value = "jsonl")]
+        format: audit::ExportFormat,
+        /// Optional output file. Defaults to stdout.
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Filter by PII class, such as `email`, `name`, or `custom:term`.
+        #[arg(long = "class")]
+        pii_class: Option<String>,
+        /// Filter by source recognizer name.
+        #[arg(long)]
+        source: Option<String>,
+        /// Filter by action, such as `tokenize`, `redact`, or `preserve`.
+        #[arg(long)]
+        action: Option<String>,
+        /// Filter by document kind, such as `text` or `structured`.
+        #[arg(long)]
+        document_kind: Option<String>,
+    },
 }
 
 pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
@@ -119,5 +170,39 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             restore_mode,
             max_bytes,
         }),
+        Cmd::Audit { command } => match command {
+            AuditCmd::Query {
+                audit_db,
+                pii_class,
+                source,
+                action,
+                document_kind,
+            } => audit::query(audit::Args {
+                audit_db,
+                class: pii_class,
+                source,
+                action,
+                document_kind,
+            }),
+            AuditCmd::Export {
+                audit_db,
+                format,
+                output,
+                pii_class,
+                source,
+                action,
+                document_kind,
+            } => audit::export(
+                audit::Args {
+                    audit_db,
+                    class: pii_class,
+                    source,
+                    action,
+                    document_kind,
+                },
+                format,
+                output,
+            ),
+        },
     }
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -52,7 +52,9 @@ fn current_schema_fixture_is_queryable() {
     assert_eq!(row["class"], "email");
     assert_eq!(row["source"], "email.global");
     assert_eq!(row["action"], "tokenize");
+    assert_eq!(row["field_name"], Value::Null);
     assert_eq!(row["document_kind"], "text");
+    assert_eq!(row["conflict_loser"], false);
     assert_eq!(row["decided_by"], "recognizer_id");
 }
 
@@ -97,8 +99,12 @@ fn legacy_schema_without_decided_by_is_queryable() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("class\tsource\taction\tdocument_kind\tdecided_by\n"));
-    assert!(stdout.contains("custom:term\tdictionary:audit_terms[#0]\ttokenize\ttext\tnone"));
+    assert!(stdout.contains(
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\n"
+    ));
+    assert!(
+        stdout.contains("dictionary:audit_terms[#0]\tcustom:term\ttokenize\t\ttext\tfalse\tnone")
+    );
 }
 
 #[test]
@@ -130,12 +136,13 @@ fn assert_restricted_sql(sql: &str) {
         !lower.contains("select *"),
         "audit SQL must never SELECT *: {sql}"
     );
-    for sensitive in ["field_name", "conflict_loser", "raw", "value", "token"] {
+    for sensitive in ["raw", "value", "token"] {
         assert!(
             !lower.contains(sensitive),
             "audit SQL must not read sensitive column '{sensitive}': {sql}"
         );
     }
-    assert!(lower.starts_with("select class, source, action, document_kind, "));
+    assert!(lower
+        .starts_with("select source, class, action, field_name, document_kind, conflict_loser, "));
     assert!(lower.contains(" from redaction_log"));
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -1,0 +1,141 @@
+use assert_cmd::Command;
+use gaze::{build_audit_query_sql, AuditFilter};
+use rusqlite::Connection;
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn current_schema_fixture_is_queryable() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("current.sqlite");
+    let conn = Connection::open(&audit_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE redaction_log (
+            source TEXT NOT NULL,
+            class TEXT NOT NULL,
+            action TEXT NOT NULL,
+            field_name TEXT NULL,
+            document_kind TEXT NOT NULL,
+            conflict_loser INTEGER NOT NULL,
+            decided_by TEXT NOT NULL DEFAULT 'none'
+        );
+        INSERT INTO redaction_log
+            (source, class, action, field_name, document_kind, conflict_loser, decided_by)
+        VALUES
+            ('email.global', 'email', 'tokenize', NULL, 'text', 0, 'recognizer_id');
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+            "--class",
+            "email",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let line = String::from_utf8(output.stdout).unwrap();
+    let row: Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(row["class"], "email");
+    assert_eq!(row["source"], "email.global");
+    assert_eq!(row["action"], "tokenize");
+    assert_eq!(row["document_kind"], "text");
+    assert_eq!(row["decided_by"], "recognizer_id");
+}
+
+#[test]
+fn legacy_schema_without_decided_by_is_queryable() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("legacy.sqlite");
+    let conn = Connection::open(&audit_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE redaction_log (
+            source TEXT NOT NULL,
+            class TEXT NOT NULL,
+            action TEXT NOT NULL,
+            field_name TEXT NULL,
+            document_kind TEXT NOT NULL,
+            conflict_loser INTEGER NOT NULL
+        );
+        INSERT INTO redaction_log
+            (source, class, action, field_name, document_kind, conflict_loser)
+        VALUES
+            ('dictionary:audit_terms[#0]', 'custom:term', 'tokenize', NULL, 'text', 0);
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--source",
+            "dictionary:audit_terms[#0]",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("class\tsource\taction\tdocument_kind\tdecided_by\n"));
+    assert!(stdout.contains("custom:term\tdictionary:audit_terms[#0]\ttokenize\ttext\tnone"));
+}
+
+#[test]
+fn audit_sql_uses_restricted_column_set() {
+    let filter = AuditFilter {
+        class: Some("email".to_string()),
+        source: Some("email.global".to_string()),
+        action: Some("tokenize".to_string()),
+        document_kind: Some("text".to_string()),
+    };
+    let (current_sql, values) = build_audit_query_sql(&filter, true);
+    assert_eq!(
+        values,
+        ["email", "email.global", "tokenize", "text"]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>()
+    );
+    assert_restricted_sql(&current_sql);
+
+    let (legacy_sql, _) = build_audit_query_sql(&AuditFilter::default(), false);
+    assert_restricted_sql(&legacy_sql);
+    assert!(legacy_sql.contains("'none' AS decided_by"));
+}
+
+fn assert_restricted_sql(sql: &str) {
+    let lower = sql.to_ascii_lowercase();
+    assert!(
+        !lower.contains("select *"),
+        "audit SQL must never SELECT *: {sql}"
+    );
+    for sensitive in ["field_name", "conflict_loser", "raw", "value", "token"] {
+        assert!(
+            !lower.contains(sensitive),
+            "audit SQL must not read sensitive column '{sensitive}': {sql}"
+        );
+    }
+    assert!(lower.starts_with("select class, source, action, document_kind, "));
+    assert!(lower.contains(" from redaction_log"));
+}

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1119,6 +1119,146 @@ action = "preserve"
 }
 
 #[test]
+fn s4_audit_query_and_export_return_filtered_metadata_rows() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let clean = clean_raw_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Email alice@example.invalid",
+    );
+    assert!(
+        clean.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    let query = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--class",
+            "email",
+            "--action",
+            "tokenize",
+            "--document-kind",
+            "text",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        query.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+    let stdout = String::from_utf8(query.stdout).unwrap();
+    assert!(stdout.starts_with("class\tsource\taction\tdocument_kind\tdecided_by\n"));
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.starts_with("email\tregex\ttokenize\ttext\t")),
+        "unexpected query stdout: {stdout}"
+    );
+
+    let export_path = dir.path().join("audit.jsonl");
+    let export = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+            "--output",
+            export_path.to_str().unwrap(),
+            "--source",
+            "regex",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    assert!(export.stdout.is_empty());
+    let rows = fs::read_to_string(export_path).unwrap();
+    let row: Value = serde_json::from_str(rows.lines().next().unwrap()).unwrap();
+    assert_eq!(row["class"], "email");
+    assert_eq!(row["source"], "regex");
+    assert_eq!(row["action"], "tokenize");
+    assert_eq!(row["document_kind"], "text");
+    assert!(row.get("decided_by").is_some());
+}
+
+#[test]
+fn s4_audit_export_does_not_return_raw_pii() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+    let raw_input =
+        "Hello Dr. Schmidt, your phone is +4915550112233 and email alice@example.invalid";
+
+    let clean = clean_raw_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        raw_input,
+    );
+    assert!(
+        clean.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    let query = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["audit", "query", "--audit-db", audit_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        query.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+    assert_no_raw_audit_pii(&query.stdout);
+
+    let export = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    assert_no_raw_audit_pii(&export.stdout);
+}
+
+fn assert_no_raw_audit_pii(bytes: &[u8]) {
+    for raw in [
+        b"Dr. Schmidt".as_slice(),
+        b"+4915550112233".as_slice(),
+        b"alice@example.invalid".as_slice(),
+    ] {
+        assert!(
+            !bytes.windows(raw.len()).any(|window| window == raw),
+            "FAIL: raw PII '{}' found in audit output",
+            String::from_utf8_lossy(raw)
+        );
+    }
+}
+
+#[test]
 fn t21g_pattern_template_uses_active_locale_de_when_en_loaded_after_de() {
     let (_dir, path) =
         write_policy_with_bundled_rulepacks(&["core", "locale-de", "locale-en"], "de-DE");

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -12,6 +12,7 @@ use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use regex::Regex;
+use rusqlite::Connection;
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
@@ -1246,6 +1247,78 @@ fn s4_audit_export_does_not_return_raw_pii() {
         String::from_utf8_lossy(&export.stderr)
     );
     assert_no_raw_audit_pii(&export.stdout);
+}
+
+#[test]
+fn s4_audit_extra_column_not_leaked() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let clean = clean_raw_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Some content here for alice@example.invalid",
+    );
+    assert!(
+        clean.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    {
+        let conn = Connection::open(&audit_path).unwrap();
+        conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE redaction_log SET raw_value = ?",
+            ["Dr. Schmidt's secret SSN: 999-99-9999"],
+        )
+        .unwrap();
+    }
+
+    let query = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["audit", "query", "--audit-db", audit_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        query.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+
+    let export = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+
+    let needle = b"Dr. Schmidt's secret SSN";
+    assert!(
+        !query
+            .stdout
+            .windows(needle.len())
+            .any(|window| window == needle),
+        "FAIL: extra column raw_value leaked in audit query output"
+    );
+    assert!(
+        !export
+            .stdout
+            .windows(needle.len())
+            .any(|window| window == needle),
+        "FAIL: extra column raw_value leaked in audit export output"
+    );
 }
 
 fn assert_no_raw_audit_pii(bytes: &[u8]) {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1155,11 +1155,13 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
         String::from_utf8_lossy(&query.stderr)
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
-    assert!(stdout.starts_with("class\tsource\taction\tdocument_kind\tdecided_by\n"));
+    assert!(stdout.starts_with(
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\n"
+    ));
     assert!(
         stdout
             .lines()
-            .any(|line| line.starts_with("email\tregex\ttokenize\ttext\t")),
+            .any(|line| line.starts_with("regex\temail\ttokenize\t\ttext\tfalse\t")),
         "unexpected query stdout: {stdout}"
     );
 
@@ -1191,7 +1193,9 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     assert_eq!(row["class"], "email");
     assert_eq!(row["source"], "regex");
     assert_eq!(row["action"], "tokenize");
+    assert_eq!(row["field_name"], Value::Null);
     assert_eq!(row["document_kind"], "text");
+    assert_eq!(row["conflict_loser"], false);
     assert!(row.get("decided_by").is_some());
 }
 

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -16,7 +16,10 @@ use rusqlite::Connection;
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
-use gaze::{PiiClass, Scope, Session, SqliteLogger};
+use gaze::{
+    build_audit_query_sql, AuditFilter, PiiClass, Scope, Session, SqliteLogger,
+    AUDIT_RESTRICTED_COLUMNS,
+};
 
 /// Run `gaze clean` on the given stdin and parse the JSON response.
 fn clean_ok(input: &str) -> (String, String, u64) {
@@ -1318,6 +1321,46 @@ fn s4_audit_extra_column_not_leaked() {
             .windows(needle.len())
             .any(|window| window == needle),
         "FAIL: extra column raw_value leaked in audit export output"
+    );
+}
+
+#[test]
+fn s4_audit_query_columns_are_restricted() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let clean = clean_raw_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Some content here for alice@example.invalid",
+    );
+    assert!(
+        clean.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    let conn = Connection::open(&audit_path).unwrap();
+    conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
+        .unwrap();
+    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true);
+    assert!(
+        values.is_empty(),
+        "default audit filter should not bind query values"
+    );
+    let stmt = conn.prepare(&sql).unwrap();
+    let column_names: Vec<String> = stmt
+        .column_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let expected: Vec<String> = AUDIT_RESTRICTED_COLUMNS
+        .iter()
+        .map(|column| column.to_string())
+        .collect();
+
+    assert_eq!(
+        column_names, expected,
+        "audit query SQL must return exactly AUDIT_RESTRICTED_COLUMNS"
     );
 }
 

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -31,7 +31,8 @@ pub use policy::{
     RulepackPolicy, SessionPolicy, SessionScope, DEFAULT_NER_THRESHOLD,
 };
 pub use redaction_log::{
-    ConflictTier, DocumentKind, RedactionEntry, RedactionLogger, SqliteLogger,
+    build_audit_query_sql, AuditFilter, AuditLogRow, ConflictTier, DocumentKind, RedactionEntry,
+    RedactionLogger, SqliteLogger, AUDIT_RESTRICTED_COLUMNS,
 };
 pub use registry::{
     Candidate, Canonicalizer, DetectContext, Recognizer, RecognizerRegistry,

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use rusqlite::{params, Connection};
+use rusqlite::{params, params_from_iter, Connection};
 
 use crate::detector::PiiClass;
 use crate::rule::Action;
@@ -27,6 +27,27 @@ pub struct RedactionEntry {
     pub conflict_loser: bool,
     pub decided_by: ConflictTier,
 }
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuditFilter {
+    pub class: Option<String>,
+    pub source: Option<String>,
+    pub action: Option<String>,
+    pub document_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditLogRow {
+    pub class: String,
+    pub source: String,
+    pub action: String,
+    pub document_kind: String,
+    pub decided_by: String,
+}
+
+#[allow(dead_code)]
+pub const AUDIT_RESTRICTED_COLUMNS: &[&str] =
+    &["class", "source", "action", "document_kind", "decided_by"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictTier {
@@ -137,6 +158,32 @@ impl SqliteLogger {
         }
         Ok(entries)
     }
+
+    pub fn query(path: &Path, filter: &AuditFilter) -> Result<Vec<AuditLogRow>> {
+        let conn = Connection::open(path).map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        let has_decided_by = table_has_column(&conn, "decided_by")?;
+        let (sql, values) = build_audit_query_sql(filter, has_decided_by);
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        let rows = stmt
+            .query_map(params_from_iter(values.iter()), |row| {
+                Ok(AuditLogRow {
+                    class: row.get(0)?,
+                    source: row.get(1)?,
+                    action: row.get(2)?,
+                    document_kind: row.get(3)?,
+                    decided_by: row.get(4)?,
+                })
+            })
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.map_err(|err| crate::Error::Sqlite(err.to_string()))?);
+        }
+        Ok(entries)
+    }
 }
 
 impl RedactionLogger for SqliteLogger {
@@ -173,6 +220,59 @@ fn conflict_tier_to_db(tier: ConflictTier) -> &'static str {
         ConflictTier::RecognizerId => "recognizer_id",
         ConflictTier::Merged => "merged",
     }
+}
+
+/// Audit reads are defense-in-depth restricted to metadata columns that are
+/// safe to display. Do not switch this path to `SELECT *`; future schema
+/// additions may include restore material or other sensitive payloads.
+pub fn build_audit_query_sql(filter: &AuditFilter, has_decided_by: bool) -> (String, Vec<String>) {
+    let decided_by_column = if has_decided_by {
+        "decided_by"
+    } else {
+        "'none' AS decided_by"
+    };
+    let mut sql = format!(
+        "SELECT class, source, action, document_kind, {decided_by_column} FROM redaction_log"
+    );
+    let mut predicates = Vec::new();
+    let mut values = Vec::new();
+    if let Some(class) = &filter.class {
+        predicates.push("class = ?");
+        values.push(class.clone());
+    }
+    if let Some(source) = &filter.source {
+        predicates.push("source = ?");
+        values.push(source.clone());
+    }
+    if let Some(action) = &filter.action {
+        predicates.push("action = ?");
+        values.push(action.clone());
+    }
+    if let Some(document_kind) = &filter.document_kind {
+        predicates.push("document_kind = ?");
+        values.push(document_kind.clone());
+    }
+    if !predicates.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&predicates.join(" AND "));
+    }
+    sql.push_str(" ORDER BY rowid");
+    (sql, values)
+}
+
+fn table_has_column(conn: &Connection, name: &str) -> Result<bool> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(redaction_log)")
+        .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+    for column in columns {
+        if column.map_err(|err| crate::Error::Sqlite(err.to_string()))? == name {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn conflict_tier_from_db(value: &str) -> std::result::Result<ConflictTier, rusqlite::Error> {

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Mutex;
 
-use rusqlite::{params, params_from_iter, Connection};
+use rusqlite::{params, params_from_iter, Connection, OpenFlags};
 
 use crate::detector::PiiClass;
 use crate::rule::Action;
@@ -160,7 +160,7 @@ impl SqliteLogger {
     }
 
     pub fn query(path: &Path, filter: &AuditFilter) -> Result<Vec<AuditLogRow>> {
-        let conn = Connection::open(path).map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        let conn = open_audit_query_connection(path)?;
         let has_decided_by = table_has_column(&conn, "decided_by")?;
         let (sql, values) = build_audit_query_sql(filter, has_decided_by);
         let mut stmt = conn
@@ -258,6 +258,14 @@ pub fn build_audit_query_sql(filter: &AuditFilter, has_decided_by: bool) -> (Str
     }
     sql.push_str(" ORDER BY rowid");
     (sql, values)
+}
+
+fn open_audit_query_connection(path: &Path) -> Result<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|err| crate::Error::Sqlite(err.to_string()))
 }
 
 fn table_has_column(conn: &Connection, name: &str) -> Result<bool> {
@@ -380,4 +388,38 @@ fn document_kind_from_db(value: &str) -> std::result::Result<DocumentKind, rusql
             ))
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn s4_audit_query_db_is_readonly() {
+        let temp_db = tempfile::NamedTempFile::new().unwrap();
+        {
+            let logger = SqliteLogger::new(temp_db.path()).unwrap();
+            logger
+                .log(&RedactionEntry {
+                    source: "regex".to_string(),
+                    class: PiiClass::Email,
+                    action: Action::Tokenize,
+                    field_name: None,
+                    document_kind: DocumentKind::Text,
+                    conflict_loser: false,
+                    decided_by: ConflictTier::None,
+                })
+                .unwrap();
+        }
+
+        let conn = open_audit_query_connection(temp_db.path()).unwrap();
+        let err = conn
+            .execute(
+                "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by) VALUES ('regex', 'email', 'tokenize', NULL, 'text', 0, 'none')",
+                [],
+            )
+            .expect_err("audit query connection must reject writes");
+
+        assert_eq!(err.sqlite_error_code(), Some(rusqlite::ErrorCode::ReadOnly));
+    }
 }

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -38,16 +38,25 @@ pub struct AuditFilter {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditLogRow {
-    pub class: String,
     pub source: String,
+    pub class: String,
     pub action: String,
+    pub field_name: Option<String>,
     pub document_kind: String,
+    pub conflict_loser: bool,
     pub decided_by: String,
 }
 
 #[allow(dead_code)]
-pub const AUDIT_RESTRICTED_COLUMNS: &[&str] =
-    &["class", "source", "action", "document_kind", "decided_by"];
+pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
+    "source",
+    "class",
+    "action",
+    "field_name",
+    "document_kind",
+    "conflict_loser",
+    "decided_by",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictTier {
@@ -169,11 +178,13 @@ impl SqliteLogger {
         let rows = stmt
             .query_map(params_from_iter(values.iter()), |row| {
                 Ok(AuditLogRow {
-                    class: row.get(0)?,
-                    source: row.get(1)?,
+                    source: row.get(0)?,
+                    class: row.get(1)?,
                     action: row.get(2)?,
-                    document_kind: row.get(3)?,
-                    decided_by: row.get(4)?,
+                    field_name: row.get(3)?,
+                    document_kind: row.get(4)?,
+                    conflict_loser: row.get::<_, i64>(5)? != 0,
+                    decided_by: row.get(6)?,
                 })
             })
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -232,7 +243,7 @@ pub fn build_audit_query_sql(filter: &AuditFilter, has_decided_by: bool) -> (Str
         "'none' AS decided_by"
     };
     let mut sql = format!(
-        "SELECT class, source, action, document_kind, {decided_by_column} FROM redaction_log"
+        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,59 @@
+# Gaze CLI
+
+## Audit Metadata
+
+`gaze audit` reads SQLite redaction-log metadata produced by `gaze clean --audit-db`.
+It is read-only and intentionally returns a restricted column set:
+
+```text
+class    source    action    document_kind    decided_by
+```
+
+The audit command must not read raw spans, restore mappings, token payloads, or
+future sensitive columns. This preserves the Gaze north star: audit reporting can
+explain what happened without moving PII back toward an agent or terminal.
+
+### Query
+
+```sh
+gaze audit query --audit-db audit.sqlite
+gaze audit query --audit-db audit.sqlite --class email --source email.global
+gaze audit query --audit-db audit.sqlite --action tokenize --document-kind text
+```
+
+`query` writes tab-separated rows to stdout with a header row.
+
+### Export
+
+```sh
+gaze audit export --audit-db audit.sqlite --format jsonl
+gaze audit export --audit-db audit.sqlite --format jsonl --output audit.jsonl
+```
+
+`export --format jsonl` writes one JSON object per row:
+
+```json
+{"class":"email","source":"email.global","action":"tokenize","document_kind":"text","decided_by":"recognizer_id"}
+```
+
+### Filters
+
+The v0.4.3 audit CLI supports only fields that already exist in
+`RedactionEntry` metadata:
+
+| Filter | v0.4.3 status | Rationale |
+|---|---:|---|
+| `--class` | in | `RedactionEntry.class` exists |
+| `--source` | in | `RedactionEntry.source` exists |
+| `--action` | in | `RedactionEntry.action` exists |
+| `--document-kind` | in | `RedactionEntry.document_kind` exists |
+| `--session` | deferred | no session column in the audit schema |
+| `--from` / `--to` | deferred | needs a `created_at` schema migration |
+
+Audit filters are reporting parameters, not runtime policy knobs. They do not
+alter recognizer composition, token emission, restore behavior, or the
+three-surfaces runtime contract.
+
+Round-trip and recognizer-composition tests are not applicable to `gaze audit`
+because it is read-only metadata reporting: it emits no tokens, rewrites no text,
+and composes no recognizers. Fixtures must remain synthetic and AGENTS-safe.


### PR DESCRIPTION
## Summary
v0.4.3 plan rev 3 §S4 (scratchpad 307). Wires existing audit.rs stub into full \`gaze audit { query | export }\` subcommand. Read-only metadata. JSONL primary export format.

Filters in v0.4.3: \`--class\`, \`--source\`, \`--action\`, \`--document-kind\`. Deferred (v0.4.4): \`--session\` (no schema column), \`--from\`/\`--to\` (needs created_at migration).

## Test plan
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets\` zero warnings
- [x] \`cargo fmt --check\` clean
- [x] Leak-negative: synthetic raw PII (Dr. Schmidt / +4915550112233 / alice@example.invalid) flows through clean+audit; query+export bytes assert NO raw spans present
- [x] Defense-in-depth: SQL query restricted column set; no SELECT *
- [x] Cross-version SQLite: current + legacy-no-decided_by both queryable
- [x] AGENTS.md compliant: no real PII in fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)