### PR TITLE
v0.4.6 S3: derive bundle class list from rulepack (#173)

### DIFF
--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -10,9 +10,10 @@ use base64::Engine;
 use serde::Serialize;
 
 use gaze::{
-    Action, DictionaryBundle, DictionarySource, DocumentKind, LocaleTag, PiiClass, Policy,
-    RawDocument, RedactionEntry, RedactionLogger, Result as GazeResult, RuleSpec, RulepackPolicy,
-    Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope, SqliteLogger, TypedContext,
+    Action, DictionaryBundle, DictionarySource, DocumentKind, LocaleTag, Policy, RawDocument,
+    RedactionEntry, RedactionLogger, Result as GazeResult, RuleSpec, Rulepack, RulepackPolicy,
+    RulepackSource, Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope, SqliteLogger,
+    TypedContext,
 };
 
 use crate::clean_overrides::CleanOverrides;
@@ -60,7 +61,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         None => None,
     };
     let cli_rulepack_policy = if loaded_policy.is_none() && has_rulepack_overrides(&options) {
-        Some(policy_for_rulepack_overrides(&clean_overrides))
+        Some(policy_for_rulepack_overrides(&clean_overrides)?)
     } else {
         None
     };
@@ -210,8 +211,10 @@ fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
     !options.rulepack_bundled.is_empty() || !options.rulepack_paths.is_empty()
 }
 
-fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
-    let mut rules = class_rules_for_bundled_overrides(clean_overrides);
+fn policy_for_rulepack_overrides(
+    clean_overrides: &CleanOverrides,
+) -> std::result::Result<Policy, CliError> {
+    let mut rules = class_rules_for_bundled_overrides(clean_overrides)?;
     rules.push(RuleSpec::Default {
         action: Action::Preserve,
     });
@@ -230,46 +233,29 @@ fn policy_for_rulepack_overrides(clean_overrides: &CleanOverrides) -> Policy {
         },
         locale: None,
     };
-    clean_overrides.apply_to(&base)
+    Ok(clean_overrides.apply_to(&base))
 }
 
