### PR TITLE
v0.4.6 S4: broaden DE national-phone (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [bundle-tokenization-drift] Baseline snapshot contract added for `core` and `core-extended` no-policy bundled tokenization output; future snapshot drift must carry an explicit source ACK and this Changed-section marker.
+- [bundle-tokenization-drift] `core`/`core-extended` baselines updated for the S4 `core-extended` DE national phone broaden fixture.
 
 ## [0.4.5] - 2026-04-26
 

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2250,6 +2250,25 @@ fn s2_cli_bundled_core_extended_no_policy_tokenizes_national_de_and_us_phones() 
 }
 
 #[test]
+fn s4_cli_bundled_core_extended_round_trips_broadened_de_area_code_phone() {
+    let input = "Phone +49 40 0000 0000";
+    let value = clean_json_with_args(&["--rulepack-bundled", "core-extended"], input);
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(
+        Regex::new(r"^Phone <[0-9a-f]{8}:Custom:phone_1>$")
+            .unwrap()
+            .is_match(clean),
+        "unexpected DE clean text: {clean}"
+    );
+    assert_eq!(value["stats"]["detections"], 1);
+    assert_eq!(
+        restore_success_text(value["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+}
+
+#[test]
 fn s2_core_extended_cli_locale_gating_and_plain_en_negative() {
     let (_dir, policy) =
         write_policy_with_core_extended_rulepacks(&["core", "core-extended"], "en-US");

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -32,7 +32,7 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?x)(?:\+49[\s.-]*|0)(?:30|151)[\s.-]*(?:\d[\s.-]*){6,8}\d\b'''
+pattern = '''(?x)(?:\+49[\s.-]*|0)(?:30|40|69|89|221|711|151)[\s.-]*(?:\d[\s.-]*){6,8}\d\b'''
 
 [recognizers.validator]
 kind = "e164_phone_national_de"

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -194,6 +194,7 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ),
         vec!["+49 30 0000 0000".to_string()]
     );
+    // drift-ack: S4 DE national phone broaden — internal recall per gaze-laravel
     for (input, expected) in [
         // Source: synthetic-non-reachable; Germany has no official fictional
         // range equivalent to NANPA 555-01XX, so these literals are

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -194,6 +194,22 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ),
         vec!["+49 30 0000 0000".to_string()]
     );
+    for (input, expected) in [
+        // Source: synthetic-non-reachable; Germany has no official fictional
+        // range equivalent to NANPA 555-01XX, so these literals are
+        // parser-valid but intentionally non-routable-looking test shapes.
+        ("Phone +49 40 0000 0000", "+49 40 0000 0000"),
+        ("Phone +49 89 0000 0000", "+49 89 0000 0000"),
+        ("Phone +49 69 0000 0000", "+49 69 0000 0000"),
+        ("Phone +49 221 0000 000", "+49 221 0000 000"),
+        ("Phone +49 711 0000 000", "+49 711 0000 000"),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),
+            vec![expected.to_string()],
+            "{input}"
+        );
+    }
     assert_eq!(
         detect_recognizer(
             &rulepack,
@@ -232,17 +248,28 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
 
     for input in [
         "1.2.3.4567",
+        "1.2.3",
         "version v1.2.3.4",
         "2026-04-25",
         "0815 12345",
         "0123-456789",
         "+99999999",
+        "Order_42",
+        "Subscriber_12345",
+        "This bare inventory count is 12345 in a non-postal sentence",
         "Subscriber_0001234567",
+        "Subscriber_4915550112233",
+        "Customer_4915550112234",
+        "Order_4915550112235",
         "Order_0815",
     ] {
         assert!(
             detect_recognizer(&rulepack, "phone.structural", input, LocaleTag::DeDe).is_empty(),
             "phone.structural must not fire for {input}"
+        );
+        assert!(
+            detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe).is_empty(),
+            "phone.national.de must not fire for {input}"
         );
     }
 }

--- a/crates/xtask/fixtures/drift-corpus.txt
+++ b/crates/xtask/fixtures/drift-corpus.txt
@@ -4,7 +4,7 @@
 From: "Dr. Schmidt" <alice@example.invalid>
 Contact email bob.audit@example.invalid for updates.
 
-US reserved phone +1 555 0100 routes nowhere.
+DE broadened synthetic phone +49 40 0000 0000 routes nowhere.
 DE synthetic phone +49 30 0000 0000 routes nowhere.
 Extended IBAN sample GB82WEST12345698765432 is synthetic.
 Test card 4111 1111 1111 1111 is a Luhn fixture.

--- a/crates/xtask/snapshots/core-extended-no-policy.json
+++ b/crates/xtask/snapshots/core-extended-no-policy.json
@@ -2,13 +2,13 @@
   "schema_version": 1,
   "bundle": "core-extended",
   "rulepack_version": "0.4.5",
-  "fixtures_sha256": "688b6313f178d62993aa714ee993adda9e4f1ad8f913fedff0100b1d2f294679",
+  "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {
       "recognizer_id": "card.structural",
       "class": "custom:credit_card",
       "byte_span": {
-        "start": 376,
+        "start": 392,
         "len": 19
       },
       "family": "session_custom_counter",
@@ -19,7 +19,7 @@
       "recognizer_id": "iban.structural",
       "class": "custom:iban",
       "byte_span": {
-        "start": 329,
+        "start": 345,
         "len": 22
       },
       "family": "session_custom_counter",
@@ -30,7 +30,7 @@
       "recognizer_id": "ip.v4",
       "class": "custom:ip_address",
       "byte_span": {
-        "start": 432,
+        "start": 448,
         "len": 10
       },
       "family": "session_custom_counter",
@@ -41,7 +41,7 @@
       "recognizer_id": "ip.v6",
       "class": "custom:ip_address",
       "byte_span": {
-        "start": 493,
+        "start": 509,
         "len": 28
       },
       "family": "session_custom_counter",
@@ -49,11 +49,22 @@
       "count": 1
     },
     {
-      "recognizer_id": "phone.national.us",
+      "recognizer_id": "phone.national.de",
       "class": "custom:phone",
       "byte_span": {
-        "start": 228,
-        "len": 11
+        "start": 239,
+        "len": 16
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:phone_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "phone.national.de",
+      "class": "custom:phone",
+      "byte_span": {
+        "start": 291,
+        "len": 16
       },
       "family": "session_custom_counter",
       "token_shape": "<session:Custom:phone_{N}>",
@@ -63,7 +74,7 @@
       "recognizer_id": "postal.us",
       "class": "custom:postal_code",
       "byte_span": {
-        "start": 553,
+        "start": 569,
         "len": 10
       },
       "family": "session_custom_counter",
@@ -74,7 +85,7 @@
       "recognizer_id": "postal.us",
       "class": "custom:postal_code",
       "byte_span": {
-        "start": 611,
+        "start": 627,
         "len": 5
       },
       "family": "session_custom_counter",
@@ -83,12 +94,12 @@
     }
   ],
   "stats": {
-    "detections": 7,
+    "detections": 8,
     "classes": {
       "custom:credit_card": 1,
       "custom:iban": 1,
       "custom:ip_address": 2,
-      "custom:phone": 1,
+      "custom:phone": 2,
       "custom:postal_code": 2
     }
   }

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "bundle": "core",
   "rulepack_version": "0.4.5",
-  "fixtures_sha256": "688b6313f178d62993aa714ee993adda9e4f1ad8f913fedff0100b1d2f294679",
+  "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {
       "recognizer_id": "email.global",
@@ -30,7 +30,7 @@
       "recognizer_id": "email.global",
       "class": "Email",
       "byte_span": {
-        "start": 1363,
+        "start": 1379,
         "len": 23
       },
       "family": "session_builtin_counter",

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -339,9 +339,12 @@ gaze clean --rulepack-bundled core,core-extended --policy ./policy.toml
   unassigned values such as `+99999999` do not emit detections.
 - `phone.national.de` and `phone.national.us` match parser-backed national
   phone shapes and emit `custom:phone` under the bundled default locale chain
-  (`en-US`, `de-DE`, `de-AT`, `de-CH`, then `global`). These recognizers
-  cooperate with `phone.structural` so the rulepack can carry multiple phone
-  recognizers without fail-closed same-class rejection.
+  (`en-US`, `de-DE`, `de-AT`, `de-CH`, then `global`). The DE recognizer
+  includes Berlin (`30`), Hamburg (`40`), Frankfurt (`69`), Munich (`89`),
+  Cologne (`221`), Stuttgart (`711`), and the synthetic mobile fixture shape
+  (`151`) while still requiring `e164_phone_national_de` validation. These
+  recognizers cooperate with `phone.structural` so the rulepack can carry
+  multiple phone recognizers without fail-closed same-class rejection.
 - `iban.structural` emits `custom:iban` only for IBAN-shaped candidates that
   pass `iban_mod97`; the canonical form is normalized with `iban_canonical`.
 - `card.structural` emits `custom:credit_card` only for 13- to 19-digit


### PR DESCRIPTION
## Summary

Draft PR for S4 (#167). Broadens `phone.national.de` to cover parser-backed DE area codes needed by internal gaze-laravel phone-recall work: Hamburg (`40`), Munich (`89`), Frankfurt (`69`), Cologne (`221`), and Stuttgart (`711`), while preserving `e164_phone_national_de` parser validation as the authority.

This is intentionally draft and blocked on S1 merge because `bundle-tokenization-drift` is not present on current `origin/main`; Phase 3 snapshot ACK cannot be completed until S1 lands.

## Acceptance Criteria

1. Positive fixtures tokenize: Hamburg `+49 40 0000 0000`, Munich `+49 89 0000 0000`, Frankfurt `+49 69 0000 0000`, Cologne `+49 221 0000 000`, Stuttgart `+49 711 0000 000`.
2. Negative fixtures do not tokenize as phone: `Order_42`, `1.2.3`, `Subscriber_12345`, a bare 5-digit `12345` in a non-postal sentence, plus parser-valid E.164-looking tenant IDs `Subscriber_4915550112233`, `Customer_4915550112234`, `Order_4915550112235`.
3. Internal phone-recall need: proceeding per orchestrator unconditional S4 directive, using gaze-laravel-internal phone-recall needs as driver.
4. Snapshot ACK: BLOCKED until S1 merges. Current base has no `bundle-tokenization-drift` subcommand; draft remains blocked pending `crates/xtask/snapshots/core-extended-no-policy.json`, `// drift-ack: S4 DE national phone broaden — internal recall per gaze-laravel`, and `[bundle-tokenization-drift]` CHANGELOG line.
5. CLI round-trip: added clean→restore test for a broadened Hamburg fixture; restore returns the original input byte-for-byte.

## Axis-1 rationale

Recall broadening is constrained to known DE area-code prefixes and remains parser-backed with `e164_phone_national_de`. Tenant-shaped negative fixtures are explicit because parser-valid E.164-looking strings can still be adopter IDs semantically; this keeps recall gain from becoming a tenant-ID leak regression.

## Verification

- `cargo test -p gaze-recognizers --test core_extended corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs --features phone-parser`
- `cargo test -p gaze-cli --test cli_pipe s4_cli_bundled_core_extended_round_trips_broadened_de_area_code_phone`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo run -p xtask -- bundle-tokenization-drift` currently fails as expected: `unrecognized subcommand` because S1 has not merged

## Draft blocker

Do not request review until S1 lands and this branch is rebased with snapshot baseline + drift ACK + CHANGELOG Changed line.