### PR TITLE
v0.4.3 P4: release plumbing — version bump + CHANGELOG + roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-04-26
+
+### Added
+
+- **S1 ValidatorKind substrate** (#47): three new validators in `crates/gaze-recognizers/src/regex.rs`: `Luhn` for Mod 10 checksums, `IbanMod97` for ISO 7064 mod-97 validation, and `IbanCanonical` for uppercase-plus-whitespace-stripped normalization.
+- **S2 core-extended Phase 2** (#48): two validator-backed recognizers in `core-extended.toml`:
+  - `iban.structural` matches IBANs with optional whitespace, applies the `iban_mod97` validator plus `iban_canonical` normalizer, and emits class `custom:iban`.
+  - `card.structural` matches broad credit-card shapes with optional space or hyphen separators, applies the `luhn` validator, and emits class `custom:credit_card`.
+  - Default `[[rule]]` entries now ship in the rulepack so `--rulepack-bundled core,core-extended` tokenizes these classes out of the box, following the CLI shipping divergence pattern captured in drawer `gaze_architecture_c6eefa4b`.
+  - The bundled `core-extended` rulepack version is now `0.4.3`.
+- **S3 xtask `no_tenant_knowledge` gate** (#46): production-code lint scanner rejects tenant-pattern strings (`order_id`, `Order_42`, `Song_42`, `User_7`) in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. Allow markers (`// allow(tenant-fixture)`) hard-fail in production scope and remain valid only in `tests/`, `benches/`, `docs/`, and `CONTRIBUTING.md`. CI runs the gate through `.github/workflows/no-tenant-knowledge.yml`, and an adversarial in-PR self-test verifies the scanner actually scans rather than printing success.
+- **S4 `gaze audit query/export` CLI** (#45): the existing `commands/audit.rs` stub is now wired into full read-only metadata export from audit SQLite. Filters include `--class`, `--source`, `--action`, and `--document-kind`; JSONL is the default output. A restricted column set defends against extra-column leaks, with cross-version SQLite fixture coverage for current and legacy schemas.
+- Tenant numeric ID negative fixtures (`Subscriber_*`, `Order_*`, `Customer_*`, `0815 12345`) are explicitly proven not to fire as IBAN or credit-card matches.
+
+### Changed
+
+- Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.3`.
+- `--audit-db` queries now open the SQLite database read-only via `OpenFlags::SQLITE_OPEN_READ_ONLY` for defense in depth, so the audit CLI cannot write to the DB even if compromised.
+
+### Deferred to v0.4.4
+
+- `--session` and `--from`/`--to` audit filters need a session column and `created_at` schema migration.
+- Date recognizer needs an explicit policy-posture brainstorm, including the GH #5 tradeoff considerations.
+- National phone patterns need parser-backed per-locale validation because of collision risk with tenant numeric IDs.
+- Open-key `PiiClass` refactor plus crate-shape Option B remain targeted for v0.5.
+
+### Notes for adopters
+
+- The Linux x86_64 binary requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer), the same constraint as v0.4.2.
+- Phase 2 validator-backed recognizers are opt-in via the `core-extended` rulepack; adopters using only `core` get no behavior change.
+
 ## [0.4.2] - 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "gaze"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"

--- a/docs/roadmap/v0.4/v0.4.3.md
+++ b/docs/roadmap/v0.4/v0.4.3.md
@@ -1,0 +1,34 @@
+# v0.4.3 Release Notes
+
+Status: release plumbing for 2026-04-26.
+
+v0.4.3 closes the v0.4.3 Wave C hardening pass. The release adds validator-backed detection for high-risk structured identifiers, introduces a production-code gate against tenant-pattern knowledge, and exposes read-only audit metadata export while preserving the core Gaze contract: reliable, reversible PII pseudonymization for agentic workflows.
+
+## Shipped Scope
+
+- **S1 ValidatorKind substrate (#47):** `crates/gaze-recognizers/src/regex.rs` now includes `Luhn` for Mod 10 checksums, `IbanMod97` for ISO 7064 mod-97 validation, and `IbanCanonical` for uppercase-plus-whitespace-stripped normalization. These validators keep broad regex matches from becoming broad false-positive leaks.
+- **S2 core-extended Phase 2 (#48):** the opt-in `core-extended` rulepack now ships validator-backed `iban.structural` and `card.structural` recognizers. `iban.structural` accepts optional whitespace, canonicalizes IBANs, validates mod-97, and emits `custom:iban`. `card.structural` accepts optional spaces or hyphens, validates with Luhn, and emits `custom:credit_card`. Default rules are bundled so `--rulepack-bundled core,core-extended` tokenizes these classes without adopter-side rule authoring.
+- **S3 xtask `no_tenant_knowledge` gate (#46):** production source under `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/` is now scanned for tenant-pattern strings such as `order_id`, `Order_42`, `Song_42`, and `User_7`. Allow markers hard-fail in production scope and remain valid only in tests, benches, docs, and `CONTRIBUTING.md`. CI runs the gate, and an adversarial self-test proves it is scanning real input.
+- **S4 `gaze audit query/export` CLI (#45):** `gaze audit` now provides read-only metadata export from audit SQLite through `query` and `export` subcommands. Filters cover class, source, action, and document kind, with JSONL as the default output. The implementation selects a restricted column set to avoid accidental extra-column leakage and includes current plus legacy SQLite fixture coverage.
+- **Tenant numeric ID negative fixtures:** `Subscriber_*`, `Order_*`, `Customer_*`, and `0815 12345` are explicitly covered as non-matches for IBAN and credit-card recognizers.
+
+## Release Checks
+
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets`
+- `cargo fmt --check`
+- `cargo build --workspace`
+- `cargo metadata` confirms only `gaze`, `gaze-assembly`, `gaze-recognizers`, and `gaze-cli` are versioned `0.4.3`; `xtask` remains `0.0.1` and `debug-proxy` remains `0.3.1`.
+
+Final tag acceptance requires `v0.4.3-rc.1` and `v0.4.3` release workflows to publish macOS aarch64 and Linux x86_64 binaries, each with SHA256 files and packaged-binary smoke coverage. The Linux x86_64 binary continues to require glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer).
+
+## Deferred
+
+- `--session` and `--from`/`--to` audit filters, pending a session column and `created_at` schema migration.
+- Date recognizer policy posture, including GH #5 tradeoff considerations.
+- National phone patterns, pending parser-backed per-locale validation to reduce tenant numeric ID collisions.
+- Open-key `PiiClass` refactor and crate-shape Option B, targeted for v0.5.
+
+## Adopter Notes
+
+The Phase 2 recognizers are opt-in through `core-extended`; users who load only the default `core` rulepack see no detection behavior change. The audit CLI opens SQLite with `OpenFlags::SQLITE_OPEN_READ_ONLY`, so metadata export cannot mutate the audit database.


### PR DESCRIPTION
Per rev 3 §S5 (scratchpad 307). Bumps 4 release crates (gaze, gaze-assembly, gaze-recognizers, gaze-cli) to 0.4.3. Aggregates CHANGELOG (S5-only aggregation per drawer gaze_decisions_433c5c3c). Adds v0.4.3 roadmap entry.

After merge: tag v0.4.3-rc.1 → CI smoke (macOS aarch64 + Linux x86_64) → tag v0.4.3 → release → Homebrew bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)