### PR TITLE
chore(org): sweep URLs after gaze transfer to piinuts org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,10 +282,10 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/Naoray/gaze/compare/v0.4.2...HEAD
-[0.4.2]: https://github.com/Naoray/gaze/compare/v0.4.0-rc.1...v0.4.2
-[0.4.0-rc.1]: https://github.com/Naoray/gaze/releases/tag/v0.4.0-rc.1
-[v0.3.1]: https://github.com/Naoray/gaze/releases/tag/v0.3.1
-[0.3.0]: https://github.com/Naoray/gaze/releases/tag/v0.3.0
-[0.3.0-rc.2]: https://github.com/Naoray/gaze/releases/tag/v0.3.0-rc.2
-[0.3.0-rc.1]: https://github.com/Naoray/gaze/releases/tag/v0.3.0-rc.1
+[Unreleased]: https://github.com/piinuts/gaze/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/piinuts/gaze/compare/v0.4.0-rc.1...v0.4.2
+[0.4.0-rc.1]: https://github.com/piinuts/gaze/releases/tag/v0.4.0-rc.1
+[v0.3.1]: https://github.com/piinuts/gaze/releases/tag/v0.3.1
+[0.3.0]: https://github.com/piinuts/gaze/releases/tag/v0.3.0
+[0.3.0-rc.2]: https://github.com/piinuts/gaze/releases/tag/v0.3.0-rc.2
+[0.3.0-rc.1]: https://github.com/piinuts/gaze/releases/tag/v0.3.0-rc.1

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ v0.4.4 is the current stable release.
 Apple Silicon macOS via release asset:
 
 ```bash
-curl -L -o gaze https://github.com/Naoray/gaze/releases/download/v0.4.4/gaze-aarch64-apple-darwin
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.4/gaze-aarch64-apple-darwin
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -52,7 +52,7 @@ The Homebrew formula exists in `dist/homebrew/gaze.rb`, but the public `naoray/t
 Linux x86_64 binary download from the release assets:
 
 ```bash
-curl -L -o gaze https://github.com/Naoray/gaze/releases/download/v0.4.4/gaze-x86_64-unknown-linux-gnu
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.4/gaze-x86_64-unknown-linux-gnu
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -67,9 +67,9 @@ Intel macOS binaries are not published; build from source with `cargo build --re
 
 | Platform | Status | Notes |
 |---|---|---|
