### PR TITLE
v0.4.3 S1: ValidatorKind substrate (Luhn + IbanMod97 + IbanCanonical)

### DIFF
--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1608,7 +1608,7 @@ fn context_json_standalone_dictionary_detects_without_policy_entry() {
 fn rulepack_rejects_unknown_validator_kind() {
     let rulepack = de_email_rulepack("\"global\"").replace(
         "[recognizers.token]",
-        "[recognizers.validator]\nkind = \"iban_mod97\"\n\n[recognizers.token]",
+        "[recognizers.validator]\nkind = \"iban_modxx\"\n\n[recognizers.token]",
     );
     let (_dir, path) = write_policy_with_rulepack(&rulepack, None);
     let out = clean_raw_with_args(
@@ -1627,7 +1627,7 @@ fn rulepack_rejects_unknown_validator_kind() {
 fn rulepack_rejects_unknown_normalizer_kind() {
     let rulepack = de_email_rulepack("\"global\"").replace(
         "[recognizers.token]",
-        "[recognizers.validator]\nkind = \"email_rfc\"\n\n[recognizers.normalizer]\nkind = \"iban_canonical\"\n\n[recognizers.token]",
+        "[recognizers.validator]\nkind = \"email_rfc\"\n\n[recognizers.normalizer]\nkind = \"iban_canonicalx\"\n\n[recognizers.token]",
     );
     let (_dir, path) = write_policy_with_rulepack(&rulepack, None);
     let out = clean_raw_with_args(

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -370,6 +370,14 @@ fn write_policy_with_rulepack(
     rulepack: &str,
     locale_active: Option<&str>,
 ) -> (tempfile::TempDir, std::path::PathBuf) {
+    write_policy_with_rulepack_and_class(rulepack, locale_active, "email")
+}
+
+fn write_policy_with_rulepack_and_class(
+    rulepack: &str,
+    locale_active: Option<&str>,
+    class: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempdir().unwrap();
     let rulepack_path = dir.path().join("rulepack.toml");
     fs::write(&rulepack_path, rulepack).unwrap();
@@ -391,7 +399,7 @@ paths = ["{}"]
 
 [[rule]]
 kind = "class"
-class = "email"
+class = "{class}"
 action = "tokenize"
 
 [[rule]]
@@ -1676,6 +1684,89 @@ fn rulepack_accepts_email_rfc_validator_kind() {
 
     assert!(clean.starts_with("Email <"));
     assert!(clean.ends_with(":Email_1>"));
+    assert_eq!(v["stats"]["detections"], 1);
+}
+
+#[test]
+fn rulepack_accepts_luhn_validator_kind() {
+    let rulepack = r#"
+schema_version = "0.1.0"
+rulepack_id = "test-luhn"
+rulepack_version = "0.4.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "card.test"
+class = "custom:credit_card_or_iban"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '\b\d{16}\b'
+
+[recognizers.validator]
+kind = "luhn"
+
+[recognizers.scoring]
+base = 0.90
+priority = 77
+
+[recognizers.token]
+"#;
+    let (_dir, path) =
+        write_policy_with_rulepack_and_class(rulepack, None, "custom:credit_card_or_iban");
+    let v = clean_json_with_args(
+        &[&format!("--policy={}", path.display())],
+        "Card 4111111111111111",
+    );
+    let clean = v["clean_text"].as_str().unwrap();
+
+    assert!(clean.starts_with("Card <"));
+    assert!(clean.ends_with(":Custom:credit_card_or_iban_1>"));
+    assert_eq!(v["stats"]["detections"], 1);
+}
+
+#[test]
+fn rulepack_accepts_iban_mod97_validator_and_iban_canonical_normalizer() {
+    let rulepack = r#"
+schema_version = "0.1.0"
+rulepack_id = "test-iban"
+rulepack_version = "0.4.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "iban.test"
+class = "custom:credit_card_or_iban"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b'
+
+[recognizers.validator]
+kind = "iban_mod97"
+
+[recognizers.normalizer]
+kind = "iban_canonical"
+
+[recognizers.scoring]
+base = 0.90
+priority = 77
+
+[recognizers.token]
+"#;
+    let (_dir, path) =
+        write_policy_with_rulepack_and_class(rulepack, None, "custom:credit_card_or_iban");
+    let v = clean_json_with_args(
+        &[&format!("--policy={}", path.display())],
+        "IBAN GB82WEST12345698765432",
+    );
+    let clean = v["clean_text"].as_str().unwrap();
+
+    assert!(clean.starts_with("IBAN <"));
+    assert!(clean.ends_with(":Custom:credit_card_or_iban_1>"));
     assert_eq!(v["stats"]["detections"], 1);
 }
 

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -7,15 +7,27 @@ use regex::Regex;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValidatorKind {
     EmailRfc,
+    Luhn,
+    IbanMod97,
 }
 
 impl ValidatorKind {
     pub fn parse(s: &str) -> std::result::Result<Self, RulepackError> {
         match s {
             "email_rfc" => Ok(Self::EmailRfc),
+            "luhn" => Ok(Self::Luhn),
+            "iban_mod97" => Ok(Self::IbanMod97),
             other => Err(RulepackError::UnsupportedValidator {
                 kind: other.to_string(),
             }),
+        }
+    }
+
+    pub fn validates(self, input: &str) -> bool {
+        match self {
+            Self::EmailRfc => is_basic_email(input),
+            Self::Luhn => luhn_check(input),
+            Self::IbanMod97 => iban_mod97_check(input),
         }
     }
 }
@@ -23,15 +35,24 @@ impl ValidatorKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NormalizerKind {
     EmailCanonical,
+    IbanCanonical,
 }
 
 impl NormalizerKind {
     pub fn parse(s: &str) -> std::result::Result<Self, RulepackError> {
         match s {
             "email_canonical" => Ok(Self::EmailCanonical),
+            "iban_canonical" => Ok(Self::IbanCanonical),
             other => Err(RulepackError::UnsupportedNormalizer {
                 kind: other.to_string(),
             }),
+        }
+    }
+
+    pub fn normalize(self, input: &str) -> String {
+        match self {
+            Self::EmailCanonical => input.to_ascii_lowercase(),
+            Self::IbanCanonical => iban_canonicalize(input),
         }
     }
 }
@@ -202,6 +223,73 @@ fn is_basic_email(input: &str) -> bool {
         return false;
     };
     !local.is_empty() && domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+}
+
+fn luhn_check(input: &str) -> bool {
+    let mut digits = Vec::new();
+    for byte in input.bytes() {
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        if !byte.is_ascii_digit() {
+            return false;
+        }
+        digits.push(byte - b'0');
+    }
+    if digits.len() < 2 {
+        return false;
+    }
+
+    let sum: u32 = digits
+        .iter()
+        .rev()
+        .enumerate()
+        .map(|(index, digit)| {
+            let mut value = u32::from(*digit);
+            if index % 2 == 1 {
+                value *= 2;
+                if value > 9 {
+                    value -= 9;
+                }
+            }
+            value
+        })
+        .sum();
+    sum.is_multiple_of(10)
+}
+
+fn iban_canonicalize(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .flat_map(char::to_uppercase)
+        .collect()
+}
+
+fn iban_mod97_check(input: &str) -> bool {
+    let canonical = iban_canonicalize(input);
+    if !(15..=34).contains(&canonical.len()) {
+        return false;
+    }
+    if !canonical.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+        return false;
+    }
+
+    let mut remainder = 0u32;
+    for ch in canonical[4..].chars().chain(canonical[..4].chars()) {
+        match ch {
+            '0'..='9' => {
+                remainder = (remainder * 10 + ch.to_digit(10).expect("digit")) % 97;
+            }
+            'A'..='Z' => {
+                let value = u32::from(ch) - u32::from('A') + 10;
+                remainder = (remainder * 10 + value / 10) % 97;
+                remainder = (remainder * 10 + value % 10) % 97;
+            }
+            _ => return false,
+        }
+    }
+    remainder == 1
 }
 
 #[cfg(test)]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -161,17 +161,23 @@ impl Recognizer for RegexDetector {
                 let matched = &input[span.clone()];
                 (!self.is_excluded(matched)).then_some((span, matched))
             })
-            .map(|(span, matched)| Candidate {
-                span,
-                class: self.class.clone(),
-                recognizer_id: self.source.clone(),
-                score: self.base_score,
-                priority: self.priority,
-                canonical_form: self.canonical_form(matched),
-                token_family: self.token_family().to_string(),
-                source: self.source.clone(),
-                decided_by: ConflictTier::None,
-                merged_sources: Vec::new(),
+            .filter_map(|(span, matched)| {
+                let canonical_form = self.canonical_form(matched);
+                if self.validator_kind.is_some() && canonical_form.is_none() {
+                    return None;
+                }
+                Some(Candidate {
+                    span,
+                    class: self.class.clone(),
+                    recognizer_id: self.source.clone(),
+                    score: self.base_score,
+                    priority: self.priority,
+                    canonical_form,
+                    token_family: self.token_family().to_string(),
+                    source: self.source.clone(),
+                    decided_by: ConflictTier::None,
+                    merged_sources: Vec::new(),
+                })
             })
             .collect()
     }

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -194,11 +194,11 @@ impl RegexDetector {
 
     fn canonical_form(&self, matched: &str) -> Option<String> {
         match self.validator_kind {
-            Some(ValidatorKind::EmailRfc) if is_basic_email(matched) => {
-                Some(match self.normalizer_kind {
-                    Some(NormalizerKind::EmailCanonical) => matched.to_ascii_lowercase(),
-                    _ => matched.to_string(),
-                })
+            Some(validator_kind) if validator_kind.validates(matched) => {
+                Some(self.normalizer_kind.map_or_else(
+                    || matched.to_string(),
+                    |normalizer| normalizer.normalize(matched),
+                ))
             }
             Some(_) => None,
             None => None,

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -1,0 +1,155 @@
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, PiiClass, Pipeline, RawDocument, Scope, Session,
+};
+use gaze_recognizers::{NormalizerKind, RegexDetector, ValidatorKind};
+
+fn validator_pipeline(
+    pattern: &str,
+    validator: ValidatorKind,
+    normalizer: Option<NormalizerKind>,
+) -> Pipeline {
+    Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                pattern,
+                PiiClass::custom("credit_card_or_iban"),
+                "s1.validator.test",
+                vec![gaze::LocaleTag::Global],
+                0.90,
+                50,
+                "counter",
+                None,
+                Vec::new(),
+                Some(validator),
+                normalizer,
+            )
+            .expect("regex detector"),
+        )
+        .rule(ClassRule::new(
+            PiiClass::custom("credit_card_or_iban"),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .expect("pipeline")
+}
+
+fn clean_text(pipeline: &Pipeline, session: &Session, input: &str) -> String {
+    let clean = pipeline
+        .redact(session, RawDocument::Text(input.to_string()))
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+    text
+}
+
+fn restore_tokens(session: &Session, clean: &str) -> String {
+    gaze::token_shape::pattern()
+        .replace_all(clean, |captures: &regex::Captures<'_>| {
+            session.restore_strict(&captures[0]).expect("known token")
+        })
+        .to_string()
+}
+
+#[test]
+fn luhn_algorithm_accepts_public_test_numbers_and_rejects_mutants() {
+    for input in [
+        "4111111111111111",
+        "4012888888881881",
+        "5555555555554444",
+        "5105105105105100",
+        "378282246310005",
+        "371449635398431",
+        "4111 1111 1111 1111",
+    ] {
+        assert!(ValidatorKind::Luhn.validates(input), "{input}");
+    }
+
+    for input in ["4111111111111112", "5555555555554445", "378282246310006"] {
+        assert!(!ValidatorKind::Luhn.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn iban_mod97_accepts_spec_examples_and_rejects_check_digit_mutants() {
+    for input in [
+        "BE71 0961 2345 6769",
+        "DE89 3704 0044 0532 0130 00",
+        "FR14 2004 1010 0505 0001 3M02 606",
+        "GB82 WEST 1234 5698 7654 32",
+    ] {
+        assert!(ValidatorKind::IbanMod97.validates(input), "{input}");
+    }
+
+    for input in ["GB99WEST12345698765432", "DE99370400440532013000"] {
+        assert!(!ValidatorKind::IbanMod97.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn iban_canonical_is_uppercase_whitespace_free_and_idempotent() {
+    let canonical = NormalizerKind::IbanCanonical.normalize("gb82 west 1234 5698 7654 32");
+
+    assert_eq!(canonical, "GB82WEST12345698765432");
+    assert_eq!(
+        NormalizerKind::IbanCanonical.normalize(&canonical),
+        canonical
+    );
+}
+
+#[test]
+fn s1_luhn_passing_card_emits_detection() {
+    let pipeline = validator_pipeline(r"\b\d{16}\b", ValidatorKind::Luhn, None);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Card: 4111111111111111";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert!(clean.starts_with("Card: <"), "{clean}");
+    assert!(clean.ends_with(":Custom:credit_card_or_iban_1>"), "{clean}");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn s1_luhn_failing_card_emits_no_detection() {
+    // ADVERSARIAL: deleting the validator_kind field-read in
+    // RegexDetector::canonical_form MUST cause s1_luhn_failing_card_emits_no_detection
+    // to FAIL (validator-failing candidate would slip through). This proves the
+    // data-flow gate is exercised, not just symbol-present.
+    let pipeline = validator_pipeline(r"\b\d{16}\b", ValidatorKind::Luhn, None);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Card: 4111111111111112";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert_eq!(clean, input);
+}
+
+#[test]
+fn s1_iban_mod97_passing_iban_emits_detection() {
+    let pipeline = validator_pipeline(
+        r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b",
+        ValidatorKind::IbanMod97,
+        Some(NormalizerKind::IbanCanonical),
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "IBAN: GB82WEST12345698765432";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert!(clean.starts_with("IBAN: <"), "{clean}");
+    assert!(clean.ends_with(":Custom:credit_card_or_iban_1>"), "{clean}");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn s1_iban_mod97_failing_iban_emits_no_detection() {
+    let pipeline = validator_pipeline(
+        r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b",
+        ValidatorKind::IbanMod97,
+        Some(NormalizerKind::IbanCanonical),
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "IBAN: GB99WEST12345698765432";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert_eq!(clean, input);
+}

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -302,7 +302,7 @@ Bundled rulepacks:
 | Bundle | Recognizers | Classes | Notes |
 |--------|-------------|---------|-------|
 | `core` | `email.global`, `email.header.name` | `email`, `name` | Default bundle when `[policy.rulepacks]` is omitted. |
-| `core-extended` | `phone.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:ip_address`, `custom:postal_code` | Opt-in Phase 1 bundle. Shape-only recognizers; no validators yet. |
+| `core-extended` | `phone.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:ip_address`, `custom:postal_code` | Opt-in Phase 1 bundle. Shape-only recognizers. |
 
 Opt into `core-extended` alongside `core`:
 
@@ -326,9 +326,9 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 - `postal.us` emits `custom:postal_code` only under active locale `en-US`.
   Plain `en` does not activate `postal.us`.
 
-Phase 1 is shape-only. IBAN, credit-card, and national-phone recognizers need
-validator support and are planned for v0.4.3 with the `ValidatorKind`
-extension.
+Phase 1 is shape-only. v0.4.3 adds validator and normalizer primitives for
+rulepack authors, but the bundled `core-extended` recognizer list does not add
+IBAN or credit-card recognizers until the follow-on bundle update.
 
 Within a rulepack, every `[[recognizers]]` block has an `id`, `class`, and
 `[recognizers.match]` table. If two recognizers in the same rulepack emit the
@@ -350,6 +350,53 @@ capture_groups = [1]
 Missing cooperation fails rulepack load with
 `RulepackError::SameClassWithoutCooperation`. The check is strict by design:
 there is no line-anchor heuristic or implicit overlap analysis.
+
+#### Built-in validators
+
+Regex rulepack recognizers may include an optional `[recognizers.validator]`
+table. Validators are deterministic, closed-registry names. Unknown validator
+strings fail policy load with `RulepackError::UnsupportedValidator`.
+
+```toml
+[recognizers.validator]
+kind = "luhn"
+```
+
+| Kind | Applies to | Behavior |
+|------|------------|----------|
+| `email_rfc` | Email-like regex candidates | Basic email shape validation used by the bundled core email recognizer. |
+| `luhn` | Credit-card-like numeric candidates | Mod 10 checksum. ASCII whitespace is ignored; any other non-digit fails validation. |
+| `iban_mod97` | IBAN-like alphanumeric candidates | ISO 7064 mod-97 check. Input is canonicalized as uppercase with ASCII whitespace removed before validation. |
+
+Validator-backed regex candidates fail closed: a regex match whose validator
+returns false emits no detection. This is intentionally stricter than emitting
+an unvalidated candidate because shape-only false positives are a PII-leak risk
+for agent workflows.
+
+S1 adds validator names to rulepack TOML only. Three-surfaces parity is not
+applicable because validators are recognizer policy data, not runtime knobs:
+there is no CLI flag or default runtime surface for swapping validator
+semantics per invocation. `cooperates_with` parity is also not applicable in S1
+because no bundled recognizers are added; cooperation tests belong to bundle
+composition changes.
+
+#### Built-in normalizers
+
+Regex rulepack recognizers may include an optional `[recognizers.normalizer]`
+table. Normalizers affect canonical form used for validated candidate identity;
+restore still uses the original matched bytes from the session manifest.
+Unknown normalizer strings fail policy load with
+`RulepackError::UnsupportedNormalizer`.
+
+```toml
+[recognizers.normalizer]
+kind = "iban_canonical"
+```
+
+| Kind | Behavior |
+|------|----------|
+| `email_canonical` | Lowercase ASCII email candidates. |
+| `iban_canonical` | Remove ASCII whitespace and uppercase letters. |
 
 Rulepack locale metadata can define adopter-specific vocabulary buckets under
 `[locale.<bucket>]`. Bucket tables are intentionally open by name; each bucket


### PR DESCRIPTION
## Summary
v0.4.3 plan rev 3 §S1 (scratchpad 307). Adds three items to the validator/normalizer dispatch surface:

- \`ValidatorKind::Luhn\` — Mod 10 checksum
- \`ValidatorKind::IbanMod97\` — ISO 7064 mod-97 IBAN check
- \`NormalizerKind::IbanCanonical\` — uppercase + strip spaces

End-to-end pipeline pair tests for each validator (passing → emits, failing → drops). Adversarial mutation comment block per drawer architecture_853a0593.

## Test plan
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets\` zero warnings
- [x] \`cargo fmt --check\` clean
- [x] s1_luhn_passing/failing pair tests run through Pipeline::process end-to-end
- [x] s1_iban_mod97_passing/failing pair tests run through Pipeline::process end-to-end
- [x] Round-trip restore identity for every validator-emitted token
- [x] Adversarial mutation: deleting validator_kind field-read in RegexDetector::canonical_form makes failing tests pass detections (manually verified)
- [x] No real PII in fixtures (test reserved numbers only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)