### PR TITLE
v0.4.5 S1: --session audit filter (opaque metadata, NOT session_hex)

### DIFF
--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -17,6 +17,7 @@ pub(crate) struct Args {
     pub(crate) document_kind: Option<String>,
     pub(crate) from_iso8601: Option<String>,
     pub(crate) to_iso8601: Option<String>,
+    pub(crate) session_id: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
@@ -31,7 +32,7 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     for row in rows {
         writeln!(
             stdout,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.class,
             row.action,
@@ -41,7 +42,8 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
             row.decided_by,
             row.created_at
                 .map(|created_at| created_at.to_string())
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            row.session_id.unwrap_or_default()
         )
         .map_err(|_| CliError::Io)?;
     }
@@ -71,6 +73,7 @@ fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
         document_kind: args.document_kind.clone(),
         from_epoch_ms,
         to_epoch_ms,
+        session_id: args.session_id.clone(),
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -115,6 +118,7 @@ struct JsonlRow {
     conflict_loser: bool,
     decided_by: String,
     created_at: Option<i64>,
+    session_id: Option<String>,
 }
 
 impl From<AuditLogRow> for JsonlRow {
@@ -128,6 +132,7 @@ impl From<AuditLogRow> for JsonlRow {
             conflict_loser: row.conflict_loser,
             decided_by: row.decided_by,
             created_at: row.created_at,
+            session_id: row.session_id,
         }
     }
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -109,6 +109,9 @@ enum AuditCmd {
         /// Include rows created at or before this ISO 8601 timestamp.
         #[arg(long = "to")]
         to_iso8601: Option<String>,
+        /// Filter by opaque audit session id.
+        #[arg(long = "session")]
+        session_id: Option<String>,
     },
     /// Export filtered audit metadata rows.
     Export {
@@ -139,6 +142,9 @@ enum AuditCmd {
         /// Include rows created at or before this ISO 8601 timestamp.
         #[arg(long = "to")]
         to_iso8601: Option<String>,
+        /// Filter by opaque audit session id.
+        #[arg(long = "session")]
+        session_id: Option<String>,
     },
 }
 
@@ -191,6 +197,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 document_kind,
                 from_iso8601,
                 to_iso8601,
+                session_id,
             } => audit::query(audit::Args {
                 audit_db,
                 class: pii_class,
@@ -199,6 +206,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 document_kind,
                 from_iso8601,
                 to_iso8601,
+                session_id,
             }),
             AuditCmd::Export {
                 audit_db,
@@ -210,6 +218,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 document_kind,
                 from_iso8601,
                 to_iso8601,
+                session_id,
             } => audit::export(
                 audit::Args {
                     audit_db,
@@ -219,6 +228,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                     document_kind,
                     from_iso8601,
                     to_iso8601,
+                    session_id,
                 },
                 format,
                 output,

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -86,6 +86,7 @@ fn v0_4_3_shape_without_created_at_is_queryable_but_time_filters_omit_nulls() {
     assert_eq!(row["conflict_loser"], false);
     assert_eq!(row["decided_by"], "recognizer_id");
     assert_eq!(row["created_at"], Value::Null);
+    assert_eq!(row["session_id"], Value::Null);
 }
 
 #[test]
@@ -143,6 +144,86 @@ fn v0_4_4_shape_with_created_at_is_queryable_and_time_filtered() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["source"], "email.global");
     assert_eq!(rows[0]["created_at"], 1700000000000_i64);
