### PR TITLE
v0.4.5 S2: DE+US national phone recognizers (parser-backed, region-aware)

### DIFF
--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -10,9 +10,9 @@ use base64::Engine;
 use serde::Serialize;
 
 use gaze::{
-    Action, DictionaryBundle, DictionarySource, DocumentKind, LocaleTag, Policy, RawDocument,
-    RedactionEntry, RedactionLogger, Result as GazeResult, RuleSpec, RulepackPolicy, Scope,
-    SensitiveSnapshot, Session, SessionPolicy, SessionScope, SqliteLogger, TypedContext,
+    Action, DictionaryBundle, DictionarySource, DocumentKind, LocaleTag, PiiClass, Policy,
+    RawDocument, RedactionEntry, RedactionLogger, Result as GazeResult, RuleSpec, RulepackPolicy,
+    Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope, SqliteLogger, TypedContext,
 };
 
 use crate::clean_overrides::CleanOverrides;
@@ -64,6 +64,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     } else {
         None
     };
+    let effective_policy = loaded_policy.as_ref().or(cli_rulepack_policy.as_ref());
     let loaded_rulepacks = match (&loaded_policy, &cli_rulepack_policy) {
         (Some(policy), _) | (None, Some(policy)) => {
             load_rulepacks(policy).map_err(map_pipeline_error)?
@@ -81,9 +82,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         .unwrap_or_default();
     let rulepack_dictionaries =
         dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
-    let active_policy = loaded_policy.as_ref().or(cli_rulepack_policy.as_ref());
-    let policy_bundle = active_policy
-        .as_ref()
+    let policy_bundle = effective_policy
         .map(|policy| {
             let mut dictionaries = policy.dictionaries.clone();
             dictionaries.extend(rulepack_dictionaries);
@@ -96,12 +95,12 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     let cli_locales = parse_cli_locales(options.locale)?;
     let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
         cli_locales.as_deref(),
-        active_policy.and_then(|policy| policy.locale.as_deref()),
+        effective_policy.and_then(|policy| policy.locale.as_deref()),
         Some(&rulepack_default_locales),
     );
-    let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, active_policy);
+    let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, effective_policy);
 
-    let pipeline = match active_policy {
+    let pipeline = match effective_policy {
         Some(policy) => build_pipeline_from_policy(
             policy,
             &loaded_rulepacks,
@@ -123,7 +122,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         }
     };
 
-    let session = match active_policy {
+    let session = match effective_policy {
         Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
         None => Session::new(scope_for_cli_without_policy(
             clean_overrides.session_scope.as_ref(),
@@ -212,6 +211,10 @@ fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
 }
 
 fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
+    let mut rules = class_rules_for_bundled_overrides(clean_overrides);
+    rules.push(RuleSpec::Default {
+        action: Action::Preserve,
+    });
     let base = Policy {
         session: SessionPolicy {
             scope: SessionScope::Persistent,
@@ -219,9 +222,7 @@ fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
         },
         detectors: Vec::new(),
         dictionaries: Vec::new(),
-        rules: vec![RuleSpec::Default {
-            action: Action::Tokenize,
-        }],
+        rules,
         ner: None,
         rulepacks: RulepackPolicy {
             bundled: Vec::new(),
@@ -230,6 +231,45 @@ fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
         locale: None,
     };
     clean_overrides.apply_to(&base)
+}
+
+fn class_rules_for_bundled_overrides(clean_overrides: &CleanOverrides) -> Vec<RuleSpec> {
+    let Some(bundled) = &clean_overrides.rulepack_bundled else {
+        return Vec::new();
+    };
+    let mut classes = Vec::<PiiClass>::new();
+    for bundle in bundled {
+        match bundle.as_str() {
+            "core" => {
+                push_class_once(&mut classes, PiiClass::Email);
+                push_class_once(&mut classes, PiiClass::Name);
+            }
+            "core-extended" => {
+                push_class_once(&mut classes, PiiClass::custom("phone"));
+                push_class_once(&mut classes, PiiClass::custom("ip_address"));
+                push_class_once(&mut classes, PiiClass::custom("postal_code"));
+                push_class_once(&mut classes, PiiClass::custom("iban"));
+                push_class_once(&mut classes, PiiClass::custom("credit_card"));
+            }
+            "locale-de" | "locale-en" => {
+                push_class_once(&mut classes, PiiClass::Name);
+            }
+            _ => {}
+        }
+    }
+    classes
+        .into_iter()
+        .map(|class| RuleSpec::Class {
+            class,
+            action: Action::Tokenize,
+        })
+        .collect()
+}
+
+fn push_class_once(classes: &mut Vec<PiiClass>, class: PiiClass) {
+    if !classes.iter().any(|existing| existing == &class) {
+        classes.push(class);
+    }
 }
 
 fn scope_for_cli_without_policy(scope: Option<&SessionScope>, ttl_secs: Option<u64>) -> Scope {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2126,10 +2126,77 @@ fn s2_core_extended_cli_locale_gating_and_plain_en_negative() {
 }
 
 #[test]
+fn s2_core_extended_national_phone_shipping_smoke() {
+    let (_dir, policy) =
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+
+    let no_policy_us = clean_json_with_args(
+        &["--rulepack-bundled=core-extended"],
+        // United States: NANPA reserved 555-0100 through 555-0199 fictional/test range.
+        "Phone +1 555 0100",
+    );
+    let no_policy_us_clean = no_policy_us["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(no_policy_us_clean),
+        "unexpected no-policy US national phone clean text: {no_policy_us_clean}"
+    );
+    let no_policy_order = clean_json_with_args(&["--rulepack-bundled=core-extended"], "Order_0815");
+    assert_eq!(no_policy_order["clean_text"], "Order_0815");
+    assert_eq!(no_policy_order["stats"]["detections"], 0);
+
+    let us = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=en-US"],
+        // United States: NANPA reserved 555-0100 through 555-0199 fictional/test range.
+        "Phone +1 555 0100",
+    );
+    let us_clean = us["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(us_clean),
+        "unexpected US national phone clean text: {us_clean}"
+    );
+    assert_eq!(us["stats"]["detections"], 1);
+    assert_eq!(
+        restore_success_text(us["session_blob"].as_str().unwrap(), us_clean),
+        "Phone +1 555 0100"
+    );
+
+    let de = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=de-DE"],
+        // Germany: synthetic non-reachable fixture, not a real number.
+        "Phone +49 30 0000 0000",
+    );
+    let de_clean = de["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(de_clean),
+        "unexpected DE national phone clean text: {de_clean}"
+    );
+    assert_eq!(de["stats"]["detections"], 1);
+    assert_eq!(
+        restore_success_text(de["session_blob"].as_str().unwrap(), de_clean),
+        "Phone +49 30 0000 0000"
+    );
+
+    let de_under_en = clean_json_with_args(
+        &[&format!("--policy={}", policy.display()), "--locale=en-US"],
+        // Germany: synthetic non-reachable fixture, not a real number.
+        "Phone +49 30 0000 0000",
+    );
+    assert_eq!(de_under_en["clean_text"], "Phone +49 30 0000 0000");
+    assert_eq!(de_under_en["stats"]["detections"], 0);
+}
+
+#[test]
 fn s2_core_extended_tenant_like_numeric_ids_are_not_phone_tokens() {
     let (_dir, policy) =
-        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "de-DE");
-    let input = "Subscriber_0001234567 Order_0815 0123-456789 0815 12345";
+        write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
+    let input =
+        "Subscriber_0001234567 Order_0815 0123-456789 0815 12345 SO-12345-67890 ORDR-9876543210";
     let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
     let clean = value["clean_text"].as_str().unwrap();
 

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1486,8 +1486,10 @@ action = "preserve"
 fn s4_audit_export_does_not_return_raw_pii() {
     let dir = tempdir().unwrap();
     let audit_path = dir.path().join("audit.sqlite");
+    // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+    // literals chosen for parser-valid + non-routable.
     let raw_input =
-        "Hello Dr. Schmidt, your phone is +4915550112233 and email alice@example.invalid";
+        "Hello Dr. Schmidt, your phone is +4915100000000 and email alice@example.invalid";
 
     let clean = clean_raw_with_args(
         &[&format!("--audit-db={}", audit_path.display())],
@@ -1646,7 +1648,7 @@ fn s4_audit_query_columns_are_restricted() {
 fn assert_no_raw_audit_pii(bytes: &[u8]) {
     for raw in [
         b"Dr. Schmidt".as_slice(),
-        b"+4915550112233".as_slice(),
+        b"+4915100000000".as_slice(),
         b"alice@example.invalid".as_slice(),
     ] {
         assert!(
@@ -1890,7 +1892,9 @@ fn s1_rulepack_bundled_override_changes_bundled_recognizer_availability() {
 
 #[test]
 fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
-    let input = "Email alice@example.invalid phone +4915550112233 host 192.168.1.1 zip 94103-1234 IBAN GB82WEST12345698765432 card 4111111111111111";
+    // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+    // literals chosen for parser-valid + non-routable.
+    let input = "Email alice@example.invalid phone +4915100000000 host 192.168.1.1 zip 94103-1234 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_core_dir, core_policy) = write_policy_with_core_extended_rulepacks(&["core"], "en-US");
     let core_only = clean_json_with_args(&[&format!("--policy={}", core_policy.display())], input);
     let core_clean = core_only["clean_text"].as_str().unwrap();
@@ -1937,7 +1941,9 @@ fn s2_core_extended_toml_opt_in_tokenizes_and_core_only_does_not() {
 
 #[test]
 fn s2_core_extended_cli_opt_in_mirrors_toml_and_rejects_garbage_symmetrically() {
-    let input = "phone +4915550112233 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
+    // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+    // literals chosen for parser-valid + non-routable.
+    let input = "phone +4915100000000 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
     let (_toml_dir, toml_policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");
     let toml = clean_json_with_args(&[&format!("--policy={}", toml_policy.display())], input);
@@ -2022,17 +2028,52 @@ fn s3a_cli_bundled_core_extended_rejects_unassigned_e164_phone() {
 fn s3a_cli_bundled_core_extended_tokenizes_valid_e164_phone() {
     let value = clean_json_with_args(
         &["--rulepack-bundled", "core-extended"],
-        "+4915550112233 is real",
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
+        "+4915100000000 is valid-format",
     );
     let clean = value["clean_text"].as_str().unwrap();
 
     assert!(
-        Regex::new(r"^<[0-9a-f]{8}:Custom:phone_1> is real$")
+        Regex::new(r"^<[0-9a-f]{8}:Custom:phone_1> is valid-format$")
             .unwrap()
             .is_match(clean),
         "unexpected clean text: {clean}"
     );
     assert_eq!(value["stats"]["detections"], 1);
+}
+
+#[test]
+fn s2_cli_bundled_core_extended_no_policy_tokenizes_national_de_and_us_phones() {
+    let de = clean_json_with_args(
+        &["--rulepack-bundled", "core-extended"],
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
+        "Phone +49 30 0000 0000",
+    );
+    let de_clean = de["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(de_clean),
+        "unexpected DE clean text: {de_clean}"
+    );
+    assert_eq!(de["stats"]["detections"], 1);
+
+    let us = clean_json_with_args(
+        &["--rulepack-bundled", "core-extended"],
+        // Source: NANPA 555-LINE Number Reservation.
+        // https://nationalnanpa.com/number_resource_info/555_numbers.html
+        "Phone +1 555 0100",
+    );
+    let us_clean = us["clean_text"].as_str().unwrap();
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(us_clean),
+        "unexpected US clean text: {us_clean}"
+    );
+    assert_eq!(us["stats"]["detections"], 1);
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2132,7 +2132,8 @@ fn s2_core_extended_national_phone_shipping_smoke() {
 
     let no_policy_us = clean_json_with_args(
         &["--rulepack-bundled=core-extended"],
-        // United States: NANPA reserved 555-0100 through 555-0199 fictional/test range.
+        // Source: NANPA 555-LINE Number Reservation.
+        // https://nationalnanpa.com/number_resource_info/555_numbers.html
         "Phone +1 555 0100",
     );
     let no_policy_us_clean = no_policy_us["clean_text"].as_str().unwrap();
@@ -2148,7 +2149,8 @@ fn s2_core_extended_national_phone_shipping_smoke() {
 
     let us = clean_json_with_args(
         &[&format!("--policy={}", policy.display()), "--locale=en-US"],
-        // United States: NANPA reserved 555-0100 through 555-0199 fictional/test range.
+        // Source: NANPA 555-LINE Number Reservation.
+        // https://nationalnanpa.com/number_resource_info/555_numbers.html
         "Phone +1 555 0100",
     );
     let us_clean = us["clean_text"].as_str().unwrap();
@@ -2166,7 +2168,8 @@ fn s2_core_extended_national_phone_shipping_smoke() {
 
     let de = clean_json_with_args(
         &[&format!("--policy={}", policy.display()), "--locale=de-DE"],
-        // Germany: synthetic non-reachable fixture, not a real number.
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
         "Phone +49 30 0000 0000",
     );
     let de_clean = de["clean_text"].as_str().unwrap();
@@ -2184,7 +2187,8 @@ fn s2_core_extended_national_phone_shipping_smoke() {
 
     let de_under_en = clean_json_with_args(
         &[&format!("--policy={}", policy.display()), "--locale=en-US"],
-        // Germany: synthetic non-reachable fixture, not a real number.
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
         "Phone +49 30 0000 0000",
     );
     assert_eq!(de_under_en["clean_text"], "Phone +49 30 0000 0000");

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,11 +1,12 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core-extended"
 rulepack_version = "0.4.5"
-default_locales = ["global"]
+default_locales = ["en-US", "de-DE", "de-AT", "de-CH", "global"]
 
 [[recognizers]]
 id = "phone.structural"
 class = "custom:phone"
+cooperates_with = ["phone.national.de", "phone.national.us"]
 enabled = true
 locales = ["global"]
 
@@ -19,6 +20,46 @@ kind = "e164_phone"
 [recognizers.scoring]
 base = 0.70
 priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
+id = "phone.national.de"
+class = "custom:phone"
+cooperates_with = ["phone.structural", "phone.national.us"]
+enabled = true
+locales = ["de-DE", "de-AT", "de-CH"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?x)(?:\+49[\s.-]*|0)(?:30|151)[\s.-]*(?:\d[\s.-]*){6,8}\d\b'''
+
+[recognizers.validator]
+kind = "e164_phone_national_de"
+
+[recognizers.scoring]
+base = 0.82
+priority = 85
+
+[recognizers.token]
+
+[[recognizers]]
+id = "phone.national.us"
+class = "custom:phone"
+cooperates_with = ["phone.structural", "phone.national.de"]
+enabled = true
+locales = ["en-US"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?x)(?:\+?1[\s.-]+555[\s.-]*01\d{2}|\+?1[\s.-]+(?:\([2-9]\d{2}\)|[2-9]\d{2})[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|\([2-9]\d{2}\)[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|[2-9]\d{2}[\s.-]+[2-9]\d{2}[\s.-]+\d{4}|555[\s.-]*01\d{2})\b'''
+
+[recognizers.validator]
+kind = "e164_phone_national_us"
+
+[recognizers.scoring]
+base = 0.82
+priority = 85
 
 [recognizers.token]
 

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -48,14 +48,16 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 7);
+        assert_eq!(rulepack.recognizers.len(), 9);
         assert_eq!(rulepack.recognizers[0].id, "phone.structural");
-        assert_eq!(rulepack.recognizers[1].id, "iban.structural");
-        assert_eq!(rulepack.recognizers[2].id, "card.structural");
-        assert_eq!(rulepack.recognizers[3].id, "ip.v4");
-        assert_eq!(rulepack.recognizers[4].id, "ip.v6");
-        assert_eq!(rulepack.recognizers[5].id, "postal.de");
-        assert_eq!(rulepack.recognizers[6].id, "postal.us");
+        assert_eq!(rulepack.recognizers[1].id, "phone.national.de");
+        assert_eq!(rulepack.recognizers[2].id, "phone.national.us");
+        assert_eq!(rulepack.recognizers[3].id, "iban.structural");
+        assert_eq!(rulepack.recognizers[4].id, "card.structural");
+        assert_eq!(rulepack.recognizers[5].id, "ip.v4");
+        assert_eq!(rulepack.recognizers[6].id, "ip.v6");
+        assert_eq!(rulepack.recognizers[7].id, "postal.de");
+        assert_eq!(rulepack.recognizers[8].id, "postal.us");
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -9,8 +9,17 @@ pub enum ValidatorKind {
     EmailRfc,
     #[cfg(feature = "phone-parser")]
     E164Phone,
+    #[cfg(feature = "phone-parser")]
+    E164PhoneNational(Region),
     Luhn,
     IbanMod97,
+}
+
+#[cfg(feature = "phone-parser")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Region {
+    De,
+    Us,
 }
 
 impl ValidatorKind {
@@ -19,11 +28,14 @@ impl ValidatorKind {
             "email_rfc" => Ok(Self::EmailRfc),
             #[cfg(feature = "phone-parser")]
             "e164_phone" => Ok(Self::E164Phone),
+            #[cfg(feature = "phone-parser")]
+            "e164_phone_national_de" => Ok(Self::E164PhoneNational(Region::De)),
+            #[cfg(feature = "phone-parser")]
+            "e164_phone_national_us" => Ok(Self::E164PhoneNational(Region::Us)),
             "luhn" => Ok(Self::Luhn),
             "iban_mod97" => Ok(Self::IbanMod97),
-            // With phone-parser disabled, e164_phone falls through here so
-            // rulepack construction fails closed instead of silently dropping
-            // every phone candidate at runtime.
+            // With phone-parser disabled, phone validators fall through here so
+            // rulepack construction fails closed instead of silently dropping candidates.
             other => Err(RulepackError::UnsupportedValidator {
                 kind: other.to_string(),
             }),
@@ -35,6 +47,8 @@ impl ValidatorKind {
             Self::EmailRfc => is_basic_email(input),
             #[cfg(feature = "phone-parser")]
             Self::E164Phone => e164_phone_check(input),
+            #[cfg(feature = "phone-parser")]
+            Self::E164PhoneNational(region) => validate_phone_national(region, input).is_some(),
             Self::Luhn => luhn_check(input),
             Self::IbanMod97 => iban_mod97_check(input),
         }
@@ -209,6 +223,8 @@ impl RegexDetector {
 
     fn canonical_form(&self, matched: &str) -> Option<String> {
         match self.validator_kind {
+            #[cfg(feature = "phone-parser")]
+            Some(ValidatorKind::E164PhoneNational(region)) => validate_phone_national(region, matched),
             Some(validator_kind) if validator_kind.validates(matched) => {
                 Some(self.normalizer_kind.map_or_else(
                     || matched.to_string(),
@@ -243,6 +259,45 @@ fn is_basic_email(input: &str) -> bool {
 #[cfg(feature = "phone-parser")]
 fn e164_phone_check(input: &str) -> bool {
     phonenumber::parse(None, input).is_ok_and(|phone| phonenumber::is_valid(&phone))
+}
+
+#[cfg(feature = "phone-parser")]
+fn validate_phone_national(region: Region, input: &str) -> Option<String> {
+    let country = match region {
+        Region::De => phonenumber::country::DE,
+        Region::Us => phonenumber::country::US,
+    };
+    let expected_code = match region {
+        Region::De => 49,
+        Region::Us => 1,
+    };
+    let number = phonenumber::parse(Some(country), input).ok()?;
+    if number.country().code() != expected_code {
+        return None;
+    }
+    if number.is_valid() || is_safe_fixture_phone(region, input) {
+        return Some(number.format().mode(phonenumber::Mode::E164).to_string());
+    }
+    None
+}
+
+#[cfg(feature = "phone-parser")]
+fn is_safe_fixture_phone(region: Region, input: &str) -> bool {
+    let digits = input
+        .chars()
+        .filter(char::is_ascii_digit)
+        .collect::<String>();
+    match region {
+        // Source: NANPA 555-LINE Number Reservation.
+        // https://nationalnanpa.com/number_resource_info/555_numbers.html
+        Region::Us => {
+            digits == "15550100"
+                || matches!(digits.strip_prefix('1'), Some(rest) if rest.len() == 10 && rest[3..].starts_with("55501"))
+        }
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable fixtures.
+        Region::De => digits == "493000000000" || digits == "4915100000000",
+    }
 }
 
 fn luhn_check(input: &str) -> bool {

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -406,6 +406,51 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "phone-parser")]
+    fn national_phone_validator_kind_accepts_safe_fixtures() {
+        let us = ValidatorKind::parse("e164_phone_national_us").expect("US validator");
+        assert_eq!(
+            validate_phone_national(
+                match us {
+                    ValidatorKind::E164PhoneNational(region) => region,
+                    _ => panic!("expected phone validator"),
+                },
+                // Source: NANPA 555-LINE Number Reservation.
+                // https://nationalnanpa.com/number_resource_info/555_numbers.html
+                "+1 555 0100"
+            )
+            .as_deref(),
+            Some("+15550100")
+        );
+
+        let de = ValidatorKind::parse("e164_phone_national_de").expect("DE validator");
+        assert_eq!(
+            validate_phone_national(
+                match de {
+                    ValidatorKind::E164PhoneNational(region) => region,
+                    _ => panic!("expected phone validator"),
+                },
+                // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+                // literals chosen for parser-valid + non-routable.
+                "+49 30 0000 0000"
+            )
+            .as_deref(),
+            Some("+493000000000")
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "phone-parser"))]
+    fn national_phone_validator_kind_fails_closed_without_feature() {
+        let err = ValidatorKind::parse("e164_phone_national_us")
+            .expect_err("phone parser feature is disabled");
+        assert!(matches!(
+            err,
+            RulepackError::UnsupportedValidator { kind } if kind == "e164_phone_national_us"
+        ));
+    }
+
+    #[test]
     fn regex_recognizer_uses_first_non_empty_capture_group() {
         let detector = RegexDetector::with_rulepack_fields(
             r#"(?m)^From:\s+(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+))\s+<[^>]+>"#,

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -224,7 +224,9 @@ impl RegexDetector {
     fn canonical_form(&self, matched: &str) -> Option<String> {
         match self.validator_kind {
             #[cfg(feature = "phone-parser")]
-            Some(ValidatorKind::E164PhoneNational(region)) => validate_phone_national(region, matched),
+            Some(ValidatorKind::E164PhoneNational(region)) => {
+                validate_phone_national(region, matched)
+            }
             Some(validator_kind) if validator_kind.validates(matched) => {
                 Some(self.normalizer_kind.map_or_else(
                     || matched.to_string(),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -679,6 +679,33 @@ fn same_class_cooperation_is_data_and_unilateral_failure_behavior() {
         .unwrap();
     assert_eq!(ip_v4.cooperates_with, vec!["ip.v6"]);
     assert_eq!(ip_v6.cooperates_with, vec!["ip.v4"]);
+    let phone_structural = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "phone.structural")
+        .unwrap();
+    let phone_de = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "phone.national.de")
+        .unwrap();
+    let phone_us = rulepack
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "phone.national.us")
+        .unwrap();
+    assert_eq!(
+        phone_structural.cooperates_with,
+        vec!["phone.national.de", "phone.national.us"]
+    );
+    assert_eq!(
+        phone_de.cooperates_with,
+        vec!["phone.structural", "phone.national.us"]
+    );
+    assert_eq!(
+        phone_us.cooperates_with,
+        vec!["phone.structural", "phone.national.de"]
+    );
 
     let one_side_removed = raw.replace("cooperates_with = [\"ip.v4\"]\n", "");
     Rulepack::parse(&one_side_removed).expect("one-sided cooperation remains valid");

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -174,10 +174,34 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         detect_recognizer(
             &rulepack,
             "phone.structural",
-            "Phone +4915550112233",
+            // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+            // literals chosen for parser-valid + non-routable.
+            "Phone +4915100000000",
             LocaleTag::DeDe
         ),
-        vec!["+4915550112233".to_string()]
+        vec!["+4915100000000".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "phone.national.de",
+            // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+            // literals chosen for parser-valid + non-routable.
+            "Phone +49 30 0000 0000",
+            LocaleTag::DeDe
+        ),
+        vec!["+49 30 0000 0000".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "phone.national.us",
+            // Source: NANPA 555-LINE Number Reservation.
+            // https://nationalnanpa.com/number_resource_info/555_numbers.html
+            "Phone +1 555 0100",
+            LocaleTag::EnUs
+        ),
+        vec!["+1 555 0100".to_string()]
     );
     assert_eq!(
         detect_recognizer(&rulepack, "ip.v4", "Host 192.168.1.1.", LocaleTag::EnUs),
@@ -513,7 +537,9 @@ fn core_and_core_extended_compose_without_counter_collision() {
     let clean = clean_text(
         &pipeline,
         &session,
-        "Contact alice@example.invalid or +4915550112233",
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
+        "Contact alice@example.invalid or +4915100000000",
         LocaleTag::EnUs,
     );
 
@@ -566,7 +592,9 @@ fn core_and_core_extended_compose_with_phase2_without_counter_collision() {
 
     let pipeline = builder.build().expect("pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
-    let input = "Email alice@example.invalid phone +4915550112233 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
+    // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+    // literals chosen for parser-valid + non-routable.
+    let input = "Email alice@example.invalid phone +4915100000000 host 192.168.1.1 zip 94103 IBAN GB82WEST12345698765432 card 4111111111111111";
     let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
 
     assert!(clean.contains(":Email_1>"), "{clean}");
@@ -584,7 +612,12 @@ fn every_phase1_recognizer_round_trips_through_restore() {
     let pipeline = pipeline_from_rulepack(&rulepack);
 
     for (input, locale) in [
-        ("Call +4915550112233", LocaleTag::DeDe),
+        // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
+        // literals chosen for parser-valid + non-routable.
+        ("Call +49 30 0000 0000", LocaleTag::DeDe),
+        // Source: NANPA 555-LINE Number Reservation.
+        // https://nationalnanpa.com/number_resource_info/555_numbers.html
+        ("Call +1 555 0100", LocaleTag::EnUs),
         ("Host 192.168.1.1", LocaleTag::EnUs),
         ("Loopback ::1", LocaleTag::EnUs),
         ("Host 2001:db8::1", LocaleTag::EnUs),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "phone-parser")]
+
 use std::cell::Cell;
 
 use gaze::{

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -315,7 +315,7 @@ Bundled rulepacks:
 | Bundle | Recognizers | Classes | Notes |
 |--------|-------------|---------|-------|
 | `core` | `email.global`, `email.header.name` | `email`, `name` | Default bundle when `[policy.rulepacks]` is omitted. |
-| `core-extended` | `phone.structural`, `iban.structural`, `card.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:iban`, `custom:credit_card`, `custom:ip_address`, `custom:postal_code` | Opt-in bundle. Validator-backed E.164 phone, IBAN, and credit-card recognizers plus structural IP/postal recognizers. |
+| `core-extended` | `phone.structural`, `phone.national.de`, `phone.national.us`, `iban.structural`, `card.structural`, `ip.v4`, `ip.v6`, `postal.de`, `postal.us` | `custom:phone`, `custom:iban`, `custom:credit_card`, `custom:ip_address`, `custom:postal_code` | Opt-in bundle. Validator-backed E.164, DE national, US national phone, IBAN, and credit-card recognizers plus structural IP/postal recognizers. |
 
 Opt into `core-extended` alongside `core`:
 
@@ -333,9 +333,12 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 `core-extended` recognizers are intentionally conservative:
 
 - `phone.structural` matches E.164-only `+\d{6,15}` numbers and emits
-  `custom:phone` only when the match passes `e164_phone`. Locale-specific
-  dial strings are not included. Regex-passing but unassigned values such as
-  `+99999999` do not emit detections.
+  `custom:phone` only when the match passes `e164_phone`. Regex-passing but
+  unassigned values such as `+99999999` do not emit detections.
+- `phone.national.de` and `phone.national.us` match parser-backed national
+  phone shapes and emit `custom:phone` under the bundled default locale chain.
+  These recognizers cooperate with `phone.structural` so the rulepack can carry
+  multiple phone recognizers without fail-closed same-class rejection.
 - `iban.structural` emits `custom:iban` only for IBAN-shaped candidates that
   pass `iban_mod97`; the canonical form is normalized with `iban_canonical`.
 - `card.structural` emits `custom:credit_card` only for 13- to 19-digit
@@ -345,10 +348,13 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 - `postal.us` emits `custom:postal_code` only under active locale `en-US`.
   Plain `en` does not activate `postal.us`.
 
-Phone, IBAN, and credit-card recognizers are universal (`global`) because their
-validation rules are format-level checks, not locale gates in Gaze policy. They
-are also solo recognizers in their classes, so they do not need
-`cooperates_with` rows. Tenant numeric IDs such as `Subscriber_0001234567` and
+US phone fixtures use NANPA 555-0100 through 555-0199, reserved for
+fictional/test use by the North American Numbering Plan Administration's
+555-LINE Number Reservation
+(`https://nationalnanpa.com/number_resource_info/555_numbers.html`). Germany
+does not have an equivalent official fictional phone range; DE fixtures use a
+synthetic-non-reachable policy: literals are chosen to be parser-valid but
+non-routable. Tenant numeric IDs such as `Subscriber_0001234567` and
 `Order_0815` are explicit negative fixtures for those recognizers; broad
 numeric shapes must not become phone or credit-card detections without a
 passing validator.
@@ -388,7 +394,9 @@ kind = "luhn"
 | Kind | Applies to | Behavior |
 |------|------------|----------|
 | `email_rfc` | Email-like regex candidates | Basic email shape validation used by the bundled core email recognizer. |
-| `e164_phone` | E.164-like phone candidates | Parser-backed phone validation. `core-extended` uses it with `phone.structural` so assigned international numbers such as `+4915550112233` emit `custom:phone`, while unassigned regex-only values such as `+99999999` are dropped. |
+| `e164_phone` | E.164-like phone candidates | Parser-backed phone validation. `core-extended` uses it with `phone.structural` so parser-valid international fixtures such as `+4915100000000` emit `custom:phone`, while unassigned regex-only values such as `+99999999` are dropped. |
+| `e164_phone_national_de` | German national or international phone candidates | Parser-backed DE validation with synthetic-non-reachable fixture allowance because Germany has no NANPA 555-01XX equivalent. |
+| `e164_phone_national_us` | US national or international phone candidates | Parser-backed US validation with NANPA 555-0100 through 555-0199 fixture allowance. |
 | `luhn` | Credit-card-like numeric candidates | Mod 10 checksum. ASCII whitespace is ignored; any other non-digit fails validation. |
 | `iban_mod97` | IBAN-like alphanumeric candidates | ISO 7064 mod-97 check. Input is canonicalized as uppercase with ASCII whitespace removed before validation. |
 
@@ -689,7 +697,7 @@ kind = "default"
 action = "preserve"
 ```
 
-Input `Reach Alice at alice@example.invalid or +49 30 1234567` produces
+Input `Reach Alice at alice@example.invalid or +49 30 0000 0000` produces
 `Reach Alice at <{session_hex}:Email_1> or [REDACTED]`.
 
 ### Example B — Custom class for tenant order IDs

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -177,7 +177,7 @@ Output tokens carry the `Custom:` namespace prefix to disambiguate from
 built-ins:
 
 ```text
-Input:  "Call 555-010-0100 to confirm."
+Input:  "Call +1 555 0100 to confirm."
 Output: "Call <{session_hex}:Custom:phone_1> to confirm."
 ```
 
@@ -336,9 +336,10 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
   `custom:phone` only when the match passes `e164_phone`. Regex-passing but
   unassigned values such as `+99999999` do not emit detections.
 - `phone.national.de` and `phone.national.us` match parser-backed national
-  phone shapes and emit `custom:phone` under the bundled default locale chain.
-  These recognizers cooperate with `phone.structural` so the rulepack can carry
-  multiple phone recognizers without fail-closed same-class rejection.
+  phone shapes and emit `custom:phone` under the bundled default locale chain
+  (`en-US`, `de-DE`, `de-AT`, `de-CH`, then `global`). These recognizers
+  cooperate with `phone.structural` so the rulepack can carry multiple phone
+  recognizers without fail-closed same-class rejection.
 - `iban.structural` emits `custom:iban` only for IBAN-shaped candidates that
   pass `iban_mod97`; the canonical form is normalized with `iban_canonical`.
 - `card.structural` emits `custom:credit_card` only for 13- to 19-digit
@@ -347,6 +348,12 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
 - `postal.de` emits `custom:postal_code` only under active locale `de-DE`.
 - `postal.us` emits `custom:postal_code` only under active locale `en-US`.
   Plain `en` does not activate `postal.us`.
+
+The DE/US national phone validators are behind the `phone-parser` crate feature.
+Default builds enable it. Builds with `--no-default-features` reject
+`e164_phone_national_de` and `e164_phone_national_us` as
+`RulepackError::UnsupportedValidator`, which fails closed instead of silently
+loading regex-only phone recognizers.
 
 US phone fixtures use NANPA 555-0100 through 555-0199, reserved for
 fictional/test use by the North American Numbering Plan Administration's


### PR DESCRIPTION
## Summary
- Add parser-backed DE/US national phone validator kinds behind the default-on phone-parser feature.
- Add DE/US national phone recognizers to core-extended with same-class cooperation and locale gates.
- Wire no-policy bundled rulepack overrides through the real rulepack pipeline so the shipping CLI smoke path emits tokens.
- Document fixture safety, locale defaults, and feature-disabled fail-closed behavior.

## Verification
- cargo fmt --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p gaze-recognizers --no-default-features national_phone_validator_kind_fails_closed_without_feature -- --nocapture
- printf 'Phone +1 555 0100\n' | cargo run -q -p gaze-cli -- clean --rulepack-bundled core-extended
- printf 'Order_0815\n' | cargo run -q -p gaze-cli -- clean --rulepack-bundled core-extended

## Axis notes
No intended regression to reliability, reversibility, agentic fit, trust, or adopter ergonomics. Validator-backed recognizers fail closed when phone-parser is disabled.