### PR TITLE
v0.4.6 S2: fixture-citation xtask lint (#166)

### DIFF
--- a/.github/workflows/fixture-citation-lint.yml
+++ b/.github/workflows/fixture-citation-lint.yml
@@ -1,0 +1,19 @@
+name: fixture-citation-lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  fixture-citation-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run fixture citation lint gate
+        run: cargo run -p xtask -- fixture-citation-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,26 @@ The `order_id` denylist is intentionally broad — it catches `Order_42`, `order
 
 Round-trip, three-surfaces, and recognizer-composition cross-cutting rows are N/A for this structural gate: it emits no tokens, adds no runtime knobs, and does not compose recognizers. The no-tenant-knowledge row is enforced by CI so production code must pass post-merge.
 
+## Fixture citations in production code
+
+Production Rust code in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`
+MUST NOT introduce hardcoded fixture-shaped PII literals unless the line or
+immediately preceding line cites the behavioral test that owns the fixture:
+
+```rust
+// fixture-cited(crates/gaze/tests/email.rs:gaze::tests::email_round_trip)
+const FIXTURE_EMAIL: &str = "alice@example.invalid";
+```
+
+The `cargo run -p xtask -- fixture-citation-lint` gate verifies two things:
+the production literal has a `fixture-cited(...)` marker, and
+`cargo test --workspace -- --list` contains the cited fully qualified test name
+exactly. Suffix-only matches and path-only markers do not pass.
+
+Known limitation: this gate proves the cited test exists, not that the test body
+still asserts that exact fixture literal. Reviewers must still check that the
+citation points at a meaningful behavioral assertion.
+
 ## Phone-number fixtures
 
 Test and benchmark fixtures that contain phone numbers MUST use synthetic, non-reachable values from documented reservation ranges:
@@ -42,6 +62,7 @@ cargo run -p xtask -- symmetric-potemkin
 cargo run -p xtask -- class-map-override-safety
 cargo run -p xtask -- recognizer-composition-validator
 cargo run -p xtask -- no-tenant-knowledge
+cargo run -p xtask -- fixture-citation-lint
 cargo run -p xtask -- audit-metadata-only
 ```
 

--- a/crates/xtask/src/fixture_citation.rs
+++ b/crates/xtask/src/fixture_citation.rs
@@ -1,0 +1,326 @@
+use std::{
+    collections::HashSet,
+    error::Error,
+    fmt, fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const PRODUCTION_CRATES: &[&str] = &["gaze", "gaze-recognizers", "gaze-assembly", "gaze-cli"];
+const MARKER_PREFIX: &str = "// fixture-cited(";
+const MARKER_SUFFIX: &str = ")";
+const FIXTURE_PATTERNS: &[&str] = &[
+    concat!("@", "example.invalid"),
+    concat!("+1-555-", "01"),
+    concat!("+44-7700-", "900"),
+    concat!("+49 1555 ", "011"),
+    concat!("Dr. ", "Schmidt"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FixtureCitationError {
+    MissingCitation { violations: Vec<Violation> },
+    MissingTest { violations: Vec<Violation> },
+    InvalidMarker { violations: Vec<Violation> },
+    Io { path: PathBuf, message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub path: PathBuf,
+    pub line: usize,
+    pub pattern: &'static str,
+    pub text: String,
+    pub citation: Option<Citation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Citation {
+    pub test_path: String,
+    pub test_name: String,
+}
+
+pub type Result<T> = std::result::Result<T, FixtureCitationError>;
+
+pub fn run() -> anyhow::Result<()> {
+    let listed_tests = workspace_test_names()?;
+    scan_root_with_tests(".", &listed_tests)?;
+    println!("fixture_citation_lint: passed");
+    Ok(())
+}
+
+pub fn scan_root_with_tests(root: impl AsRef<Path>, listed_tests: &HashSet<String>) -> Result<()> {
+    let root = root.as_ref();
+    let mut missing_citation = Vec::new();
+    let mut missing_test = Vec::new();
+    let mut invalid_marker = Vec::new();
+
+    for file in production_files(root)? {
+        let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
+        let active_lines = active_production_lines(&content);
+        for (line_index, line) in active_lines.iter().enumerate() {
+            let line_number = line_index + 1;
+            let Some(pattern) = fixture_pattern(line) else {
+                continue;
+            };
+            let marker_text = marker_for_line(&active_lines, line_index);
+            let Some(marker_text) = marker_text else {
+                missing_citation.push(violation(&file, line_number, pattern, line, None));
+                continue;
+            };
+            let citation = match parse_marker(marker_text) {
+                Some(citation) => citation,
+                None => {
+                    invalid_marker.push(violation(&file, line_number, pattern, line, None));
+                    continue;
+                }
+            };
+            if !listed_tests.contains(&citation.test_name) {
+                missing_test.push(violation(&file, line_number, pattern, line, Some(citation)));
+            }
+        }
+    }
+
+    if !invalid_marker.is_empty() {
+        return Err(FixtureCitationError::InvalidMarker {
+            violations: invalid_marker,
+        });
+    }
+
+    if !missing_citation.is_empty() {
+        return Err(FixtureCitationError::MissingCitation {
+            violations: missing_citation,
+        });
+    }
+
+    if !missing_test.is_empty() {
+        return Err(FixtureCitationError::MissingTest {
+            violations: missing_test,
+        });
+    }
+
+    Ok(())
+}
+
+fn workspace_test_names() -> anyhow::Result<HashSet<String>> {
+    let output = Command::new("cargo")
+        .arg("test")
+        .arg("--workspace")
+        .arg("--")
+        .arg("--list")
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to list workspace tests: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(parse_test_list(&String::from_utf8_lossy(&output.stdout)))
+}
+
+pub fn parse_test_list(output: &str) -> HashSet<String> {
+    output
+        .lines()
+        .filter_map(|line| line.strip_suffix(": test"))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn production_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for crate_name in PRODUCTION_CRATES {
+        let src = root.join("crates").join(crate_name).join("src");
+        if !src.exists() {
+            continue;
+        }
+        collect_rs_files(&src, &mut files)?;
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).map_err(|error| io_error(dir, error))? {
+        let entry = entry.map_err(|error| io_error(dir, error))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, files)?;
+        } else if path.extension().is_some_and(|extension| extension == "rs")
+            && !is_test_only_file(&path)
+        {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn is_test_only_file(path: &Path) -> bool {
+    matches!(
+        path.file_stem().and_then(|stem| stem.to_str()),
+        Some("tests" | "test_support")
+    )
+}
+
+fn active_production_lines(content: &str) -> Vec<String> {
+    let mut active = Vec::new();
+    let mut pending_cfg_test = false;
+    let mut test_mod_depth: Option<isize> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if test_mod_depth.is_some() {
+            update_depth(&mut test_mod_depth, line);
+            active.push(String::new());
+            continue;
+        }
+
+        if trimmed.starts_with("#[cfg(test)]") {
+            pending_cfg_test = true;
+            active.push(String::new());
+            continue;
+        }
+
+        if pending_cfg_test && trimmed.starts_with("mod ") {
+            pending_cfg_test = false;
+            let mut depth = 0;
+            apply_brace_delta(&mut depth, line);
+            if depth > 0 {
+                test_mod_depth = Some(depth);
+            }
+            active.push(String::new());
+            continue;
+        }
+
+        pending_cfg_test = false;
+        active.push(line.to_owned());
+    }
+
+    active
+}
+
+fn update_depth(depth: &mut Option<isize>, line: &str) {
+    if let Some(value) = depth.as_mut() {
+        apply_brace_delta(value, line);
+        if *value <= 0 {
+            *depth = None;
+        }
+    }
+}
+
+fn apply_brace_delta(depth: &mut isize, line: &str) {
+    for ch in line.chars() {
+        match ch {
+            '{' => *depth += 1,
+            '}' => *depth -= 1,
+            _ => {}
+        }
+    }
+}
+
+fn fixture_pattern(line: &str) -> Option<&'static str> {
+    FIXTURE_PATTERNS
+        .iter()
+        .copied()
+        .find(|pattern| line.contains(pattern))
+}
+
+fn marker_for_line(lines: &[String], line_index: usize) -> Option<&str> {
+    if let Some(marker) = extract_marker(&lines[line_index]) {
+        return Some(marker);
+    }
+    if line_index == 0 {
+        return None;
+    }
+    extract_marker(&lines[line_index - 1])
+}
+
+fn extract_marker(line: &str) -> Option<&str> {
+    let marker_start = line.find(MARKER_PREFIX)?;
+    let after_prefix = marker_start + MARKER_PREFIX.len();
+    let marker_end = line[after_prefix..].find(MARKER_SUFFIX)? + after_prefix;
+    Some(&line[after_prefix..marker_end])
+}
+
+fn parse_marker(marker: &str) -> Option<Citation> {
+    let (test_path, test_name) = marker.split_once(':')?;
+    if test_path.is_empty()
+        || test_name.is_empty()
+        || !test_path.ends_with(".rs")
+        || !test_name.contains("::")
+    {
+        return None;
+    }
+    Some(Citation {
+        test_path: test_path.to_owned(),
+        test_name: test_name.to_owned(),
+    })
+}
+
+fn violation(
+    path: &Path,
+    line: usize,
+    pattern: &'static str,
+    text: &str,
+    citation: Option<Citation>,
+) -> Violation {
+    Violation {
+        path: path.to_path_buf(),
+        line,
+        pattern,
+        text: text.trim().to_owned(),
+        citation,
+    }
+}
+
+fn io_error(path: &Path, error: io::Error) -> FixtureCitationError {
+    FixtureCitationError::Io {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    }
+}
+
+impl fmt::Display for FixtureCitationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FixtureCitationError::MissingCitation { violations } => {
+                writeln!(formatter, "FixtureCitationMissingCitation")?;
+                write_violations(formatter, violations)
+            }
+            FixtureCitationError::MissingTest { violations } => {
+                writeln!(formatter, "FixtureCitationMissingTest")?;
+                write_violations(formatter, violations)
+            }
+            FixtureCitationError::InvalidMarker { violations } => {
+                writeln!(formatter, "FixtureCitationInvalidMarker")?;
+                write_violations(formatter, violations)
+            }
+            FixtureCitationError::Io { path, message } => {
+                write!(formatter, "{}: {}", path.display(), message)
+            }
+        }
+    }
+}
+
+impl Error for FixtureCitationError {}
+
+fn write_violations(formatter: &mut fmt::Formatter<'_>, violations: &[Violation]) -> fmt::Result {
+    for violation in violations {
+        write!(
+            formatter,
+            "{}:{} matched {}: {}",
+            violation.path.display(),
+            violation.line,
+            violation.pattern,
+            violation.text
+        )?;
+        if let Some(citation) = &violation.citation {
+            write!(
+                formatter,
+                " cited {}:{}",
+                citation.test_path, citation.test_name
+            )?;
+        }
+        writeln!(formatter)?;
+    }
+    Ok(())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@ use std::process::Command as ProcessCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
+mod fixture_citation;
 mod no_tenant_knowledge;
 
 #[derive(Debug, Parser)]
@@ -21,6 +22,7 @@ enum Command {
     ClassMapOverrideSafety,
     RecognizerCompositionValidator,
     NoTenantKnowledge,
+    FixtureCitationLint,
     AuditMetadataOnly,
 }
 
@@ -31,6 +33,7 @@ fn main() -> Result<()> {
         Command::ClassMapOverrideSafety => run_class_map_override_safety_gate(),
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NoTenantKnowledge => no_tenant_knowledge::run(),
+        Command::FixtureCitationLint => fixture_citation::run(),
         Command::AuditMetadataOnly => run_audit_metadata_only_gate(),
     }
 }

--- a/crates/xtask/tests/adversarial_fixture_citation.rs
+++ b/crates/xtask/tests/adversarial_fixture_citation.rs
@@ -1,0 +1,129 @@
+#![allow(dead_code)]
+
+use std::{collections::HashSet, fs};
+
+#[path = "../src/fixture_citation.rs"]
+mod fixture_citation;
+
+use fixture_citation::{scan_root_with_tests, FixtureCitationError};
+
+#[test]
+fn fixture_email_in_production_scope_without_citation_fails_with_file_and_line() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    let fixture = src_dir.join("lib.rs");
+    fs::write(
+        &fixture,
+        "pub fn fixture() {\n    let _ = \"alice@example.invalid\";\n}\n",
+    )
+    .expect("write seeded production fixture");
+
+    let result = scan_root_with_tests(temp.path(), &HashSet::new());
+    fs::remove_file(&fixture).expect("remove seeded production fixture");
+
+    let error = result.expect_err("uncited fixture-shaped literal must fail");
+    let output = error.to_string();
+    assert!(
+        matches!(error, FixtureCitationError::MissingCitation { .. }),
+        "expected missing citation, got {output}"
+    );
+    assert!(
+        output.contains("lib.rs:2"),
+        "gate output must include file:line pointer: {output}"
+    );
+    assert!(
+        output.contains("@example.invalid"),
+        "gate output must mention matched fixture pattern: {output}"
+    );
+}
+
+#[test]
+fn fixture_email_with_exact_existing_test_citation_passes() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    fs::write(
+        src_dir.join("lib.rs"),
+        concat!(
+            "// fixture-cited(crates/gaze/tests/email.rs:gaze::tests::email_round_trip)\n",
+            "pub const EMAIL: &str = \"alice@example.invalid\";\n",
+        ),
+    )
+    .expect("write cited production fixture");
+    let listed_tests = HashSet::from(["gaze::tests::email_round_trip".to_string()]);
+
+    scan_root_with_tests(temp.path(), &listed_tests)
+        .expect("exact cited test name should satisfy citation gate");
+}
+
+#[test]
+fn fixture_email_with_suffix_only_test_match_fails() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    fs::write(
+        src_dir.join("lib.rs"),
+        concat!(
+            "pub const EMAIL: &str = \"alice@example.invalid\"; ",
+            "// fixture-cited(crates/gaze/tests/email.rs:gaze::tests::email_round_trip)\n",
+        ),
+    )
+    .expect("write cited production fixture");
+    let listed_tests = HashSet::from(["email_round_trip".to_string()]);
+
+    let error = scan_root_with_tests(temp.path(), &listed_tests)
+        .expect_err("suffix-only test names must not satisfy citation gate");
+    let output = error.to_string();
+    assert!(
+        matches!(error, FixtureCitationError::MissingTest { .. }),
+        "expected missing exact test, got {output}"
+    );
+    assert!(
+        output.contains("gaze::tests::email_round_trip"),
+        "missing-test output must mention the cited exact test name: {output}"
+    );
+}
+
+#[test]
+fn fixture_email_with_renamed_cited_test_fails_adversarially() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    fs::write(
+        src_dir.join("lib.rs"),
+        concat!(
+            "// fixture-cited(crates/gaze/tests/email.rs:gaze::tests::email_round_trip)\n",
+            "pub const EMAIL: &str = \"alice@example.invalid\";\n",
+        ),
+    )
+    .expect("write cited production fixture");
+    let listed_tests = HashSet::from(["gaze::tests::email_round_trip_renamed".to_string()]);
+
+    let error = scan_root_with_tests(temp.path(), &listed_tests)
+        .expect_err("renaming the cited test must fail the citation gate");
+    let output = error.to_string();
+    assert!(
+        matches!(error, FixtureCitationError::MissingTest { .. }),
+        "expected missing cited test after rename, got {output}"
+    );
+    assert!(
+        output.contains("FixtureCitationMissingTest"),
+        "gate output must identify missing-test failure: {output}"
+    );
+}
+
+#[test]
+fn fixture_strings_inside_cfg_test_modules_are_outside_production_lint_surface() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let src_dir = temp.path().join("crates/gaze/src");
+    fs::create_dir_all(&src_dir).expect("create mock production src");
+    fs::write(
+        src_dir.join("lib.rs"),
+        "#[cfg(test)]\nmod tests {\n    const EMAIL: &str = \"alice@example.invalid\";\n}\n",
+    )
+    .expect("write cfg-test fixture");
+
+    scan_root_with_tests(temp.path(), &HashSet::new())
+        .expect("fixture-shaped strings in cfg(test) modules are not production code");
+}

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -10,6 +10,7 @@ $ cargo run -p xtask -- symmetric-potemkin
 $ cargo run -p xtask -- class-map-override-safety
 $ cargo run -p xtask -- recognizer-composition-validator
 $ cargo run -p xtask -- no-tenant-knowledge
+$ cargo run -p xtask -- fixture-citation-lint
 ```
 
 The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.rs).