+    assert_eq!(rows[0]["session_id"], Value::Null);
+}
+
+#[test]
+fn v0_4_5_shape_with_session_id_is_queryable_and_session_filtered() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("v0.4.5.sqlite");
+    let conn = Connection::open(&audit_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE redaction_log (
+            source TEXT NOT NULL,
+            class TEXT NOT NULL,
+            action TEXT NOT NULL,
+            field_name TEXT NULL,
+            document_kind TEXT NOT NULL,
+            conflict_loser INTEGER NOT NULL,
+            decided_by TEXT NOT NULL DEFAULT 'none',
+            created_at INTEGER NULL,
+            session_id TEXT NULL
+        );
+        INSERT INTO redaction_log
+            (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id)
+        VALUES
+            ('email.global', 'email', 'tokenize', NULL, 'text', 0, 'recognizer_id', 1700000000000, '018bcfe5-6800-7a2f-9d1b-47b7565b2d10'),
+            ('phone.global', 'custom:phone', 'tokenize', NULL, 'text', 0, 'recognizer_id', 1700001000000, '018bcff4-aa40-7b01-9fcb-0c98049b2a02'),
+            ('legacy.global', 'custom:legacy', 'tokenize', NULL, 'text', 0, 'recognizer_id', 1700002000000, NULL);
+        "#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+            "--session",
+            "018bcfe5-6800-7a2f-9d1b-47b7565b2d10",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rows: Vec<Value> = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["source"], "email.global");
+    assert_eq!(
+        rows[0]["session_id"],
+        "018bcfe5-6800-7a2f-9d1b-47b7565b2d10"
+    );
+
+    let output = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8(output.stdout).unwrap().lines().count(), 3);
 }
 
 #[test]
