### PR TITLE
v0.4.6 S5: no-feature phone parser fail-closed regression (#172)

### DIFF
--- a/.github/workflows/no-phone-parser.yml
+++ b/.github/workflows/no-phone-parser.yml
@@ -1,0 +1,21 @@
+name: no-phone-parser
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  no-phone-parser:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run no-phone-parser recognizer tests
+        run: cargo test -p gaze-recognizers --no-default-features
+      - name: Verify feature-matrix CI contract
+        run: cargo run -p xtask -- ci-feature-matrix

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -9,6 +9,24 @@ pub use ner::{
 };
 pub use regex::{NormalizerKind, RegexDetector, ValidatorKind};
 
+pub fn load_rulepack(source: gaze::RulepackSource) -> Result<gaze::Rulepack, gaze::RulepackError> {
+    let rulepack = gaze::Rulepack::load(source)?;
+    validate_rulepack_recognizers(&rulepack)?;
+    Ok(rulepack)
+}
+
+fn validate_rulepack_recognizers(rulepack: &gaze::Rulepack) -> Result<(), gaze::RulepackError> {
+    for recognizer in &rulepack.recognizers {
+        if let Some(validator) = &recognizer.validator {
+            ValidatorKind::parse(&validator.kind)?;
+        }
+        if let Some(normalizer) = &recognizer.normalizer {
+            NormalizerKind::parse(&normalizer.kind)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn embedded(name: &str) -> Option<&'static str> {
     match name {
         "core" => Some(include_str!("../embedded/core.toml")),

--- a/crates/gaze-recognizers/tests/no_phone_parser_fail_closed.rs
+++ b/crates/gaze-recognizers/tests/no_phone_parser_fail_closed.rs
@@ -1,0 +1,54 @@
+#![cfg(not(feature = "phone-parser"))]
+
+use gaze::{RulepackError, RulepackSource};
+
+#[test]
+fn phone_validators_fail_closed_at_rulepack_load_without_phone_parser() {
+    for validator in [
+        "e164_phone",
+        "e164_phone_national_de",
+        "e164_phone_national_us",
+    ] {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("rulepack.toml");
+        std::fs::write(&path, rulepack(validator)).expect("write minimal rulepack");
+
+        let err = gaze_recognizers::load_rulepack(RulepackSource::Path(path))
+            .expect_err("phone validator must fail closed without phone-parser feature");
+
+        assert!(
+            matches!(err, RulepackError::UnsupportedValidator { ref kind } if kind == validator),
+            "expected UnsupportedValidator for {validator}, got {err:?}"
+        );
+    }
+}
+
+fn rulepack(validator: &str) -> String {
+    format!(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "no-phone-parser-fail-closed-{validator}"
+rulepack_version = "0.4.6"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "phone.{validator}"
+class = "custom:phone"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\+\d{{6,15}}\b'''
+
+[recognizers.validator]
+kind = "{validator}"
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+"#
+    )
+}

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -1,0 +1,42 @@
+use std::{fs, path::Path};
+
+use anyhow::{bail, Context, Result};
+
+const NO_PHONE_PARSER_WORKFLOW: &str = ".github/workflows/no-phone-parser.yml";
+const REQUIRED_NO_FEATURE_TEST_COMMAND: &str =
+    "cargo test -p gaze-recognizers --no-default-features";
+const REQUIRED_PACKAGE_TARGET: &str = "gaze-recognizers";
+const REQUIRED_NO_DEFAULT_FEATURES: &str = "--no-default-features";
+
+pub fn run() -> Result<()> {
+    let workflow = Path::new(NO_PHONE_PARSER_WORKFLOW);
+    let contents = fs::read_to_string(workflow)
+        .with_context(|| format!("failed to read {}", workflow.display()))?;
+
+    if !contents.contains(REQUIRED_PACKAGE_TARGET) {
+        bail!(
+            "ci_feature_matrix: {} no longer targets {}",
+            workflow.display(),
+            REQUIRED_PACKAGE_TARGET
+        );
+    }
+
+    if !contents.contains(REQUIRED_NO_DEFAULT_FEATURES) {
+        bail!(
+            "ci_feature_matrix: {} no longer uses {}",
+            workflow.display(),
+            REQUIRED_NO_DEFAULT_FEATURES
+        );
+    }
+
+    if !contents.contains(REQUIRED_NO_FEATURE_TEST_COMMAND) {
+        bail!(
+            "ci_feature_matrix: {} must contain `{}`",
+            workflow.display(),
+            REQUIRED_NO_FEATURE_TEST_COMMAND
+        );
+    }
+
+    println!("ci_feature_matrix: passed");
+    Ok(())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@ use std::process::Command as ProcessCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
+mod ci_feature_matrix;
 mod no_tenant_knowledge;
 
 #[derive(Debug, Parser)]
@@ -22,6 +23,7 @@ enum Command {
     RecognizerCompositionValidator,
     NoTenantKnowledge,
     AuditMetadataOnly,
+    CiFeatureMatrix,
 }
 
 fn main() -> Result<()> {
@@ -32,6 +34,7 @@ fn main() -> Result<()> {
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NoTenantKnowledge => no_tenant_knowledge::run(),
         Command::AuditMetadataOnly => run_audit_metadata_only_gate(),
+        Command::CiFeatureMatrix => ci_feature_matrix::run(),
     }
 }
 


### PR DESCRIPTION
## Summary

Implements S5 for v0.4.6: prove `gaze-recognizers` fails closed when built without default phone parser support instead of silently loading phone-backed recognizers.

## Changes

- Adds `gaze_recognizers::load_rulepack` validation for recognizer validator/normalizer names at rulepack load time.
- Adds table-driven no-default-features regression coverage for `e164_phone`, `e164_phone_national_de`, and `e164_phone_national_us`.
- Adds `ci-feature-matrix` xtask and a `no-phone-parser` GitHub Actions workflow on `ubuntu-24.04`.

## Verification

Worker 792 recorded all verification in Solo scratchpad `spawn-792-status`:

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo build -p gaze-recognizers --no-default-features`
- `cargo test -p gaze-recognizers --no-default-features`
- `cargo run -p xtask -- ci-feature-matrix`

Adversarial rehearsal: temporarily ignored `ValidatorKind::parse` errors in the recognizer-aware loader and confirmed `cargo test -p gaze-recognizers --no-default-features --test no_phone_parser_fail_closed` failed non-zero, then reverted the temporary change.

## Axis impact

Strengthens reliability and trust: unsupported parser-backed recognizers fail closed in no-feature builds, and CI now proves that build matrix remains covered.