-| **macOS aarch64 (Apple Silicon)** | ✅ Supported | Download from [releases](https://github.com/Naoray/gaze/releases). Homebrew formula exists in `dist/homebrew/gaze.rb`, but is not published in `naoray/tap` yet. |
+| **macOS aarch64 (Apple Silicon)** | ✅ Supported | Download from [releases](https://github.com/piinuts/gaze/releases). Homebrew formula exists in `dist/homebrew/gaze.rb`, but is not published in `naoray/tap` yet. |
 | **Linux x86_64 (glibc)** | ✅ Supported | **Requires glibc 2.39+** (Ubuntu 24.04, Debian 13, RHEL 10, or newer). The bundled ONNX Runtime needs C23 symbols (`__isoc23_strtoll` etc.) introduced in glibc 2.39. Older distributions: build from source. |
-| **Linux aarch64 / musl** | ❌ Not shipped | Adopter-driven; [open an issue](https://github.com/Naoray/gaze/issues/new) if needed. |
+| **Linux aarch64 / musl** | ❌ Not shipped | Adopter-driven; [open an issue](https://github.com/piinuts/gaze/issues/new) if needed. |
 | **macOS x86_64 (Intel)** | ❌ Not shipped | Apple Silicon focus. Build from source if needed. |
 | **Windows** | ❌ Not shipped | Linux/WSL2 recommended. |
 
@@ -83,7 +83,7 @@ All platforms supported via `cargo`:
   - `phone-parser` (default-on for `gaze-recognizers` and therefore `gaze-cli`): pulls `phonenumber` crate for parser-backed E.164 phone validation. Disable with `--no-default-features` for raw recognizer-library use without phone deps.
 
 ```bash
-git clone https://github.com/Naoray/gaze
+git clone https://github.com/piinuts/gaze
 cd gaze
 cargo build --release -p gaze-cli
 ./target/release/gaze --version

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -250,7 +250,7 @@ impl TryFrom<RawPolicy> for Policy {
 
         if !raw.detectors.is_empty() {
             return Err(PolicyError::LegacyDetectorUnsupported(
-                "https://github.com/Naoray/gaze/blob/main/docs/policy.md#migrating-detector",
+                "https://github.com/piinuts/gaze/blob/main/docs/policy.md#migrating-detector",
             ));
         }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -226,8 +226,8 @@ When you pick up a roadmap item:
 1. Read the existing spec files at `docs/roadmap/v0.3/cli.md`, this
    `docs/ROADMAP.md`, and `docs/research/gaze-first-principles-vision.md`
    for current context.
-2. Check open GitHub issues on the relevant repo (`Naoray/gaze`,
-   `Naoray/gaze-laravel`) for acceptance criteria and status updates.
+2. Check open GitHub issues on the relevant repo (`piinuts/gaze`,
+   `piinuts/gaze-laravel`) for acceptance criteria and status updates.
 3. Follow brainstorm → plan → multi-review → dispatch impl before
    touching code on non-trivial features.
 4. **Never re-open locked decisions** documented in this roadmap's
@@ -259,5 +259,5 @@ execution state.
 - **v0.3 spec archive:** `docs/roadmap/v0.3/cli.md`,
   `docs/roadmap/v0.3/laravel.md`
 - **Project rules:** `AGENTS.md`, `CLAUDE.md`
-- **Adopter repo:** `Naoray/gaze-laravel` (see its issue tracker for
+- **Adopter repo:** `piinuts/gaze-laravel` (see its issue tracker for
   adopter signals feeding this roadmap).

--- a/docs/research/v0.4.4-date-posture.md
+++ b/docs/research/v0.4.4-date-posture.md
@@ -42,7 +42,7 @@ If/when Date recognition lands:
 
 ## 4. Decision: GH #5 token-spam tradeoff
 
-GH issue #5 (https://github.com/Naoray/gaze/issues/5) raised concern about date redaction trade-offs: relative-distance preservation and locale ambiguity. This memo resolves that concern as:
+GH issue #5 (https://github.com/piinuts/gaze/issues/5) raised concern about date redaction trade-offs: relative-distance preservation and locale ambiguity. This memo resolves that concern as:
 
 - Gaze does NOT redact dates in prose by default. This memo locks the no-default-on stance.
 - Adopters who need DOB redaction get a bounded, locale-explicit, opt-in recognizer.


### PR DESCRIPTION
Mechanical sweep after `Naoray/gaze` -> `piinuts/gaze` transfer.

Replaced literal `Naoray/gaze` URL/path forms across:
- CHANGELOG.md (release-comparison URL footer table)
- README.md (download URLs)
- crates/gaze/src/policy.rs (doc URL string)
- docs/ROADMAP.md (`Naoray/gaze`, `Naoray/gaze-laravel` prose refs)

Preserved:
- Brew tap references (`Naoray/gaze/gaze`, `naoray/tap`) - separate concern, may stay under maintainer personal namespace. Follow-up todo to be filed.
- Bare `Naoray` author attribution (no instances found in swept content).

Notes:
- This main-based worktree does not contain `docs/research/v0.4.4-date-posture.md` or the pre-inventoried README issue/clone URLs, so no changes were needed there.
- GitHub auto-redirects old URLs; this PR makes the canonical references explicit.

Verified:
- `grep -rn "Naoray/gaze" ... | grep -v target` returns only the preserved brew-tap references.
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `gh pr view 59 --repo piinuts/gaze` resolves post-transfer.