### PR TITLE
v0.4.5 S4: ClassMapOverrideSafety extension audit (matrix or test)

### DIFF
--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -549,6 +549,71 @@ mod tests {
     }
 
     #[test]
+    fn t20b_rulepack_context_dict_override_fails_closed_when_uncovered() {
+        let policy = gaze::Policy {
+            session: SessionPolicy {
+                scope: SessionScope::Ephemeral,
+                ttl_secs: None,
+            },
+            detectors: Vec::new(),
+            dictionaries: Vec::new(),
+            rules: vec![
+                RuleSpec::Class {
+                    class: PiiClass::custom("foo"),
+                    action: Action::Tokenize,
+                },
+                RuleSpec::Default {
+                    action: Action::Preserve,
+                },
+            ],
+            ner: None,
+            rulepacks: gaze::RulepackPolicy {
+                bundled: Vec::new(),
+                paths: Vec::new(),
+            },
+            locale: Some(vec![LocaleTag::Global]),
+        };
+        let context = context_with_alpha_override();
+        let rulepack = Rulepack::parse(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "tenant-rulepack"
+rulepack_version = "0.4.5"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "tenant.alpha"
+class = "custom:foo"
+enabled = true
+
+[recognizers.match]
+kind = "dictionary"
+terms_from_context = "dict_alpha"
+case_sensitive = true
+"#,
+        )
+        .expect("rulepack");
+        let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+
+        let err = match build_pipeline(&policy, &context, &[rulepack], &active_locales, None) {
+            Ok(_) => panic!("rulepack context dictionary override must fail closed"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(
+            err,
+            BuildError::Rulepack(RulepackError::ClassMapOverrideClash {
+                dict,
+                old_class,
+                new_class,
+                ..
+            }) if dict == "dict_alpha"
+                && old_class == PiiClass::custom("foo")
+                && new_class == PiiClass::custom("bar")
+        ));
+    }
+
+    #[test]
     fn pattern_template_lowers_correctly_under_locale_chain_de() {
         let core = Rulepack::load(gaze::RulepackSource::Embedded(
             gaze_recognizers::embedded("core").expect("core"),

--- a/crates/xtask/README.md
+++ b/crates/xtask/README.md
@@ -23,7 +23,7 @@ Clap converts enum variants to kebab-case command names.
 | Gate | Command | Behavior |
 |------|---------|----------|
 | `SymmetricPotemkin` | `symmetric-potemkin` | Checks that every named behavioral test in `SYMMETRIC_POTEMKIN_TESTS` exists, then runs each exact test. |
-| `ClassMapOverrideSafety` | `class-map-override-safety` | Scaffolded placeholder. It prints `class_map_override_safety: scaffolded` and exits successfully. |
+| `ClassMapOverrideSafety` | `class-map-override-safety` | Checks that every named behavioral test in `CLASS_MAP_OVERRIDE_SAFETY_TESTS` exists, then runs each exact test. |
 | `RecognizerCompositionValidator` | `recognizer-composition-validator` | Checks that every named behavioral test in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS` exists, then runs each exact test. |
 
 The implementation lives in [`src/main.rs`](src/main.rs). The broader gate
@@ -44,9 +44,6 @@ Each gate exits non-zero when:
 - a protected test has been renamed or removed
 - a protected test fails
 - the underlying `cargo test` command cannot be started
-
-The current `class-map-override-safety` command is a placeholder and should not
-be treated as proof until it runs named behavioral tests.
 
 ## Adding a gate
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -21,10 +21,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::SymmetricPotemkin => run_symmetric_potemkin_gate(),
-        Command::ClassMapOverrideSafety => {
-            println!("class_map_override_safety: scaffolded");
-            Ok(())
-        }
+        Command::ClassMapOverrideSafety => run_class_map_override_safety_gate(),
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
     }
 }
@@ -128,6 +125,29 @@ const RECOGNIZER_COMPOSITION_VALIDATOR_TESTS: &[BehavioralTest] = &[
     },
 ];
 
+const CLASS_MAP_OVERRIDE_SAFETY_TESTS: &[BehavioralTest] = &[
+    BehavioralTest {
+        package: "gaze-assembly",
+        test_target: None,
+        name: "tests::t20_context_class_map_overrides_policy_dict_class",
+    },
+    BehavioralTest {
+        package: "gaze-assembly",
+        test_target: None,
+        name: "tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered",
+    },
+    BehavioralTest {
+        package: "gaze-assembly",
+        test_target: None,
+        name: "tests::t20b_rulepack_context_dict_override_fails_closed_when_uncovered",
+    },
+    BehavioralTest {
+        package: "gaze-cli",
+        test_target: Some("cli_pipe"),
+        name: "context_json_standalone_dictionary_detects_without_policy_entry",
+    },
+];
+
 fn run_symmetric_potemkin_gate() -> Result<()> {
     println!(
         "symmetric_potemkin_gate: checking {} behavioral tests",
@@ -140,6 +160,21 @@ fn run_symmetric_potemkin_gate() -> Result<()> {
         run_behavioral_test(*test)?;
     }
     println!("symmetric_potemkin_gate: passed");
+    Ok(())
+}
+
+fn run_class_map_override_safety_gate() -> Result<()> {
+    println!(
+        "class_map_override_safety: checking {} behavioral tests",
+        CLASS_MAP_OVERRIDE_SAFETY_TESTS.len()
+    );
+    for test in CLASS_MAP_OVERRIDE_SAFETY_TESTS {
+        ensure_test_exists(*test)?;
+    }
+    for test in CLASS_MAP_OVERRIDE_SAFETY_TESTS {
+        run_behavioral_test(*test)?;
+    }
+    println!("class_map_override_safety: passed");
     Ok(())
 }
 
@@ -180,7 +215,7 @@ fn ensure_test_exists(test: BehavioralTest) -> Result<()> {
 }
 
 fn run_behavioral_test(test: BehavioralTest) -> Result<()> {
-    println!("symmetric_potemkin_gate: running {}", describe(test));
+    println!("behavioral_test: running {}", describe(test));
     let status = cargo_test_command(test, Some(test.name))
         .arg("--")
         .arg("--exact")

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -18,7 +18,7 @@ The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.
 | Gate | Command | Current behavior |
 |------|---------|------------------|
 | `SymmetricPotemkin` | `cargo run -p xtask -- symmetric-potemkin` | Lists and runs the behavioral tests in `SYMMETRIC_POTEMKIN_TESTS`. The gate fails if any named test is missing or fails. |
-| `ClassMapOverrideSafety` | `cargo run -p xtask -- class-map-override-safety` | Scaffolded placeholder that prints `class_map_override_safety: scaffolded` and exits successfully. The related class-map behavioral tests currently run under `SymmetricPotemkin`. |
+| `ClassMapOverrideSafety` | `cargo run -p xtask -- class-map-override-safety` | Lists and runs the behavioral tests in `CLASS_MAP_OVERRIDE_SAFETY_TESTS`. The gate fails if any named test is missing or fails. |
 | `RecognizerCompositionValidator` | `cargo run -p xtask -- recognizer-composition-validator` | Lists and runs the behavioral tests in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS`. The gate fails if the rulepack composition validator tests are missing or failing. |
 
 ## Recursive-Potemkin discipline
@@ -58,10 +58,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::SymmetricPotemkin => run_symmetric_potemkin_gate(),
-        Command::ClassMapOverrideSafety => {
-            println!("class_map_override_safety: scaffolded");
-            Ok(())
-        }
+        Command::ClassMapOverrideSafety => run_class_map_override_safety_gate(),
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NewBehaviorGate => run_new_behavior_gate(),
     }

--- a/docs/research/v0.4.5-classmap-coverage.md
+++ b/docs/research/v0.4.5-classmap-coverage.md
@@ -1,0 +1,34 @@
+# v0.4.5 Class Map Override Coverage
+
+**Date:** 2026-04-26
+
+## Scope
+
+This audit covers every current class-rule mutation path where `context_json`
+`class_map` can change the class emitted by a dictionary recognizer.
+
+`class_map` is intentionally narrow runtime metadata for dictionary recognizer
+construction. It is not a general policy override mechanism. A changed class is
+accepted only when the resulting class has a tokenize-or-stricter action rule:
+`Tokenize`, `Redact`, `FormatPreserve`, or `Generalize`.
+
+## Matrix
+
+| Row | Surface | Code path | Can `class_map` change emitted class? | Guard | Rationale |
+|-----|---------|-----------|----------------------------------------|-------|-----------|
+| 1 | Context JSON parse | `crates/gaze/src/context.rs::Context::try_from` | Yes, by parsing `class_map` values into `PiiClass`. | Parse-time only: unknown classes fail closed with `ContextError::UnknownClass`. | N/A for action coverage because no recognizer is built in this layer; guarded by `crates/gaze/src/context.rs::tests::parses_typed_context_envelope` and `ContextError::UnknownClass` parsing. |
+| 2 | Policy custom dictionary recognizer with inline or file terms | `crates/gaze-assembly/src/lib.rs::build_pipeline` detector loop, then `class_for_dictionary` | Yes, when `context.class_map[dictionary_name]` differs from the detector class. | `class_for_dictionary` rejects changed classes without tokenize-or-stricter coverage. | Guarded by `tests::t20_context_class_map_overrides_policy_dict_class` and `tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered`. |
+| 3 | Policy custom dictionary recognizer with `terms_from_context` | `crates/gaze/src/policy.rs::parse_dictionary_detector` stores the context dictionary name, then assembly `class_for_dictionary` | Yes, same registered-dictionary path as row 2. | `class_for_dictionary` rejects uncovered changed classes. | Guarded by `tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered`; the detector path is identical after `dictionary_name` resolution. |
+| 4 | Rulepack dictionary recognizer with inline or file terms | `crates/gaze-assembly/src/lib.rs` rulepack dictionary loop, then `class_for_dictionary` using recognizer id as dictionary name | Yes, when `class_map[recognizer.id]` is present and differs from the rulepack class. | `class_for_dictionary` rejects uncovered changed classes. | Guarded by the shared `class_for_dictionary` path; row remains N/A for new fixture because inline/file rulepack terms use the same branch as row 5 after dictionary-name resolution. |
+| 5 | Rulepack dictionary recognizer with `terms_from_context` | `crates/gaze-assembly/src/lib.rs` rulepack dictionary loop resolves `terms_from_context`, then `class_for_dictionary` | Yes, when `class_map[terms_from_context]` differs from the rulepack class. | `class_for_dictionary` rejects uncovered changed classes. | Guarded by new behavioral test `tests::t20b_rulepack_context_dict_override_fails_closed_when_uncovered`. |
+| 6 | Context-only dictionaries under a policy | `crates/gaze-assembly/src/lib.rs` final context dictionary loop, then `class_for_dictionary` with original `custom:<dictionary_name>` | Yes, when `class_map[name]` differs from the default custom class. | `class_for_dictionary` rejects uncovered changed classes; unchanged/default class still follows normal rules. | Guarded by the same fail-closed function as rows 2 and 5; N/A for separate test in this audit because no distinct mutation branch exists beyond the original class passed to the helper. |
+| 7 | Context-only dictionaries without a policy | `crates/gaze-cli/src/pipeline/build.rs::build_context_pipeline` | Yes, `class_map` selects the emitted class. | The CLI creates a matching `ClassRule::new(class, Action::Tokenize)` for every registered context dictionary. | Guarded by CLI shipping smoke `crates/gaze-cli/tests/cli_pipe.rs::context_json_standalone_dictionary_detects_without_policy_entry`; no uncovered-class failure mode exists because the rule is generated from the resolved class. |
+| 8 | Rule actions | `crates/gaze-assembly/src/lib.rs::class_has_tokenize_or_stricter_action` and policy rule lowering | No direct mutation; actions decide whether the changed class is safe to use. | First matching explicit class or default rule must be tokenize-or-stricter. Preserve does not cover an override. | Guarded by `tests::t20a_class_map_override_fails_closed_when_action_rule_uncovered` and new `tests::t20b_rulepack_context_dict_override_fails_closed_when_uncovered`. |
+
+## Result
+
+The audit found one gate-coverage gap rather than a runtime guard gap: rulepack
+dictionary recognizers already flow through `class_for_dictionary`, but the
+dedicated `ClassMapOverrideSafety` xtask gate was still a scaffold and did not
+protect that behavior. v0.4.5 S4 adds the rulepack-context behavioral test and
+wires `CLASS_MAP_OVERRIDE_SAFETY_TESTS` so the gate runs real behavior.


### PR DESCRIPTION
## Summary
- add a rulepack context-dictionary fail-closed behavioral test for class_map overrides
- wire ClassMapOverrideSafety to a real CLASS_MAP_OVERRIDE_SAFETY_TESTS gate, including CLI context-json shipping smoke
- add docs/research/v0.4.5-classmap-coverage.md with per-row rationale for the audited class-rule mutation surface

## Verification
- cargo test --workspace
- cargo run -p xtask -- class-map-override-safety
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check

## Axis note
No reliability, reversibility, agentic fit, trust, or adopter ergonomics regression intended. This strengthens reliability/trust by making the class_map override guard executable in the dedicated gate.