### PR TITLE
v0.4.3 S3: xtask no_tenant_knowledge gate (production-code scoped + AllowMarkerInProductionScope hard-fail)

### DIFF
--- a/.github/workflows/no-tenant-knowledge.yml
+++ b/.github/workflows/no-tenant-knowledge.yml
@@ -1,0 +1,17 @@
+name: no-tenant-knowledge
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  no-tenant-knowledge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run no_tenant_knowledge gate
+        run: cargo run -p xtask -- no-tenant-knowledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,10 @@
 
 Test fixtures and benchmark labels MUST use neutral class names (e.g. `class_alpha`, `tenant_class_a`, `dict_alpha`), never tenant-specific patterns like `order_id`, `Order_42`, `Song_42`, `User_7`. Rationale: drawer `eac549ae` — gaze core has no built-in tenant knowledge.
 
-Forward-reference: a future `// gaze-allow-tenant-knowledge: <reason>` comment marker may be introduced for legitimate cases (drawer `eac549ae` + planned v0.4.3 lint gate). Use neutral placeholders by default.
+The `cargo run -p xtask -- no-tenant-knowledge` gate scans production Rust code in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/**/*.rs` and fails on those tenant-specific patterns. It intentionally does not scan `tests/`, `benches/`, docs, `CONTRIBUTING.md`, `crates/xtask/`, or `debug-proxy/`.
+
+Use `// allow(tenant-fixture)` only in tests, benches, or docs when a tenant-like fixture is necessary to exercise behavior. That marker is a production-bypass attempt in `crates/*/src/` and hard-fails the gate with `AllowMarkerInProductionScope`.
+
+The `order_id` denylist is intentionally broad — it catches `Order_42`, `order_ids`, etc. If a legitimate production identifier (e.g. `order_history_index_id` for an unrelated subsystem) collides with the denylist post-v0.4.3, coordinate with maintainers to add to allowlist with rationale comment. Do NOT silently bypass via `// allow(tenant-fixture)` in production code — that marker hard-fails the gate (drawer `eac549ae`).
+
+Round-trip, three-surfaces, and recognizer-composition cross-cutting rows are N/A for this structural gate: it emits no tokens, adds no runtime knobs, and does not compose recognizers. The no-tenant-knowledge row is enforced by CI so production code must pass post-merge.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,6 +4591,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3,6 +3,8 @@ use std::process::Command as ProcessCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
+mod no_tenant_knowledge;
+
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
 struct Cli {
@@ -15,6 +17,7 @@ enum Command {
     SymmetricPotemkin,
     ClassMapOverrideSafety,
     RecognizerCompositionValidator,
+    NoTenantKnowledge,
 }
 
 fn main() -> Result<()> {
@@ -26,6 +29,7 @@ fn main() -> Result<()> {
             Ok(())
         }
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
+        Command::NoTenantKnowledge => no_tenant_knowledge::run(),
     }
 }
 

