### PR TITLE
v0.4.6 S6: brew tap location decision (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
 
-The Homebrew formula exists in `dist/homebrew/gaze.rb`, but the public `piinuts/tap` formula is not published yet.
+Homebrew is repo-local for now. The formula source exists at `dist/homebrew/gaze.rb`, but no public `piinuts/tap` or `piinuts/homebrew-tap` formula is published yet, and this repository is private. Maintainers can smoke the formula by staging it into a scratch local tap; direct `brew install piinuts/tap/gaze` is not supported yet.
+
+Public `brew install piinuts/tap/gaze` documentation should wait until a public tap exists and the release process publishes to it.
 
 Linux x86_64 binary download from the release assets:
 
@@ -70,7 +72,7 @@ Intel macOS binaries are not published; build from source with `cargo build --re
 
 | Platform | Status | Notes |
 |---|---|---|
-| **macOS aarch64 (Apple Silicon)** | ✅ Supported | Download from [releases](https://github.com/piinuts/gaze/releases). Homebrew formula exists in `dist/homebrew/gaze.rb`, but is not published in `piinuts/tap` yet. |
+| **macOS aarch64 (Apple Silicon)** | ✅ Supported | Download from [releases](https://github.com/piinuts/gaze/releases). Homebrew is repo-local at `dist/homebrew/gaze.rb`; no public tap is published yet. |
 | **Linux x86_64 (glibc)** | ✅ Supported | **Requires glibc 2.39+** (Ubuntu 24.04, Debian 13, RHEL 10, or newer). The bundled ONNX Runtime needs C23 symbols (`__isoc23_strtoll` etc.) introduced in glibc 2.39. Older distributions: build from source. |
 | **Linux aarch64 / musl** | ❌ Not shipped | Adopter-driven; [open an issue](https://github.com/piinuts/gaze/issues/new) if needed. |
 | **macOS x86_64 (Intel)** | ❌ Not shipped | Apple Silicon focus. Build from source if needed. |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,26 @@
+# Release Process
+
+## Homebrew Tap Location
+
+Decision for v0.4.6 S6 (#184): keep Homebrew repo-local until the organization creates an explicit public tap and release publication target.
+
+Current state:
+
+- The formula source lives in this repository at `dist/homebrew/gaze.rb`.
+- No public `piinuts/tap` or `piinuts/homebrew-tap` repository is visible from this repo-local audit.
+- `piinuts/gaze` is private, so public Homebrew installation is not a supported path yet.
+- `.github/workflows/release.yml` intentionally remains artifact-only: it builds and uploads GitHub release assets, but does not push formula updates to an external tap.
+- Modern Homebrew rejects direct install/info commands for formula files outside a tap, so local smoke means staging the formula into a scratch tap rather than installing `./dist/homebrew/gaze.rb` directly.
+
+Axis-5 rationale: documenting the repo-local formula is more ergonomic than advertising a tap that adopters cannot use. It gives collaborators a concrete smoke path while keeping public install instructions honest and reversible when a public tap is created.
+
+Local smoke for maintainers:
+
+```bash
+brew tap-new piinuts/gaze-smoke
+cp dist/homebrew/gaze.rb "$(brew --repo piinuts/gaze-smoke)/Formula/gaze.rb"
+brew info piinuts/gaze-smoke/gaze
+brew untap piinuts/gaze-smoke
+```
+
+Future public tap work is org-level operations outside this repo PR. When a public tap exists, update this document, the README install section, and `.github/workflows/release.yml` together so the formula location, adopter instructions, and release automation agree.


### PR DESCRIPTION
## Decision

Keep Homebrew repo-local for v0.4.6 S6 (#184). The formula source remains at `dist/homebrew/gaze.rb`; no public `piinuts/tap` or `piinuts/homebrew-tap` formula is documented because no public tap is visible from this repo-local audit and `piinuts/gaze` is private.

## Axis-5 rationale

This is the most ergonomic adopter posture right now because it avoids advertising a `brew install` command that public users cannot run. The README stays honest about the current state, while `docs/release-process.md` gives maintainers a concrete scratch-tap smoke path and a clear future update point once a public tap exists.

## Repo-local boundary

No external tap repo was created or mutated. `.github/workflows/release.yml` is intentionally unchanged: the release workflow remains artifact-only and does not push formula updates until the org chooses a public tap/release publication target.

## Verification

- `cargo fmt --all -- --check`
- Local Homebrew formula smoke by staging `dist/homebrew/gaze.rb` into a scratch tap and running `brew info piinuts/gaze-smoke-793/gaze`, then `brew untap piinuts/gaze-smoke-793`
