### PR TITLE
v0.4.5 S3: audit retention manual purge + audit_metadata_only xtask gate

### DIFF
--- a/.github/workflows/audit-metadata-only.yml
+++ b/.github/workflows/audit-metadata-only.yml
@@ -1,0 +1,14 @@
+name: audit-metadata-only
+
+on:
+  pull_request:
+
+jobs:
+  audit-metadata-only:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run audit_metadata_only gate
+        run: cargo run -p xtask -- audit-metadata-only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,6 +4755,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "syn",
  "tempfile",
 ]
 

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -20,9 +20,22 @@ pub(crate) struct Args {
     pub(crate) session_id: Option<String>,
 }
 
+pub(crate) struct PurgeArgs {
+    pub(crate) audit_db: PathBuf,
+    pub(crate) before: String,
+    pub(crate) dry_run: bool,
+}
+
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExportFormat {
     Jsonl,
+}
+
+#[derive(Serialize)]
+struct PurgeResponse {
+    dry_run: bool,
+    matched: usize,
+    deleted: usize,
 }
 
 pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
@@ -61,6 +74,29 @@ pub(crate) fn export(
     }
 }
 
+pub(crate) fn purge(args: PurgeArgs) -> std::result::Result<(), CliError> {
+    let before = parse_iso8601_utc_epoch_ms(&args.before)?;
+    let logger = SqliteLogger::new(&args.audit_db).map_err(|_| CliError::Pipeline)?;
+    let matched = logger
+        .count_before(before)
+        .map_err(|_| CliError::Pipeline)?;
+    let deleted = if args.dry_run {
+        0
+    } else {
+        logger
+            .purge_before(before)
+            .map_err(|_| CliError::Pipeline)?
+    };
+    let json = serde_json::to_string(&PurgeResponse {
+        dry_run: args.dry_run,
+        matched,
+        deleted,
+    })
+    .map_err(|_| CliError::Pipeline)?;
+    println!("{json}");
+    Ok(())
+}
+
 fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
     // Keep CLI flag parse rejection identical to any future TOML audit-filter
     // default surface: invalid timestamps are PolicyConfig/exit 2, never clap.
@@ -90,6 +126,19 @@ fn parse_iso8601_epoch_ms(value: Option<&str>) -> std::result::Result<Option<i64
                 })
         })
         .transpose()