@@ -22,6 +23,30 @@ The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.
 | `ClassMapOverrideSafety` | `cargo run -p xtask -- class-map-override-safety` | Activated in v0.4.4. Lists and runs `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered`. An adversarial in-PR self-test verifies the gate fails non-zero when a listed test is missing or renamed, following the meta-Potemkin guard captured in drawer `gaze_architecture_12b32d53`. |
 | `RecognizerCompositionValidator` | `cargo run -p xtask -- recognizer-composition-validator` | Lists and runs the behavioral tests in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS`. The gate fails if the rulepack composition validator tests are missing or failing. |
 | `NoTenantKnowledge` | `cargo run -p xtask -- no-tenant-knowledge` | Added in v0.4.3. Production-code lint scanner that rejects tenant-pattern strings (`order_id`, `Order_42`, `Song_42`, `User_7`) in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. Allow markers (`// allow(tenant-fixture)`) hard-fail in production scope and remain valid only in tests, benches, docs, and `CONTRIBUTING.md`. |
+| `FixtureCitationLint` | `cargo run -p xtask -- fixture-citation-lint` | Added in v0.4.6 S2. Production-code lint scanner for fixture-shaped PII literals in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. Each production fixture literal must carry `// fixture-cited(<test-path>:<fully-qualified-test-name>)`, and the fully qualified test name must appear exactly in `cargo test --workspace -- --list`. |
+
+## fixture_citation_lint self-test + limitation
+
+The fixture citation gate prevents production code from accumulating
+uncited fixture-shaped PII literals. It intentionally scans the same crate
+source roots as `no_tenant_knowledge`, while excluding Rust regions compiled
+only under `#[cfg(test)]`.
+
+Adversarial self-test for reviewers:
+
+1. On a throwaway branch, add a production-scope fixture literal such as
+   `"alice@example.invalid"` with a valid-looking marker:
+   `// fixture-cited(crates/gaze/tests/email.rs:gaze::tests::email_round_trip)`.
+2. Run `cargo run -p xtask -- fixture-citation-lint`; it must fail unless
+   `cargo test --workspace -- --list` contains the cited test name exactly.
+3. If the cited test exists, temporarily rename the test, rerun the gate, and
+   confirm it exits non-zero with `FixtureCitationMissingTest`.
+4. Revert the throwaway changes before merging.
+
+Known limitation: the gate proves that the cited test exists. It does not prove
+that the test body still asserts the specific fixture literal. That deeper
+semantic tie is out of scope for the v0.4.6 S2 two-point lint gate and remains
+a code-review responsibility.
 
 ## audit_metadata_only — known limitations (v0.4.5)
 


### PR DESCRIPTION
## Summary

Implements v0.4.6 S2 from solo scratchpad 421 §S2 / issue #166.

- Adds `cargo run -p xtask -- fixture-citation-lint` for production-scope fixture-shaped PII literals in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`.
- Requires `// fixture-cited(<test-path>:<fully-qualified-test-name>)` and exact presence in `cargo test --workspace -- --list`; no suffix or path-only matching.
- Adds adversarial xtask integration coverage and CI workflow with `cargo fmt --all -- --check` plus the gate.
- Documents reviewer self-test instructions and the known limitation: the gate proves the cited test exists, not that its body asserts the fixture.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo run -p xtask -- fixture-citation-lint`
- Manual adversarial rehearsal: temporary production probe cited `gaze::tests::email_round_trip_renamed`; `fixture-citation-lint` exited non-zero with `FixtureCitationMissingTest`, then the probe was removed and the worktree returned clean.