@@ -187,7 +268,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\n"
     ));
     assert!(
         stdout.contains("dictionary:audit_terms[#0]\tcustom:term\ttokenize\t\ttext\tfalse\tnone")
@@ -203,8 +284,9 @@ fn audit_sql_uses_restricted_column_set() {
         document_kind: Some("text".to_string()),
         from_epoch_ms: Some(1_700_000_000_000),
         to_epoch_ms: Some(1_700_000_010_000),
+        session_id: Some("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
     };
-    let (current_sql, values) = build_audit_query_sql(&filter, true, true);
+    let (current_sql, values) = build_audit_query_sql(&filter, true, true, true);
     assert_eq!(
         values,
         [
@@ -214,6 +296,7 @@ fn audit_sql_uses_restricted_column_set() {
             SqlValue::Text("text".to_string()),
             SqlValue::Integer(1_700_000_000_000),
             SqlValue::Integer(1_700_000_010_000),
+            SqlValue::Text("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
         ]
         .into_iter()
         .collect::<Vec<_>>()
@@ -221,24 +304,29 @@ fn audit_sql_uses_restricted_column_set() {
     assert_restricted_sql(&current_sql);
     assert!(current_sql.contains("created_at >= ?"));
     assert!(current_sql.contains("created_at <= ?"));
+    assert!(current_sql.contains("session_id = ?"));
     assert!(!current_sql.contains("created_at IS NULL"));
 
     let legacy_filter = AuditFilter {
         from_epoch_ms: Some(1_700_000_000_000),
         to_epoch_ms: Some(1_700_000_010_000),
+        session_id: Some("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
         ..AuditFilter::default()
     };
-    let (legacy_sql, legacy_values) = build_audit_query_sql(&legacy_filter, false, false);
+    let (legacy_sql, legacy_values) = build_audit_query_sql(&legacy_filter, false, false, false);
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
     assert!(legacy_sql.contains("NULL AS created_at"));
+    assert!(legacy_sql.contains("NULL AS session_id"));
     assert!(legacy_sql.contains("NULL >= ?"));
     assert!(legacy_sql.contains("NULL <= ?"));
+    assert!(legacy_sql.contains("NULL = ?"));
     assert_eq!(
         legacy_values,
         [
             SqlValue::Integer(1_700_000_000_000),
             SqlValue::Integer(1_700_000_010_000),
+            SqlValue::Text("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
         ]
         .into_iter()
         .collect::<Vec<_>>()

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1170,7 +1170,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\n"
     ));
     assert!(
         stdout
@@ -1211,6 +1211,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     assert_eq!(row["document_kind"], "text");
     assert_eq!(row["conflict_loser"], false);
     assert!(row.get("decided_by").is_some());
+    assert!(row.get("session_id").is_some());
 }
 
 #[test]
@@ -1256,7 +1257,7 @@ fn s2_audit_cli_smoke_filters_created_at_range() {
         .expect("expected email audit row in bounded time range");
     let created_at = row
         .split('\t')
-        .next_back()
+        .nth(7)
         .expect("created_at column")
         .parse::<i64>()
         .expect("created_at is epoch milliseconds");
@@ -1288,6 +1289,127 @@ fn s2_audit_cli_smoke_filters_created_at_range() {
 }
 
 #[test]
+fn s1_audit_cli_smoke_filters_session_without_leaking_raw_or_other_session() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+    let raw_a = "Email alice@example.invalid";
+    let raw_b = "Email bob@example.invalid";
+
+    for raw in [raw_a, raw_b] {
+        let clean = clean_raw_with_args(&[&format!("--audit-db={}", audit_path.display())], raw);
+        assert!(
+            clean.status.success(),
+            "clean failed: {}",
+            String::from_utf8_lossy(&clean.stderr)
+        );
+    }
+
+    let export = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    assert_no_raw_audit_pii(&export.stdout);
+    assert!(!export
+        .stdout
+        .windows(b"bob@example.invalid".len())
+        .any(|window| window == b"bob@example.invalid"));
+    let rows: Vec<Value> = String::from_utf8(export.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let session_a = rows[0]["session_id"].as_str().unwrap().to_string();
+    let session_b = rows[1]["session_id"].as_str().unwrap().to_string();
+    assert_ne!(session_a, session_b);
+
+    let query = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--session",
+            &session_a,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        query.status.success(),
+        "audit query failed: {}",
+        String::from_utf8_lossy(&query.stderr)
+    );
+    assert_no_raw_audit_pii(&query.stdout);
+    assert!(
+        !query
+            .stdout
+            .windows(session_b.len())
+            .any(|window| window == session_b.as_bytes()),
+        "non-matching session id leaked in filtered output"
+    );
+    let stdout = String::from_utf8(query.stdout).unwrap();
+    assert!(stdout.contains(&session_a), "filtered output: {stdout}");
+    assert_eq!(stdout.lines().count(), 2, "filtered output: {stdout}");
+}
+
+#[test]
+fn t_audit_session_id_is_opaque_not_session_hex() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let clean = clean_json_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Email alice@example.invalid",
+    );
+    let clean_text = clean["clean_text"].as_str().unwrap();
+    let token = clean_text
+        .split_whitespace()
+        .find(|part| part.starts_with('<'))
+        .expect("tokenized email");
+    let token_session_hex = token
+        .trim_start_matches('<')
+        .split(':')
+        .next()
+        .expect("token prefix");
+
+    let export = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "export",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+            "--format",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        export.status.success(),
+        "audit export failed: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    let row: Value = serde_json::from_slice(&export.stdout).unwrap();
+    let audit_session_id = row["session_id"].as_str().unwrap();
+    assert_ne!(audit_session_id, token_session_hex);
+    assert_eq!(audit_session_id.len(), 36);
+    assert_eq!(&audit_session_id[14..15], "7");
+}
+
+#[test]
 fn s2_audit_invalid_iso8601_is_policy_config_for_query_and_export() {
     let dir = tempdir().unwrap();
     let audit_path = dir.path().join("audit.sqlite");
@@ -1316,6 +1438,48 @@ fn s2_audit_invalid_iso8601_is_policy_config_for_query_and_export() {
             format!("invalid audit ISO 8601 timestamp: {:?}", "invalid-date")
         );
     }
+}
+
+#[test]
+fn s1_policy_audit_defaults_are_not_supported() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.audit]
+session = "0196758d-5f00-7a8a-9a4c-6b1347a1f0d2"
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = '(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = clean_raw_with_args(
+        &[&format!("--policy={}", path.display())],
+        "Email alice@example.invalid",
+    );
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty());
+    let stderr: Value = serde_json::from_slice(&out.stderr).unwrap();
+    assert_eq!(stderr["error"], "PolicyConfig");
 }
 
 #[test]