+}
+
+fn parse_iso8601_utc_epoch_ms(input: &str) -> std::result::Result<i64, CliError> {
+    if input.is_empty() || !input.ends_with('Z') || !input.contains('T') || input.contains('t') {
+        return Err(CliError::AuditPurgeIso8601 {
+            input: input.to_string(),
+        });
+    }
+    DateTime::parse_from_rfc3339(input)
+        .map(|datetime| datetime.timestamp_millis())
+        .map_err(|_| CliError::AuditPurgeIso8601 {
+            input: input.to_string(),
+        })
 }
 
 fn write_jsonl(

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -77,7 +77,7 @@ enum Cmd {
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
     },
-    /// Query or export redaction-log metadata without reading raw PII payloads.
+    /// Query, export, or maintain redaction-log metadata without reading raw PII payloads.
     Audit {
         #[command(subcommand)]
         command: AuditCmd,
@@ -145,6 +145,18 @@ enum AuditCmd {
         /// Filter by opaque audit session id.
         #[arg(long = "session")]
         session_id: Option<String>,
+    },
+    /// Purge audit metadata rows older than an ISO 8601 UTC timestamp.
+    Purge {
+        /// SQLite redaction-log database path.
+        #[arg(long)]
+        audit_db: PathBuf,
+        /// Purge rows where created_at is before this ISO 8601 UTC timestamp.
+        #[arg(long)]
+        before: String,
+        /// Count matching rows without deleting them.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -233,6 +245,15 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 format,
                 output,
             ),
+            AuditCmd::Purge {
+                audit_db,
+                before,
+                dry_run,
+            } => audit::purge(audit::PurgeArgs {
+                audit_db,
+                before,
+                dry_run,
+            }),
         },
     }
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -155,7 +155,7 @@ enum AuditCmd {
         #[arg(long)]
         before: String,
         /// Count matching rows without deleting them.
-        #[arg(long)]
+        #[arg(long, alias = "count")]
         dry_run: bool,
     },
 }

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -12,6 +12,7 @@ pub(crate) enum CliError {
     InvalidEncoding,
     PolicyConfig,
     PolicyConfigDetail(String),
+    AuditPurgeIso8601 { input: String },
     UnknownToken { token: String },
     InvalidSignature,
     InvalidBlobVersion,
@@ -25,7 +26,7 @@ impl CliError {
     pub(crate) fn exit_code(&self) -> u8 {
         match self {
             Self::StdinParse | Self::EmptyInput | Self::InputTooLarge | Self::InvalidEncoding => 1,
-            Self::PolicyConfig | Self::PolicyConfigDetail(_) => 2,
+            Self::PolicyConfig | Self::PolicyConfigDetail(_) | Self::AuditPurgeIso8601 { .. } => 2,
             Self::UnknownToken { .. }
             | Self::InvalidSignature
             | Self::InvalidBlobVersion
@@ -42,6 +43,7 @@ impl CliError {
             Self::InputTooLarge => "InputTooLarge",
             Self::InvalidEncoding => "InvalidEncoding",
             Self::PolicyConfig | Self::PolicyConfigDetail(_) => "PolicyConfig",
+            Self::AuditPurgeIso8601 { .. } => "AuditPurgeIso8601",
             Self::UnknownToken { .. } => "UnknownToken",
             Self::InvalidSignature => "InvalidSignature",
             Self::InvalidBlobVersion => "InvalidBlobVersion",
@@ -62,6 +64,16 @@ impl CliError {
                     self.variant_name(),
                     self.exit_code(),
                     detail
+                )
+            }
+            Self::AuditPurgeIso8601 { input } => {
+                let input = serde_json::to_string(input)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"input":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    input
                 )
             }
             Self::UnknownToken { token } => {

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -12,7 +12,7 @@ use assert_cmd::Command;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use regex::Regex;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 use serde_json::{json, Value};
 use tempfile::tempdir;
 
@@ -1655,6 +1655,144 @@ fn assert_no_raw_audit_pii(bytes: &[u8]) {
             String::from_utf8_lossy(raw)
         );
     }
+}
+
+#[test]
+fn t23_audit_purge_counts_deletes_and_restore_still_round_trips() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+
+    let v = clean_json_with_args(
+        &[&format!("--audit-db={}", audit_path.display())],
+        "Email alice@example.invalid and bob@example.invalid.",
+    );
+    assert_eq!(v["stats"]["detections"], 2);
+    let clean = v["clean_text"].as_str().unwrap();
+    let blob = v["session_blob"].as_str().unwrap();
+    assert_audit_db_has_no_raw_fixture_values(&audit_path);
+
+    let conn = Connection::open(&audit_path).unwrap();
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(total, 2);
+    conn.execute(
+        "UPDATE redaction_log SET created_at = ?1 WHERE rowid = (SELECT rowid FROM redaction_log ORDER BY rowid LIMIT 1)",
+        params![1_767_225_600_000_i64],
+    )
+    .unwrap();
+    conn.execute(
+        "UPDATE redaction_log SET created_at = ?1 WHERE rowid = (SELECT rowid FROM redaction_log ORDER BY rowid LIMIT 1 OFFSET 1)",
+        params![1_772_323_200_000_i64],
+    )
+    .unwrap();
+    drop(conn);
+
+    let dry_run = Command::cargo_bin("gaze")
+        .unwrap()
+        .arg("audit")
+        .arg("purge")
+        .arg(format!("--audit-db={}", audit_path.display()))
+        .arg("--before=2026-02-01T00:00:00Z")
+        .arg("--dry-run")
+        .output()
+        .unwrap();
+    assert!(
+        dry_run.status.success(),
+        "dry-run failed: {}",
+        String::from_utf8_lossy(&dry_run.stderr)
+    );
+    assert!(dry_run.stderr.is_empty());
+    let dry_run_json: Value = serde_json::from_slice(&dry_run.stdout).unwrap();
+    assert_eq!(
+        dry_run_json,
+        json!({ "dry_run": true, "matched": 1, "deleted": 0 })
+    );
+
+    let conn = Connection::open(&audit_path).unwrap();
+    let total_after_dry_run: i64 = conn
+        .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(total_after_dry_run, 2);
+    drop(conn);
+
+    let purge = Command::cargo_bin("gaze")
+        .unwrap()
+        .arg("audit")
+        .arg("purge")
+        .arg(format!("--audit-db={}", audit_path.display()))
+        .arg("--before=2026-02-01T00:00:00Z")
+        .output()
+        .unwrap();
+    assert!(
+        purge.status.success(),
+        "purge failed: {}",
+        String::from_utf8_lossy(&purge.stderr)
+    );
+    assert!(purge.stderr.is_empty());
+    let purge_json: Value = serde_json::from_slice(&purge.stdout).unwrap();
+    assert_eq!(
+        purge_json,
+        json!({ "dry_run": false, "matched": 1, "deleted": 1 })
+    );
+
+    let conn = Connection::open(&audit_path).unwrap();
+    let remaining: i64 = conn
+        .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(remaining, 1);
+    let remaining_created_at: i64 = conn
+        .query_row(
+            "SELECT created_at FROM redaction_log ORDER BY rowid",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(remaining_created_at, 1_772_323_200_000_i64);
+    drop(conn);
+    assert_audit_db_has_no_raw_fixture_values(&audit_path);
+
+    let restored = restore_success_text(blob, clean);
+    assert_eq!(
+        restored,
+        "Email alice@example.invalid and bob@example.invalid."
+    );
+}
+
+fn assert_audit_db_has_no_raw_fixture_values(path: &std::path::Path) {
+    let bytes = fs::read(path).unwrap();
+    for raw in [
+        b"alice@example.invalid".as_slice(),
+        b"bob@example.invalid".as_slice(),
+    ] {
+        assert!(
+            !bytes.windows(raw.len()).any(|window| window == raw),
+            "FAIL: raw fixture value '{}' found in audit DB bytes",
+            String::from_utf8_lossy(raw)
+        );
+    }
+}
+
+#[test]
+fn t23_audit_purge_rejects_non_iso8601_before_with_quoted_input() {
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .arg("audit")
+        .arg("purge")
+        .arg(format!("--audit-db={}", audit_path.display()))
+        .arg("--before=not-iso8601")
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty());
+    let stderr = parse_stderr_variant(&out.stderr);
+    assert_eq!(
+        stderr,
+        json!({ "error": "AuditPurgeIso8601", "exit": 2, "input": "not-iso8601" })
+    );
 }
 
 #[test]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1716,6 +1716,31 @@ fn t23_audit_purge_counts_deletes_and_restore_still_round_trips() {
     assert_eq!(total_after_dry_run, 2);
     drop(conn);
 
+    let count = Command::cargo_bin("gaze")
+        .unwrap()
+        .arg("audit")
+        .arg("purge")
+        .arg(format!("--audit-db={}", audit_path.display()))
+        .arg("--before=2026-02-01T00:00:00Z")
+        .arg("--count")
+        .output()
+        .unwrap();
+    assert!(
+        count.status.success(),
+        "--count failed: {}",
+        String::from_utf8_lossy(&count.stderr)
+    );
+    assert!(count.stderr.is_empty());
+    let count_json: Value = serde_json::from_slice(&count.stdout).unwrap();
+    assert_eq!(count_json, dry_run_json);
+
+    let conn = Connection::open(&audit_path).unwrap();
+    let total_after_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(total_after_count, 2);
+    drop(conn);
+
     let purge = Command::cargo_bin("gaze")
         .unwrap()
         .arg("audit")
@@ -1777,22 +1802,33 @@ fn assert_audit_db_has_no_raw_fixture_values(path: &std::path::Path) {
 fn t23_audit_purge_rejects_non_iso8601_before_with_quoted_input() {
     let dir = tempdir().unwrap();
     let audit_path = dir.path().join("audit.sqlite");
-    let out = Command::cargo_bin("gaze")
-        .unwrap()
-        .arg("audit")
-        .arg("purge")
-        .arg(format!("--audit-db={}", audit_path.display()))
-        .arg("--before=not-iso8601")
-        .output()
-        .unwrap();
+    for invalid in [
+        "not-iso8601",
+        "2026-02-31T00:00:00Z",
+        "2025-04-31T00:00:00Z",
+        "2026-13-01T00:00:00Z",
+        "2026-02-01t00:00:00Z",
+        "2026-02-01T00:00:00+01:00",
+        "",
+    ] {
+        let out = Command::cargo_bin("gaze")
+            .unwrap()
+            .arg("audit")
+            .arg("purge")
+            .arg(format!("--audit-db={}", audit_path.display()))
+            .arg(format!("--before={invalid}"))
+            .output()
+            .unwrap();
 
-    assert_eq!(out.status.code(), Some(2));
-    assert!(out.stdout.is_empty());
-    let stderr = parse_stderr_variant(&out.stderr);
-    assert_eq!(
-        stderr,
-        json!({ "error": "AuditPurgeIso8601", "exit": 2, "input": "not-iso8601" })
-    );
+        assert_eq!(out.status.code(), Some(2), "invalid input: {invalid}");
+        assert!(out.stdout.is_empty());
+        let stderr = parse_stderr_variant(&out.stderr);
+        assert_eq!(
+            stderr,
+            json!({ "error": "AuditPurgeIso8601", "exit": 2, "input": invalid }),
+            "invalid input: {invalid}"
+        );
+    }
 }
 
 #[test]

--- a/crates/gaze/src/redaction_log.rs
+++ b/crates/gaze/src/redaction_log.rs
@@ -234,6 +234,35 @@ impl SqliteLogger {
         }
         Ok(entries)
     }
+
+    pub fn count_before(&self, before_epoch_ms: i64) -> Result<usize> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM redaction_log WHERE created_at < ?1",
+                params![before_epoch_ms],
+                |row| row.get(0),
+            )
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        Ok(count as usize)
+    }
+
+    pub fn purge_before(&self, before_epoch_ms: i64) -> Result<usize> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Sqlite("sqlite mutex poisoned".to_string()))?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM redaction_log WHERE created_at < ?1",
+                params![before_epoch_ms],
+            )
+            .map_err(|err| crate::Error::Sqlite(err.to_string()))?;
+        Ok(deleted)
+    }
 }
 
 impl RedactionLogger for SqliteLogger {

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -534,10 +534,12 @@ fn sqlite_logger_migrates_legacy_tables_and_purges_by_created_at() {
             document_kind: gaze::DocumentKind::Text,
             conflict_loser: false,
             decided_by: gaze::ConflictTier::None,
+            created_at: 1_767_225_600_000,
+            session_id: None,
         })
         .expect("log entry");
 