--- a/crates/xtask/src/no_tenant_knowledge.rs
+++ b/crates/xtask/src/no_tenant_knowledge.rs
@@ -1,0 +1,154 @@
+use std::{
+    error::Error,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+const PRODUCTION_CRATES: &[&str] = &["gaze", "gaze-recognizers", "gaze-assembly", "gaze-cli"];
+const ALLOW_MARKER: &str = "// allow(tenant-fixture)";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TenantKnowledgeError {
+    DenylistHit { violations: Vec<Violation> },
+    AllowMarkerInProductionScope { violations: Vec<Violation> },
+    Io { path: PathBuf, message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub path: PathBuf,
+    pub line: usize,
+    pub pattern: &'static str,
+    pub text: String,
+}
+
+pub type Result<T> = std::result::Result<T, TenantKnowledgeError>;
+
+pub fn run() -> anyhow::Result<()> {
+    scan_root(".")?;
+    println!("no_tenant_knowledge: passed");
+    Ok(())
+}
+
+pub fn scan_root(root: impl AsRef<Path>) -> Result<()> {
+    let root = root.as_ref();
+    let mut allow_marker_violations = Vec::new();
+    let mut denylist_violations = Vec::new();
+
+    for file in production_files(root)? {
+        let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
+        for (line_index, line) in content.lines().enumerate() {
+            if line.contains(ALLOW_MARKER) {
+                allow_marker_violations.push(Violation {
+                    path: file.clone(),
+                    line: line_index + 1,
+                    pattern: ALLOW_MARKER,
+                    text: line.trim().to_owned(),
+                });
+            }
+            if let Some(pattern) = denylist_pattern(line) {
+                denylist_violations.push(Violation {
+                    path: file.clone(),
+                    line: line_index + 1,
+                    pattern,
+                    text: line.trim().to_owned(),
+                });
+            }
+        }
+    }
+
+    if !allow_marker_violations.is_empty() {
+        return Err(TenantKnowledgeError::AllowMarkerInProductionScope {
+            violations: allow_marker_violations,
+        });
+    }
+
+    if !denylist_violations.is_empty() {
+        return Err(TenantKnowledgeError::DenylistHit {
+            violations: denylist_violations,
+        });
+    }
+
+    Ok(())
+}
+
+fn production_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for crate_name in PRODUCTION_CRATES {
+        let src = root.join("crates").join(crate_name).join("src");
+        if !src.exists() {
+            continue;
+        }
+        collect_rs_files(&src, &mut files)?;
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).map_err(|error| io_error(dir, error))? {
+        let entry = entry.map_err(|error| io_error(dir, error))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, files)?;
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn denylist_pattern(line: &str) -> Option<&'static str> {
+    if line.contains("order_id") {
+        Some("order_id")
+    } else if line.contains("Order_42") {
+        Some("Order_42")
+    } else if line.contains("Song_42") {
+        Some("Song_42")
+    } else if line.contains("User_7") {
+        Some("User_7")
+    } else {
+        None
+    }
+}
+
+fn io_error(path: &Path, error: io::Error) -> TenantKnowledgeError {
+    TenantKnowledgeError::Io {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    }
+}
+
+impl fmt::Display for TenantKnowledgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TenantKnowledgeError::DenylistHit { violations } => {
+                writeln!(formatter, "NoTenantKnowledgeDenylistHit")?;
+                write_violations(formatter, violations)
+            }
+            TenantKnowledgeError::AllowMarkerInProductionScope { violations } => {
+                writeln!(formatter, "AllowMarkerInProductionScope")?;
+                write_violations(formatter, violations)
+            }
+            TenantKnowledgeError::Io { path, message } => {
+                write!(formatter, "{}: {}", path.display(), message)
+            }
+        }
+    }
+}
+
+impl Error for TenantKnowledgeError {}
+
+fn write_violations(formatter: &mut fmt::Formatter<'_>, violations: &[Violation]) -> fmt::Result {
+    for violation in violations {
+        writeln!(
+            formatter,
+            "{}:{} matched {}: {}",
+            violation.path.display(),
+            violation.line,
+            violation.pattern,
+            violation.text
+        )?;
+    }
+    Ok(())
+}