-fn class_rules_for_bundled_overrides(clean_overrides: &CleanOverrides) -> Vec<RuleSpec> {
+fn class_rules_for_bundled_overrides(
+    clean_overrides: &CleanOverrides,
+) -> std::result::Result<Vec<RuleSpec>, CliError> {
     let Some(bundled) = &clean_overrides.rulepack_bundled else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    let mut classes = Vec::<PiiClass>::new();
+    let mut classes = std::collections::BTreeSet::new();
     for bundle in bundled {
-        match bundle.as_str() {
-            "core" => {
-                push_class_once(&mut classes, PiiClass::Email);
-                push_class_once(&mut classes, PiiClass::Name);
-            }
-            "core-extended" => {
-                push_class_once(&mut classes, PiiClass::custom("phone"));
-                push_class_once(&mut classes, PiiClass::custom("ip_address"));
-                push_class_once(&mut classes, PiiClass::custom("postal_code"));
-                push_class_once(&mut classes, PiiClass::custom("iban"));
-                push_class_once(&mut classes, PiiClass::custom("credit_card"));
-            }
-            "locale-de" | "locale-en" => {
-                push_class_once(&mut classes, PiiClass::Name);
-            }
-            _ => {}
-        }
+        let contents = gaze_recognizers::embedded(bundle).ok_or(CliError::PolicyConfig)?;
+        let rulepack = Rulepack::load(RulepackSource::Embedded(contents))
+            .map_err(|_| CliError::PolicyConfig)?;
+        classes.extend(rulepack.activated_classes());
     }
-    classes
+    Ok(classes
         .into_iter()
         .map(|class| RuleSpec::Class {
             class,
             action: Action::Tokenize,
         })
-        .collect()
-}
-
-fn push_class_once(classes: &mut Vec<PiiClass>, class: PiiClass) {
-    if !classes.iter().any(|existing| existing == &class) {
-        classes.push(class);
-    }
+        .collect())
 }
 
 fn scope_for_cli_without_policy(scope: Option<&SessionScope>, ttl_secs: Option<u64>) -> Scope {

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -179,6 +179,14 @@ impl Rulepack {
     pub fn parse(raw: &str) -> Result<Rulepack, RulepackError> {
         let raw: RawRulepack = toml::from_str(raw).map_err(RulepackError::Toml)?;
         raw.try_into()
+    }
+
+    pub fn activated_classes(&self) -> BTreeSet<PiiClass> {
+        self.recognizers
+            .iter()
+            .filter(|recognizer| recognizer.enabled)
+            .map(|recognizer| recognizer.class.clone())
+            .collect()
     }
 }
 
@@ -569,6 +577,69 @@ license = "Apache-2.0"
         assert_eq!(recognizer.class, PiiClass::Email);
         assert_eq!(recognizer.scoring.priority, 90);
         assert!(matches!(recognizer.matcher, RawMatch::Regex { .. }));
+    }
+
+    #[test]
+    fn embedded_core_activated_classes_match_rulepack_classes() {
+        let rulepack = Rulepack::load(RulepackSource::Embedded(
+            gaze_recognizers::embedded("core").expect("core rulepack"),
+        ))
+        .expect("embedded core rulepack");
+
+        assert_eq!(
+            rulepack.activated_classes(),
+            BTreeSet::from([PiiClass::Email, PiiClass::Name])
+        );
+    }
+
+    #[test]
+    fn embedded_core_extended_activated_classes_match_rulepack_classes() {
+        let rulepack = Rulepack::load(RulepackSource::Embedded(
+            gaze_recognizers::embedded("core-extended").expect("core-extended rulepack"),
+        ))
+        .expect("embedded core-extended rulepack");
+
+        assert_eq!(
+            rulepack.activated_classes(),
+            BTreeSet::from([
+                PiiClass::custom("phone"),
+                PiiClass::custom("iban"),
+                PiiClass::custom("credit_card"),
+                PiiClass::custom("ip_address"),
+                PiiClass::custom("postal_code"),
+            ])
+        );
+    }
+
+    #[test]
+    fn activated_classes_include_new_rulepack_recognizer_class() {
+        let raw = format!(
+            r#"{}
+
+[[recognizers]]
+id = "test.only"
+class = "custom:test_only"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = "TEST_ONLY"
+
+[recognizers.scoring]
+base = 0.70
+priority = 1
+"#,
+            gaze_recognizers::embedded("core-extended").expect("core-extended rulepack")
+        );
+        let rulepack = Rulepack::parse(&raw).expect("core-extended with synthetic recognizer");
+
+        assert!(
+            rulepack
+                .activated_classes()
+                .contains(&PiiClass::custom("test_only")),
+            "new recognizer class must be derived from rulepack data"
+        );
     }
 
     #[test]

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -310,7 +310,9 @@ bundled = ["core"]
 paths = ["./tenant-rulepack.toml"]
 ```
 
-Bundled rulepacks:
+Bundled rulepacks. The classes shown here come from the embedded rulepack TOML
+`class` fields; runtime bundle activation derives the active class set from the
+loaded rulepack rather than a separate hand-maintained list.
 
 | Bundle | Recognizers | Classes | Notes |
 |--------|-------------|---------|-------|


### PR DESCRIPTION
Closes todo #173. Hard prereq for v0.4.6 S1 (recognizer-activation snapshot contract).

Replaces hand-maintained bundle class lists with `Rulepack::activated_classes()`, derived from loaded rulepack recognizers.

Per plan rev 2 (scratchpad 421) §S3.

Verification:
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo run -p xtask -- audit-metadata-only`
- `cargo run -p xtask -- class-map-override-safety`
- `cargo run -p xtask -- recognizer-composition-validator`
- `cargo run -p xtask -- no-tenant-knowledge`

Reviewer replay for AC #4:
- `rg -n 'custom:(phone|iban|credit_card|ip_address|postal_code)' crates/gaze/src crates/gaze-cli/src crates/gaze-assembly/src -g '*.rs'`