-    assert_eq!(logger.count_before("2100-01-01T00:00:00Z").unwrap(), 1);
-    assert_eq!(logger.purge_before("2100-01-01T00:00:00Z").unwrap(), 1);
+    assert_eq!(logger.count_before(4_102_444_800_000).unwrap(), 1);
+    assert_eq!(logger.purge_before(4_102_444_800_000).unwrap(), 1);
     assert_eq!(logger.entries().unwrap().len(), 0);
 }

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -9,6 +9,7 @@ use gaze::{
     Session, SqliteLogger, UntrustedExecRequest, ValidatedExecRequest, Value,
 };
 use gaze_recognizers::RegexDetector;
+use rusqlite::Connection;
 
 #[test]
 fn pipeline_is_clone_send_and_sync() {
@@ -500,4 +501,43 @@ fn sqlite_logger_persists_entries() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].source, "regex");
     assert_eq!(rows[0].field_name.as_deref(), Some("email"));
+}
+
+#[test]
+fn sqlite_logger_migrates_legacy_tables_and_purges_by_created_at() {
+    let temp = tempfile::NamedTempFile::new().expect("temp db");
+    {
+        let conn = Connection::open(temp.path()).expect("legacy sqlite");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE redaction_log (
+                source TEXT NOT NULL,
+                class TEXT NOT NULL,
+                action TEXT NOT NULL,
+                field_name TEXT NULL,
+                document_kind TEXT NOT NULL,
+                conflict_loser INTEGER NOT NULL,
+                decided_by TEXT NOT NULL DEFAULT 'none'
+            );
+            "#,
+        )
+        .expect("legacy schema");
+    }
+
+    let logger = SqliteLogger::new(temp.path()).expect("migrated sqlite logger");
+    logger
+        .log(&RedactionEntry {
+            source: "regex".to_string(),
+            class: PiiClass::Email,
+            action: Action::Tokenize,
+            field_name: None,
+            document_kind: gaze::DocumentKind::Text,
+            conflict_loser: false,
+            decided_by: gaze::ConflictTier::None,
+        })
+        .expect("log entry");
+
+    assert_eq!(logger.count_before("2100-01-01T00:00:00Z").unwrap(), 1);
+    assert_eq!(logger.purge_before("2100-01-01T00:00:00Z").unwrap(), 1);
+    assert_eq!(logger.entries().unwrap().len(), 0);
 }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -205,6 +205,7 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
 }
 
 const RESTORE_AUDIT_FORBIDDEN_SYMBOLS: &[&str] = &[
+    "__renamed_gaze_root__",
     "redaction_log",
     "ConflictTier",
     "DocumentKind",
@@ -293,6 +294,13 @@ fn collect_use_tree_names_with_root(
         syn::UseTree::Rename(rename) => {
             names.push(rename.ident.to_string());
             names.push(rename.rename.to_string());
+            let root = current_root.unwrap_or_else(|| use_tree_root(&rename.ident));
+            if matches!(
+                root,
+                UseTreeRoot::Crate | UseTreeRoot::Gaze | UseTreeRoot::GazeCli
+            ) {
+                names.push("__renamed_gaze_root__".to_string());
+            }
         }
         syn::UseTree::Glob(_) => {
             if matches!(

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -204,8 +204,10 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
     Ok(())
 }
 
+const RESTORE_AUDIT_RENAMED_ROOT_MARKER: &str = "__renamed_gaze_root__";
+
 const RESTORE_AUDIT_FORBIDDEN_SYMBOLS: &[&str] = &[
-    "__renamed_gaze_root__",
+    RESTORE_AUDIT_RENAMED_ROOT_MARKER,
     "redaction_log",
     "ConflictTier",
     "DocumentKind",
@@ -299,7 +301,7 @@ fn collect_use_tree_names_with_root(
                 root,
                 UseTreeRoot::Crate | UseTreeRoot::Gaze | UseTreeRoot::GazeCli
             ) {
-                names.push("__renamed_gaze_root__".to_string());
+                names.push(RESTORE_AUDIT_RENAMED_ROOT_MARKER.to_string());
             }
         }
         syn::UseTree::Glob(_) => {
@@ -310,6 +312,7 @@ fn collect_use_tree_names_with_root(
                 names.extend(
                     RESTORE_AUDIT_FORBIDDEN_SYMBOLS
                         .iter()
+                        .filter(|symbol| **symbol != RESTORE_AUDIT_RENAMED_ROOT_MARKER)
                         .map(|symbol| (*symbol).to_string()),
                 );
             } else {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
 use anyhow::{bail, Context, Result};
@@ -18,6 +20,7 @@ enum Command {
     ClassMapOverrideSafety,
     RecognizerCompositionValidator,
     NoTenantKnowledge,
+    AuditMetadataOnly,
 }
 
 fn main() -> Result<()> {
@@ -27,6 +30,7 @@ fn main() -> Result<()> {
         Command::ClassMapOverrideSafety => run_class_map_override_safety_gate(),
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NoTenantKnowledge => no_tenant_knowledge::run(),
+        Command::AuditMetadataOnly => run_audit_metadata_only_gate(),
     }
 }
 
@@ -197,6 +201,109 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
         run_behavioral_test("recognizer_composition_validator", *test)?;
     }
     println!("recognizer_composition_validator: passed");
+    Ok(())
+}
+
+const RESTORE_AUDIT_FORBIDDEN_SYMBOLS: &[&str] = &[
+    "redaction_log",
+    "ConflictTier",
+    "DocumentKind",
+    "RedactionEntry",
+    "RedactionLogger",
+    "SqliteLogger",
+    // Extend denylist on each new audit export.
+    "AuditFilter",
+    "AuditLogRow",
+    "AUDIT_RESTRICTED_COLUMNS",
+    "build_audit_query_sql",
+    "current_epoch_ms",
+];
+
+fn run_audit_metadata_only_gate() -> Result<()> {
+    let root = std::env::current_dir().context("failed to resolve current directory")?;
+    let restore_files = restore_files(&root)?;
+    println!(
+        "audit_metadata_only: scanning {} restore files",
+        restore_files.len()
+    );
+    for path in restore_files {
+        let source = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let parsed = syn::parse_file(&source)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        reject_forbidden_use_imports(&path, &parsed)?;
+    }
+    println!("audit_metadata_only: passed");
+    Ok(())
+}
+
+fn reject_forbidden_use_imports(path: &Path, file: &syn::File) -> Result<()> {
+    for item in &file.items {
+        if let syn::Item::Use(item_use) = item {
+            let mut imported = Vec::new();
+            collect_use_tree_names(&item_use.tree, &mut imported);
+            if let Some(symbol) = RESTORE_AUDIT_FORBIDDEN_SYMBOLS
+                .iter()
+                .find(|symbol| imported.iter().any(|name| name == **symbol))
+            {
+                bail!(
+                    "audit metadata import in restore path: {} imports {}",
+                    path.display(),
+                    symbol
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_use_tree_names(tree: &syn::UseTree, names: &mut Vec<String>) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            names.push(path.ident.to_string());
+            collect_use_tree_names(&path.tree, names);
+        }
+        syn::UseTree::Name(name) => names.push(name.ident.to_string()),
+        syn::UseTree::Rename(rename) => {
+            names.push(rename.ident.to_string());
+            names.push(rename.rename.to_string());
+        }
+        syn::UseTree::Glob(_) => names.push("*".to_string()),
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_tree_names(item, names);
+            }
+        }
+    }
+}
+
+fn restore_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let cli_restore = root.join("crates/gaze-cli/src/restore");
+    if cli_restore.exists() {
+        collect_rs_files(&cli_restore, &mut files)?;
+    }
+    let core_restore = root.join("crates/gaze/src/restore.rs");
+    if core_restore.exists() {
+        files.push(core_restore);
+    }
+    if files.is_empty() {
+        bail!("audit_metadata_only found no restore files to scan");
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, files)?;
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+            files.push(path);
+        }
+    }
     Ok(())
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
@@ -254,27 +255,466 @@ fn reject_forbidden_use_imports(path: &Path, file: &syn::File) -> Result<()> {
 
 fn walk_items(items: &[syn::Item], path: &Path) -> Result<()> {
     for item in items {
-        if let syn::Item::Use(item_use) = item {
-            let mut imported = Vec::new();
-            collect_use_tree_names(&item_use.tree, &mut imported);
-            if let Some(symbol) = RESTORE_AUDIT_FORBIDDEN_SYMBOLS
-                .iter()
-                .find(|symbol| imported.iter().any(|name| name == **symbol))
-            {
-                bail!(
-                    "audit metadata import in restore path: {} imports {}",
-                    path.display(),
-                    symbol
-                );
+        match item {
+            syn::Item::Use(item_use) => check_use(item_use, path)?,
+            syn::Item::ExternCrate(extern_crate) => {
+                if matches!(extern_crate.ident.to_string().as_str(), "gaze" | "gaze_cli") {
+                    bail!(
+                        "audit metadata import in restore path: {} imports {}",
+                        path.display(),
+                        RESTORE_AUDIT_RENAMED_ROOT_MARKER
+                    );
+                }
             }
-        }
-        if let syn::Item::Mod(item_mod) = item {
-            if let Some((_, items)) = &item_mod.content {
-                walk_items(items, path)?;
+            syn::Item::Mod(item_mod) => {
+                if let Some((_, items)) = &item_mod.content {
+                    walk_items(items, path)?;
+                }
             }
+            syn::Item::Fn(item_fn) => walk_block_stmts(&item_fn.block, path)?,
+            syn::Item::Impl(item_impl) => {
+                for item in &item_impl.items {
+                    match item {
+                        syn::ImplItem::Const(item_const) => walk_expr(&item_const.expr, path)?,
+                        syn::ImplItem::Fn(item_fn) => walk_block_stmts(&item_fn.block, path)?,
+                        _ => {}
+                    }
+                }
+            }
+            syn::Item::Trait(item_trait) => {
+                for item in &item_trait.items {
+                    match item {
+                        syn::TraitItem::Const(item_const) => {
+                            if let Some((_, expr)) = &item_const.default {
+                                walk_expr(expr, path)?;
+                            }
+                        }
+                        syn::TraitItem::Fn(item_fn) => {
+                            if let Some(block) = &item_fn.default {
+                                walk_block_stmts(block, path)?;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            syn::Item::Const(item_const) => walk_expr(&item_const.expr, path)?,
+            syn::Item::Static(item_static) => walk_expr(&item_static.expr, path)?,
+            _ => {}
         }
     }
     Ok(())
+}
+
+fn walk_block_stmts(block: &syn::Block, path: &Path) -> Result<()> {
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Item(item) => walk_items(std::slice::from_ref(item), path)?,
+            syn::Stmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    walk_expr(&init.expr, path)?;
+                }
+            }
+            syn::Stmt::Expr(expr, _) => walk_expr(expr, path)?,
+            syn::Stmt::Macro(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn walk_expr(expr: &syn::Expr, path: &Path) -> Result<()> {
+    match expr {
+        syn::Expr::Array(expr) => {
+            for item in &expr.elems {
+                walk_expr(item, path)?;
+            }
+        }
+        syn::Expr::Assign(expr) => {
+            walk_expr(&expr.left, path)?;
+            walk_expr(&expr.right, path)?;
+        }
+        syn::Expr::Async(expr) => walk_block_stmts(&expr.block, path)?,
+        syn::Expr::Await(expr) => walk_expr(&expr.base, path)?,
+        syn::Expr::Binary(expr) => {
+            walk_expr(&expr.left, path)?;
+            walk_expr(&expr.right, path)?;
+        }
+        syn::Expr::Block(expr) => walk_block_stmts(&expr.block, path)?,
+        syn::Expr::Break(expr) => {
+            if let Some(value) = &expr.expr {
+                walk_expr(value, path)?;
+            }
+        }
+        syn::Expr::Call(expr) => {
+            walk_expr(&expr.func, path)?;
+            for arg in &expr.args {
+                walk_expr(arg, path)?;
+            }
+        }
+        syn::Expr::Cast(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::Closure(expr) => walk_expr(&expr.body, path)?,
+        syn::Expr::Const(expr) => walk_block_stmts(&expr.block, path)?,
+        syn::Expr::Field(expr) => walk_expr(&expr.base, path)?,
+        syn::Expr::ForLoop(expr) => {
+            walk_expr(&expr.expr, path)?;
+            walk_block_stmts(&expr.body, path)?;
+        }
+        syn::Expr::Group(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::If(expr) => {
+            walk_expr(&expr.cond, path)?;
+            walk_block_stmts(&expr.then_branch, path)?;
+            if let Some((_, else_branch)) = &expr.else_branch {
+                walk_expr(else_branch, path)?;
+            }
+        }
+        syn::Expr::Index(expr) => {
+            walk_expr(&expr.expr, path)?;
+            walk_expr(&expr.index, path)?;
+        }
+        syn::Expr::Let(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::Loop(expr) => walk_block_stmts(&expr.body, path)?,
+        syn::Expr::Macro(_) => {}
+        syn::Expr::Match(expr) => {
+            walk_expr(&expr.expr, path)?;
+            for arm in &expr.arms {
+                if let Some((_, guard)) = &arm.guard {
+                    walk_expr(guard, path)?;
+                }
+                walk_expr(&arm.body, path)?;
+            }
+        }
+        syn::Expr::MethodCall(expr) => {
+            walk_expr(&expr.receiver, path)?;
+            for arg in &expr.args {
+                walk_expr(arg, path)?;
+            }
+        }
+        syn::Expr::Paren(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::Range(expr) => {
+            if let Some(start) = &expr.start {
+                walk_expr(start, path)?;
+            }
+            if let Some(end) = &expr.end {
+                walk_expr(end, path)?;
+            }
+        }
+        syn::Expr::Reference(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::Repeat(expr) => {
+            walk_expr(&expr.expr, path)?;
+            walk_expr(&expr.len, path)?;
+        }
+        syn::Expr::Return(expr) => {
+            if let Some(value) = &expr.expr {
+                walk_expr(value, path)?;
+            }
+        }
+        syn::Expr::Struct(expr) => {
+            for field in &expr.fields {
+                walk_expr(&field.expr, path)?;
+            }
+            if let Some(rest) = &expr.rest {
+                walk_expr(rest, path)?;
+            }
+        }
+        syn::Expr::Try(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::TryBlock(expr) => walk_block_stmts(&expr.block, path)?,
+        syn::Expr::Tuple(expr) => {
+            for item in &expr.elems {
+                walk_expr(item, path)?;
+            }
+        }
+        syn::Expr::Unary(expr) => walk_expr(&expr.expr, path)?,
+        syn::Expr::Unsafe(expr) => walk_block_stmts(&expr.block, path)?,
+        syn::Expr::While(expr) => {
+            walk_expr(&expr.cond, path)?;
+            walk_block_stmts(&expr.body, path)?;
+        }
+        syn::Expr::Yield(expr) => {
+            if let Some(value) = &expr.expr {
+                walk_expr(value, path)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn check_use(item_use: &syn::ItemUse, path: &Path) -> Result<()> {
+    let mut imported = Vec::new();
+    collect_use_tree_names(&item_use.tree, &mut imported);
+    if let Some(symbol) = RESTORE_AUDIT_FORBIDDEN_SYMBOLS
+        .iter()
+        .find(|symbol| imported.iter().any(|name| name == **symbol))
+    {
+        bail!(
+            "audit metadata import in restore path: {} imports {}",
+            path.display(),
+            symbol
+        );
+    }
+    Ok(())
+}
+
+fn collect_external_mod_files(path: &Path, items: &[syn::Item]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for item in items {
+        match item {
+            syn::Item::Mod(item_mod) => {
+                if let Some((_, items)) = &item_mod.content {
+                    files.extend(collect_external_mod_files(path, items)?);
+                } else {
+                    files.extend(resolve_external_mod_files(path, item_mod));
+                }
+            }
+            syn::Item::Fn(item_fn) => {
+                files.extend(collect_external_mod_files_in_block(path, &item_fn.block)?);
+            }
+            syn::Item::Impl(item_impl) => {
+                for item in &item_impl.items {
+                    match item {
+                        syn::ImplItem::Const(item_const) => {
+                            files.extend(collect_external_mod_files_in_expr(
+                                path,
+                                &item_const.expr,
+                            )?);
+                        }
+                        syn::ImplItem::Fn(item_fn) => {
+                            files
+                                .extend(collect_external_mod_files_in_block(path, &item_fn.block)?);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            syn::Item::Trait(item_trait) => {
+                for item in &item_trait.items {
+                    match item {
+                        syn::TraitItem::Const(item_const) => {
+                            if let Some((_, expr)) = &item_const.default {
+                                files.extend(collect_external_mod_files_in_expr(path, expr)?);
+                            }
+                        }
+                        syn::TraitItem::Fn(item_fn) => {
+                            if let Some(block) = &item_fn.default {
+                                files.extend(collect_external_mod_files_in_block(path, block)?);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            syn::Item::Const(item_const) => {
+                files.extend(collect_external_mod_files_in_expr(path, &item_const.expr)?);
+            }
+            syn::Item::Static(item_static) => {
+                files.extend(collect_external_mod_files_in_expr(path, &item_static.expr)?);
+            }
+            _ => {}
+        }
+    }
+    Ok(files)
+}
+
+fn collect_external_mod_files_in_block(path: &Path, block: &syn::Block) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for stmt in &block.stmts {
+        match stmt {
+            syn::Stmt::Item(item) => {
+                files.extend(collect_external_mod_files(
+                    path,
+                    std::slice::from_ref(item),
+                )?);
+            }
+            syn::Stmt::Local(local) => {
+                if let Some(init) = &local.init {
+                    files.extend(collect_external_mod_files_in_expr(path, &init.expr)?);
+                }
+            }
+            syn::Stmt::Expr(expr, _) => {
+                files.extend(collect_external_mod_files_in_expr(path, expr)?);
+            }
+            syn::Stmt::Macro(_) => {}
+        }
+    }
+    Ok(files)
+}
+
+fn collect_external_mod_files_in_expr(path: &Path, expr: &syn::Expr) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    match expr {
+        syn::Expr::Array(expr) => {
+            for item in &expr.elems {
+                files.extend(collect_external_mod_files_in_expr(path, item)?);
+            }
+        }
+        syn::Expr::Assign(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.left)?);
+            files.extend(collect_external_mod_files_in_expr(path, &expr.right)?);
+        }
+        syn::Expr::Async(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.block)?)
+        }
+        syn::Expr::Await(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.base)?)
+        }
+        syn::Expr::Binary(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.left)?);
+            files.extend(collect_external_mod_files_in_expr(path, &expr.right)?);
+        }
+        syn::Expr::Block(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.block)?)
+        }
+        syn::Expr::Break(expr) => {
+            if let Some(value) = &expr.expr {
+                files.extend(collect_external_mod_files_in_expr(path, value)?);
+            }
+        }
+        syn::Expr::Call(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.func)?);
+            for arg in &expr.args {
+                files.extend(collect_external_mod_files_in_expr(path, arg)?);
+            }
+        }
+        syn::Expr::Cast(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?)
+        }
+        syn::Expr::Closure(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.body)?)
+        }
+        syn::Expr::Const(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.block)?)
+        }
+        syn::Expr::Field(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.base)?)
+        }
+        syn::Expr::ForLoop(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?);
+            files.extend(collect_external_mod_files_in_block(path, &expr.body)?);
+        }
+        syn::Expr::Group(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?)
+        }
+        syn::Expr::If(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.cond)?);
+            files.extend(collect_external_mod_files_in_block(
+                path,
+                &expr.then_branch,
+            )?);
+            if let Some((_, else_branch)) = &expr.else_branch {
+                files.extend(collect_external_mod_files_in_expr(path, else_branch)?);
+            }
+        }
+        syn::Expr::Index(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?);
+            files.extend(collect_external_mod_files_in_expr(path, &expr.index)?);
+        }
+        syn::Expr::Let(expr) => files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?),
+        syn::Expr::Loop(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.body)?)
+        }
+        syn::Expr::Macro(_) => {}
+        syn::Expr::Match(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?);
+            for arm in &expr.arms {
+                if let Some((_, guard)) = &arm.guard {
+                    files.extend(collect_external_mod_files_in_expr(path, guard)?);
+                }
+                files.extend(collect_external_mod_files_in_expr(path, &arm.body)?);
+            }
+        }
+        syn::Expr::MethodCall(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.receiver)?);
+            for arg in &expr.args {
+                files.extend(collect_external_mod_files_in_expr(path, arg)?);
+            }
+        }
+        syn::Expr::Paren(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?)
+        }
+        syn::Expr::Range(expr) => {
+            if let Some(start) = &expr.start {
+                files.extend(collect_external_mod_files_in_expr(path, start)?);
+            }
+            if let Some(end) = &expr.end {
+                files.extend(collect_external_mod_files_in_expr(path, end)?);
+            }
+        }
+        syn::Expr::Reference(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?)
+        }
+        syn::Expr::Repeat(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?);
+            files.extend(collect_external_mod_files_in_expr(path, &expr.len)?);
+        }
+        syn::Expr::Return(expr) => {
+            if let Some(value) = &expr.expr {
+                files.extend(collect_external_mod_files_in_expr(path, value)?);
+            }
+        }
+        syn::Expr::Struct(expr) => {
+            for field in &expr.fields {
+                files.extend(collect_external_mod_files_in_expr(path, &field.expr)?);
+            }
+            if let Some(rest) = &expr.rest {
+                files.extend(collect_external_mod_files_in_expr(path, rest)?);
+            }
+        }
+        syn::Expr::Try(expr) => files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?),
+        syn::Expr::TryBlock(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.block)?)
+        }
+        syn::Expr::Tuple(expr) => {
+            for item in &expr.elems {
+                files.extend(collect_external_mod_files_in_expr(path, item)?);
+            }
+        }
+        syn::Expr::Unary(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.expr)?)
+        }
+        syn::Expr::Unsafe(expr) => {
+            files.extend(collect_external_mod_files_in_block(path, &expr.block)?)
+        }
+        syn::Expr::While(expr) => {
+            files.extend(collect_external_mod_files_in_expr(path, &expr.cond)?);
+            files.extend(collect_external_mod_files_in_block(path, &expr.body)?);
+        }
+        syn::Expr::Yield(expr) => {
+            if let Some(value) = &expr.expr {
+                files.extend(collect_external_mod_files_in_expr(path, value)?);
+            }
+        }
+        _ => {}
+    }
+    Ok(files)
+}
+
+fn resolve_external_mod_files(path: &Path, item_mod: &syn::ItemMod) -> Vec<PathBuf> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    if let Some(path_attr) = item_mod.attrs.iter().find_map(path_attribute_value) {
+        return vec![dir.join(path_attr)];
+    }
+
+    let name = item_mod.ident.to_string();
+    vec![
+        dir.join(format!("{name}.rs")),
+        dir.join(name).join("mod.rs"),
+    ]
+}
+
+fn path_attribute_value(attr: &syn::Attribute) -> Option<String> {
+    if !attr.path().is_ident("path") {
+        return None;
+    }
+    let syn::Meta::NameValue(value) = &attr.meta else {
+        return None;
+    };
+    let syn::Expr::Lit(expr_lit) = &value.value else {
+        return None;
+    };
+    let syn::Lit::Str(path) = &expr_lit.lit else {
+        return None;
+    };
+    Some(path.value())
 }
 
 fn collect_use_tree_names(tree: &syn::UseTree, names: &mut Vec<String>) {
@@ -340,15 +780,38 @@ fn use_tree_root(ident: &syn::Ident) -> UseTreeRoot {
 }
 
 fn restore_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut queue = VecDeque::new();
+    let mut seen = HashSet::new();
     let mut files = Vec::new();
     let cli_restore = root.join("crates/gaze-cli/src/restore");
     if cli_restore.exists() {
-        collect_rs_files(&cli_restore, &mut files)?;
+        collect_rs_files(&cli_restore, &mut queue)?;
     }
     let core_restore = root.join("crates/gaze/src/restore.rs");
     if core_restore.exists() {
-        files.push(core_restore);
+        queue.push_back(core_restore);
     }
+
+    while let Some(path) = queue.pop_front() {
+        let canonical = path
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize {}", path.display()))?;
+        if !seen.insert(canonical.clone()) {
+            continue;
+        }
+
+        let source = fs::read_to_string(&canonical)
+            .with_context(|| format!("failed to read {}", canonical.display()))?;
+        let parsed = syn::parse_file(&source)
+            .with_context(|| format!("failed to parse {}", canonical.display()))?;
+        for external_mod in collect_external_mod_files(&canonical, &parsed.items)? {
+            if external_mod.exists() {
+                queue.push_back(external_mod);
+            }
+        }
+        files.push(canonical);
+    }
+
     if files.is_empty() {
         bail!("audit_metadata_only found no restore files to scan");
     }
@@ -356,14 +819,14 @@ fn restore_files(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+fn collect_rs_files(dir: &Path, files: &mut VecDeque<PathBuf>) -> Result<()> {
     for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
         let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
         let path = entry.path();
         if path.is_dir() {
             collect_rs_files(&path, files)?;
         } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
-            files.push(path);
+            files.push_back(path);
         }
     }
     Ok(())

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -219,6 +219,14 @@ const RESTORE_AUDIT_FORBIDDEN_SYMBOLS: &[&str] = &[
     "current_epoch_ms",
 ];
 
+#[derive(Clone, Copy)]
+enum UseTreeRoot {
+    Crate,
+    Gaze,
+    GazeCli,
+    Other,
+}
+
 fn run_audit_metadata_only_gate() -> Result<()> {
     let root = std::env::current_dir().context("failed to resolve current directory")?;
     let restore_files = restore_files(&root)?;
@@ -267,22 +275,56 @@ fn walk_items(items: &[syn::Item], path: &Path) -> Result<()> {
 }
 
 fn collect_use_tree_names(tree: &syn::UseTree, names: &mut Vec<String>) {
+    collect_use_tree_names_with_root(tree, names, None);
+}
+
+fn collect_use_tree_names_with_root(
+    tree: &syn::UseTree,
+    names: &mut Vec<String>,
+    current_root: Option<UseTreeRoot>,
+) {
     match tree {
         syn::UseTree::Path(path) => {
             names.push(path.ident.to_string());
-            collect_use_tree_names(&path.tree, names);
+            let root = current_root.unwrap_or_else(|| use_tree_root(&path.ident));
+            collect_use_tree_names_with_root(&path.tree, names, Some(root));
         }
         syn::UseTree::Name(name) => names.push(name.ident.to_string()),
         syn::UseTree::Rename(rename) => {
             names.push(rename.ident.to_string());
             names.push(rename.rename.to_string());
         }
-        syn::UseTree::Glob(_) => names.push("*".to_string()),
-        syn::UseTree::Group(group) => {
-            for item in &group.items {
-                collect_use_tree_names(item, names);
+        syn::UseTree::Glob(_) => {
+            if matches!(
+                current_root,
+                Some(UseTreeRoot::Crate | UseTreeRoot::Gaze | UseTreeRoot::GazeCli)
+            ) {
+                names.extend(
+                    RESTORE_AUDIT_FORBIDDEN_SYMBOLS
+                        .iter()
+                        .map(|symbol| (*symbol).to_string()),
+                );
+            } else {
+                names.push("*".to_string());
             }
         }
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_tree_names_with_root(item, names, current_root);
+            }
+        }
+    }
+}
+
+fn use_tree_root(ident: &syn::Ident) -> UseTreeRoot {
+    if ident == "crate" {
+        UseTreeRoot::Crate
+    } else if ident == "gaze" {
+        UseTreeRoot::Gaze
+    } else if ident == "gaze_cli" {
+        UseTreeRoot::GazeCli
+    } else {
+        UseTreeRoot::Other
     }
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -238,7 +238,11 @@ fn run_audit_metadata_only_gate() -> Result<()> {
 }
 
 fn reject_forbidden_use_imports(path: &Path, file: &syn::File) -> Result<()> {
-    for item in &file.items {
+    walk_items(&file.items, path)
+}
+
+fn walk_items(items: &[syn::Item], path: &Path) -> Result<()> {
+    for item in items {
         if let syn::Item::Use(item_use) = item {
             let mut imported = Vec::new();
             collect_use_tree_names(&item_use.tree, &mut imported);
@@ -251,6 +255,11 @@ fn reject_forbidden_use_imports(path: &Path, file: &syn::File) -> Result<()> {
                     path.display(),
                     symbol
                 );
+            }
+        }
+        if let syn::Item::Mod(item_mod) = item {
+            if let Some((_, items)) = &item_mod.content {
+                walk_items(items, path)?;
             }
         }
     }

--- a/crates/xtask/tests/adversarial_audit_metadata_only.rs
+++ b/crates/xtask/tests/adversarial_audit_metadata_only.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+#[test]
+fn audit_metadata_only_fails_when_restore_imports_redaction_entry() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "use gaze::RedactionEntry;\n\npub fn restore() {}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xtask"))
+        .arg("audit-metadata-only")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "gate unexpectedly passed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("RedactionEntry"),
+        "stderr should name forbidden symbol, got: {stderr}"
+    );
+}
+
+#[test]
+fn audit_metadata_only_fails_when_restore_imports_multiline_redaction_entry() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "use gaze::{\n    RedactionEntry,\n};\n\npub fn restore() {}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
+fn audit_metadata_only_fails_for_each_forbidden_audit_symbol() {
+    for symbol in [
+        "redaction_log",
+        "ConflictTier",
+        "DocumentKind",
+        "RedactionEntry",
+        "RedactionLogger",
+        "SqliteLogger",
+        "AuditFilter",
+        "AuditLogRow",
+        "AUDIT_RESTRICTED_COLUMNS",
+        "build_audit_query_sql",
+        "current_epoch_ms",
+    ] {
+        let dir = tempdir().unwrap();
+        let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+        fs::create_dir_all(&restore_dir).unwrap();
+        fs::write(
+            restore_dir.join("mod.rs"),
+            format!("use gaze::{symbol};\n\npub fn restore() {{}}\n"),
+        )
+        .unwrap();
+
+        assert_gate_rejects(dir.path(), symbol);
+    }
+}
+
+fn assert_gate_rejects(root: &std::path::Path, symbol: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_xtask"))
+        .arg("audit-metadata-only")
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "gate unexpectedly passed for {symbol}: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(symbol),
+        "stderr should name forbidden symbol {symbol}, got: {stderr}"
+    );
+}
+
+#[test]
+fn audit_metadata_only_passes_when_restore_imports_no_audit_metadata() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "use crate::error::CliError;\n\npub fn restore(_: CliError) {}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_xtask"))
+        .arg("audit-metadata-only")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "gate failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/xtask/tests/adversarial_audit_metadata_only.rs
+++ b/crates/xtask/tests/adversarial_audit_metadata_only.rs
@@ -118,6 +118,34 @@ fn audit_metadata_only_fails_on_impl_method_body_use() {
 }
 
 #[test]
