### PR TITLE
v0.4.4 S2: audit schema v2 (created_at + --from/--to ISO 8601 filters)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ version = "0.4.3"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "gaze",
  "gaze-assembly",

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 base64 = "0.22"
+chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 gaze = { path = "../gaze" }
 gaze-assembly = { path = "../gaze-assembly" }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -62,6 +62,8 @@ fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
         source: args.source.clone(),
         action: args.action.clone(),
         document_kind: args.document_kind.clone(),
+        from_epoch_ms: None,
+        to_epoch_ms: None,
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -28,14 +28,17 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     for row in rows {
         writeln!(
             stdout,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.class,
             row.action,
             row.field_name.as_deref().unwrap_or(""),
             row.document_kind,
             row.conflict_loser,
-            row.decided_by
+            row.decided_by,
+            row.created_at
+                .map(|created_at| created_at.to_string())
+                .unwrap_or_default()
         )
         .map_err(|_| CliError::Io)?;
     }
@@ -88,6 +91,7 @@ struct JsonlRow {
     document_kind: String,
     conflict_loser: bool,
     decided_by: String,
+    created_at: Option<i64>,
 }
 
 impl From<AuditLogRow> for JsonlRow {
@@ -100,6 +104,7 @@ impl From<AuditLogRow> for JsonlRow {
             document_kind: row.document_kind,
             conflict_loser: row.conflict_loser,
             decided_by: row.decided_by,
+            created_at: row.created_at,
         }
     }
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -80,7 +80,11 @@ fn parse_iso8601_epoch_ms(value: Option<&str>) -> std::result::Result<Option<i64
         .map(|value| {
             DateTime::parse_from_rfc3339(value)
                 .map(|datetime| datetime.timestamp_millis())
-                .map_err(|_| CliError::PolicyConfigDetail("invalid audit ISO 8601 timestamp"))
+                .map_err(|_| {
+                    CliError::PolicyConfigDetail(format!(
+                        "invalid audit ISO 8601 timestamp: {value:?}"
+                    ))
+                })
         })
         .transpose()
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+use chrono::DateTime;
 use clap::ValueEnum;
 use gaze::{AuditFilter, AuditLogRow, SqliteLogger, AUDIT_RESTRICTED_COLUMNS};
 use serde::Serialize;
