### PR TITLE
v0.4.5 S5: rulepack version bump + drift-prevention rule

### DIFF
--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core-extended"
-rulepack_version = "0.4.2"
+rulepack_version = "0.4.5"
 default_locales = ["global"]
 
 [[recognizers]]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core"
-rulepack_version = "0.4.0"
+rulepack_version = "0.4.5"
 default_locales = ["global"]
 
 [locale.email_headers]

--- a/crates/gaze-recognizers/embedded/locale-de.toml
+++ b/crates/gaze-recognizers/embedded/locale-de.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-de"
-rulepack_version = "0.4.0"
+rulepack_version = "0.4.5"
 default_locales = ["de-DE", "de-AT", "de-CH"]
 
 # Phase 2 ports DACH structured recognizers.

--- a/crates/gaze-recognizers/embedded/locale-en.toml
+++ b/crates/gaze-recognizers/embedded/locale-en.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-en"
-rulepack_version = "0.4.0"
+rulepack_version = "0.4.5"
 default_locales = ["en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
 
 # Phase 2 ports English locale recognizers.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -74,6 +74,19 @@ recognizer definitions (`[[policy.custom_recognizers]]`), rule definitions
 define the auditable contract; changing them requires changing the policy or
 rulepack document itself.
 
+## Bundled rulepack version drift
+
+Bundled rulepacks in
+[`crates/gaze-recognizers/embedded`](../crates/gaze-recognizers/embedded) are
+release artifacts. Their `rulepack_version` tracks the `gaze-recognizers` crate
+version unless a deliberate desync rule is documented before the release ships.
+
+A deliberate desync rule must name the affected bundled rulepack IDs, explain
+why the rulepack contract differs from the crate release, and state when the
+versions converge again. Undocumented drift is a release defect because it
+weakens the audit trail for which recognizer contract shipped with a given
+crate.
+
 ## Configuration surfaces - three-surfaces parity table
 
 This table audits every current `policy.toml` field accepted by


### PR DESCRIPTION
## Summary
- Bump every bundled `crates/gaze-recognizers/embedded/*.toml` `rulepack_version` to `0.4.5`.
- Document the bundled rulepack drift-prevention rule in `docs/policy.md`.
- Omit the optional xtask gate because current crate manifests are still `0.4.2`; filed Solo todo 153 for v0.4.6 hygiene with the requested gate wording.

## Verification
- Pre-flight: `cargo test --workspace`
- Pre-flight: `cargo clippy --workspace --all-targets -- -D warnings`
- Pre-flight and final: `cargo fmt --check`
- Post-edit: `cargo test -p gaze-recognizers`

## Notes
- Did not touch `CHANGELOG.md`.
- No axis regression: this improves trust/auditability for bundled recognizer contracts.