--- a/crates/xtask/src/no_tenant_knowledge.rs
+++ b/crates/xtask/src/no_tenant_knowledge.rs
@@ -6,6 +6,16 @@ use std::{
 
 const PRODUCTION_CRATES: &[&str] = &["gaze", "gaze-recognizers", "gaze-assembly", "gaze-cli"];
 const ALLOW_MARKER: &str = "// allow(tenant-fixture)";
+// Denylist literals split via concat!() so this source file does not contain
+// the contiguous strings the gate scans for. This is meta-Potemkin avoidance:
+// the gate's own implementation must not appear to violate its own discipline,
+// even though crates/xtask/ is excluded from the gate's scan scope per plan S3.
+const DENYLIST: &[&str] = &[
+    concat!("ord", "er_id"),
+    concat!("Ord", "er_42"),
+    concat!("Son", "g_42"),
+    concat!("Use", "r_7"),
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TenantKnowledgeError {
@@ -99,17 +109,10 @@ fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
 }
 
 fn denylist_pattern(line: &str) -> Option<&'static str> {
-    if line.contains("order_id") {
-        Some("order_id")
-    } else if line.contains("Order_42") {
-        Some("Order_42")
-    } else if line.contains("Song_42") {
-        Some("Song_42")
-    } else if line.contains("User_7") {
-        Some("User_7")
-    } else {
-        None
-    }
+    DENYLIST
+        .iter()
+        .copied()
+        .find(|pattern| line.contains(pattern))
 }
 
 fn io_error(path: &Path, error: io::Error) -> TenantKnowledgeError {

--- a/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
+++ b/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
@@ -1,0 +1,76 @@
+#![allow(dead_code)]
+
+use std::fs;
+
+#[path = "../src/no_tenant_knowledge.rs"]
+mod no_tenant_knowledge;
+
+use no_tenant_knowledge::{scan_root, TenantKnowledgeError};
+
+#[test]
+fn seeded_order_id_in_production_scope_fails_gate_and_mentions_literal() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    let fixture = src_dir.join("lib.rs");
+    fs::write(&fixture, "fn fixture() {\n    let _ = \"order_id\";\n}\n")
+        .expect("write seeded production fixture");
+
+    let result = scan_root(temp.path());
+    fs::remove_file(&fixture).expect("remove seeded production fixture");
+
+    let error = result.expect_err("seeded tenant literal must fail");
+    let output = error.to_string();
+    assert!(
+        matches!(error, TenantKnowledgeError::DenylistHit { .. }),
+        "expected denylist hit, got {output}"
+    );
+    assert!(
+        output.contains("order_id"),
+        "gate output must mention seeded literal: {output}"
+    );
+}
+
+#[test]
+fn allow_marker_hard_fails_in_production_but_passes_outside_production_scope() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    let production_fixture = src_dir.join("lib.rs");
+    fs::write(
+        &production_fixture,
+        "// allow(tenant-fixture)\nfn fixture() {\n    let _ = \"order_id\";\n}\n",
+    )
+    .expect("write production allow-marker fixture");
+
+    let result = scan_root(temp.path());
+    fs::remove_file(&production_fixture).expect("remove production allow-marker fixture");
+
+    let error = result.expect_err("production allow marker must hard-fail");
+    let output = error.to_string();
+    assert!(
+        matches!(
+            error,
+            TenantKnowledgeError::AllowMarkerInProductionScope { .. }
+        ),
+        "expected production allow-marker failure, got {output}"
+    );
+    assert!(
+        output.contains("AllowMarkerInProductionScope"),
+        "gate output must identify allow-marker policy failure: {output}"
+    );
+
+    let test_dir = temp.path().join("crates/gaze/tests");
+    fs::create_dir_all(&test_dir).expect("create mock tests dir");
+    let test_fixture = test_dir.join("fixture.rs");
+    fs::write(
+        &test_fixture,
+        "// allow(tenant-fixture)\nfn fixture() {\n    let _ = \"order_id\";\n}\n",
+    )
+    .expect("write tests allow-marker fixture");
+
+    let result = scan_root(temp.path());
+    fs::remove_file(&test_fixture).expect("remove tests allow-marker fixture");
+
+    result.expect("allow marker outside production scope should pass");
+}


### PR DESCRIPTION
## Summary
v0.4.3 plan rev 3 §S3 (scratchpad 307). Closes drawer eac549ae open todo. Production-code scoped lint gate that fails CI if tenant-pattern strings (order_id, Order_42, Song_42, User_7) appear in crates/*/src/.

\`// allow(tenant-fixture)\` marker is valid in tests/benches/docs but HARD-FAILS in production-scope (B3 from counselors r1).

In-PR adversarial self-test programmatically seeds forbidden literal + verifies gate detection + cleans up.

## Test plan
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets\` zero warnings
- [x] \`cargo fmt --check\` clean
- [x] adversarial_no_tenant_knowledge test runs gate against temp-seeded fixtures + asserts denylist hit
- [x] adversarial test verifies AllowMarkerInProductionScope hard-failure
- [x] CI workflow runs gate on PR + push to main
- [x] Production code passes gate post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)