### PR TITLE
v0.4.4 Pn: release plumbing — version bump + CHANGELOG + roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-04-26
+
+### Added
+
+- **S1 ClassMapOverrideSafety xtask gate** (#51): the previously scaffolded gate is now active. The behavioral test runner invokes `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered` through `cargo test`, while `.github/workflows/class-map-override-safety.yml` runs the gate on PRs and pushes to `main`. An adversarial in-PR self-test programmatically verifies the gate fails non-zero when a listed test is missing or renamed, following the meta-Potemkin guard captured in drawer `gaze_architecture_12b32d53`. Closes todo #132.
+- **S2 audit schema v2** (#53): `RedactionEntry` now includes `created_at: i64` epoch milliseconds, with an on-open SQLite `ALTER TABLE` migration so legacy DBs without `created_at` remain queryable through a NULL default. `gaze audit query` and `gaze audit export` now accept `--from <iso8601>` and `--to <iso8601>` filters, JSONL export includes `created_at`, and ISO 8601 parse failures emit typed `CliError::PolicyConfig` messages with the offending input quoted. Time-filtered queries omit NULL `created_at` legacy rows by SQL semantics; unfiltered queries still include them. Fixture coverage covers both v0.4.3-shaped and v0.4.4-shaped SQLite DBs.
+- **S3a phonenumber-backed `E164Phone` validator** (#52): the `phonenumber` crate is available behind the optional `phone-parser` feature, default-on for `gaze-cli` and opt-in for raw library users. `ValidatorKind::E164Phone` extends the existing `phone.structural` recognizer in `core-extended.toml`, preserving valid E.164 matches such as `+4915550112233` while rejecting regex-passing but unassigned shapes such as `+99999999`. Builds without `phone-parser` reject the `e164_phone` validator at rulepack load time with `RulepackError::UnsupportedValidator`, preserving axis-1 fail-closed behavior rather than silently dropping phone detection at runtime. Audit notes live in `docs/research/v0.4.4-phonenumber-audit.md`.
+- **S4 Date posture memo** (#50): `docs/research/v0.4.4-date-posture.md` locks Gaze's Date-as-PII stance. Dates are not PII by default, never ship in default `core` or `core-extended` bundles, and future v0.4.5+ implementation scope is limited to DOB-only structured contexts. General-prose dates require context classification research for v0.5+, and the GH #5 token-spam tradeoff is resolved as no-default-on. The negative corpus covers version strings, IPs, file paths, ID-shaped numerics, year-only strings, and build or CI metadata.
+
+### Changed
+
+- Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.4`.
+- ClassMapOverrideSafety is no longer a scaffold; `cargo run -p xtask -- class-map-override-safety` now executes its named tests and returns a meaningful exit code.
+- The audit query path continues to open SQLite read-only via `OpenFlags::SQLITE_OPEN_READ_ONLY`, carrying forward the v0.4.3 S4 hardening.
+
+### Notes for adopters
+
+- The Linux x86_64 binary requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer), the same constraint as v0.4.2 and v0.4.3.
+- Phone validation is feature-gated. `gaze-cli` enables `phone-parser` by default; raw library users opt in with `gaze-recognizers = { features = ["phone-parser"] }` when they need parser-backed E.164 validation. Without that feature, `e164_phone` is rejected at rulepack load time.
+- Audit time filters accept ISO 8601 timestamps through `--from` and `--to`. Legacy audit DBs without `created_at` are still queryable, but time-filtered queries exclude their NULL timestamp rows by SQL semantics.
+
+### Deferred to v0.4.5
+
+- `--session` audit filtering, deferred from v0.4.4 until the session identifier storage type design is locked.
+- DOB-scoped Date recognizer, per the S4 memo and only if Markus or another adopter provides a concrete DOB leak fixture.
+- S3b national phone recognizers for DE and US, deferred from v0.4.4 due to scope budget.
+- ClassMapOverrideSafety coverage for other class-rule paths.
+- Audit retention and auto-purge, now unblocked by the v0.4.4 `created_at` foundation.
+
+### Deferred to v0.5
+
+- Open-key `PiiClass` refactor, per scratchpad 256 LOCK 2.
+- Crate-shape Option B: extract `gaze-types` and collapse `gaze-assembly`.
+
 ## [0.4.3] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "gaze"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"

--- a/docs/roadmap/v0.4/v0.4.4.md
+++ b/docs/roadmap/v0.4/v0.4.4.md
@@ -1,0 +1,35 @@
+# v0.4.4 Release Notes
+
+Status: release plumbing for 2026-04-26.
+
+v0.4.4 closes the v0.4.4 Wave C reliability pass. The release activates the ClassMapOverrideSafety gate, adds timestamped audit filtering, backs E.164 phone detection with parser validation, and locks the Date-as-PII posture for future work. The core contract remains unchanged: reliable, reversible PII pseudonymization for agentic workflows, with fail-closed behavior when optional validation support is unavailable.
+
+## Shipped Scope
+
+- **S1 ClassMapOverrideSafety xtask gate (#51):** `cargo run -p xtask -- class-map-override-safety` now runs the named class-map override safety tests instead of acting as a scaffold. CI runs the gate on PRs and pushes to `main`, and the in-PR adversarial self-test proves the gate fails if a listed test is missing or renamed.
+- **S2 audit schema v2 (#53):** `RedactionEntry` includes `created_at` epoch milliseconds, with an on-open SQLite migration for legacy DBs. `gaze audit query` and `gaze audit export` accept `--from` and `--to` ISO 8601 filters, JSONL export includes `created_at`, and invalid timestamp input is reported through typed `CliError::PolicyConfig` output.
+- **S3a parser-backed E.164 validation (#52):** `ValidatorKind::E164Phone` extends `phone.structural` in `core-extended.toml`. Valid E.164 numbers continue to match, while regex-passing but unassigned shapes are rejected. The parser is behind `phone-parser`, default-on for `gaze-cli` and opt-in for raw library consumers; disabled builds reject `e164_phone` at rulepack load time.
+- **S4 Date posture memo (#50):** `docs/research/v0.4.4-date-posture.md` records that Date is not PII by default, Date recognizers do not belong in default bundles, DOB-only structured-context work is the nearest implementation candidate, and general-prose Date handling needs v0.5+ context-classification research.
+
+## Release Checks
+
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets`
+- `cargo fmt --check`
+- `cargo build --workspace`
+- `cargo metadata` confirms only `gaze`, `gaze-assembly`, `gaze-recognizers`, and `gaze-cli` are versioned `0.4.4`; `xtask` remains `0.0.1` and `debug-proxy` remains `0.3.1`.
+
+Final tag acceptance requires `v0.4.4-rc.1` and `v0.4.4` release workflows to publish macOS aarch64 and Linux x86_64 binaries, each with SHA256 files and packaged-binary smoke coverage. The Linux x86_64 binary continues to require glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer).
+
+## Deferred
+
+- `--session` audit filtering, pending a locked session identifier storage design.
+- DOB-scoped Date recognizer, only with a concrete adopter leak fixture.
+- National phone recognizers for DE and US, pending parser-backed per-locale scope.
+- ClassMapOverrideSafety extension to other class-rule paths.
+- Audit retention and auto-purge, now unblocked by `created_at`.
+- Open-key `PiiClass` refactor and crate-shape Option B, targeted for v0.5.
+
+## Adopter Notes
+
+Phone validation is feature-gated. `gaze-cli` enables parser-backed validation by default; raw library users opt in with `gaze-recognizers = { features = ["phone-parser"] }`. Audit time filters accept ISO 8601 timestamps through `--from` and `--to`; legacy DBs without `created_at` remain queryable but are excluded from time-filtered results by SQL NULL semantics.


### PR DESCRIPTION
Per rev 2 §S5 (scratchpad 339). Bumps 4 release crates to 0.4.4. Aggregates CHANGELOG (S5-only per drawer gaze_decisions_433c5c3c). Adds v0.4.4 roadmap entry.

After merge: tag v0.4.4-rc.1 → CI smoke → tag v0.4.4 → release → Homebrew bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)