### PR TITLE
v0.4.3 S2: core-extended Phase 2 (IBAN mod-97 + CreditCard Luhn, validator-backed)

### DIFF
--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -81,7 +81,8 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         .unwrap_or_default();
     let rulepack_dictionaries =
         dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
-    let policy_bundle = loaded_policy
+    let active_policy = loaded_policy.as_ref().or(cli_rulepack_policy.as_ref());
+    let policy_bundle = active_policy
         .as_ref()
         .map(|policy| {
             let mut dictionaries = policy.dictionaries.clone();
@@ -95,14 +96,12 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     let cli_locales = parse_cli_locales(options.locale)?;
     let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
         cli_locales.as_deref(),
-        loaded_policy
-            .as_ref()
-            .and_then(|policy| policy.locale.as_deref()),
+        active_policy.and_then(|policy| policy.locale.as_deref()),
         Some(&rulepack_default_locales),
     );
-    let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, loaded_policy.as_ref());
+    let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, active_policy);
 
-    let pipeline = match &loaded_policy {
+    let pipeline = match active_policy {
         Some(policy) => build_pipeline_from_policy(
             policy,
             &loaded_rulepacks,
@@ -124,7 +123,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         }
     };
 
-    let session = match &loaded_policy {
+    let session = match active_policy {
         Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
         None => Session::new(scope_for_cli_without_policy(
             clean_overrides.session_scope.as_ref(),
@@ -221,7 +220,7 @@ fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
         detectors: Vec::new(),
         dictionaries: Vec::new(),
         rules: vec![RuleSpec::Default {
-            action: Action::Preserve,
+            action: Action::Tokenize,
         }],
         ner: None,
         rulepacks: RulepackPolicy {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -535,6 +535,16 @@ class = "custom:postal_code"
 action = "tokenize"
 
 [[rule]]
+kind = "class"
+class = "custom:iban"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:credit_card"
+action = "tokenize"
+
+[[rule]]
 kind = "default"
 action = "preserve"
 "#
@@ -1611,7 +1621,7 @@ fn s1_rulepack_bundled_override_changes_bundled_recognizer_availability() {
 
 #[test]
 fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
-    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103-1234";
+    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103-1234 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_core_dir, core_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
     let core_only = clean_json_with_args(&[&format!("--policy={}", core_policy.display())], input);
     let core_clean = core_only["clean_text"].as_str().unwrap();
@@ -1619,6 +1629,8 @@ fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
     assert!(!core_clean.contains("Custom:phone"), "{core_clean}");
     assert!(!core_clean.contains("Custom:ip_address"), "{core_clean}");
     assert!(!core_clean.contains("Custom:postal_code"), "{core_clean}");
+    assert!(!core_clean.contains("Custom:iban"), "{core_clean}");
+    assert!(!core_clean.contains("Custom:credit_card"), "{core_clean}");
     assert_eq!(core_only["stats"]["detections"], 1);
 
     let (_extended_dir, extended_policy) =
@@ -1639,7 +1651,15 @@ fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
         extended_clean.contains(":Custom:postal_code_1>"),
         "{extended_clean}"
     );
-    assert_eq!(extended["stats"]["detections"], 4);
+    assert!(
+        extended_clean.contains(":Custom:iban_1>"),
+        "{extended_clean}"
+    );
+    assert!(
+        extended_clean.contains(":Custom:credit_card_1>"),
+        "{extended_clean}"
+    );
+    assert_eq!(extended["stats"]["detections"], 6);
     assert_eq!(
         restore_success_text(extended["session_blob"].as_str().unwrap(), extended_clean),
         input
@@ -1648,7 +1668,7 @@ fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
 
 #[test]
 fn s2_core_extended_cli_opt_in_mirrors_toml_and_rejects_garbage_symmetrically() {
-    let input = "phone +4915112345678 host 192.168.1.1 zip 94103";
+    let input = "phone +4915112345678 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_toml_dir, toml_policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
     let toml = clean_json_with_args(&[&format!("--policy={}", toml_policy.display())], input);
@@ -1680,6 +1700,15 @@ fn s2_core_extended_cli_opt_in_mirrors_toml_and_rejects_garbage_symmetrically() 
     );
     let toml_out = clean_raw_with_args(&[&format!("--policy={}", invalid_policy.display())], input);
     assert_symmetric_policy_config(cli_out, toml_out);
+}
+
+#[test]
+fn s2_core_extended_default_surface_does_not_load_phase2_recognizers() {
+    let input = "IBAN GB82WEST12345698765432 card 4111111111111111";
+    let default = clean_json_with_args(&[], input);
+
+    assert_eq!(default["clean_text"], input);
+    assert_eq!(default["stats"]["detections"], 0);
 }
 
 #[test]
@@ -1740,9 +1769,67 @@ fn s2_core_extended_tenant_like_numeric_ids_are_not_phone_tokens() {
     let clean = value["clean_text"].as_str().unwrap();
 
     assert!(!clean.contains("Custom:phone"), "{clean}");
+    assert!(!clean.contains("Custom:iban"), "{clean}");
+    assert!(!clean.contains("Custom:credit_card"), "{clean}");
     assert!(clean.contains("Subscriber_0001234567"), "{clean}");
     assert!(clean.contains("Order_0815"), "{clean}");
     assert!(clean.contains("0123-456789"), "{clean}");
+}
+
+#[test]
+fn s2_core_extended_cli_validator_backed_iban_and_cards_emit_or_drop() {
+    let (_dir, policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+
+    for (input, class) in [
+        ("Card 4111111111111111", "credit_card"),
+        ("Card 5555555555554444", "credit_card"),
+        ("Card 378282246310005", "credit_card"),
+        ("IBAN GB82WEST12345698765432", "iban"),
+        ("IBAN DE89370400440532013000", "iban"),
+        ("IBAN FR1420041010050500013M02606", "iban"),
+        ("IBAN BE68539007547034", "iban"),
+        ("IBAN NL91ABNA0417164300", "iban"),
+    ] {
+        let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+        let clean = value["clean_text"].as_str().unwrap();
+        assert!(
+            Regex::new(&format!(r"^.+<[0-9a-f]{{8}}:Custom:{class}_1>$"))
+                .unwrap()
+                .is_match(clean),
+            "unexpected clean text for {input}: {clean}"
+        );
+        assert_eq!(value["stats"]["detections"], 1, "{input}");
+        assert_eq!(
+            restore_success_text(value["session_blob"].as_str().unwrap(), clean),
+            input
+        );
+    }
+
+    for input in [
+        "Card 4111111111111112",
+        "Card 5555555555554445",
+        "Card 378282246310006",
+        "IBAN GB99WEST12345698765432",
+        "IBAN DE99370400440532013000",
+    ] {
+        let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+        let clean = value["clean_text"].as_str().unwrap();
+        assert_eq!(clean, input, "{input}");
+        assert_eq!(value["stats"]["detections"], 0, "{input}");
+    }
+
+    for input in [
+        "Subscriber_0001234567",
+        "Order_0815",
+        "0815 12345",
+        "Customer_42",
+    ] {
+        let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+        let clean = value["clean_text"].as_str().unwrap();
+        assert!(!clean.contains("Custom:iban"), "{input}: {clean}");
+        assert!(!clean.contains("Custom:credit_card"), "{input}: {clean}");
+    }
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1712,6 +1712,33 @@ fn s2_core_extended_default_surface_does_not_load_phase2_recognizers() {
 }
 
 #[test]
+fn s2_cli_bundled_smoke_emits_formatted_phase2_tokens() {
+    let value = clean_json_with_args(
+        &["--rulepack-bundled", "core,core-extended"],
+        "IBAN DE89 3704 0044 0532 0130 00 card 4111 1111 1111 1111",
+    );
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(clean.contains("Custom:iban"), "{clean}");
+    assert!(clean.contains("Custom:credit_card"), "{clean}");
+    assert!(!clean.contains("3704 0044"), "{clean}");
+    assert!(!clean.contains("4111 1111"), "{clean}");
+    assert_eq!(value["stats"]["detections"], 2);
+}
+
+#[test]
+fn s2_cli_bundled_smoke_drops_luhn_failing_formatted_cc() {
+    let value = clean_json_with_args(
+        &["--rulepack-bundled", "core,core-extended"],
+        "Card 4111 1111 1111 1112",
+    );
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(!clean.contains("Custom:credit_card"), "{clean}");
+    assert_eq!(value["stats"]["detections"], 0);
+}
+
+#[test]
 fn s2_core_extended_cli_locale_gating_and_plain_en_negative() {
     let (_dir, policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core-extended"
-rulepack_version = "0.4.2"
+rulepack_version = "0.4.3"
 default_locales = ["global"]
 
 [[recognizers]]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -20,6 +20,47 @@ priority = 80
 [recognizers.token]
 
 [[recognizers]]
+id = "iban.structural"
+class = "custom:iban"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b'''
+
+[recognizers.validator]
+kind = "iban_mod97"
+
+[recognizers.normalizer]
+kind = "iban_canonical"
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
+id = "card.structural"
+class = "custom:credit_card"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b\d{13,19}\b'''
+
+[recognizers.validator]
+kind = "luhn"
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
 id = "ip.v4"
 class = "custom:ip_address"
 cooperates_with = ["ip.v6"]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -27,7 +27,8 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b'''
+# Allows internal whitespace; iban_canonical normalizer strips before mod-97 validation.
+pattern = '''\b[A-Z]{2}\d{2}(?: ?[A-Z0-9]{4}){2,7} ?[A-Z0-9]{1,4}\b'''
 
 [recognizers.validator]
 kind = "iban_mod97"
@@ -49,7 +50,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''\b\d{13,19}\b'''
+pattern = '''\b\d(?:[\s-]?\d){12,18}\b'''
 
 [recognizers.validator]
 kind = "luhn"

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -43,17 +43,19 @@ mod tests {
     }
 
     #[test]
-    fn embedded_core_extended_rulepack_parses_and_contains_phase1_recognizers() {
+    fn embedded_core_extended_rulepack_parses_and_contains_phase2_recognizers() {
         let core_extended = embedded("core-extended").expect("core-extended rulepack");
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 5);
+        assert_eq!(rulepack.recognizers.len(), 7);
         assert_eq!(rulepack.recognizers[0].id, "phone.structural");
-        assert_eq!(rulepack.recognizers[1].id, "ip.v4");
-        assert_eq!(rulepack.recognizers[2].id, "ip.v6");
-        assert_eq!(rulepack.recognizers[3].id, "postal.de");
-        assert_eq!(rulepack.recognizers[4].id, "postal.us");
+        assert_eq!(rulepack.recognizers[1].id, "iban.structural");
+        assert_eq!(rulepack.recognizers[2].id, "card.structural");
+        assert_eq!(rulepack.recognizers[3].id, "ip.v4");
+        assert_eq!(rulepack.recognizers[4].id, "ip.v6");
+        assert_eq!(rulepack.recognizers[5].id, "postal.de");
+        assert_eq!(rulepack.recognizers[6].id, "postal.us");
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -234,7 +234,7 @@ fn is_basic_email(input: &str) -> bool {
 fn luhn_check(input: &str) -> bool {
     let mut digits = Vec::new();
     for byte in input.bytes() {
-        if byte.is_ascii_whitespace() {
+        if byte.is_ascii_whitespace() || byte == b'-' {
             continue;
         }
         if !byte.is_ascii_digit() {
@@ -242,7 +242,7 @@ fn luhn_check(input: &str) -> bool {
         }
         digits.push(byte - b'0');
     }
-    if digits.len() < 2 {
+    if !(13..=19).contains(&digits.len()) {
         return false;
     }
 

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -352,6 +352,74 @@ fn phase2_validators_drop_failing_candidates_and_iban_canonicalizes() {
 }
 
 #[test]
+fn phase2_formatted_iban_with_spaces_tokenizes_and_round_trips() {
+    let rulepack = core_extended();
+    let input = "Bank IBAN: DE89 3704 0044 0532 0130 00";
+
+    assert_eq!(
+        detect_recognizer(&rulepack, "iban.structural", input, LocaleTag::DeDe),
+        vec!["DE89 3704 0044 0532 0130 00".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer_canonical_forms(&rulepack, "iban.structural", input, LocaleTag::DeDe),
+        vec![Some("DE89370400440532013000".to_string())]
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::DeDe);
+    assert_custom_token(&clean, "iban");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn phase2_formatted_card_with_spaces_tokenizes_and_round_trips() {
+    let rulepack = core_extended();
+    let input = "Card: 4111 1111 1111 1111";
+
+    assert_eq!(
+        detect_recognizer(&rulepack, "card.structural", input, LocaleTag::EnUs),
+        vec!["4111 1111 1111 1111".to_string()]
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+    assert_custom_token(&clean, "credit_card");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn phase2_formatted_card_with_hyphens_tokenizes_and_round_trips() {
+    let rulepack = core_extended();
+    let input = "Card: 4111-1111-1111-1111";
+
+    assert_eq!(
+        detect_recognizer(&rulepack, "card.structural", input, LocaleTag::EnUs),
+        vec!["4111-1111-1111-1111".to_string()]
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+    assert_custom_token(&clean, "credit_card");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn phase2_formatted_card_failing_luhn_drops() {
+    let rulepack = core_extended();
+    let input = "Card: 4111 1111 1111 1112";
+
+    assert!(detect_recognizer(&rulepack, "card.structural", input, LocaleTag::EnUs).is_empty());
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+    assert_eq!(clean, input);
+}
+
+#[test]
 fn phase2_iban_and_cards_are_universal_and_solo_classes() {
     let rulepack = core_extended();
     let iban = rulepack

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -5,7 +5,7 @@ use gaze::{
     PiiClass, Pipeline, RawDocument, RawMatch, Recognizer, RecognizerSpec, Rulepack, RulepackError,
     RulepackSource, Scope, Session,
 };
-use gaze_recognizers::{embedded, RegexDetector};
+use gaze_recognizers::{embedded, NormalizerKind, RegexDetector, ValidatorKind};
 use serde_json::Map;
 
 fn core_extended() -> Rulepack {
@@ -38,8 +38,12 @@ fn regex_from_spec(spec: &RecognizerSpec) -> RegexDetector {
             .as_ref()
             .map(|context| context.exclusions.clone())
             .unwrap_or_default(),
-        None,
-        None,
+        spec.validator
+            .as_ref()
+            .map(|validator| ValidatorKind::parse(&validator.kind).expect("validator kind")),
+        spec.normalizer
+            .as_ref()
+            .map(|normalizer| NormalizerKind::parse(&normalizer.kind).expect("normalizer kind")),
     )
     .expect("regex detector")
 }
@@ -71,6 +75,33 @@ fn detect_recognizer(
         .collect()
 }
 
+fn detect_recognizer_canonical_forms(
+    rulepack: &Rulepack,
+    recognizer_id: &str,
+    input: &str,
+    locale: LocaleTag,
+) -> Vec<Option<String>> {
+    let dictionaries = DictionaryBundle::default();
+    let fields = Map::new();
+    let ctx = DetectContext {
+        locale_chain: &[locale, LocaleTag::Global],
+        dictionaries: &dictionaries,
+        fields: &fields,
+        degraded: Cell::new(false),
+    };
+    let spec = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == recognizer_id)
+        .unwrap_or_else(|| panic!("missing recognizer {recognizer_id}"));
+    let detector = regex_from_spec(spec);
+
+    Recognizer::detect(&detector, input, &ctx)
+        .into_iter()
+        .map(|candidate| candidate.canonical_form)
+        .collect()
+}
+
 fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
     let mut builder = Pipeline::builder()
         .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
@@ -84,6 +115,14 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
         ))
         .rule(ClassRule::new(
             PiiClass::Custom("postal_code".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("iban".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("credit_card".to_string()),
             Action::Tokenize,
         ))
         .rule(DefaultRule::new(Action::Preserve));
@@ -109,6 +148,22 @@ fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: Local
         panic!("expected text document");
     };
     text
+}
+
+fn restore_tokens(session: &Session, clean: &str) -> String {
+    gaze::token_shape::pattern()
+        .replace_all(clean, |captures: &regex::Captures<'_>| {
+            session.restore_strict(&captures[0]).expect("known token")
+        })
+        .to_string()
+}
+
+fn assert_custom_token(clean: &str, class: &str) {
+    let pattern = format!(r"^.+<[0-9a-f]{{8}}:Custom:{class}_1>.*$");
+    assert!(
+        regex::Regex::new(&pattern).unwrap().is_match(clean),
+        "missing Custom:{class} token in {clean}"
+    );
 }
 
 #[test]
@@ -166,6 +221,200 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
 }
 
 #[test]
+fn phase2_corpus_accepts_validator_passing_iban_and_cards_only() {
+    let rulepack = core_extended();
+
+    for (input, recognizer_id, expected) in [
+        (
+            "IBAN GB82WEST12345698765432",
+            "iban.structural",
+            "GB82WEST12345698765432",
+        ),
+        (
+            "IBAN DE89370400440532013000",
+            "iban.structural",
+            "DE89370400440532013000",
+        ),
+        (
+            "IBAN FR1420041010050500013M02606",
+            "iban.structural",
+            "FR1420041010050500013M02606",
+        ),
+        (
+            "IBAN BE68539007547034",
+            "iban.structural",
+            "BE68539007547034",
+        ),
+        (
+            "IBAN NL91ABNA0417164300",
+            "iban.structural",
+            "NL91ABNA0417164300",
+        ),
+        (
+            "Card 4111111111111111",
+            "card.structural",
+            "4111111111111111",
+        ),
+        (
+            "Card 4012888888881881",
+            "card.structural",
+            "4012888888881881",
+        ),
+        ("Card 4222222222222", "card.structural", "4222222222222"),
+        (
+            "Card 5555555555554444",
+            "card.structural",
+            "5555555555554444",
+        ),
+        (
+            "Card 5105105105105100",
+            "card.structural",
+            "5105105105105100",
+        ),
+        ("Card 378282246310005", "card.structural", "378282246310005"),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, recognizer_id, input, LocaleTag::EnUs),
+            vec![expected.to_string()],
+            "{input}"
+        );
+    }
+
+    for input in [
+        "Card 4111111111111112",
+        "Card 4012888888881882",
+        "Card 4222222222223",
+        "Card 5555555555554445",
+        "Card 5105105105105101",
+        "Card 378282246310006",
+        "IBAN GB99WEST12345698765432",
+        "IBAN DE99370400440532013000",
+        "IBAN FR9920041010050500013M02606",
+        "IBAN BE99539007547034",
+        "IBAN NL99ABNA0417164300",
+        "Subscriber_0001234567",
+        "Order_0815",
+        "0815 12345",
+        "Customer_42",
+    ] {
+        assert!(
+            detect_recognizer(&rulepack, "card.structural", input, LocaleTag::EnUs).is_empty(),
+            "card.structural must not fire for {input}"
+        );
+        assert!(
+            detect_recognizer(&rulepack, "iban.structural", input, LocaleTag::EnUs).is_empty(),
+            "iban.structural must not fire for {input}"
+        );
+    }
+}
+
+#[test]
+fn phase2_validators_drop_failing_candidates_and_iban_canonicalizes() {
+    let rulepack = core_extended();
+
+    // ADVERSARIAL: this test relies on S1 ValidatorKind dispatch in
+    // RegexDetector::canonical_form. Disabling that dispatch (deleting
+    // validator_kind field-read) MUST cause the FAILING tests to start
+    // passing. This proves Phase 2 inherits the data-flow gate from S1
+    // (drawer architecture_853a0593).
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "card.structural",
+            "Card 4111111111111111",
+            LocaleTag::EnUs
+        ),
+        vec!["4111111111111111".to_string()]
+    );
+    assert!(detect_recognizer(
+        &rulepack,
+        "card.structural",
+        "Card 4111111111111112",
+        LocaleTag::EnUs
+    )
+    .is_empty());
+    assert_eq!(
+        detect_recognizer_canonical_forms(
+            &rulepack,
+            "iban.structural",
+            "IBAN GB82WEST12345698765432",
+            LocaleTag::EnUs
+        ),
+        vec![Some("GB82WEST12345698765432".to_string())]
+    );
+    assert!(detect_recognizer(
+        &rulepack,
+        "iban.structural",
+        "IBAN GB99WEST12345698765432",
+        LocaleTag::EnUs
+    )
+    .is_empty());
+}
+
+#[test]
+fn phase2_iban_and_cards_are_universal_and_solo_classes() {
+    let rulepack = core_extended();
+    let iban = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "iban.structural")
+        .expect("iban.structural");
+    let card = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "card.structural")
+        .expect("card.structural");
+
+    assert_eq!(iban.locales, vec![LocaleTag::Global]);
+    assert_eq!(card.locales, vec![LocaleTag::Global]);
+    assert!(iban.cooperates_with.is_empty());
+    assert!(card.cooperates_with.is_empty());
+    assert_eq!(
+        rulepack
+            .recognizers
+            .iter()
+            .filter(|recognizer| recognizer.class == PiiClass::Custom("iban".to_string()))
+            .count(),
+        1
+    );
+    assert_eq!(
+        rulepack
+            .recognizers
+            .iter()
+            .filter(|recognizer| recognizer.class == PiiClass::Custom("credit_card".to_string()))
+            .count(),
+        1
+    );
+
+    for locale in [
+        LocaleTag::EnUs,
+        LocaleTag::DeDe,
+        LocaleTag::Other("fr-FR".to_string()),
+    ] {
+        assert_eq!(
+            detect_recognizer(
+                &rulepack,
+                "iban.structural",
+                "IBAN GB82WEST12345698765432",
+                locale.clone()
+            ),
+            vec!["GB82WEST12345698765432".to_string()],
+            "{locale:?}"
+        );
+        assert_eq!(
+            detect_recognizer(
+                &rulepack,
+                "card.structural",
+                "Card 4111111111111111",
+                locale.clone()
+            ),
+            vec!["4111111111111111".to_string()],
+            "{locale:?}"
+        );
+    }
+}
+
+#[test]
 fn core_and_core_extended_compose_without_counter_collision() {
     let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
     let extended = core_extended();
@@ -209,6 +458,58 @@ fn core_and_core_extended_compose_without_counter_collision() {
 }
 
 #[test]
+fn core_and_core_extended_compose_with_phase2_without_counter_collision() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+    let extended = core_extended();
+    let mut builder = Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("phone".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("ip_address".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("postal_code".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("iban".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("credit_card".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve));
+
+    let email_spec = core
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "email.global")
+        .expect("email.global");
+    builder = builder.recognizer(regex_from_spec(email_spec));
+    for spec in &extended.recognizers {
+        builder = builder.recognizer(regex_from_spec(spec));
+    }
+
+    let pipeline = builder.build().expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+
+    assert!(clean.contains(":Email_1>"), "{clean}");
+    assert_custom_token(&clean, "phone");
+    assert_custom_token(&clean, "ip_address");
+    assert_custom_token(&clean, "postal_code");
+    assert_custom_token(&clean, "iban");
+    assert_custom_token(&clean, "credit_card");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
 fn every_phase1_recognizer_round_trips_through_restore() {
     let rulepack = core_extended();
     let pipeline = pipeline_from_rulepack(&rulepack);
@@ -233,13 +534,31 @@ fn every_phase1_recognizer_round_trips_through_restore() {
 }
 
 #[test]
-fn embedded_core_extended_load_smoke_has_at_least_five_recognizers() {
+fn every_phase2_recognizer_round_trips_through_restore() {
+    let rulepack = core_extended();
+    let pipeline = pipeline_from_rulepack(&rulepack);
+
+    for (input, locale) in [
+        ("IBAN GB82WEST12345698765432", LocaleTag::EnUs),
+        ("IBAN DE89370400440532013000", LocaleTag::DeDe),
+        ("Card 4111111111111111", LocaleTag::EnUs),
+        ("Card 5555555555554444", LocaleTag::DeDe),
+    ] {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, locale);
+        assert_ne!(clean, input, "expected tokenized output for {input}");
+        assert_eq!(restore_tokens(&session, &clean), input);
+    }
+}
+
+#[test]
+fn embedded_core_extended_load_smoke_has_at_least_seven_recognizers() {
     let rulepack = Rulepack::load(RulepackSource::Embedded(
         embedded("core-extended").expect("core-extended embedded rulepack"),
     ))
     .expect("core-extended loads");
 
-    assert!(rulepack.recognizers.len() >= 5);
+    assert!(rulepack.recognizers.len() >= 7);
 }
 
 #[test]

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -302,7 +302,7 @@ Bundled rulepacks:
 | Bundle | Recognizers | Classes | Notes |
 |--------|-------------|---------|-------|
 | `core` | `email.global`, `email.header.name` | `email`, `name` | Default bundle when `[policy.rulepacks]` is omitted. |
-| `core-extended` | `phone.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:ip_address`, `custom:postal_code` | Opt-in Phase 1 bundle. Shape-only recognizers. |
+| `core-extended` | `phone.structural`, `iban.structural`, `card.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:iban`, `custom:credit_card`, `custom:ip_address`, `custom:postal_code` | Opt-in bundle. Phase 1 shape recognizers plus Phase 2 validator-backed IBAN and credit-card recognizers. |
 
 Opt into `core-extended` alongside `core`:
 
@@ -317,18 +317,25 @@ Or override the bundle list for one CLI run:
 gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 ```
 
-`core-extended` Phase 1 recognizers are intentionally conservative:
+`core-extended` recognizers are intentionally conservative:
 
 - `phone.structural` matches E.164-only `+\d{6,15}` numbers. National phone
   patterns are not included.
+- `iban.structural` emits `custom:iban` only for IBAN-shaped candidates that
+  pass `iban_mod97`; the canonical form is normalized with `iban_canonical`.
+- `card.structural` emits `custom:credit_card` only for 13- to 19-digit
+  candidates that pass `luhn`.
 - `ip.v4` and `ip.v6` emit `custom:ip_address`.
 - `postal.de` emits `custom:postal_code` only under active locale `de-DE`.
 - `postal.us` emits `custom:postal_code` only under active locale `en-US`.
   Plain `en` does not activate `postal.us`.
 
-Phase 1 is shape-only. v0.4.3 adds validator and normalizer primitives for
-rulepack authors, but the bundled `core-extended` recognizer list does not add
-IBAN or credit-card recognizers until the follow-on bundle update.
+IBAN and credit-card recognizers are universal (`global`) because their
+validation rules are format-level checks, not national locale gates. They are
+also solo recognizers in their classes, so they do not need `cooperates_with`
+rows. Tenant numeric IDs such as `Subscriber_0001234567` and `Order_0815`
+are explicit negative fixtures for those recognizers; broad numeric shapes must
+not become credit-card detections without a passing validator.
 
 Within a rulepack, every `[[recognizers]]` block has an `id`, `class`, and
 `[recognizers.match]` table. If two recognizers in the same rulepack emit the


### PR DESCRIPTION
## Summary
v0.4.3 plan rev 3 §S2 (scratchpad 307). Validator-backed Phase 2 recognizers in opt-in \`core-extended\` rulepack:

- \`iban.structural\` — IBAN regex + \`iban_mod97\` validator + \`iban_canonical\` normalizer → \`custom:iban\`
- \`card.structural\` — broad CC regex + \`luhn\` validator → \`custom:credit_card\`

End-to-end pair tests prove S1 ValidatorKind dispatch is exercised: passing-validator → emits, failing-validator → drops.

Tenant numeric IDs (Subscriber_*, Order_*) are explicit negative fixtures — they must NOT fire as IBAN or CC.

## Test plan
- [ ] \`cargo test --workspace\` green
- [ ] \`cargo clippy --workspace --all-targets\` zero warnings
- [ ] \`cargo fmt --check\` clean
- [ ] All S2.test 1-9 rows present + passing
- [ ] Round-trip identity per validator-emitted token
- [ ] AGENTS.md compliant: only test reserved CC numbers + ISO IBAN test examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)