### PR TITLE
v0.4.4 S4: Date posture memo (binding conclusions, NO recognizer code)

### DIFF
--- a/docs/research/v0.4.4-date-posture.md
+++ b/docs/research/v0.4.4-date-posture.md
@@ -1,0 +1,88 @@
+# v0.4.4 Date Posture Memo
+
+**Date:** 2026-04-26
+**Scope:** v0.4.4 plan rev 2 S4 binding conclusions for Date handling.
+**Status:** Binding for any future v0.4.5+ Date implementation.
+
+This memo locks Gaze's v0.4.x stance on Date-as-PII handling. It is a posture memo only: no recognizer code, no rulepack change, and no default bundle behavior change.
+
+## 1. Decision: PII-by-default = NO
+
+Date strings in input are NOT PII by default. Gaze's `core` and `core-extended` rulepacks MUST NOT include any date recognizer that fires on default-on opt-in.
+
+Rationale:
+
+- Dates appear pervasively in non-PII contexts: timestamps in tool calls, version strings, file paths, software changelog entries, build metadata, deadlines, calendar references, prose narrative.
+- Validator-backed calendar validity (`2026-04-26` is a real date) does NOT prove the date is PII versus operational metadata.
+- Token-spam from over-broad date recognition would degrade adopter trust (axis 4) and session manifest size (axis 5) without proportional axis-1 reliability gain.
+- Without context classification, which Gaze v0.4.x architecture does not provide because `cooperates_with` is pattern-overlap, not semantic grounding, Date detection collapses to coarse pattern matching with high false-positive cost.
+
+## 2. Decision: Never in default bundles
+
+Date recognizers MUST NOT ship in:
+
+- `core.toml`
+- `core-extended.toml` (Phase 1, 2, 3)
+- Any "default-on if you opt in to extended" bundle
+
+If implemented in v0.4.5+, Date recognizers ship in a SEPARATE opt-in bundle, such as `core-extended-date.toml`. Adopters must explicitly opt in via:
+
+```toml
+bundled = ["core", "core-extended", "core-extended-date"]
+```
+
+## 3. Decision: Future implementation scope = DOB-only
+
+If/when Date recognition lands in v0.4.5+:
+
+- **DOB-scoped only**: date-of-birth contexts such as form-field metadata or structured input where the field semantically is DOB.
+- General-prose dates require context classification and are deferred to v0.5+ research. `gaze` would need semantic grounding capability not present in v0.4.x.
+- Format scope, when implemented: ISO 8601 (`YYYY-MM-DD`) plus locale-specific structured forms ONLY. NO written-out (`January 2nd, 2026`), NO relative (`yesterday`).
+- Validator-backed: `DateCalendar` validator rejects impossible dates (`2026-13-45`).
+
+## 4. Decision: GH #5 token-spam tradeoff
+
+GH issue #5 (https://github.com/Naoray/gaze/issues/5) raised concern about date redaction trade-offs: relative-distance preservation and locale ambiguity. This memo resolves that concern as:
+
+- Gaze does NOT redact dates in prose by default. This memo locks the no-default-on stance.
+- Adopters who need DOB redaction get a bounded, locale-explicit, opt-in recognizer in v0.4.5+.
+- Relative-date semantics (`yesterday`, `next Tuesday`) are out of scope. They require natural-language parsing and are v0.5+ research if at all.
+
+## 5. Negative corpus enumeration
+
+This section is binding for any future v0.4.5+ Date implementation.
+
+The following categories MUST drop with NO tokenization under any future Date recognizer:
+
+- Version strings: `1.4.3`, `v2.0.1-beta`, `2024.04.26-build`
+- IP-like patterns: `192.168.1.1`, `10.0.0.42`
+- File paths: `/var/log/2024/04/26/access.log`, `C:\Users\admin\2026-04-26.csv`
+- ID-shaped numerics: `2024050001234567`, `Order-2024-0001`
+- Year-only references: `2026`, `Q1 2026`, `FY2024`
+- Build/CI metadata: `build-2026-04-26-1234`, `release-2024.04`
+
+## 6. Implementation triggers
+
+This section is binding.
+
+The following adopter signals would promote DOB-scoped Date work to v0.4.5:
+
+- Markus reports DOB leak in Dashboard pipeline with concrete fixture.
+- New adopter explicitly requests DOB redaction with structured input fixtures.
+- New adopter reports HIPAA/GDPR compliance gap traceable to Date PII.
+
+The following do NOT trigger Date implementation:
+
+- Generic "we'd like date redaction" requests. These are too unscoped and should be deferred with the policy posture explanation from this memo.
+- Token-spam complaints. These validate this memo's no-default-on stance.
+- Compliance audit requests with no fixture. Request a fixture first.
+
+## 7. v0.5+ research scope
+
+For general-prose date PII detection, Gaze would need:
+
+- Context classification: semantic grounding of date occurrence, such as whether it is DOB, a medical record date, a legal filing date, or an operational timestamp.
+- Cross-recognizer state passing. Currently `cooperates_with` is pattern-overlap only, not semantic state.
+- Possibly NER-based date entity recognition with confidence threshold.
+
+These are v0.5+ research items, NOT v0.4.x implementation.


### PR DESCRIPTION
## Summary
v0.4.4 plan rev 2 §S4 (scratchpad 339). Pure docs/research deliverable. Locks Gaze's stance on Date-as-PII handling for v0.4.4 + sets binding scope for any future v0.4.5+ Date implementation.

Key conclusions:
- PII-by-default = NO
- Never in default bundles (core / core-extended)
- Future impl scope: DOB-only in structured contexts (general-prose dates → v0.5+ research)
- GH #5 token-spam tradeoff resolved as no-default-on stance
- Negative corpus enumerated (version strings, IPs, file paths, ID-shaped numerics, year-only, build metadata)
- Implementation triggers documented

## Test plan
- [x] Memo file exists at docs/research/v0.4.4-date-posture.md
- [x] All 7 binding conclusions present
- [x] No source code changes
- [x] No CHANGELOG touches (Pn aggregates)
- [x] cargo test --workspace green (sanity, no behavior change expected)
- [x] cargo clippy --workspace --all-targets -- -D warnings green
- [x] cargo fmt --check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)