### PR TITLE
v0.4.4 S3a: phonenumber audit + E164Phone validator (gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +616,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -929,6 +953,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1270,7 @@ dependencies = [
  "hex",
  "ndarray 0.16.1",
  "ort",
+ "phonenumber",
  "regex",
  "serde",
  "serde_json",
@@ -1328,6 +1365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1421,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1837,6 +1897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1928,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "lzma-rust2"
@@ -2111,6 +2186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oncemutex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
+
+[[package]]
 name = "onig"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,7 +2286,7 @@ checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2217,7 +2298,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "structmeta",
  "syn",
 ]
@@ -2242,6 +2323,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phonenumber"
+version = "0.3.9+9.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
+dependencies = [
+ "either",
+ "fnv",
+ "nom",
+ "once_cell",
+ "postcard",
+ "quick-xml",
+ "regex",
+ "regex-cache",
+ "serde",
+ "serde_derive",
+ "strum",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pin-project"
@@ -2346,6 +2447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2611,7 +2734,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2622,8 +2745,26 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-cache"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7b62d69743b8b94f353b6b7c3deb4c5582828328bcb8d5fedf214373808793"
+dependencies = [
+ "lru-cache",
+ "oncemutex",
+ "regex",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3395,6 +3536,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3631,7 +3793,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "serde",
  "serde_json",
  "spm_precompiled",

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1621,7 +1621,7 @@ fn s1_rulepack_bundled_override_changes_bundled_recognizer_availability() {
 
 #[test]
 fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
-    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103-1234 IBAN GB82WEST12345698765432 card 4111111111111111";
+    let input = "Email alice@example.invalid phone +4915550112233 host 192.168.1.1 zip 94103-1234 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_core_dir, core_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
     let core_only = clean_json_with_args(&[&format!("--policy={}", core_policy.display())], input);
     let core_clean = core_only["clean_text"].as_str().unwrap();
@@ -1668,7 +1668,7 @@ fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
 
 #[test]
 fn s2_core_extended_cli_opt_in_mirrors_toml_and_rejects_garbage_symmetrically() {
-    let input = "phone +4915112345678 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
+    let input = "phone +4915550112233 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_toml_dir, toml_policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
     let toml = clean_json_with_args(&[&format!("--policy={}", toml_policy.display())], input);

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1739,6 +1739,34 @@ fn s2_cli_bundled_smoke_drops_luhn_failing_formatted_cc() {
 }
 
 #[test]
+fn s3a_cli_bundled_core_extended_rejects_unassigned_e164_phone() {
+    let value = clean_json_with_args(
+        &["--rulepack-bundled", "core-extended"],
+        "+99999999 is fake",
+    );
+
+    assert_eq!(value["clean_text"], "+99999999 is fake");
+    assert_eq!(value["stats"]["detections"], 0);
+}
+
+#[test]
+fn s3a_cli_bundled_core_extended_tokenizes_valid_e164_phone() {
+    let value = clean_json_with_args(
+        &["--rulepack-bundled", "core-extended"],
+        "+4915550112233 is real",
+    );
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(
+        Regex::new(r"^<[0-9a-f]{8}:Custom:phone_1> is real$")
+            .unwrap()
+            .is_match(clean),
+        "unexpected clean text: {clean}"
+    );
+    assert_eq!(value["stats"]["detections"], 1);
+}
+
+#[test]
 fn s2_core_extended_cli_locale_gating_and_plain_en_negative() {
     let (_dir, policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -7,7 +7,9 @@ license = "Apache-2.0"
 description = "Built-in recognizers for Gaze"
 
 [features]
-default = []
+# phone-parser feature gates phonenumber dep; default-on for gaze-cli, default-off for raw lib.
+default = ["phone-parser"]
+phone-parser = ["dep:phonenumber"]
 test-support = []
 
 [dependencies]
@@ -16,6 +18,7 @@ gaze = { path = "../gaze" }
 hex = "0.4"
 ndarray = "0.16"
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["ndarray", "std", "download-binaries", "tls-rustls"] }
+phonenumber = { version = "0.3.9", default-features = false, optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -13,6 +13,9 @@ locales = ["global"]
 kind = "regex"
 pattern = '''\+\d{6,15}\b'''
 
+[recognizers.validator]
+kind = "e164_phone"
+
 [recognizers.scoring]
 base = 0.70
 priority = 80

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValidatorKind {
     EmailRfc,
+    #[cfg(feature = "phone-parser")]
     E164Phone,
     Luhn,
     IbanMod97,
@@ -16,9 +17,13 @@ impl ValidatorKind {
     pub fn parse(s: &str) -> std::result::Result<Self, RulepackError> {
         match s {
             "email_rfc" => Ok(Self::EmailRfc),
+            #[cfg(feature = "phone-parser")]
             "e164_phone" => Ok(Self::E164Phone),
             "luhn" => Ok(Self::Luhn),
             "iban_mod97" => Ok(Self::IbanMod97),
+            // With phone-parser disabled, e164_phone falls through here so
+            // rulepack construction fails closed instead of silently dropping
+            // every phone candidate at runtime.
             other => Err(RulepackError::UnsupportedValidator {
                 kind: other.to_string(),
             }),
@@ -28,6 +33,7 @@ impl ValidatorKind {
     pub fn validates(self, input: &str) -> bool {
         match self {
             Self::EmailRfc => is_basic_email(input),
+            #[cfg(feature = "phone-parser")]
             Self::E164Phone => e164_phone_check(input),
             Self::Luhn => luhn_check(input),
             Self::IbanMod97 => iban_mod97_check(input),
@@ -237,11 +243,6 @@ fn is_basic_email(input: &str) -> bool {
 #[cfg(feature = "phone-parser")]
 fn e164_phone_check(input: &str) -> bool {
     phonenumber::parse(None, input).is_ok_and(|phone| phonenumber::is_valid(&phone))
-}
-
-#[cfg(not(feature = "phone-parser"))]
-fn e164_phone_check(_input: &str) -> bool {
-    false
 }
 
 fn luhn_check(input: &str) -> bool {

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValidatorKind {
     EmailRfc,
+    E164Phone,
     Luhn,
     IbanMod97,
 }
@@ -15,6 +16,7 @@ impl ValidatorKind {
     pub fn parse(s: &str) -> std::result::Result<Self, RulepackError> {
         match s {
             "email_rfc" => Ok(Self::EmailRfc),
+            "e164_phone" => Ok(Self::E164Phone),
             "luhn" => Ok(Self::Luhn),
             "iban_mod97" => Ok(Self::IbanMod97),
             other => Err(RulepackError::UnsupportedValidator {
@@ -26,6 +28,7 @@ impl ValidatorKind {
     pub fn validates(self, input: &str) -> bool {
         match self {
             Self::EmailRfc => is_basic_email(input),
+            Self::E164Phone => e164_phone_check(input),
             Self::Luhn => luhn_check(input),
             Self::IbanMod97 => iban_mod97_check(input),
         }
@@ -229,6 +232,16 @@ fn is_basic_email(input: &str) -> bool {
         return false;
     };
     !local.is_empty() && domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+}
+
+#[cfg(feature = "phone-parser")]
+fn e164_phone_check(input: &str) -> bool {
+    phonenumber::parse(None, input).is_ok_and(|phone| phonenumber::is_valid(&phone))
+}
+
+#[cfg(not(feature = "phone-parser"))]
+fn e164_phone_check(_input: &str) -> bool {
+    false
 }
 
 fn luhn_check(input: &str) -> bool {

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -174,10 +174,10 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         detect_recognizer(
             &rulepack,
             "phone.structural",
-            "Phone +4915112345678",
+            "Phone +4915550112233",
             LocaleTag::DeDe
         ),
-        vec!["+4915112345678".to_string()]
+        vec!["+4915550112233".to_string()]
     );
     assert_eq!(
         detect_recognizer(&rulepack, "ip.v4", "Host 192.168.1.1.", LocaleTag::EnUs),
@@ -210,6 +210,7 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         "2026-04-25",
         "0815 12345",
         "0123-456789",
+        "+99999999",
         "Subscriber_0001234567",
         "Order_0815",
     ] {
@@ -512,7 +513,7 @@ fn core_and_core_extended_compose_without_counter_collision() {
     let clean = clean_text(
         &pipeline,
         &session,
-        "Contact alice@example.invalid or +4915112345678",
+        "Contact alice@example.invalid or +4915550112233",
         LocaleTag::EnUs,
     );
 

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -566,7 +566,7 @@ fn core_and_core_extended_compose_with_phase2_without_counter_collision() {
 
     let pipeline = builder.build().expect("pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
-    let input = "Email alice@example.invalid phone +4915112345678 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
+    let input = "Email alice@example.invalid phone +4915550112233 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
     let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
 
     assert!(clean.contains(":Email_1>"), "{clean}");
@@ -584,7 +584,7 @@ fn every_phase1_recognizer_round_trips_through_restore() {
     let pipeline = pipeline_from_rulepack(&rulepack);
 
     for (input, locale) in [
-        ("Call +4915112345678", LocaleTag::DeDe),
+        ("Call +4915550112233", LocaleTag::DeDe),
         ("Host 192.168.1.1", LocaleTag::EnUs),
         ("Loopback ::1", LocaleTag::EnUs),
         ("Host 2001:db8::1", LocaleTag::EnUs),

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "phone-parser"))]
+use gaze::RulepackError;
 use gaze::{
     Action, ClassRule, CleanDocument, DefaultRule, PiiClass, Pipeline, RawDocument, Scope, Session,
 };
@@ -98,6 +100,21 @@ fn iban_mod97_accepts_spec_examples_and_rejects_check_digit_mutants() {
     }
 }
 
+#[cfg(not(feature = "phone-parser"))]
+#[test]
+fn e164_phone_fails_closed_when_phone_parser_feature_disabled() {
+    let result = ValidatorKind::parse("e164_phone");
+
+    assert!(
+        matches!(
+            result,
+            Err(RulepackError::UnsupportedValidator { ref kind }) if kind == "e164_phone"
+        ),
+        "feature-disabled build MUST reject e164_phone with UnsupportedValidator (axis-1 fail-closed); got: {result:?}"
+    );
+}
+
+#[cfg(feature = "phone-parser")]
 #[test]
 fn e164_phone_accepts_assigned_international_number_and_rejects_unassigned_prefix() {
     assert!(ValidatorKind::E164Phone.validates("+4915550112233"));
@@ -116,6 +133,7 @@ fn iban_canonical_is_uppercase_whitespace_free_and_idempotent() {
     );
 }
 
+#[cfg(feature = "phone-parser")]
 #[test]
 fn s3a_e164_phone_passing_candidate_emits_detection_and_round_trips() {
     let pipeline = custom_validator_pipeline(
@@ -133,6 +151,7 @@ fn s3a_e164_phone_passing_candidate_emits_detection_and_round_trips() {
     assert_eq!(restore_tokens(&session, &clean), input);
 }
 
+#[cfg(feature = "phone-parser")]
 #[test]
 fn s3a_e164_phone_unassigned_candidate_emits_no_detection() {
     let pipeline = custom_validator_pipeline(

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -8,11 +8,25 @@ fn validator_pipeline(
     validator: ValidatorKind,
     normalizer: Option<NormalizerKind>,
 ) -> Pipeline {
+    custom_validator_pipeline(
+        pattern,
+        PiiClass::custom("credit_card_or_iban"),
+        validator,
+        normalizer,
+    )
+}
+
+fn custom_validator_pipeline(
+    pattern: &str,
+    class: PiiClass,
+    validator: ValidatorKind,
+    normalizer: Option<NormalizerKind>,
+) -> Pipeline {
     Pipeline::builder()
         .recognizer(
             RegexDetector::with_rulepack_fields(
                 pattern,
-                PiiClass::custom("credit_card_or_iban"),
+                class.clone(),
                 "s1.validator.test",
                 vec![gaze::LocaleTag::Global],
                 0.90,
@@ -25,10 +39,7 @@ fn validator_pipeline(
             )
             .expect("regex detector"),
         )
-        .rule(ClassRule::new(
-            PiiClass::custom("credit_card_or_iban"),
-            Action::Tokenize,
-        ))
+        .rule(ClassRule::new(class, Action::Tokenize))
         .rule(DefaultRule::new(Action::Preserve))
         .build()
         .expect("pipeline")
@@ -88,6 +99,13 @@ fn iban_mod97_accepts_spec_examples_and_rejects_check_digit_mutants() {
 }
 
 #[test]
+fn e164_phone_accepts_assigned_international_number_and_rejects_unassigned_prefix() {
+    assert!(ValidatorKind::E164Phone.validates("+4915550112233"));
+    assert!(!ValidatorKind::E164Phone.validates("+99999999"));
+    assert!(!ValidatorKind::E164Phone.validates("4915550112233"));
+}
+
+#[test]
 fn iban_canonical_is_uppercase_whitespace_free_and_idempotent() {
     let canonical = NormalizerKind::IbanCanonical.normalize("gb82 west 1234 5698 7654 32");
 
@@ -96,6 +114,38 @@ fn iban_canonical_is_uppercase_whitespace_free_and_idempotent() {
         NormalizerKind::IbanCanonical.normalize(&canonical),
         canonical
     );
+}
+
+#[test]
+fn s3a_e164_phone_passing_candidate_emits_detection_and_round_trips() {
+    let pipeline = custom_validator_pipeline(
+        r"\+\d{6,15}\b",
+        PiiClass::custom("phone"),
+        ValidatorKind::E164Phone,
+        None,
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Phone: +4915550112233";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert!(clean.starts_with("Phone: <"), "{clean}");
+    assert!(clean.ends_with(":Custom:phone_1>"), "{clean}");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn s3a_e164_phone_unassigned_candidate_emits_no_detection() {
+    let pipeline = custom_validator_pipeline(
+        r"\+\d{6,15}\b",
+        PiiClass::custom("phone"),
+        ValidatorKind::E164Phone,
+        None,
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Phone: +99999999";
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert_eq!(clean, input);
 }
 
 #[test]

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -302,7 +302,7 @@ Bundled rulepacks:
 | Bundle | Recognizers | Classes | Notes |
 |--------|-------------|---------|-------|
 | `core` | `email.global`, `email.header.name` | `email`, `name` | Default bundle when `[policy.rulepacks]` is omitted. |
-| `core-extended` | `phone.structural`, `iban.structural`, `card.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:iban`, `custom:credit_card`, `custom:ip_address`, `custom:postal_code` | Opt-in bundle. Phase 1 shape recognizers plus Phase 2 validator-backed IBAN and credit-card recognizers. |
+| `core-extended` | `phone.structural`, `iban.structural`, `card.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:iban`, `custom:credit_card`, `custom:ip_address`, `custom:postal_code` | Opt-in bundle. Validator-backed E.164 phone, IBAN, and credit-card recognizers plus structural IP/postal recognizers. |
 
 Opt into `core-extended` alongside `core`:
 
@@ -319,8 +319,10 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 
 `core-extended` recognizers are intentionally conservative:
 
-- `phone.structural` matches E.164-only `+\d{6,15}` numbers. National phone
-  patterns are not included.
+- `phone.structural` matches E.164-only `+\d{6,15}` numbers and emits
+  `custom:phone` only when the match passes `e164_phone`. National phone
+  patterns are not included. Regex-passing but unassigned values such as
+  `+99999999` do not emit detections.
 - `iban.structural` emits `custom:iban` only for IBAN-shaped candidates that
   pass `iban_mod97`; the canonical form is normalized with `iban_canonical`.
 - `card.structural` emits `custom:credit_card` only for 13- to 19-digit
@@ -330,12 +332,13 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 - `postal.us` emits `custom:postal_code` only under active locale `en-US`.
   Plain `en` does not activate `postal.us`.
 
-IBAN and credit-card recognizers are universal (`global`) because their
-validation rules are format-level checks, not national locale gates. They are
-also solo recognizers in their classes, so they do not need `cooperates_with`
-rows. Tenant numeric IDs such as `Subscriber_0001234567` and `Order_0815`
-are explicit negative fixtures for those recognizers; broad numeric shapes must
-not become credit-card detections without a passing validator.
+Phone, IBAN, and credit-card recognizers are universal (`global`) because their
+validation rules are format-level checks, not locale gates in Gaze policy. They
+are also solo recognizers in their classes, so they do not need
+`cooperates_with` rows. Tenant numeric IDs such as `Subscriber_0001234567` and
+`Order_0815` are explicit negative fixtures for those recognizers; broad
+numeric shapes must not become phone or credit-card detections without a
+passing validator.
 
 Within a rulepack, every `[[recognizers]]` block has an `id`, `class`, and
 `[recognizers.match]` table. If two recognizers in the same rulepack emit the
@@ -372,6 +375,7 @@ kind = "luhn"
 | Kind | Applies to | Behavior |
 |------|------------|----------|
 | `email_rfc` | Email-like regex candidates | Basic email shape validation used by the bundled core email recognizer. |
+| `e164_phone` | E.164-like phone candidates | Parser-backed phone validation. `core-extended` uses it with `phone.structural` so assigned international numbers such as `+4915550112233` emit `custom:phone`, while unassigned regex-only values such as `+99999999` are dropped. |
 | `luhn` | Credit-card-like numeric candidates | Mod 10 checksum. ASCII whitespace is ignored; any other non-digit fails validation. |
 | `iban_mod97` | IBAN-like alphanumeric candidates | ISO 7064 mod-97 check. Input is canonicalized as uppercase with ASCII whitespace removed before validation. |
 
@@ -380,12 +384,11 @@ returns false emits no detection. This is intentionally stricter than emitting
 an unvalidated candidate because shape-only false positives are a PII-leak risk
 for agent workflows.
 
-S1 adds validator names to rulepack TOML only. Three-surfaces parity is not
-applicable because validators are recognizer policy data, not runtime knobs:
-there is no CLI flag or default runtime surface for swapping validator
-semantics per invocation. `cooperates_with` parity is also not applicable in S1
-because no bundled recognizers are added; cooperation tests belong to bundle
-composition changes.
+Validator names live in rulepack TOML and are compile-time/library behavior,
+not per-invocation CLI policy. `e164_phone` is backed by the
+`gaze-recognizers` `phone-parser` feature, which gates the optional
+`phonenumber` dependency and is enabled in default builds. There is no CLI flag
+or policy runtime knob for swapping validator semantics per invocation.
 
 #### Built-in normalizers
 

--- a/docs/research/v0.4.4-phonenumber-audit.md
+++ b/docs/research/v0.4.4-phonenumber-audit.md
@@ -13,7 +13,7 @@ Required criteria:
 | --- | --- | --- |
 | Permissive license | PASS | crates.io version metadata reports `Apache-2.0`; the repository is also Apache-2.0. |
 | Active maintenance | PASS | Latest crates.io release: `0.3.9+9.0.21` on 2026-01-14. GitHub has commits through 2026-03-26. |
-| Transitive closure adds <30 crates | PASS | Incremental package-name impact against the current workspace `Cargo.lock`: 15 new packages. |
+| Transitive closure adds <30 crates | PASS | Incremental impact against the current workspace `Cargo.lock`: 17 package versions, 15 package names. |
 | Network-independent validate path | PASS | The crate builds from packaged XML metadata and runtime validation uses embedded compiled metadata. Offline cargo test passed after the initial registry fetch. |
 | Default features can be disabled if heavy | PASS | The crate publishes no feature flags. `default-features = false` is accepted by Cargo and pulls the same normal dependency tree. |
 
@@ -116,10 +116,15 @@ strum
 strum_macros
 ```
 
+The final workspace `Cargo.lock` adds 17 package versions because
+`embedded-io` and `regex-syntax` each appear at an additional version already
+outside the simple package-name count.
+
 The standalone closure is larger because it includes packages Gaze already
 depends on (`regex`, `serde`, `thiserror`, `syn`, `quote`, and others). The
 criterion is evaluated as impact when adding the crate to `gaze-recognizers`,
-so the relevant number is the 15-package incremental addition.
+so the relevant number is the 17-version incremental addition, still below
+the 30-crate gate.
 
 ## Network independence
 
@@ -163,4 +168,3 @@ fails a maintenance or dependency-size gate, candidates to evaluate are:
   releases, but larger source footprint and a newer/less proven Rust API.
 - `phonelib`: emerging Rust phone-number crate; would need a full maturity,
   license, offline, and closure-size audit before use.
-

--- a/docs/research/v0.4.4-phonenumber-audit.md
+++ b/docs/research/v0.4.4-phonenumber-audit.md
@@ -1,0 +1,166 @@
+# v0.4.4 S3a phonenumber dependency audit
+
+Date: 2026-04-26
+
+## Outcome
+
+PASS. The `phonenumber` crate is acceptable for the v0.4.4 S3a `E164Phone`
+validator gate.
+
+Required criteria:
+
+| Criterion | Result | Evidence |
+| --- | --- | --- |
+| Permissive license | PASS | crates.io version metadata reports `Apache-2.0`; the repository is also Apache-2.0. |
+| Active maintenance | PASS | Latest crates.io release: `0.3.9+9.0.21` on 2026-01-14. GitHub has commits through 2026-03-26. |
+| Transitive closure adds <30 crates | PASS | Incremental package-name impact against the current workspace `Cargo.lock`: 15 new packages. |
+| Network-independent validate path | PASS | The crate builds from packaged XML metadata and runtime validation uses embedded compiled metadata. Offline cargo test passed after the initial registry fetch. |
+| Default features can be disabled if heavy | PASS | The crate publishes no feature flags. `default-features = false` is accepted by Cargo and pulls the same normal dependency tree. |
+
+## Source verification
+
+- crates.io API for `phonenumber`: `newest_version = 0.3.9+9.0.21`,
+  version license `Apache-2.0`, release timestamp
+  `2026-01-14T09:19:33Z`, repository
+  `https://github.com/whisperfish/rust-phonenumber`.
+- GitHub API for `whisperfish/rust-phonenumber`: recent commits include
+  `2e5f4de` on 2026-03-26 (`fix: clippy lint on let Some`) and
+  `416118f` on 2026-01-14 (`bump to 0.3.9+9.0.21`).
+- Registry source inspection:
+  `phonenumber-0.3.9+9.0.21/Cargo.toml` declares `license = "Apache-2.0"`.
+
+## Transitive closure measurement
+
+Measured with a disposable Cargo project using:
+
+```bash
+cargo new --lib /tmp/gaze-phonenumber-audit
+cd /tmp/gaze-phonenumber-audit
+cargo add phonenumber@0.3.9 --no-default-features
+cargo tree -e normal
+```
+
+Raw `cargo tree -e normal` snippet:
+
+```text
+gaze-phonenumber-audit v0.1.0 (/private/tmp/gaze-phonenumber-audit)
+└── phonenumber v0.3.9+9.0.21
+    ├── either v1.15.0
+    ├── fnv v1.0.7
+    ├── nom v7.1.3
+    │   ├── memchr v2.8.0
+    │   └── minimal-lexical v0.2.1
+    ├── once_cell v1.21.4
+    ├── postcard v1.1.3
+    │   ├── cobs v0.3.0
+    │   │   └── thiserror v2.0.18
+    │   │       └── thiserror-impl v2.0.18 (proc-macro)
+    │   │           ├── proc-macro2 v1.0.106
+    │   │           ├── quote v1.0.45
+    │   │           └── syn v2.0.117
+    │   ├── heapless v0.7.17
+    │   │   ├── hash32 v0.2.1
+    │   │   │   └── byteorder v1.5.0
+    │   │   ├── serde v1.0.228
+    │   │   │   ├── serde_core v1.0.228
+    │   │   │   └── serde_derive v1.0.228 (proc-macro)
+    │   │   └── stable_deref_trait v1.2.1
+    │   └── serde v1.0.228
+    ├── quick-xml v0.38.4
+    │   └── memchr v2.8.0
+    ├── regex v1.12.3
+    │   ├── aho-corasick v1.1.4
+    │   ├── memchr v2.8.0
+    │   ├── regex-automata v0.4.14
+    │   │   ├── aho-corasick v1.1.4
+    │   │   ├── memchr v2.8.0
+    │   │   └── regex-syntax v0.8.10
+    │   └── regex-syntax v0.8.10
+    ├── regex-cache v0.2.1
+    │   ├── lru-cache v0.1.2
+    │   │   └── linked-hash-map v0.5.6
+    │   ├── oncemutex v0.1.1
+    │   ├── regex v1.12.3
+    │   └── regex-syntax v0.6.29
+    ├── serde v1.0.228
+    ├── serde_derive v1.0.228 (proc-macro)
+    ├── strum v0.27.2
+    │   └── strum_macros v0.27.2 (proc-macro)
+    │       ├── heck v0.5.0
+    │       ├── proc-macro2 v1.0.106
+    │       ├── quote v1.0.45
+    │       └── syn v2.0.117
+    └── thiserror v2.0.18
+```
+
+Incremental impact against the current Gaze workspace lockfile:
+
+```text
+existing packages: 420
+phonenumber audit lock packages: 42
+incremental new package names: 15
+atomic-polyfill
+cobs
+critical-section
+embedded-io
+hash32
+heapless
+linked-hash-map
+lru-cache
+oncemutex
+phonenumber
+postcard
+quick-xml
+regex-cache
+strum
+strum_macros
+```
+
+The standalone closure is larger because it includes packages Gaze already
+depends on (`regex`, `serde`, `thiserror`, `syn`, `quote`, and others). The
+criterion is evaluated as impact when adding the crate to `gaze-recognizers`,
+so the relevant number is the 15-package incremental addition.
+
+## Network independence
+
+Registry source inspection shows no runtime network path:
+
+- `build.rs` opens `assets/PhoneNumberMetadata.xml` from the packaged crate,
+  parses it, and writes `database.bin` into `OUT_DIR`.
+- Source search for `http`, `https`, socket, `reqwest`, `ureq`, `Tcp`, and
+  `Udp` inside `phonenumber-0.3.9+9.0.21` found only license/doc links and no
+  runtime network client.
+- Offline verification after dependency fetch:
+
+```bash
+cd /tmp/gaze-phonenumber-audit
+CARGO_NET_OFFLINE=true cargo test
+```
+
+Result:
+
+```text
+Finished `test` profile [unoptimized + debuginfo] target(s) in 48.88s
+running 1 test
+test tests::it_works ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+## Default-feature posture
+
+`phonenumber-0.3.9+9.0.21` exposes no Cargo features. Cargo accepts
+`default-features = false`, but this does not change the normal dependency
+tree. Gaze should still declare the dependency as optional behind a local
+`phone-parser` feature so raw library adopters can opt out of the parser-backed
+phone validator dependency while CLI/default builds keep the safer validator on.
+
+## Alternatives
+
+No fallback crate is required because the audit passed. If this crate later
+fails a maintenance or dependency-size gate, candidates to evaluate are:
+
+- `rlibphonenumber`: Apache-2.0 Rust port of libphonenumber with recent 2025
+  releases, but larger source footprint and a newer/less proven Rust API.
+- `phonelib`: emerging Rust phone-number crate; would need a full maturity,
+  license, offline, and closure-size audit before use.
+


### PR DESCRIPTION
## Summary
v0.4.4 plan rev 2 §S3 (scratchpad 339). Phase 1: audit phonenumber crate. Phase 2 (gated on audit pass): wire ValidatorKind::E164Phone into existing phone.structural recognizer to reject regex-passing-but-unassigned numbers.

## Audit outcome
See `docs/research/v0.4.4-phonenumber-audit.md` — PASS: Apache-2.0 license, 2026 release plus recent commits, 17 incremental package versions (<30), offline validation/build path verified, and local `phone-parser` feature gates the optional dependency.

## Test plan
- [x] phonenumber audit doc complete
- [x] cargo test --workspace green
- [x] cargo clippy + cargo fmt --check clean
- [x] CLI shipping smoke (drawer c6eefa4b): +99999999 rejects, +4915550112233 tokenizes
- [x] Existing phone.structural behavior preserved for valid numbers
- [x] phone-parser feature gates dep; default-on for gaze-cli
- [x] AGENTS-safe synthetic test phones only

🤖 Generated with [Claude Code](https://claude.com/claude-code)