+fn audit_metadata_only_fails_on_trait_default_method_body_use() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "trait RestoreProbe {\n    fn run(&self) {\n        use gaze::RedactionEntry;\n    }\n}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_const_block_initializer_use() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "const _: () = {\n    use gaze::redaction_log;\n};\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "redaction_log");
+}
+
+#[test]
 fn audit_metadata_only_fails_on_extern_crate_alias() {
     let dir = tempdir().unwrap();
     let restore_dir = dir.path().join("crates/gaze-cli/src/restore");

--- a/crates/xtask/tests/adversarial_audit_metadata_only.rs
+++ b/crates/xtask/tests/adversarial_audit_metadata_only.rs
@@ -90,6 +90,73 @@ fn audit_metadata_only_fails_on_gaze_renamed_crate_alias() {
 }
 
 #[test]
+fn audit_metadata_only_fails_on_function_body_use() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "pub fn restore() {\n    use gaze::RedactionEntry;\n}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_impl_method_body_use() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "struct Foo;\n\nimpl Foo {\n    fn run(&self) {\n        use gaze::RedactionEntry;\n    }\n}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_extern_crate_alias() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(restore_dir.join("mod.rs"), "extern crate gaze as g;\n").unwrap();
+
+    assert_gate_rejects(dir.path(), "__renamed_gaze_root__");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_plain_extern_crate() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(restore_dir.join("mod.rs"), "extern crate gaze;\n").unwrap();
+
+    assert_gate_rejects(dir.path(), "__renamed_gaze_root__");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_path_attribute_external_module() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "#[path = \"../external.rs\"]\nmod _path_escape;\n",
+    )
+    .unwrap();
+    fs::write(
+        restore_dir.join("../external.rs"),
+        "use gaze::RedactionEntry;\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
 fn audit_metadata_only_fails_for_each_forbidden_audit_symbol() {
     for symbol in [
         "redaction_log",

--- a/crates/xtask/tests/adversarial_audit_metadata_only.rs
+++ b/crates/xtask/tests/adversarial_audit_metadata_only.rs
@@ -48,6 +48,48 @@ fn audit_metadata_only_fails_when_restore_imports_multiline_redaction_entry() {
 }
 
 #[test]
+fn audit_metadata_only_fails_on_nested_module_redaction_entry() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "mod _restore_probe {\n    use gaze::{ RedactionEntry };\n}\n\npub fn restore() {}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "RedactionEntry");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_gaze_glob_import() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "use gaze::*;\n\npub fn restore() {}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "redaction_log");
+}
+
+#[test]
+fn audit_metadata_only_fails_on_gaze_renamed_crate_alias() {
+    let dir = tempdir().unwrap();
+    let restore_dir = dir.path().join("crates/gaze-cli/src/restore");
+    fs::create_dir_all(&restore_dir).unwrap();
+    fs::write(
+        restore_dir.join("mod.rs"),
+        "use gaze as g;\n\npub fn restore() {}\n",
+    )
+    .unwrap();
+
+    assert_gate_rejects(dir.path(), "__renamed_gaze_root__");
+}
+
+#[test]
 fn audit_metadata_only_fails_for_each_forbidden_audit_symbol() {
     for symbol in [
         "redaction_log",

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -30,8 +30,9 @@ imported in restore paths" via syn-based AST scanning. As of v0.4.5 round-3,
 the gate covers:
 
 - File-scope `Item::Use` (top-level + nested inline `mod { ... }`)
-- Function body / impl method body / trait default method body `use` statements
-- Const/static initializer block-expression `use` statements
+- Function body / impl method body `use` statements
+- Trait default-method body `use` statements (covered by walker; behavioral test added in this round: `audit_metadata_only_fails_on_trait_default_method_body_use`)
+- Const/static initializer block-expression `use` statements (covered by walker; behavioral test added in this round: `audit_metadata_only_fails_on_const_block_initializer_use`)
 - `Item::ExternCrate { gaze | gaze_cli }` (with or without alias)
 - Glob imports `use gaze::*;` / `use gaze_cli::*;` / `use crate::*;` (expand to all denylist symbols)
 - Aliased crate `use gaze as <ident>;` (synthetic `__renamed_gaze_root__` marker)
@@ -43,10 +44,15 @@ Known limitations (v0.4.5 — accepted-risk; covered by code review):
 1. **Macro-emitted use statements.** `macro_rules! pull_audit { () => { use gaze::RedactionEntry; }; } pull_audit!();` — the gate does not expand macros. Code review must catch macros that emit forbidden imports. Future: see `docs/research/v0.5-dylint-audit-gate.md` (todo #181).
 2. **`use super::*;` re-export chains.** A submodule glob-importing from a `super` that re-exports audit symbols would bypass the gate. Currently no such re-exports exist, but no defense in depth.
 3. **Indirect references via name-resolution edge cases** (for example, `extern crate alloc as gaze;`). Rare and would be obvious in code review.
+4. **Fully-qualified path references without `use` statement.** A restore module can reference an audit symbol via fully-qualified path WITHOUT importing it: `let _ = std::marker::PhantomData::<gaze::RedactionEntry>;` or `let _ = gaze::current_epoch_ms();` or `fn x(_: gaze::AuditFilter)`. The walker scans `Item::Use` and `Item::ExternCrate` and recursively walks block statements for nested `use`, but does NOT inspect `syn::Path` references in type positions, expression positions, function signatures, return types, struct fields, or generic args. Closing this requires walking `syn::Path` references via `syn::visit::Visit` (which is essentially recreating rustc's name resolver — see todo #181 v0.5 dylint pivot for the architectural answer).
+5. **`include!("...")` macro inlining sibling files.** `include!("../external_inc.rs")` at module scope inlines a sibling file's source into the current module. The walker hits `Item::Macro` and falls through; the included file may live outside the scanned restore tree. Distinct from `macro_rules!` emission (limitation #1) — `include!` doesn't emit, it inlines. The reviewer skimming for `macro_rules!` definitions would miss this class.
+6. **`let-else` diverge block use statements.** `let Some(_x) = predicate else { use gaze::RedactionEntry; ... };` — the `else { ... }` block is `Local::init.diverge` in the syn AST. The walker walks `local.init.expr` but not the diverge block. Stable Rust since 1.65.
 
 Architectural roadmap: todo #181 schedules a v0.5 rewrite using
 rustc-resolver-based lint (likely `dylint`). That replaces the syn-walker
 entirely and eliminates this class of recursive-Potemkin risk.
+
+**Naming caveat:** the gate is named `audit_metadata_only` to match its goal ("only non-audit metadata may live in restore"), but its actual enforcement is narrower: "no audit symbols imported via `use` or `extern crate` in restore". Adopters should NOT trust the name alone — read the limitations above. The v0.5 dylint pivot (#181) closes this gap by switching to rustc-resolver-based enforcement.
 
 ## Recursive-Potemkin discipline
 

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -23,6 +23,31 @@ The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.
 | `RecognizerCompositionValidator` | `cargo run -p xtask -- recognizer-composition-validator` | Lists and runs the behavioral tests in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS`. The gate fails if the rulepack composition validator tests are missing or failing. |
 | `NoTenantKnowledge` | `cargo run -p xtask -- no-tenant-knowledge` | Added in v0.4.3. Production-code lint scanner that rejects tenant-pattern strings (`order_id`, `Order_42`, `Song_42`, `User_7`) in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. Allow markers (`// allow(tenant-fixture)`) hard-fail in production scope and remain valid only in tests, benches, docs, and `CONTRIBUTING.md`. |
 
+## audit_metadata_only — known limitations (v0.4.5)
+
+The `audit_metadata_only` xtask gate enforces "no audit metadata symbols
+imported in restore paths" via syn-based AST scanning. As of v0.4.5 round-3,
+the gate covers:
+
+- File-scope `Item::Use` (top-level + nested inline `mod { ... }`)
+- Function body / impl method body / trait default method body `use` statements
+- Const/static initializer block-expression `use` statements
+- `Item::ExternCrate { gaze | gaze_cli }` (with or without alias)
+- Glob imports `use gaze::*;` / `use gaze_cli::*;` / `use crate::*;` (expand to all denylist symbols)
+- Aliased crate `use gaze as <ident>;` (synthetic `__renamed_gaze_root__` marker)
+- External modules declared via `#[path = "..."]` (rustc-style file resolution)
+- All denylist symbols including forward-guards (`AuditFilter`, `AuditLogRow`, `AUDIT_RESTRICTED_COLUMNS`, `build_audit_query_sql`, `current_epoch_ms`)
+
+Known limitations (v0.4.5 — accepted-risk; covered by code review):
+
+1. **Macro-emitted use statements.** `macro_rules! pull_audit { () => { use gaze::RedactionEntry; }; } pull_audit!();` — the gate does not expand macros. Code review must catch macros that emit forbidden imports. Future: see `docs/research/v0.5-dylint-audit-gate.md` (todo #181).
+2. **`use super::*;` re-export chains.** A submodule glob-importing from a `super` that re-exports audit symbols would bypass the gate. Currently no such re-exports exist, but no defense in depth.
+3. **Indirect references via name-resolution edge cases** (for example, `extern crate alloc as gaze;`). Rare and would be obvious in code review.
+
+Architectural roadmap: todo #181 schedules a v0.5 rewrite using
+rustc-resolver-based lint (likely `dylint`). That replaces the syn-walker
+entirely and eliminates this class of recursive-Potemkin risk.
+
 ## Recursive-Potemkin discipline
 
 Every gate must invoke a behavioral test. A gate may check that a test exists,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,15 +3,8 @@
 ## Audit Metadata
 
 `gaze audit` reads SQLite redaction-log metadata produced by `gaze clean --audit-db`.
-It is read-only and intentionally returns a restricted column set:
-
-```text
-source    class    action    field_name    document_kind    conflict_loser    decided_by    created_at
-```
-
-The audit command must not read raw spans, restore mappings, token payloads, or
-future sensitive columns. This preserves the Gaze north star: audit reporting can
-explain what happened without moving PII back toward an agent or terminal.
+It is intentionally restricted to metadata columns and must not read raw spans,
+restore mappings, token payloads, or future sensitive columns.
 
 ### Query
 
@@ -40,6 +33,30 @@ gaze audit export --audit-db audit.sqlite --format jsonl --from 2026-04-26T00:00
 
 ```json
 {"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"recognizer_id","created_at":1777161600000}
+```
+
+### Purge
+
+`gaze audit purge` manually removes redaction audit metadata rows older than an
+ISO 8601 UTC timestamp. It never purges session manifests and does not run in
+the background.
+
+```sh
+gaze audit purge --audit-db .gaze/audit.sqlite --before 2026-04-01T00:00:00Z --dry-run
+gaze audit purge --audit-db .gaze/audit.sqlite --before 2026-04-01T00:00:00Z
+```
+
+Successful output is JSON:
+
+```json
+{"dry_run":true,"matched":12,"deleted":0}
+```
+
+Invalid `--before` values fail closed with a typed JSON error that quotes the
+input:
+
+```json
+{"error":"AuditPurgeIso8601","exit":2,"input":"not-iso8601"}
 ```
 
 ### Filters

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,8 +43,12 @@ the background.
 
 ```sh
 gaze audit purge --audit-db .gaze/audit.sqlite --before 2026-04-01T00:00:00Z --dry-run
+gaze audit purge --audit-db .gaze/audit.sqlite --before 2026-04-01T00:00:00Z --count
 gaze audit purge --audit-db .gaze/audit.sqlite --before 2026-04-01T00:00:00Z
 ```
+
+`--count` is an alias for `--dry-run`; both flags count matching rows without
+deleting them.
 
 Successful output is JSON:
 

--- a/docs/research/v0.5-dylint-audit-gate.md
+++ b/docs/research/v0.5-dylint-audit-gate.md
@@ -1,0 +1,3 @@
+# v0.5 Dylint Audit Gate
+
+Architectural pivot: replace the syn walker with a dylint lint; tracked in todo #181. Detailed design pending v0.5 brainstorm cycle.


### PR DESCRIPTION
## Summary
- Add manual `gaze audit purge --audit-db <path> --before <iso8601>` with `--dry-run`, typed ISO 8601 errors, and restricted `DELETE FROM redaction_log WHERE created_at < ?` purge behavior.
- Add `created_at` audit-log metadata with legacy schema migration and restore-safe round-trip coverage after purge.
- Add `audit-metadata-only` xtask gate, adversarial self-test, and ubuntu-24.04 CI workflow.

## Axis impact
- Reliability/trust: strengthens audit retention controls and restore/audit separation.
- Reversibility: no change to session manifests or restore contract; purge only deletes audit metadata rows.
- Agentic/adopter ergonomics: CLI-only manual purge; no TOML default and no background auto-purge.

## Tests
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo run -p xtask -- audit-metadata-only`