### PR TITLE
v0.4.4 S1: activate ClassMapOverrideSafety xtask gate (#132)

### DIFF
--- a/.github/workflows/class-map-override-safety.yml
+++ b/.github/workflows/class-map-override-safety.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 jobs:
   class-map-override-safety:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/class-map-override-safety.yml
+++ b/.github/workflows/class-map-override-safety.yml
@@ -1,0 +1,12 @@
+name: class-map-override-safety
+
+on: [pull_request, push]
+
+jobs:
+  class-map-override-safety:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with: { toolchain: stable }
+      - run: cargo run -p xtask -- class-map-override-safety

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -24,10 +24,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::SymmetricPotemkin => run_symmetric_potemkin_gate(),
-        Command::ClassMapOverrideSafety => {
-            println!("class_map_override_safety: scaffolded");
-            Ok(())
-        }
+        Command::ClassMapOverrideSafety => run_class_map_override_safety_gate(),
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NoTenantKnowledge => no_tenant_knowledge::run(),
     }
@@ -132,6 +129,14 @@ const RECOGNIZER_COMPOSITION_VALIDATOR_TESTS: &[BehavioralTest] = &[
     },
 ];
 
+/// Adversarial self-test: reviewer manually renames one of the listed
+/// tests on a throwaway branch and verifies xtask exits non-zero.
+/// Codifies meta-Potemkin guard per drawer gaze_architecture_12b32d53.
+const CLASS_MAP_OVERRIDE_SAFETY_TESTS: &[&str] = &[
+    "tests::t20_context_class_map_overrides_policy_dict_class",
+    "tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered",
+];
+
 fn run_symmetric_potemkin_gate() -> Result<()> {
     println!(
         "symmetric_potemkin_gate: checking {} behavioral tests",
@@ -141,10 +146,36 @@ fn run_symmetric_potemkin_gate() -> Result<()> {
         ensure_test_exists(*test)?;
     }
     for test in SYMMETRIC_POTEMKIN_TESTS {
-        run_behavioral_test(*test)?;
+        run_behavioral_test("symmetric_potemkin_gate", *test)?;
     }
     println!("symmetric_potemkin_gate: passed");
     Ok(())
+}
+
+fn run_class_map_override_safety_gate() -> Result<()> {
+    println!(
+        "class_map_override_safety: checking {} behavioral tests",
+        CLASS_MAP_OVERRIDE_SAFETY_TESTS.len()
+    );
+    for name in CLASS_MAP_OVERRIDE_SAFETY_TESTS {
+        ensure_test_exists(class_map_override_safety_test(name))?;
+    }
+    for name in CLASS_MAP_OVERRIDE_SAFETY_TESTS {
+        run_behavioral_test(
+            "class_map_override_safety",
+            class_map_override_safety_test(name),
+        )?;
+    }
+    println!("class_map_override_safety: passed");
+    Ok(())
+}
+
+fn class_map_override_safety_test(name: &'static str) -> BehavioralTest {
+    BehavioralTest {
+        package: "gaze-assembly",
+        test_target: None,
+        name,
+    }
 }
 
 fn run_recognizer_composition_validator_gate() -> Result<()> {
@@ -156,7 +187,7 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
         ensure_test_exists(*test)?;
     }
     for test in RECOGNIZER_COMPOSITION_VALIDATOR_TESTS {
-        run_behavioral_test(*test)?;
+        run_behavioral_test("recognizer_composition_validator", *test)?;
     }
     println!("recognizer_composition_validator: passed");
     Ok(())
@@ -183,8 +214,8 @@ fn ensure_test_exists(test: BehavioralTest) -> Result<()> {
     Ok(())
 }
 
-fn run_behavioral_test(test: BehavioralTest) -> Result<()> {
-    println!("symmetric_potemkin_gate: running {}", describe(test));
+fn run_behavioral_test(gate: &str, test: BehavioralTest) -> Result<()> {
+    println!("{gate}: running {}", describe(test));
     let status = cargo_test_command(test, Some(test.name))
         .arg("--")
         .arg("--exact")

--- a/crates/xtask/tests/adversarial_class_map_override_safety.rs
+++ b/crates/xtask/tests/adversarial_class_map_override_safety.rs
@@ -1,58 +1,91 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 
-fn xtask_main() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs")
+const RENAMED_TEST: &str = "t20a_class_map_override_fails_closed_when_action_rule_uncovered";
+const RENAMED_TEST_DISABLED: &str =
+    "t20a_class_map_override_fails_closed_when_action_rule_uncovered_disabled";
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn run_gate(root: &Path) -> Output {
+    Command::new("cargo")
+        .args(["run", "-p", "xtask", "--", "class-map-override-safety"])
+        .current_dir(root)
+        .output()
+        .expect("run class-map-override-safety gate")
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
 }
 
 #[test]
-fn class_map_override_safety_gate_keeps_manual_attestation_contract() {
-    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
-
+fn class_map_override_safety_gate_passes_on_baseline() {
+    let output = run_gate(&workspace_root());
     assert!(
-        source.contains("Command::ClassMapOverrideSafety => run_class_map_override_safety_gate()"),
-        "class-map override safety command must dispatch to the behavioral gate"
-    );
-    assert!(
-        !source.contains("class_map_override_safety: scaffolded"),
-        "class-map override safety command must not regress to a scaffold"
-    );
-    assert!(
-        source.contains("Adversarial self-test: reviewer manually renames one of the listed"),
-        "manual reviewer-attestation guard must stay documented in source"
-    );
-    assert!(
-        source.contains("gaze_architecture_12b32d53"),
-        "source comment must retain the meta-Potemkin drawer reference"
+        output.status.success(),
+        "gate must pass on baseline; {}",
+        output_text(&output)
     );
 }
 
 #[test]
-fn class_map_override_safety_gate_lists_both_behavioral_tests() {
-    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
+fn class_map_override_safety_gate_fails_when_required_test_is_missing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture_root = temp.path().join("gaze-class-map-override-adversarial");
+    let add_status = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&fixture_root)
+        .arg("HEAD")
+        .current_dir(workspace_root())
+        .status()
+        .expect("create adversarial worktree");
+    assert!(add_status.success(), "git worktree add must succeed");
 
-    for expected in [
-        "tests::t20_context_class_map_overrides_policy_dict_class",
-        "tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered",
-    ] {
-        assert!(
-            source.contains(expected),
-            "class-map override safety gate must list behavioral test {expected}"
-        );
-    }
-}
-
-#[test]
-fn class_map_override_safety_cross_cutting_rationale_is_build_time_only() {
-    // Round-trip: N/A because this is a build-time gate and emits no tokens.
-    // Three-surfaces: N/A because there is no runtime policy, CLI, or API knob.
-    // cooperates_with: N/A because this gate does not define a recognizer.
-    // No-tenant-knowledge: this file uses synthetic test names only.
-    // CLI shipping smoke: N/A for recognizer paths; the smoke is `cargo run -p xtask`.
-    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
-
+    let assembly = fixture_root.join("crates/gaze-assembly/src/lib.rs");
+    let source = fs::read_to_string(&assembly).expect("read gaze-assembly lib");
     assert!(
-        source.contains("fn run_class_map_override_safety_gate()"),
-        "build-time xtask gate must remain the only runtime surface"
+        source.contains(RENAMED_TEST),
+        "fixture must contain required test before mutation"
+    );
+    fs::write(
+        &assembly,
+        source.replacen(RENAMED_TEST, RENAMED_TEST_DISABLED, 1),
+    )
+    .expect("rename required test in fixture");
+
+    let output = run_gate(&fixture_root);
+    let remove_status = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(&fixture_root)
+        .current_dir(workspace_root())
+        .status()
+        .expect("remove adversarial worktree");
+    assert!(remove_status.success(), "git worktree remove must succeed");
+
+    let text = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "gate must fail when a required test is missing; {text}"
+    );
+    assert!(
+        text.contains("missing behavioral test"),
+        "gate failure must identify the list-phase miss; {text}"
+    );
+    assert!(
+        text.contains("tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered"),
+        "gate failure must name the missing behavioral test; {text}"
     );
 }

--- a/crates/xtask/tests/adversarial_class_map_override_safety.rs
+++ b/crates/xtask/tests/adversarial_class_map_override_safety.rs
@@ -1,0 +1,58 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn xtask_main() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs")
+}
+
+#[test]
+fn class_map_override_safety_gate_keeps_manual_attestation_contract() {
+    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
+
+    assert!(
+        source.contains("Command::ClassMapOverrideSafety => run_class_map_override_safety_gate()"),
+        "class-map override safety command must dispatch to the behavioral gate"
+    );
+    assert!(
+        !source.contains("class_map_override_safety: scaffolded"),
+        "class-map override safety command must not regress to a scaffold"
+    );
+    assert!(
+        source.contains("Adversarial self-test: reviewer manually renames one of the listed"),
+        "manual reviewer-attestation guard must stay documented in source"
+    );
+    assert!(
+        source.contains("gaze_architecture_12b32d53"),
+        "source comment must retain the meta-Potemkin drawer reference"
+    );
+}
+
+#[test]
+fn class_map_override_safety_gate_lists_both_behavioral_tests() {
+    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
+
+    for expected in [
+        "tests::t20_context_class_map_overrides_policy_dict_class",
+        "tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered",
+    ] {
+        assert!(
+            source.contains(expected),
+            "class-map override safety gate must list behavioral test {expected}"
+        );
+    }
+}
+
+#[test]
+fn class_map_override_safety_cross_cutting_rationale_is_build_time_only() {
+    // Round-trip: N/A because this is a build-time gate and emits no tokens.
+    // Three-surfaces: N/A because there is no runtime policy, CLI, or API knob.
+    // cooperates_with: N/A because this gate does not define a recognizer.
+    // No-tenant-knowledge: this file uses synthetic test names only.
+    // CLI shipping smoke: N/A for recognizer paths; the smoke is `cargo run -p xtask`.
+    let source = fs::read_to_string(xtask_main()).expect("read xtask main");
+
+    assert!(
+        source.contains("fn run_class_map_override_safety_gate()"),
+        "build-time xtask gate must remain the only runtime surface"
+    );
+}


### PR DESCRIPTION
## Summary
v0.4.4 plan rev 2 §S1 (scratchpad 339). Closes todo #132. Replaces scaffold println with behavioral test runner per existing SymmetricPotemkin pattern. Wires CI workflow.

Tests covered:
- `t20_context_class_map_overrides_policy_dict_class`
- `t20a_class_map_override_fails_closed_when_action_rule_uncovered`

## Adversarial self-test (MANUAL — reviewer attestation per drawer gaze_architecture_12b32d53)
**S1 adversarial self-test:** Reviewer manually verifies that renaming `t20_context_class_map_overrides_policy_dict_class` (or `t20a_class_map_override_fails_closed_when_action_rule_uncovered`) on a throwaway branch causes `cargo run -p xtask -- class-map-override-safety` to exit non-zero. Codifies the meta-Potemkin guard per drawer `gaze_architecture_12b32d53`.

## Cross-cutting rows
- Round-trip: N/A, build-time gate; no token emission.
- Three-surfaces: N/A, no runtime knob.
- cooperates_with: N/A, no recognizer.
- No-tenant-knowledge: synthetic test names only.
- CLI shipping smoke: N/A for recognizer path; gate runs via `cargo run -p xtask`.

## Test plan
- [x] cargo test --workspace green
- [x] cargo clippy --workspace --all-targets zero warnings
- [x] cargo fmt --check clean
- [x] cargo run -p xtask -- class-map-override-safety exits 0 on branch
- [x] CI workflow runs gate on PR + push
- [ ] Adversarial reviewer attestation verified (see above)