@@ -1457,7 +1621,7 @@ fn s4_audit_query_columns_are_restricted() {
     let conn = Connection::open(&audit_path).unwrap();
     conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
         .unwrap();
-    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true, true);
+    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true, true, true);
     assert!(
         values.is_empty(),
         "default audit filter should not bind query values"

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -150,6 +150,7 @@ impl Pipeline {
             .collect::<Vec<_>>();
         for loser in &losers {
             self.log_entry(
+                session,
                 loser,
                 field_name,
                 document_kind.clone(),
@@ -165,7 +166,14 @@ impl Pipeline {
             let raw = text[detection.detection.span.clone()].to_string();
             let context = build_context(field_name);
             let action = self.action_for(&detection.detection, &context);
-            self.log_entry(&detection, field_name, document_kind.clone(), action, false)?;
+            self.log_entry(
+                session,
+                &detection,
+                field_name,
+                document_kind.clone(),
+                action,
+                false,
+            )?;
 
             let replacement = match action {
                 Action::Tokenize => Some(session.tokenize_with_family(
@@ -201,6 +209,7 @@ impl Pipeline {
 
     fn log_entry(
         &self,
+        session: &Session,
         detection: &IndexedDetection,
         field_name: Option<&str>,
         document_kind: DocumentKind,
@@ -216,6 +225,7 @@ impl Pipeline {
             conflict_loser,
             decided_by: detection.decided_by,
             created_at: crate::redaction_log::current_epoch_ms(),
+            session_id: Some(session.audit_session_id().to_string()),
         };
 
         for logger in &self.redaction_loggers {

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -28,6 +28,7 @@ pub struct RedactionEntry {
     pub conflict_loser: bool,
     pub decided_by: ConflictTier,
     pub created_at: i64,
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -38,6 +39,7 @@ pub struct AuditFilter {
     pub document_kind: Option<String>,
     pub from_epoch_ms: Option<i64>,
     pub to_epoch_ms: Option<i64>,
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,6 +52,7 @@ pub struct AuditLogRow {
     pub conflict_loser: bool,
     pub decided_by: String,
     pub created_at: Option<i64>,
+    pub session_id: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -62,6 +65,7 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "conflict_loser",
     "decided_by",
     "created_at",
+    "session_id",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,6 +101,7 @@ pub(crate) fn current_epoch_ms() -> i64 {
 ///     conflict_loser: false,
 ///     decided_by: gaze::ConflictTier::None,
 ///     created_at: 0,
+///     session_id: None,
 ///     raw: Some("alice@example.com".to_string()),
 /// };
 /// ```
@@ -119,7 +124,8 @@ impl SqliteLogger {
                 document_kind TEXT NOT NULL,
                 conflict_loser INTEGER NOT NULL,
                 decided_by TEXT NOT NULL DEFAULT 'none',
-                created_at INTEGER NULL
+                created_at INTEGER NULL,
+                session_id TEXT NULL
             );
             "#,
         )
@@ -151,6 +157,13 @@ impl SqliteLogger {
             )
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
         }
+        if !columns.iter().any(|column| column == "session_id") {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN session_id TEXT NULL",
+                [],
+            )
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        }
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -163,7 +176,7 @@ impl SqliteLogger {
             .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at FROM redaction_log",
+                "SELECT source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id FROM redaction_log",
             )
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
         let rows = stmt
@@ -177,6 +190,7 @@ impl SqliteLogger {
                     conflict_loser: row.get::<_, i64>(5)? != 0,
                     decided_by: conflict_tier_from_db(&row.get::<_, String>(6)?)?,
                     created_at: row.get::<_, Option<i64>>(7)?.unwrap_or(0),
+                    session_id: row.get(8)?,
                 })
             })
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -192,7 +206,9 @@ impl SqliteLogger {
         let conn = open_audit_query_connection(path)?;
         let has_decided_by = table_has_column(&conn, "decided_by")?;
         let has_created_at = table_has_column(&conn, "created_at")?;
-        let (sql, values) = build_audit_query_sql(filter, has_decided_by, has_created_at);
+        let has_session_id = table_has_column(&conn, "session_id")?;
+        let (sql, values) =
+            build_audit_query_sql(filter, has_decided_by, has_created_at, has_session_id);
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -207,6 +223,7 @@ impl SqliteLogger {
                     conflict_loser: row.get::<_, i64>(5)? != 0,
                     decided_by: row.get(6)?,
                     created_at: row.get(7)?,
+                    session_id: row.get(8)?,
                 })
             })
             .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -226,7 +243,7 @@ impl RedactionLogger for SqliteLogger {
             .lock()
             .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 entry.source,
                 pii_class_to_db(&entry.class),
@@ -236,6 +253,7 @@ impl RedactionLogger for SqliteLogger {
                 if entry.conflict_loser { 1 } else { 0 },
                 conflict_tier_to_db(entry.decided_by),
                 entry.created_at,
+                entry.session_id,
             ],
         )
         .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
@@ -263,6 +281,7 @@ pub fn build_audit_query_sql(
     filter: &AuditFilter,
     has_decided_by: bool,
     has_created_at: bool,
+    has_session_id: bool,
 ) -> (String, Vec<Value>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
@@ -274,8 +293,13 @@ pub fn build_audit_query_sql(
     } else {
         "NULL AS created_at"
     };
+    let session_id_column = if has_session_id {
+        "session_id"
+    } else {
+        "NULL AS session_id"
+    };
     let mut sql = format!(
-        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column} FROM redaction_log"
+        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();
@@ -310,6 +334,14 @@ pub fn build_audit_query_sql(
             predicates.push("NULL <= ?");
         }
         values.push(Value::Integer(to_epoch_ms));
+    }
+    if let Some(session_id) = &filter.session_id {
+        if has_session_id {
+            predicates.push("session_id = ?");
+        } else {
+            predicates.push("NULL = ?");
+        }
+        values.push(Value::Text(session_id.clone()));
     }
     if !predicates.is_empty() {
         sql.push_str(" WHERE ");
@@ -468,6 +500,7 @@ mod tests {
                     conflict_loser: false,
                     decided_by: ConflictTier::None,
                     created_at: 0,
+                    session_id: None,
                 })
                 .unwrap();
         }

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -77,6 +77,7 @@ struct SnapshotPayload {
 pub struct Session {
     scope: Scope,
     session_hex: [u8; 4],
+    audit_session_id: String,
     next_by_class: DashMap<PiiClass, usize>,
     token_by_value: DashMap<TokenKey, String>,
     value_by_token: DashMap<String, String>,
@@ -88,6 +89,7 @@ impl Session {
         Ok(Self {
             scope,
             session_hex: random_session_hex(),
+            audit_session_id: new_audit_session_id(),
             next_by_class: DashMap::new(),
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
@@ -208,6 +210,10 @@ impl Session {
         hex::encode(self.session_hex)
     }
 
+    pub fn audit_session_id(&self) -> &str {
+        &self.audit_session_id
+    }
+
     pub fn restore_strict(&self, token: &str) -> Result<String> {
         self.value_by_token
             .get(token)
@@ -319,6 +325,7 @@ impl Session {
         let session = Self {
             scope,
             session_hex,
+            audit_session_id: new_audit_session_id(),
             next_by_class: DashMap::new(),
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
@@ -359,6 +366,42 @@ impl Session {
 
 fn default_counter_family() -> String {
     DEFAULT_COUNTER_FAMILY.to_string()
+}
+
+fn new_audit_session_id() -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(0xffff_ffff_ffff) as u64)
+        .unwrap_or(0);
+    let mut bytes = [0_u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes[6..]);
+    bytes[0] = (millis >> 40) as u8;
+    bytes[1] = (millis >> 32) as u8;
+    bytes[2] = (millis >> 24) as u8;
+    bytes[3] = (millis >> 16) as u8;
+    bytes[4] = (millis >> 8) as u8;
+    bytes[5] = millis as u8;
+    bytes[6] = (bytes[6] & 0x0f) | 0x70;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
 }
 
 struct SessionKey {

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -492,6 +492,7 @@ fn sqlite_logger_persists_entries() {
             conflict_loser: false,
             decided_by: gaze::ConflictTier::None,
             created_at: 0,
+            session_id: None,
         })
         .expect("log entry");
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@
 It is read-only and intentionally returns a restricted column set:
 
 ```text
-source    class    action    field_name    document_kind    conflict_loser    decided_by    created_at
+source    class    action    field_name    document_kind    conflict_loser    decided_by    created_at    session_id
 ```
 
 The audit command must not read raw spans, restore mappings, token payloads, or
@@ -20,13 +20,16 @@ gaze audit query --audit-db audit.sqlite
 gaze audit query --audit-db audit.sqlite --class email --source email.global
 gaze audit query --audit-db audit.sqlite --action tokenize --document-kind text
 gaze audit query --audit-db audit.sqlite --from 2026-04-26T00:00:00Z --to 2026-04-27T00:00:00Z
+gaze audit query --audit-db audit.sqlite --session 0196758d-5f00-7a8a-9a4c-6b1347a1f0d2
 ```
 
 `query` writes tab-separated rows to stdout with a header row. `created_at` is
-epoch milliseconds. Legacy audit databases without a `created_at` column remain
-queryable; their `created_at` value is empty in TSV output. Unfiltered queries
-(no `--from` / `--to`) include legacy rows. Filtered queries omit NULL rows by
-SQL semantics; to access legacy rows, omit time filters.
+epoch milliseconds. `session_id` is an opaque UUIDv7-shaped audit metadata id,
+not the private token `session_hex` prefix. Legacy audit databases without
+`created_at` or `session_id` columns remain queryable; missing values are empty
+in TSV output. Unfiltered queries include legacy rows. Filtered queries omit
+NULL rows by SQL semantics; to access legacy rows, omit the matching time or
+session filter.
 
 ### Export
 
@@ -34,12 +37,13 @@ SQL semantics; to access legacy rows, omit time filters.
 gaze audit export --audit-db audit.sqlite --format jsonl
 gaze audit export --audit-db audit.sqlite --format jsonl --output audit.jsonl
 gaze audit export --audit-db audit.sqlite --format jsonl --from 2026-04-26T00:00:00Z
+gaze audit export --audit-db audit.sqlite --format jsonl --session 0196758d-5f00-7a8a-9a4c-6b1347a1f0d2
 ```
 
 `export --format jsonl` writes one JSON object per row:
 
 ```json
-{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"recognizer_id","created_at":1777161600000}
+{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"recognizer_id","created_at":1777161600000,"session_id":"0196758d-5f00-7a8a-9a4c-6b1347a1f0d2"}
 ```
 
 ### Filters
@@ -54,7 +58,7 @@ metadata:
 | `--action` | in | `RedactionEntry.action` exists |
 | `--document-kind` | in | `RedactionEntry.document_kind` exists |
 | `--from` / `--to` | in | `RedactionEntry.created_at` exists |
-| `--session` | deferred | no session column in the audit schema |
+| `--session` | in | `RedactionEntry.session_id` exists |
 
 `--from` and `--to` must be ISO 8601/RFC3339 timestamps with an explicit offset,
 for example `2026-04-26T00:00:00Z` or `2026-04-26T01:00:00+01:00`.

--- a/docs/research/v0.4.5-session-audit-id.md
+++ b/docs/research/v0.4.5-session-audit-id.md
@@ -1,0 +1,36 @@
+# v0.4.5 Session Audit ID Binding
+
+## Decision
+
+`gaze audit --session <id>` filters on a new audit metadata column:
+
+```sql
+session_id TEXT NULL
+```
+
+The stored value is an opaque UUIDv7-shaped identifier minted for the clean
+runtime session. It is timestamp-correlated, so operators can combine
+`--session` with `--from` / `--to` during incident review, but it is not derived
+from token material.
+
+## Rejected Option: `session_hex`
+
+The private `Session::session_hex` prefix is visible in emitted tokens and is
+restore-contract material. Storing that prefix as audit metadata would make the
+audit database a token-prefix lookup table. That weakens the privacy boundary
+between audit reporting and reversible manifest state.
+
+S1 therefore does not store raw `session_hex`, does not expose it through
+`RedactionEntry`, and does not add any policy/TOML default for audit sessions.
+
+## Query Semantics
+
+Legacy audit databases have `NULL` `session_id` values. Unfiltered
+query/export includes those rows. Filtered query/export with `--session <id>`
+omits `NULL` rows, matching the existing `created_at` filter behavior from
+v0.4.4.
+
+`session_id` is audit metadata only. It is not included in the restore manifest,
+does not participate in clean/restore token generation, and is never used as a
+source of PII or token material.
+


### PR DESCRIPTION
## Summary
- Add Wave A memo binding audit session storage to opaque UUIDv7-shaped metadata, not raw `session_hex`.
- Add `session_id` to audit metadata structs, SQLite schema migration, restricted projection, JSONL/TSV output, and `gaze audit query/export --session`.
- Add 3-shape cross-version coverage, CLI byte-level session filter smoke, NULL legacy semantics, and no `[policy.audit]` default coverage.

## Source-break note
- `RedactionEntry`, `AuditFilter`, and `AuditLogRow` each gain `session_id: Option<String>`. Downstream exhaustive struct literals must add the field.

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`

## Notes
- Did not touch `CHANGELOG.md` per v0.4.5 Pn aggregation instruction.