@@ -14,6 +15,8 @@ pub(crate) struct Args {
     pub(crate) source: Option<String>,
     pub(crate) action: Option<String>,
     pub(crate) document_kind: Option<String>,
+    pub(crate) from_iso8601: Option<String>,
+    pub(crate) to_iso8601: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
@@ -57,15 +60,29 @@ pub(crate) fn export(
 }
 
 fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
+    // Keep CLI flag parse rejection identical to any future TOML audit-filter
+    // default surface: invalid timestamps are PolicyConfig/exit 2, never clap.
+    let from_epoch_ms = parse_iso8601_epoch_ms(args.from_iso8601.as_deref())?;
+    let to_epoch_ms = parse_iso8601_epoch_ms(args.to_iso8601.as_deref())?;
     let filter = AuditFilter {
         class: args.class.clone(),
         source: args.source.clone(),
         action: args.action.clone(),
         document_kind: args.document_kind.clone(),
-        from_epoch_ms: None,
-        to_epoch_ms: None,
+        from_epoch_ms,
+        to_epoch_ms,
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
+}
+
+fn parse_iso8601_epoch_ms(value: Option<&str>) -> std::result::Result<Option<i64>, CliError> {
+    value
+        .map(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .map(|datetime| datetime.timestamp_millis())
+                .map_err(|_| CliError::PolicyConfigDetail("invalid audit ISO 8601 timestamp"))
+        })
+        .transpose()
 }
 
 fn write_jsonl(

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -103,6 +103,12 @@ enum AuditCmd {
         /// Filter by document kind, such as `text` or `structured`.
         #[arg(long)]
         document_kind: Option<String>,
+        /// Include rows created at or after this ISO 8601 timestamp.
+        #[arg(long = "from")]
+        from_iso8601: Option<String>,
+        /// Include rows created at or before this ISO 8601 timestamp.
+        #[arg(long = "to")]
+        to_iso8601: Option<String>,
     },
     /// Export filtered audit metadata rows.
     Export {
@@ -127,6 +133,12 @@ enum AuditCmd {
         /// Filter by document kind, such as `text` or `structured`.
         #[arg(long)]
         document_kind: Option<String>,
+        /// Include rows created at or after this ISO 8601 timestamp.
+        #[arg(long = "from")]
+        from_iso8601: Option<String>,
+        /// Include rows created at or before this ISO 8601 timestamp.
+        #[arg(long = "to")]
+        to_iso8601: Option<String>,
     },
 }
 
@@ -177,12 +189,16 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 source,
                 action,
                 document_kind,
+                from_iso8601,
+                to_iso8601,
             } => audit::query(audit::Args {
                 audit_db,
                 class: pii_class,
                 source,
                 action,
                 document_kind,
+                from_iso8601,
+                to_iso8601,
             }),
             AuditCmd::Export {
                 audit_db,
@@ -192,6 +208,8 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 source,
                 action,
                 document_kind,
+                from_iso8601,
+                to_iso8601,
             } => audit::export(
                 audit::Args {
                     audit_db,
@@ -199,6 +217,8 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                     source,
                     action,
                     document_kind,
+                    from_iso8601,
+                    to_iso8601,
                 },
                 format,
                 output,

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -11,7 +11,7 @@ pub(crate) enum CliError {
     InputTooLarge,
     InvalidEncoding,
     PolicyConfig,
-    PolicyConfigDetail(&'static str),
+    PolicyConfigDetail(String),
     UnknownToken { token: String },
     InvalidSignature,
     InvalidBlobVersion,
@@ -54,12 +54,16 @@ impl CliError {
 
     pub(crate) fn emit_stderr(&self) {
         match self {
-            Self::PolicyConfigDetail(detail) => eprintln!(
-                r#"{{"error":"{}","exit":{},"detail":"{}"}}"#,
-                self.variant_name(),
-                self.exit_code(),
-                detail
-            ),
+            Self::PolicyConfigDetail(detail) => {
+                let detail = serde_json::to_string(detail)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"detail":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    detail
+                )
+            }
             Self::UnknownToken { token } => {
                 let token = serde_json::to_string(token)
                     .unwrap_or_else(|_| "\"<unserializable>\"".to_string());

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -13,7 +13,7 @@ pub(crate) fn map_policy_error(err: PolicyError) -> CliError {
     match err {
         PolicyError::Io(_) => CliError::PolicyOpen,
         PolicyError::UnsupportedRuleKind(_) => {
-            CliError::PolicyConfigDetail("column rules not supported in CLI mode")
+            CliError::PolicyConfigDetail("column rules not supported in CLI mode".to_string())
         }
         _ => CliError::PolicyConfig,
     }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
 use gaze::{build_audit_query_sql, AuditFilter};
-use rusqlite::Connection;
+use rusqlite::{types::Value as SqlValue, Connection};
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -114,20 +114,37 @@ fn audit_sql_uses_restricted_column_set() {
         source: Some("email.global".to_string()),
         action: Some("tokenize".to_string()),
         document_kind: Some("text".to_string()),
+        from_epoch_ms: Some(1_700_000_000_000),
+        to_epoch_ms: Some(1_700_000_010_000),
     };
     let (current_sql, values) = build_audit_query_sql(&filter, true, true);
     assert_eq!(
         values,
-        ["email", "email.global", "tokenize", "text"]
-            .into_iter()
-            .map(String::from)
-            .collect::<Vec<_>>()
+        [
+            SqlValue::Text("email".to_string()),
+            SqlValue::Text("email.global".to_string()),
+            SqlValue::Text("tokenize".to_string()),
+            SqlValue::Text("text".to_string()),
+            SqlValue::Integer(1_700_000_000_000),
+            SqlValue::Integer(1_700_000_010_000),
+        ]
+        .into_iter()
+        .collect::<Vec<_>>()
     );
     assert_restricted_sql(&current_sql);
+    assert!(current_sql.contains("(created_at IS NULL OR created_at >= ?)"));
+    assert!(current_sql.contains("(created_at IS NULL OR created_at <= ?)"));
 
-    let (legacy_sql, _) = build_audit_query_sql(&AuditFilter::default(), false, false);
+    let legacy_filter = AuditFilter {
+        from_epoch_ms: Some(1_700_000_000_000),
+        to_epoch_ms: Some(1_700_000_010_000),
+        ..AuditFilter::default()
+    };
+    let (legacy_sql, legacy_values) = build_audit_query_sql(&legacy_filter, false, false);
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
+    assert!(legacy_sql.contains("NULL AS created_at"));
+    assert!(legacy_values.is_empty());
 }
 
 fn assert_restricted_sql(sql: &str) {

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use tempfile::tempdir;
 
 #[test]
-fn v0_4_3_shape_without_created_at_is_queryable_and_time_filters_pass_through() {
+fn v0_4_3_shape_without_created_at_is_queryable_but_time_filters_omit_nulls() {
     let dir = tempdir().unwrap();
     let audit_path = dir.path().join("v0.4.3.sqlite");
     let conn = Connection::open(&audit_path).unwrap();
@@ -51,8 +51,33 @@ fn v0_4_3_shape_without_created_at_is_queryable_and_time_filters_pass_through() 
         "audit export failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    let line = String::from_utf8(output.stdout).unwrap();
-    let row: Value = serde_json::from_str(line.trim()).unwrap();
+    assert!(
+        output.stdout.is_empty(),
+        "filtered legacy rows with NULL created_at must be omitted: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+            "--class",
+            "email",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let row: Value = serde_json::from_str(stdout.trim()).unwrap();
     assert_eq!(row["class"], "email");
     assert_eq!(row["source"], "email.global");
     assert_eq!(row["action"], "tokenize");
@@ -194,8 +219,9 @@ fn audit_sql_uses_restricted_column_set() {
         .collect::<Vec<_>>()
     );
     assert_restricted_sql(&current_sql);
-    assert!(current_sql.contains("(created_at IS NULL OR created_at >= ?)"));
-    assert!(current_sql.contains("(created_at IS NULL OR created_at <= ?)"));
+    assert!(current_sql.contains("created_at >= ?"));
+    assert!(current_sql.contains("created_at <= ?"));
+    assert!(!current_sql.contains("created_at IS NULL"));
 
     let legacy_filter = AuditFilter {
         from_epoch_ms: Some(1_700_000_000_000),
@@ -206,7 +232,17 @@ fn audit_sql_uses_restricted_column_set() {
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
     assert!(legacy_sql.contains("NULL AS created_at"));
-    assert!(legacy_values.is_empty());
+    assert!(legacy_sql.contains("NULL >= ?"));
+    assert!(legacy_sql.contains("NULL <= ?"));
+    assert_eq!(
+        legacy_values,
+        [
+            SqlValue::Integer(1_700_000_000_000),
+            SqlValue::Integer(1_700_000_010_000),
+        ]
+        .into_iter()
+        .collect::<Vec<_>>()
+    );
 }
 
 fn assert_restricted_sql(sql: &str) {

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -100,7 +100,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\n"
     ));
     assert!(
         stdout.contains("dictionary:audit_terms[#0]\tcustom:term\ttokenize\t\ttext\tfalse\tnone")
@@ -115,7 +115,7 @@ fn audit_sql_uses_restricted_column_set() {
         action: Some("tokenize".to_string()),
         document_kind: Some("text".to_string()),
     };
-    let (current_sql, values) = build_audit_query_sql(&filter, true);
+    let (current_sql, values) = build_audit_query_sql(&filter, true, true);
     assert_eq!(
         values,
         ["email", "email.global", "tokenize", "text"]
@@ -125,7 +125,7 @@ fn audit_sql_uses_restricted_column_set() {
     );
     assert_restricted_sql(&current_sql);
 
-    let (legacy_sql, _) = build_audit_query_sql(&AuditFilter::default(), false);
+    let (legacy_sql, _) = build_audit_query_sql(&AuditFilter::default(), false, false);
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -5,9 +5,9 @@ use serde_json::Value;
 use tempfile::tempdir;
 
 #[test]
-fn current_schema_fixture_is_queryable() {
+fn v0_4_3_shape_without_created_at_is_queryable_and_time_filters_pass_through() {
     let dir = tempdir().unwrap();
-    let audit_path = dir.path().join("current.sqlite");
+    let audit_path = dir.path().join("v0.4.3.sqlite");
     let conn = Connection::open(&audit_path).unwrap();
     conn.execute_batch(
         r#"
@@ -39,6 +39,10 @@ fn current_schema_fixture_is_queryable() {
             "jsonl",
             "--class",
             "email",
+            "--from",
+            "2099-01-01T00:00:00Z",
+            "--to",
+            "2099-01-02T00:00:00Z",
         ])
         .output()
         .unwrap();
@@ -56,6 +60,64 @@ fn current_schema_fixture_is_queryable() {
     assert_eq!(row["document_kind"], "text");
     assert_eq!(row["conflict_loser"], false);
     assert_eq!(row["decided_by"], "recognizer_id");
+    assert_eq!(row["created_at"], Value::Null);
+}
+
+#[test]
+fn v0_4_4_shape_with_created_at_is_queryable_and_time_filtered() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("v0.4.4.sqlite");
+    let conn = Connection::open(&audit_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE redaction_log (
+            source TEXT NOT NULL,
+            class TEXT NOT NULL,
+            action TEXT NOT NULL,
+            field_name TEXT NULL,
+            document_kind TEXT NOT NULL,
+            conflict_loser INTEGER NOT NULL,
+            decided_by TEXT NOT NULL DEFAULT 'none',
+            created_at INTEGER NULL
+        );
+        INSERT INTO redaction_log
+            (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at)
+        VALUES
+            ('email.global', 'email', 'tokenize', NULL, 'text', 0, 'recognizer_id', 1700000000000),
+            ('phone.global', 'custom:phone', 'tokenize', NULL, 'text', 0, 'recognizer_id', 1700001000000);
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+            "--from",
+            "2023-11-14T22:13:20Z",
+            "--to",
+            "2023-11-14T22:13:20Z",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rows: Vec<Value> = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["source"], "email.global");
+    assert_eq!(rows[0]["created_at"], 1700000000000_i64);
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1170,7 +1170,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\n"
     ));
     assert!(
         stdout
@@ -1352,7 +1352,7 @@ fn s4_audit_query_columns_are_restricted() {
     let conn = Connection::open(&audit_path).unwrap();
     conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
         .unwrap();
-    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true);
+    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true, true);
     assert!(
         values.is_empty(),
         "default audit filter should not bind query values"

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1214,6 +1214,108 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
 }
 
 #[test]
+fn s2_audit_cli_smoke_filters_created_at_range() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let clean = clean_raw_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Email alice@example.invalid",
+    );
+    assert!(
+        clean.status.success(),
+        "clean failed: {}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+
+    let query = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--from",
+            "1970-01-01T00:00:00Z",
+            "--to",
+            "2999-12-31T23:59:59Z",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        query.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+    assert_no_raw_audit_pii(&query.stdout);
+
+    let stdout = String::from_utf8(query.stdout).unwrap();
+    let row = stdout
+        .lines()
+        .find(|line| line.starts_with("regex\temail\ttokenize\t\ttext\tfalse\t"))
+        .expect("expected email audit row in bounded time range");
+    let created_at = row
+        .split('\t')
+        .next_back()
+        .expect("created_at column")
+        .parse::<i64>()
+        .expect("created_at is epoch milliseconds");
+    assert!(created_at > 0, "expected positive created_at: {row}");
+
+    let future = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--from",
+            "2999-12-31T23:59:59Z",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        future.status.success(),
+        "future audit query failed: {}",
+        String::from_utf8_lossy(&future.stderr)
+    );
+    let future_stdout = String::from_utf8(future.stdout).unwrap();
+    assert_eq!(
+        future_stdout.lines().count(),
+        1,
+        "future lower bound should return only the header: {future_stdout}"
+    );
+}
+
+#[test]
+fn s2_audit_invalid_iso8601_is_policy_config_for_query_and_export() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    for subcommand in ["query", "export"] {
+        let mut command = Command::cargo_bin("gaze").unwrap();
+        command.args([
+            "audit",
+            subcommand,
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--from",
+            "invalid-date",
+        ]);
+        if subcommand == "export" {
+            command.args(["--format", "jsonl"]);
+        }
+        let output = command.output().unwrap();
+        assert_eq!(output.status.code(), Some(2));
+        assert!(output.stdout.is_empty());
+        let stderr: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(stderr["error"], "PolicyConfig");
+        assert_eq!(stderr["exit"], 2);
+        assert_eq!(stderr["detail"], "invalid audit ISO 8601 timestamp");
+    }
+}
+
+#[test]
 fn s4_audit_export_does_not_return_raw_pii() {
     let dir = tempdir().unwrap();
     let audit_path = dir.path().join("audit.sqlite");

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1311,7 +1311,10 @@ fn s2_audit_invalid_iso8601_is_policy_config_for_query_and_export() {
         let stderr: Value = serde_json::from_slice(&output.stderr).unwrap();
         assert_eq!(stderr["error"], "PolicyConfig");
         assert_eq!(stderr["exit"], 2);
-        assert_eq!(stderr["detail"], "invalid audit ISO 8601 timestamp");
+        assert_eq!(
+            stderr["detail"],
+            format!("invalid audit ISO 8601 timestamp: {:?}", "invalid-date")
+        );
     }
 }
 

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -215,6 +215,7 @@ impl Pipeline {
             document_kind,
             conflict_loser,
             decided_by: detection.decided_by,
+            created_at: crate::redaction_log::current_epoch_ms(),
         };
 
         for logger in &self.redaction_loggers {

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -295,15 +295,21 @@ pub fn build_audit_query_sql(
         predicates.push("document_kind = ?");
         values.push(Value::Text(document_kind.clone()));
     }
-    if has_created_at {
-        if let Some(from_epoch_ms) = filter.from_epoch_ms {
-            predicates.push("(created_at IS NULL OR created_at >= ?)");
-            values.push(Value::Integer(from_epoch_ms));
+    if let Some(from_epoch_ms) = filter.from_epoch_ms {
+        if has_created_at {
+            predicates.push("created_at >= ?");
+        } else {
+            predicates.push("NULL >= ?");
         }
-        if let Some(to_epoch_ms) = filter.to_epoch_ms {
-            predicates.push("(created_at IS NULL OR created_at <= ?)");
-            values.push(Value::Integer(to_epoch_ms));
+        values.push(Value::Integer(from_epoch_ms));
+    }
+    if let Some(to_epoch_ms) = filter.to_epoch_ms {
+        if has_created_at {
+            predicates.push("created_at <= ?");
+        } else {
+            predicates.push("NULL <= ?");
         }
+        values.push(Value::Integer(to_epoch_ms));
     }
     if !predicates.is_empty() {
         sql.push_str(" WHERE ");

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{params, params_from_iter, Connection, OpenFlags};
 
@@ -26,6 +27,7 @@ pub struct RedactionEntry {
     pub document_kind: DocumentKind,
     pub conflict_loser: bool,
     pub decided_by: ConflictTier,
+    pub created_at: i64,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -45,6 +47,7 @@ pub struct AuditLogRow {
     pub document_kind: String,
     pub conflict_loser: bool,
     pub decided_by: String,
+    pub created_at: Option<i64>,
 }
 
 #[allow(dead_code)]
@@ -56,6 +59,7 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "document_kind",
     "conflict_loser",
     "decided_by",
+    "created_at",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,6 +72,13 @@ pub enum ConflictTier {
     Validator,
     RecognizerId,
     Merged,
+}
+
+pub(crate) fn current_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
 }
 
 /// `RedactionEntry` must remain metadata-only.
@@ -83,6 +94,7 @@ pub enum ConflictTier {
 ///     document_kind: DocumentKind::Text,
 ///     conflict_loser: false,
 ///     decided_by: gaze::ConflictTier::None,
+///     created_at: 0,
 ///     raw: Some("alice@example.com".to_string()),
 /// };
 /// ```
@@ -104,30 +116,35 @@ impl SqliteLogger {
                 field_name TEXT NULL,
                 document_kind TEXT NOT NULL,
                 conflict_loser INTEGER NOT NULL,
-                decided_by TEXT NOT NULL DEFAULT 'none'
+                decided_by TEXT NOT NULL DEFAULT 'none',
+                created_at INTEGER NULL
             );
             "#,
         )
         .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
-        let has_decided_by = {
+        let columns = {
             let mut stmt = conn
                 .prepare("PRAGMA table_info(redaction_log)")
                 .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
             let columns = stmt
                 .query_map([], |row| row.get::<_, String>(1))
                 .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
-            let mut found = false;
+            let mut names = Vec::new();
             for column in columns {
-                if column.map_err(|err| crate::Error::Sqlite(err.to_string()))? == "decided_by" {
-                    found = true;
-                    break;
-                }
+                names.push(column.map_err(|err| crate::Error::Sqlite(err.to_string()))?);
             }
-            found
+            names
         };
-        if !has_decided_by {
+        if !columns.iter().any(|column| column == "decided_by") {
             conn.execute(
                 "ALTER TABLE redaction_log ADD COLUMN decided_by TEXT NOT NULL DEFAULT 'none'",
+                [],
+            )
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        }
+        if !columns.iter().any(|column| column == "created_at") {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN created_at INTEGER NULL",
                 [],
             )
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -144,7 +161,7 @@ impl SqliteLogger {
             .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, class, action, field_name, document_kind, conflict_loser, decided_by FROM redaction_log",
+                "SELECT source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at FROM redaction_log",
             )
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
         let rows = stmt
@@ -157,6 +174,7 @@ impl SqliteLogger {
                     document_kind: document_kind_from_db(&row.get::<_, String>(4)?)?,
                     conflict_loser: row.get::<_, i64>(5)? != 0,
                     decided_by: conflict_tier_from_db(&row.get::<_, String>(6)?)?,
+                    created_at: row.get::<_, Option<i64>>(7)?.unwrap_or(0),
                 })
             })
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -171,7 +189,8 @@ impl SqliteLogger {
     pub fn query(path: &Path, filter: &AuditFilter) -> Result<Vec<AuditLogRow>> {
         let conn = open_audit_query_connection(path)?;
         let has_decided_by = table_has_column(&conn, "decided_by")?;
-        let (sql, values) = build_audit_query_sql(filter, has_decided_by);
+        let has_created_at = table_has_column(&conn, "created_at")?;
+        let (sql, values) = build_audit_query_sql(filter, has_decided_by, has_created_at);
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -185,6 +204,7 @@ impl SqliteLogger {
                     document_kind: row.get(4)?,
                     conflict_loser: row.get::<_, i64>(5)? != 0,
                     decided_by: row.get(6)?,
+                    created_at: row.get(7)?,
                 })
             })
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -204,7 +224,7 @@ impl RedactionLogger for SqliteLogger {
             .lock()
             .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 entry.source,
                 pii_class_to_db(&entry.class),
@@ -213,6 +233,7 @@ impl RedactionLogger for SqliteLogger {
                 document_kind_to_db(&entry.document_kind),
                 if entry.conflict_loser { 1 } else { 0 },
                 conflict_tier_to_db(entry.decided_by),
+                entry.created_at,
             ],
         )
         .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -236,14 +257,23 @@ fn conflict_tier_to_db(tier: ConflictTier) -> &'static str {
 /// Audit reads are defense-in-depth restricted to metadata columns that are
 /// safe to display. Do not switch this path to `SELECT *`; future schema
 /// additions may include restore material or other sensitive payloads.
-pub fn build_audit_query_sql(filter: &AuditFilter, has_decided_by: bool) -> (String, Vec<String>) {
+pub fn build_audit_query_sql(
+    filter: &AuditFilter,
+    has_decided_by: bool,
+    has_created_at: bool,
+) -> (String, Vec<String>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
     } else {
         "'none' AS decided_by"
     };
+    let created_at_column = if has_created_at {
+        "created_at"
+    } else {
+        "NULL AS created_at"
+    };
     let mut sql = format!(
-        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column} FROM redaction_log"
+        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();
@@ -419,6 +449,7 @@ mod tests {
                     document_kind: DocumentKind::Text,
                     conflict_loser: false,
                     decided_by: ConflictTier::None,
+                    created_at: 0,
                 })
                 .unwrap();
         }

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::{params, params_from_iter, Connection, OpenFlags};
+use rusqlite::{params, params_from_iter, types::Value, Connection, OpenFlags};
 
 use crate::detector::PiiClass;
 use crate::rule::Action;
@@ -36,6 +36,8 @@ pub struct AuditFilter {
     pub source: Option<String>,
     pub action: Option<String>,
     pub document_kind: Option<String>,
+    pub from_epoch_ms: Option<i64>,
+    pub to_epoch_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -261,7 +263,7 @@ pub fn build_audit_query_sql(
     filter: &AuditFilter,
     has_decided_by: bool,
     has_created_at: bool,
-) -> (String, Vec<String>) {
+) -> (String, Vec<Value>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
     } else {
@@ -279,19 +281,29 @@ pub fn build_audit_query_sql(
     let mut values = Vec::new();
     if let Some(class) = &filter.class {
         predicates.push("class = ?");
-        values.push(class.clone());
+        values.push(Value::Text(class.clone()));
     }
     if let Some(source) = &filter.source {
         predicates.push("source = ?");
-        values.push(source.clone());
+        values.push(Value::Text(source.clone()));
     }
     if let Some(action) = &filter.action {
         predicates.push("action = ?");
-        values.push(action.clone());
+        values.push(Value::Text(action.clone()));
     }
     if let Some(document_kind) = &filter.document_kind {
         predicates.push("document_kind = ?");
-        values.push(document_kind.clone());
+        values.push(Value::Text(document_kind.clone()));
+    }
+    if has_created_at {
+        if let Some(from_epoch_ms) = filter.from_epoch_ms {
+            predicates.push("(created_at IS NULL OR created_at >= ?)");
+            values.push(Value::Integer(from_epoch_ms));
+        }
+        if let Some(to_epoch_ms) = filter.to_epoch_ms {
+            predicates.push("(created_at IS NULL OR created_at <= ?)");
+            values.push(Value::Integer(to_epoch_ms));
+        }
     }
     if !predicates.is_empty() {
         sql.push_str(" WHERE ");

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -491,6 +491,7 @@ fn sqlite_logger_persists_entries() {
             document_kind: gaze::DocumentKind::Structured,
             conflict_loser: false,
             decided_by: gaze::ConflictTier::None,
+            created_at: 0,
         })
         .expect("log entry");
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@
 It is read-only and intentionally returns a restricted column set:
 
 ```text
-class    source    action    document_kind    decided_by
+source    class    action    field_name    document_kind    conflict_loser    decided_by    created_at
 ```
 
 The audit command must not read raw spans, restore mappings, token payloads, or
@@ -19,36 +19,45 @@ explain what happened without moving PII back toward an agent or terminal.
 gaze audit query --audit-db audit.sqlite
 gaze audit query --audit-db audit.sqlite --class email --source email.global
 gaze audit query --audit-db audit.sqlite --action tokenize --document-kind text
+gaze audit query --audit-db audit.sqlite --from 2026-04-26T00:00:00Z --to 2026-04-27T00:00:00Z
 ```
 
-`query` writes tab-separated rows to stdout with a header row.
+`query` writes tab-separated rows to stdout with a header row. `created_at` is
+epoch milliseconds. Legacy audit databases without a `created_at` column remain
+queryable; their `created_at` value is empty in TSV output and passes through
+`--from` / `--to` filters.
 
 ### Export
 
 ```sh
 gaze audit export --audit-db audit.sqlite --format jsonl
 gaze audit export --audit-db audit.sqlite --format jsonl --output audit.jsonl
+gaze audit export --audit-db audit.sqlite --format jsonl --from 2026-04-26T00:00:00Z
 ```
 
 `export --format jsonl` writes one JSON object per row:
 
 ```json
-{"class":"email","source":"email.global","action":"tokenize","document_kind":"text","decided_by":"recognizer_id"}
+{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"recognizer_id","created_at":1777161600000}
 ```
 
 ### Filters
 
-The v0.4.3 audit CLI supports only fields that already exist in
-`RedactionEntry` metadata:
+The audit CLI supports only fields that already exist in `RedactionEntry`
+metadata:
 
-| Filter | v0.4.3 status | Rationale |
+| Filter | Status | Rationale |
 |---|---:|---|
 | `--class` | in | `RedactionEntry.class` exists |
 | `--source` | in | `RedactionEntry.source` exists |
 | `--action` | in | `RedactionEntry.action` exists |
 | `--document-kind` | in | `RedactionEntry.document_kind` exists |
+| `--from` / `--to` | in | `RedactionEntry.created_at` exists |
 | `--session` | deferred | no session column in the audit schema |
-| `--from` / `--to` | deferred | needs a `created_at` schema migration |
+
+`--from` and `--to` must be ISO 8601/RFC3339 timestamps with an explicit offset,
+for example `2026-04-26T00:00:00Z` or `2026-04-26T01:00:00+01:00`.
+Invalid timestamps exit with `PolicyConfig` and code 2.
 
 Audit filters are reporting parameters, not runtime policy knobs. They do not
 alter recognizer composition, token emission, restore behavior, or the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,8 +24,9 @@ gaze audit query --audit-db audit.sqlite --from 2026-04-26T00:00:00Z --to 2026-0
 
 `query` writes tab-separated rows to stdout with a header row. `created_at` is
 epoch milliseconds. Legacy audit databases without a `created_at` column remain
-queryable; their `created_at` value is empty in TSV output and passes through
-`--from` / `--to` filters.
+queryable; their `created_at` value is empty in TSV output. Unfiltered queries
+(no `--from` / `--to`) include legacy rows. Filtered queries omit NULL rows by
+SQL semantics; to access legacy rows, omit time filters.
 
 ### Export
 


### PR DESCRIPTION
## Summary
v0.4.4 plan rev 2 §S2 (scratchpad 339). Adds created_at (epoch ms) to RedactionEntry + SQLite schema migration + --from/--to CLI filters with ISO 8601 parsing.

--session deferred to v0.4.5 per LOCK 1.

## Test plan
- [x] cargo test --workspace green
- [x] cargo clippy + cargo fmt --check clean
- [x] Cross-version fixture: v0.4.3-shape (no created_at) + v0.4.4-shape both queryable
- [x] ISO 8601 typed error on invalid date (NOT raw clap)
- [x] Compile-fail doctest preserved (raw field, NOT created_at)
- [x] AGENTS-safe synthetic fixtures only
- [x] No CHANGELOG touches (Pn aggregates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)