### PR TITLE
v0.4.6 S1: bundle-tokenization-drift xtask gate

### DIFF
--- a/.github/workflows/bundle-tokenization-drift.yml
+++ b/.github/workflows/bundle-tokenization-drift.yml
@@ -1,0 +1,17 @@
+name: bundle-tokenization-drift
+
+on: [pull_request, push]
+
+jobs:
+  bundle-tokenization-drift:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run bundle tokenization drift gate
+        run: cargo run -p xtask -- bundle-tokenization-drift
+      - name: Verify bundle tokenization drift ACK
+        run: cargo run -p xtask -- bundle-tokenization-drift --verify-ack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [bundle-tokenization-drift] Baseline snapshot contract added for `core` and `core-extended` no-policy bundled tokenization output; future snapshot drift must carry an explicit source ACK and this Changed-section marker.
+
 ## [0.4.5] - 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,6 +2769,10 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "gaze",
+ "serde",
+ "serde_json",
+ "sha2",
  "syn",
  "tempfile",
 ]

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ echo '{"text":"Email <{session_hex}:Email_1> now","session_blob":"<base64>"}' | 
 
 Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{session_hex}:Location_N>`, `<{session_hex}:Organization_N>`, `<{session_hex}:Custom:name_N>`) are wrapped in angle brackets so the LLM cannot silently dissolve them into adjacent words. Format-preserving email tokens (`email1.{session_hex}@gaze-fake.invalid`) intentionally stay bare — the whole point is to look like a real email.
 
+Default bundled-rulepack tokenization is a contract surface. The no-policy baselines for bundled outputs live in `crates/xtask/snapshots/`, and intentional drift requires a `[bundle-tokenization-drift]` `CHANGELOG.md` `[Unreleased]` Changed entry alongside a source ACK. See `ROADMAP.md` Now/Next/Later for the live stability context behind these gates.
+
 #### Audit Query and Export (v0.4.3+)
 
 When `gaze clean --audit-db <path>` is enabled, the metadata-only redaction log is queryable from the CLI:

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,7 +8,12 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+gaze = { path = "../gaze" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 syn = { version = "2", features = ["full"] }
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/xtask/fixtures/drift-corpus.txt
+++ b/crates/xtask/fixtures/drift-corpus.txt
@@ -1,0 +1,28 @@
+# bundle-tokenization-drift corpus
+# All positive PII fixture values are synthetic, non-reachable, and unique.
+
+From: "Dr. Schmidt" <alice@example.invalid>
+Contact email bob.audit@example.invalid for updates.
+
+US reserved phone +1 555 0100 routes nowhere.
+DE synthetic phone +49 30 0000 0000 routes nowhere.
+Extended IBAN sample GB82WEST12345698765432 is synthetic.
+Test card 4111 1111 1111 1111 is a Luhn fixture.
+Documentation IP 192.0.2.44 is reserved for examples.
+IPv6 documentation host 2001:db8:85a3::8a2e:370:7334 is reserved.
+US postal fixture 94103-1234 is synthetic in this corpus.
+DE postal fixture 10115 is synthetic in this corpus.
+
+# Tenant-shaped negatives that must not tokenize.
+Order_42 remains tenant metadata.
+Subscriber_12345 remains tenant metadata.
+Customer_98765432101 remains tenant metadata.
+Release version 1.2.3 remains software metadata.
+Bare counter ID54321X appears in a non-postal context.
+Long tenant numeric 1234567890123 remains an identifier.
+URL fragment https://example.invalid/orders#id12345 remains a URL fragment.
+Timestamp 2026-04-26T15:30:45Z remains event metadata.
+Sequential digit run 000111222333 remains event metadata.
+ULID-like ID 01ARZ3NDEKTSV4RRFFQ69G5FAV remains tenant metadata.
+Cross-locale postal shape DE-under-US D80331 and US-under-DE U10001 are documented negatives.
+Email local-part embedded numerics user123@example.invalid should tokenize only as email.

--- a/crates/xtask/snapshots/core-extended-no-policy.json
+++ b/crates/xtask/snapshots/core-extended-no-policy.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "bundle": "core-extended",
+  "rulepack_version": "0.4.5",
+  "fixtures_sha256": "688b6313f178d62993aa714ee993adda9e4f1ad8f913fedff0100b1d2f294679",
+  "entries": [
+    {
+      "recognizer_id": "card.structural",
+      "class": "custom:credit_card",
+      "byte_span": {
+        "start": 376,
+        "len": 19
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:credit_card_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "iban.structural",
+      "class": "custom:iban",
+      "byte_span": {
+        "start": 329,
+        "len": 22
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:iban_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "ip.v4",
+      "class": "custom:ip_address",
+      "byte_span": {
+        "start": 432,
+        "len": 10
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:ip_address_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "ip.v6",
+      "class": "custom:ip_address",
+      "byte_span": {
+        "start": 493,
+        "len": 28
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:ip_address_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "phone.national.us",
+      "class": "custom:phone",
+      "byte_span": {
+        "start": 228,
+        "len": 11
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:phone_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "postal.us",
+      "class": "custom:postal_code",
+      "byte_span": {
+        "start": 553,
+        "len": 10
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:postal_code_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "postal.us",
+      "class": "custom:postal_code",
+      "byte_span": {
+        "start": 611,
+        "len": 5
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:postal_code_{N}>",
+      "count": 1
+    }
+  ],
+  "stats": {
+    "detections": 7,
+    "classes": {
+      "custom:credit_card": 1,
+      "custom:iban": 1,
+      "custom:ip_address": 2,
+      "custom:phone": 1,
+      "custom:postal_code": 2
+    }
+  }
+}

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "bundle": "core",
+  "rulepack_version": "0.4.5",
+  "fixtures_sha256": "688b6313f178d62993aa714ee993adda9e4f1ad8f913fedff0100b1d2f294679",
+  "entries": [
+    {
+      "recognizer_id": "email.global",
+      "class": "Email",
+      "byte_span": {
+        "start": 132,
+        "len": 22
+      },
+      "family": "session_builtin_counter",
+      "token_shape": "<session:Email_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "email.global",
+      "class": "Email",
+      "byte_span": {
+        "start": 170,
+        "len": 25
+      },
+      "family": "session_builtin_counter",
+      "token_shape": "<session:Email_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "email.global",
+      "class": "Email",
+      "byte_span": {
+        "start": 1363,
+        "len": 23
+      },
+      "family": "session_builtin_counter",
+      "token_shape": "<session:Email_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "email.header.name",
+      "class": "Name",
+      "byte_span": {
+        "start": 119,
+        "len": 11
+      },
+      "family": "session_builtin_counter",
+      "token_shape": "<session:Name_{N}>",
+      "count": 1
+    }
+  ],
+  "stats": {
+    "detections": 4,
+    "classes": {
+      "Email": 3,
+      "Name": 1
+    }
+  }
+}

--- a/crates/xtask/src/bundle_tokenization_drift.rs
+++ b/crates/xtask/src/bundle_tokenization_drift.rs
@@ -83,7 +83,7 @@ pub fn run(args: Args) -> Result<()> {
     }
 
     if args.verify_ack {
-        println!("bundle-tokenization-drift: verify-ack found no snapshot diff");
+        verify_ack(&root)?;
     }
     println!("bundle-tokenization-drift: passed");
     Ok(())
@@ -531,4 +531,166 @@ fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     format!("{:x}", hasher.finalize())
+}
+
+fn verify_ack(root: &Path) -> Result<()> {
+    let changed_snapshots = changed_snapshot_files(root)?;
+    if changed_snapshots.is_empty() {
+        println!("bundle-tokenization-drift: verify-ack found no snapshot diff");
+        return Ok(());
+    }
+
+    let bundles = changed_snapshots
+        .iter()
+        .map(|path| {
+            path.strip_prefix("crates/xtask/snapshots/")
+                .unwrap_or(path)
+                .trim_end_matches("-no-policy.json")
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+
+    let mut missing = Vec::new();
+    if !diff_contains_drift_ack(root)? {
+        missing.push("missing added/changed `// drift-ack:` source or test comment".to_string());
+    }
+    let changelog_missing = changelog_missing_bundles(root, &bundles)?;
+    if !changelog_missing.is_empty() {
+        missing.push(format!(
+            "missing CHANGELOG.md [Unreleased] ### Changed `[bundle-tokenization-drift]` line for bundle(s): {}",
+            changelog_missing.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    if !missing.is_empty() {
+        bail!(
+            "bundle-tokenization-drift: --verify-ack rejected snapshot changes: {}\nchanged snapshots:\n{}",
+            missing.join("; "),
+            changed_snapshots.into_iter().collect::<Vec<_>>().join("\n")
+        );
+    }
+
+    println!(
+        "bundle-tokenization-drift: verify-ack accepted snapshot diff for {}",
+        bundles.into_iter().collect::<Vec<_>>().join(", ")
+    );
+    Ok(())
+}
+
+fn changed_snapshot_files(root: &Path) -> Result<BTreeSet<String>> {
+    let mut files = BTreeSet::new();
+    for args in [
+        vec!["diff", "--name-only", "--", "crates/xtask/snapshots"],
+        vec![
+            "diff",
+            "--cached",
+            "--name-only",
+            "--",
+            "crates/xtask/snapshots",
+        ],
+    ] {
+        collect_changed_snapshot_files(root, &args, &mut files)?;
+    }
+    if git_ref_exists(root, "origin/main")? {
+        collect_changed_snapshot_files(
+            root,
+            &[
+                "diff",
+                "--name-only",
+                "origin/main...HEAD",
+                "--",
+                "crates/xtask/snapshots",
+            ],
+            &mut files,
+        )?;
+    }
+    Ok(files)
+}
+
+fn collect_changed_snapshot_files(
+    root: &Path,
+    args: &[&str],
+    files: &mut BTreeSet<String>,
+) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    for line in String::from_utf8(output.stdout)?.lines() {
+        if line.starts_with("crates/xtask/snapshots/") && line.ends_with("-no-policy.json") {
+            files.insert(line.to_string());
+        }
+    }
+    Ok(())
+}
+
+fn diff_contains_drift_ack(root: &Path) -> Result<bool> {
+    let mut diffs = Vec::new();
+    for args in [
+        vec!["diff", "-U0"],
+        vec!["diff", "--cached", "-U0"],
+        vec!["diff", "-U0", "origin/main...HEAD"],
+    ] {
+        if args.contains(&"origin/main...HEAD") && !git_ref_exists(root, "origin/main")? {
+            continue;
+        }
+        let output = Command::new("git")
+            .args(&args)
+            .current_dir(root)
+            .output()
+            .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+        if !output.status.success() {
+            bail!(
+                "git {} failed:\n{}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        diffs.push(String::from_utf8(output.stdout)?);
+    }
+    Ok(diffs.iter().any(|diff| {
+        diff.lines().any(|line| {
+            line.starts_with('+') && !line.starts_with("+++") && line.contains("// drift-ack:")
+        })
+    }))
+}
+
+fn changelog_missing_bundles(root: &Path, bundles: &BTreeSet<String>) -> Result<BTreeSet<String>> {
+    let changelog = fs::read_to_string(root.join("CHANGELOG.md"))
+        .context("failed to read CHANGELOG.md for --verify-ack")?;
+    let unreleased = section_between(&changelog, "## [Unreleased]", "\n## ")
+        .ok_or_else(|| anyhow!("CHANGELOG.md is missing [Unreleased] section"))?;
+    let changed = section_between(unreleased, "### Changed", "\n### ").unwrap_or("");
+    Ok(bundles
+        .iter()
+        .filter(|bundle| {
+            !changed
+                .lines()
+                .any(|line| line.contains("[bundle-tokenization-drift]") && line.contains(*bundle))
+        })
+        .cloned()
+        .collect())
+}
+
+fn section_between<'a>(text: &'a str, start_marker: &str, next_marker: &str) -> Option<&'a str> {
+    let start = text.find(start_marker)? + start_marker.len();
+    let rest = &text[start..];
+    let end = rest.find(next_marker).unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+fn git_ref_exists(root: &Path, name: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", name])
+        .current_dir(root)
+        .output()
+        .with_context(|| format!("failed to check git ref {name}"))?;
+    Ok(output.status.success())
 }

--- a/crates/xtask/src/bundle_tokenization_drift.rs
+++ b/crates/xtask/src/bundle_tokenization_drift.rs
@@ -1,0 +1,534 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Parser;
+use gaze::{PiiClass, Rulepack, RulepackSource};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const SCHEMA_VERSION: u8 = 1;
+const FIXTURE_PATH: &str = "crates/xtask/fixtures/drift-corpus.txt";
+const EMBEDDED_RULEPACK_DIR: &str = "crates/gaze-recognizers/embedded";
+const SNAPSHOT_DIR: &str = "crates/xtask/snapshots";
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Rewrite committed bundle tokenization snapshots.
+    #[arg(long, alias = "write-baseline")]
+    regenerate_baseline: bool,
+    /// Require a strict source + CHANGELOG acknowledgement for changed snapshots.
+    #[arg(long)]
+    verify_ack: bool,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let root = std::env::current_dir().context("failed to resolve workspace root")?;
+    let bundles = discover_bundles(&root)?;
+    if bundles.is_empty() {
+        bail!("bundle-tokenization-drift: no bundled rulepacks discovered");
+    }
+
+    let corpus = fs::read_to_string(root.join(FIXTURE_PATH))
+        .with_context(|| format!("failed to read {FIXTURE_PATH}"))?;
+    let fixtures_sha256 = sha256_hex(corpus.as_bytes());
+
+    fs::create_dir_all(root.join(SNAPSHOT_DIR))
+        .with_context(|| format!("failed to create {SNAPSHOT_DIR}"))?;
+
+    let mut drifted = Vec::new();
+    for bundle in bundles {
+        let snapshot_path = root
+            .join(SNAPSHOT_DIR)
+            .join(format!("{}-no-policy.json", bundle.name));
+        if !snapshot_path.exists() && !args.regenerate_baseline {
+            bail!(
+                "bundle-tokenization-drift: missing snapshot for bundle `{}` at {}",
+                bundle.name,
+                snapshot_path.display()
+            );
+        }
+
+        let actual = run_bundle_snapshot(&root, &bundle, &corpus, &fixtures_sha256)?;
+        assert_no_raw_value_leak(&actual, &corpus)?;
+        let actual_json = serde_json::to_string_pretty(&actual)? + "\n";
+
+        if args.regenerate_baseline {
+            fs::write(&snapshot_path, actual_json)
+                .with_context(|| format!("failed to write {}", snapshot_path.display()))?;
+            println!(
+                "bundle-tokenization-drift: wrote {}",
+                snapshot_path.display()
+            );
+            continue;
+        }
+
+        let expected_json = fs::read_to_string(&snapshot_path)
+            .with_context(|| format!("failed to read {}", snapshot_path.display()))?;
+        let expected: Snapshot = serde_json::from_str(&expected_json)
+            .with_context(|| format!("failed to parse {}", snapshot_path.display()))?;
+        if expected != actual {
+            drifted.push(format_snapshot_diff(&bundle.name, &expected, &actual));
+        }
+    }
+
+    if !drifted.is_empty() {
+        bail!(
+            "bundle-tokenization-drift: snapshot drift detected\n{}",
+            drifted.join("\n\n")
+        );
+    }
+
+    if args.verify_ack {
+        println!("bundle-tokenization-drift: verify-ack found no snapshot diff");
+    }
+    println!("bundle-tokenization-drift: passed");
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Bundle {
+    name: String,
+    path: PathBuf,
+    rulepack: Rulepack,
+    activated_classes: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Snapshot {
+    schema_version: u8,
+    bundle: String,
+    rulepack_version: String,
+    fixtures_sha256: String,
+    entries: Vec<SnapshotEntry>,
+    stats: SnapshotStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+struct SnapshotEntry {
+    recognizer_id: String,
+    class: String,
+    byte_span: ByteSpan,
+    family: String,
+    token_shape: String,
+    count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+struct ByteSpan {
+    start: usize,
+    len: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SnapshotStats {
+    detections: u64,
+    classes: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CleanOutput {
+    clean_text: String,
+    session_blob: String,
+    stats: CleanStats,
+}
+
+#[derive(Debug, Deserialize)]
+struct CleanStats {
+    detections: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestoreOutput {
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditRow {
+    source: String,
+    class: String,
+    action: String,
+    conflict_loser: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TokenOccurrence {
+    literal: String,
+    family: String,
+    shape: String,
+}
+
+fn discover_bundles(root: &Path) -> Result<Vec<Bundle>> {
+    let mut bundles = Vec::new();
+    let mut paths = fs::read_dir(root.join(EMBEDDED_RULEPACK_DIR))
+        .with_context(|| format!("failed to read {EMBEDDED_RULEPACK_DIR}"))?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<std::io::Result<Vec<_>>>()
+        .with_context(|| format!("failed to list {EMBEDDED_RULEPACK_DIR}"))?;
+    paths.sort();
+
+    for path in paths {
+        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let rulepack = Rulepack::load(RulepackSource::Embedded(Box::leak(raw.into_boxed_str())))
+            .with_context(|| format!("failed to parse {}", path.display()))?;
+        if rulepack.recognizers.is_empty() {
+            continue;
+        }
+        let name = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or_else(|| anyhow!("invalid bundle filename {}", path.display()))?
+            .to_string();
+        let activated_classes = rulepack
+            .activated_classes()
+            .into_iter()
+            .map(class_to_snapshot_string)
+            .collect();
+        bundles.push(Bundle {
+            name,
+            path,
+            rulepack,
+            activated_classes,
+        });
+    }
+    Ok(bundles)
+}
+
+fn run_bundle_snapshot(
+    root: &Path,
+    bundle: &Bundle,
+    corpus: &str,
+    fixtures_sha256: &str,
+) -> Result<Snapshot> {
+    let temp = tempfile::tempdir().context("failed to create drift tempdir")?;
+    let audit_db = temp.path().join(format!("{}-audit.sqlite", bundle.name));
+
+    let clean = run_with_stdin(
+        root,
+        Command::new("cargo")
+            .args([
+                "run",
+                "-q",
+                "-p",
+                "gaze-cli",
+                "--",
+                "clean",
+                "--rulepack-bundled",
+                &bundle.name,
+                "--audit-db",
+            ])
+            .arg(&audit_db),
+        corpus,
+    )
+    .with_context(|| format!("failed to run clean for bundle `{}`", bundle.name))?;
+    let clean: CleanOutput =
+        serde_json::from_slice(&clean).context("failed to parse gaze clean JSON")?;
+
+    let restored = restore_text(root, &clean.session_blob, &clean.clean_text, true)
+        .context("failed to restore full clean_text")?;
+    if restored != corpus {
+        bail!(
+            "bundle-tokenization-drift: restore mismatch for bundle `{}`",
+            bundle.name
+        );
+    }
+
+    let rows = export_audit_rows(root, &audit_db)?
+        .into_iter()
+        .filter(|row| row.action == "tokenize" && !row.conflict_loser)
+        .collect::<Vec<_>>();
+    let tokens = extract_tokens(&clean.clean_text)?;
+    if rows.len() != tokens.len() {
+        bail!(
+            "bundle-tokenization-drift: bundle `{}` emitted {} audit rows but {} tokens",
+            bundle.name,
+            rows.len(),
+            tokens.len()
+        );
+    }
+    if clean.stats.detections != rows.len() as u64 {
+        bail!(
+            "bundle-tokenization-drift: bundle `{}` stats.detections={} but audit rows={}",
+            bundle.name,
+            clean.stats.detections,
+            rows.len()
+        );
+    }
+
+    let mut entries = BTreeMap::<(String, String, ByteSpan, String, String), u64>::new();
+    let mut classes = BTreeMap::<String, u64>::new();
+    for (row, token) in rows.iter().zip(tokens.iter()) {
+        let class = canonical_audit_class(&row.class);
+        if !bundle.activated_classes.contains(&class) {
+            bail!(
+                "bundle-tokenization-drift: bundle `{}` emitted class `{}` outside activated_classes {:?} from {}",
+                bundle.name,
+                class,
+                bundle.activated_classes,
+                bundle.path.display()
+            );
+        }
+        let raw = restore_text(root, &clean.session_blob, &token.literal, false)
+            .with_context(|| format!("failed to restore token `{}`", token.shape))?;
+        let span = unique_span(corpus, &raw)?;
+        *classes.entry(class.clone()).or_insert(0) += 1;
+        *entries
+            .entry((
+                row.source.clone(),
+                class,
+                span,
+                token.family.clone(),
+                token.shape.clone(),
+            ))
+            .or_insert(0) += 1;
+    }
+
+    Ok(Snapshot {
+        schema_version: SCHEMA_VERSION,
+        bundle: bundle.name.clone(),
+        rulepack_version: bundle.rulepack.rulepack_version.clone(),
+        fixtures_sha256: fixtures_sha256.to_string(),
+        entries: entries
+            .into_iter()
+            .map(
+                |((recognizer_id, class, byte_span, family, token_shape), count)| SnapshotEntry {
+                    recognizer_id,
+                    class,
+                    byte_span,
+                    family,
+                    token_shape,
+                    count,
+                },
+            )
+            .collect(),
+        stats: SnapshotStats {
+            detections: clean.stats.detections,
+            classes,
+        },
+    })
+}
+
+fn run_with_stdin(root: &Path, command: &mut Command, stdin: &str) -> Result<Vec<u8>> {
+    let mut child = command
+        .current_dir(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn command")?;
+    child
+        .stdin
+        .as_mut()
+        .context("failed to open child stdin")?
+        .write_all(stdin.as_bytes())
+        .context("failed to write child stdin")?;
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for command")?;
+    if !output.status.success() {
+        bail!(
+            "command failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output.stdout)
+}
+
+fn run_stdout(root: &Path, command: &mut Command) -> Result<Vec<u8>> {
+    let output = command
+        .current_dir(root)
+        .output()
+        .context("failed to run command")?;
+    if !output.status.success() {
+        bail!(
+            "command failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output.stdout)
+}
+
+fn restore_text(root: &Path, session_blob: &str, text: &str, tolerant: bool) -> Result<String> {
+    let body = serde_json::json!({ "session_blob": session_blob, "text": text }).to_string();
+    let mut command = Command::new("cargo");
+    command.args(["run", "-q", "-p", "gaze-cli", "--", "restore"]);
+    if tolerant {
+        command.args(["--restore-mode", "tolerant"]);
+    }
+    let out = run_with_stdin(root, &mut command, &body)?;
+    let restored: RestoreOutput =
+        serde_json::from_slice(&out).context("failed to parse gaze restore JSON")?;
+    Ok(restored.text)
+}
+
+fn export_audit_rows(root: &Path, audit_db: &Path) -> Result<Vec<AuditRow>> {
+    let out = run_stdout(
+        root,
+        Command::new("cargo")
+            .args([
+                "run",
+                "-q",
+                "-p",
+                "gaze-cli",
+                "--",
+                "audit",
+                "export",
+                "--audit-db",
+            ])
+            .arg(audit_db)
+            .args(["--format", "jsonl"]),
+    )?;
+    String::from_utf8(out)
+        .context("audit export was not UTF-8")?
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).context("failed to parse audit JSONL row"))
+        .collect()
+}
+
+fn extract_tokens(clean_text: &str) -> Result<Vec<TokenOccurrence>> {
+    let bytes = clean_text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0;
+    while let Some(open_rel) = clean_text[cursor..].find('<') {
+        let open = cursor + open_rel;
+        let Some(close_rel) = clean_text[open..].find('>') else {
+            break;
+        };
+        let close = open + close_rel + 1;
+        let literal = &clean_text[open..close];
+        let inner = &literal[1..literal.len() - 1];
+        if let Some((_, rest)) = inner.split_once(':') {
+            if let Some((class_part, _n)) = rest.rsplit_once('_') {
+                let family = if class_part.starts_with("Custom:") {
+                    "session_custom_counter"
+                } else {
+                    "session_builtin_counter"
+                };
+                tokens.push(TokenOccurrence {
+                    literal: literal.to_string(),
+                    family: family.to_string(),
+                    shape: format!("<session:{class_part}_{{N}}>"),
+                });
+            }
+        }
+        cursor = close;
+        if cursor >= bytes.len() {
+            break;
+        }
+    }
+    Ok(tokens)
+}
+
+fn unique_span(corpus: &str, raw: &str) -> Result<ByteSpan> {
+    if raw.is_empty() {
+        bail!("bundle-tokenization-drift: restored empty token");
+    }
+    let matches = corpus.match_indices(raw).collect::<Vec<_>>();
+    if matches.len() != 1 {
+        bail!(
+            "bundle-tokenization-drift: raw fixture value restored from token is not unique; match_count={}",
+            matches.len()
+        );
+    }
+    Ok(ByteSpan {
+        start: matches[0].0,
+        len: raw.len(),
+    })
+}
+
+fn assert_no_raw_value_leak(snapshot: &Snapshot, corpus: &str) -> Result<()> {
+    let json = serde_json::to_string(snapshot)?;
+    for entry in &snapshot.entries {
+        let raw = &corpus[entry.byte_span.start..entry.byte_span.start + entry.byte_span.len];
+        if raw.len() >= 4 && json.contains(raw) {
+            bail!(
+                "bundle-tokenization-drift: snapshot for `{}` contains raw fixture bytes for {}",
+                snapshot.bundle,
+                entry.recognizer_id
+            );
+        }
+    }
+    if json.contains("session_blob") || json.contains("created_at") {
+        bail!(
+            "bundle-tokenization-drift: snapshot for `{}` contains forbidden volatile audit/session field",
+            snapshot.bundle
+        );
+    }
+    Ok(())
+}
+
+fn format_snapshot_diff(bundle: &str, expected: &Snapshot, actual: &Snapshot) -> String {
+    let expected_keys = expected
+        .entries
+        .iter()
+        .map(entry_key)
+        .collect::<BTreeSet<_>>();
+    let actual_keys = actual
+        .entries
+        .iter()
+        .map(entry_key)
+        .collect::<BTreeSet<_>>();
+    let removed = expected_keys.difference(&actual_keys).take(8);
+    let added = actual_keys.difference(&expected_keys).take(8);
+    let mut lines = vec![format!(
+        "bundle `{bundle}` changed detections {} -> {}",
+        expected.stats.detections, actual.stats.detections
+    )];
+    for key in removed {
+        lines.push(format!("  removed {key}"));
+    }
+    for key in added {
+        lines.push(format!("  added {key}"));
+    }
+    lines.join("\n")
+}
+
+fn entry_key(entry: &SnapshotEntry) -> String {
+    format!(
+        "recognizer={} class={} span={}+{} shape={} count={}",
+        entry.recognizer_id,
+        entry.class,
+        entry.byte_span.start,
+        entry.byte_span.len,
+        entry.token_shape,
+        entry.count
+    )
+}
+
+fn class_to_snapshot_string(class: PiiClass) -> String {
+    match class {
+        PiiClass::Email => "Email".to_string(),
+        PiiClass::Name => "Name".to_string(),
+        PiiClass::Location => "Location".to_string(),
+        PiiClass::Organization => "Organization".to_string(),
+        PiiClass::Custom(name) => format!("custom:{name}"),
+    }
+}
+
+fn canonical_audit_class(class: &str) -> String {
+    match class {
+        "email" => "Email".to_string(),
+        "name" => "Name".to_string(),
+        "location" => "Location".to_string(),
+        "organization" => "Organization".to_string(),
+        custom => custom.to_string(),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@ use std::process::Command as ProcessCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
+mod bundle_tokenization_drift;
 mod no_tenant_knowledge;
 
 #[derive(Debug, Parser)]
@@ -22,6 +23,7 @@ enum Command {
     RecognizerCompositionValidator,
     NoTenantKnowledge,
     AuditMetadataOnly,
+    BundleTokenizationDrift(bundle_tokenization_drift::Args),
 }
 
 fn main() -> Result<()> {
@@ -32,6 +34,7 @@ fn main() -> Result<()> {
         Command::RecognizerCompositionValidator => run_recognizer_composition_validator_gate(),
         Command::NoTenantKnowledge => no_tenant_knowledge::run(),
         Command::AuditMetadataOnly => run_audit_metadata_only_gate(),
+        Command::BundleTokenizationDrift(args) => bundle_tokenization_drift::run(args),
     }
 }
 

--- a/crates/xtask/tests/bundle_tokenization_drift.rs
+++ b/crates/xtask/tests/bundle_tokenization_drift.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn run_gate(root: &Path) -> Output {
+    Command::new("cargo")
+        .args(["run", "-p", "xtask", "--", "bundle-tokenization-drift"])
+        .current_dir(root)
+        .output()
+        .expect("run bundle-tokenization-drift gate")
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn bundle_tokenization_drift_gate_passes_on_baseline() {
+    let output = run_gate(&workspace_root());
+    assert!(
+        output.status.success(),
+        "gate must pass on baseline; {}",
+        output_text(&output)
+    );
+}
+
+#[test]
+fn bundle_tokenization_drift_gate_fails_when_enabled_recognizer_id_drifts() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture_root = temp
+        .path()
+        .join("gaze-bundle-tokenization-drift-adversarial");
+    let add_status = Command::new("git")
+        .args(["worktree", "add", "--detach"])
+        .arg(&fixture_root)
+        .arg("HEAD")
+        .current_dir(workspace_root())
+        .status()
+        .expect("create adversarial worktree");
+    assert!(add_status.success(), "git worktree add must succeed");
+
+    let rulepack = fixture_root.join("crates/gaze-recognizers/embedded/core-extended.toml");
+    let source = fs::read_to_string(&rulepack).expect("read core-extended rulepack");
+    assert!(
+        source.contains("id = \"ip.v4\""),
+        "fixture must contain expected recognizer id before mutation"
+    );
+    fs::write(
+        &rulepack,
+        source.replacen("id = \"ip.v4\"", "id = \"ip.v4.drift\"", 1),
+    )
+    .expect("rename recognizer id in fixture");
+
+    let output = run_gate(&fixture_root);
+    let remove_status = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(&fixture_root)
+        .current_dir(workspace_root())
+        .status()
+        .expect("remove adversarial worktree");
+    assert!(remove_status.success(), "git worktree remove must succeed");
+
+    let text = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "gate must fail when recognizer id drifts; {text}"
+    );
+    assert!(
+        text.contains("snapshot drift detected"),
+        "gate failure must identify snapshot drift; {text}"
+    );
+    assert!(
+        text.contains("bundle `core-extended`"),
+        "gate failure must name the changed bundle; {text}"
+    );
+    assert!(
+        text.contains("recognizer=ip.v4") && text.contains("recognizer=ip.v4.drift"),
+        "gate failure must name old and new recognizer ids; {text}"
+    );
+    assert!(
+        text.contains("class=custom:ip_address"),
+        "gate failure must name the changed class; {text}"
+    );
+}

--- a/crates/xtask/tests/snapshot_ack.rs
+++ b/crates/xtask/tests/snapshot_ack.rs
@@ -1,0 +1,6 @@
+// drift-ack: bundle-tokenization-drift baseline snapshots introduced for S1.
+
+#[test]
+fn drift_ack_marker_is_source_controlled() {
+    assert!(true);
+}

--- a/docs/architecture/xtask.md
+++ b/docs/architecture/xtask.md
@@ -10,6 +10,7 @@ $ cargo run -p xtask -- symmetric-potemkin
 $ cargo run -p xtask -- class-map-override-safety
 $ cargo run -p xtask -- recognizer-composition-validator
 $ cargo run -p xtask -- no-tenant-knowledge
+$ cargo run -p xtask -- bundle-tokenization-drift
 ```
 
 The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.rs).
@@ -22,6 +23,24 @@ The gate list lives in [`crates/xtask/src/main.rs`](../../crates/xtask/src/main.
 | `ClassMapOverrideSafety` | `cargo run -p xtask -- class-map-override-safety` | Activated in v0.4.4. Lists and runs `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered`. An adversarial in-PR self-test verifies the gate fails non-zero when a listed test is missing or renamed, following the meta-Potemkin guard captured in drawer `gaze_architecture_12b32d53`. |
 | `RecognizerCompositionValidator` | `cargo run -p xtask -- recognizer-composition-validator` | Lists and runs the behavioral tests in `RECOGNIZER_COMPOSITION_VALIDATOR_TESTS`. The gate fails if the rulepack composition validator tests are missing or failing. |
 | `NoTenantKnowledge` | `cargo run -p xtask -- no-tenant-knowledge` | Added in v0.4.3. Production-code lint scanner that rejects tenant-pattern strings (`order_id`, `Order_42`, `Song_42`, `User_7`) in `crates/{gaze,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. Allow markers (`// allow(tenant-fixture)`) hard-fail in production scope and remain valid only in tests, benches, docs, and `CONTRIBUTING.md`. |
+| `BundleTokenizationDrift` | `cargo run -p xtask -- bundle-tokenization-drift` | Added in v0.4.6. Discovers recognizer-bearing bundled rulepacks from `crates/gaze-recognizers/embedded/*.toml`, runs the real `gaze clean --rulepack-bundled <bundle> --audit-db <tmp>` path against `crates/xtask/fixtures/drift-corpus.txt`, restores emitted tokens to infer byte spans, and compares canonical no-policy tokenization metadata to `crates/xtask/snapshots/<bundle>-no-policy.json`. Snapshots exclude raw values, `session_blob`, and audit `created_at`. `--verify-ack` fails closed when snapshot changes lack both a `// drift-ack:` source/test comment and a `[bundle-tokenization-drift]` line in the `[Unreleased]` `### Changed` section of `CHANGELOG.md`. |
+
+## bundle-tokenization-drift adversarial self-test
+
+Run the clean gate first:
+
+```console
+$ cargo run -p xtask -- bundle-tokenization-drift
+```
+
+Then rehearse failure on a throwaway branch or detached worktree:
+
+1. Temporarily rename an enabled recognizer id in `crates/gaze-recognizers/embedded/core-extended.toml`, for example `id = "ip.v4"` to `id = "ip.v4.drift"`.
+2. Run `cargo run -p xtask -- bundle-tokenization-drift`.
+3. Confirm the gate exits non-zero and names `core-extended`, the old/new recognizer id, `custom:ip_address`, and the changed count.
+4. Revert the TOML edit.
+
+To intentionally update snapshots, run `cargo run -p xtask -- bundle-tokenization-drift --regenerate-baseline`, add or update a nearby `// drift-ack:` source/test comment, and add a `[bundle-tokenization-drift]` line naming each changed bundle under `[Unreleased]` `### Changed` in `CHANGELOG.md`. Then run `cargo run -p xtask -- bundle-tokenization-drift --verify-ack`.
 
 ## audit_metadata_only — known limitations (v0.4.5)
 


### PR DESCRIPTION
Implements scratchpad 421 §S1, the recognizer-activation snapshot contract gate for bundled no-policy tokenization output.

Summary:
- Adds `cargo run -p xtask -- bundle-tokenization-drift` with `--regenerate-baseline` / `--write-baseline` and strict `--verify-ack`.
- Discovers recognizer-bearing bundled rulepacks from `crates/gaze-recognizers/embedded/*.toml` and fails if a paired `crates/xtask/snapshots/<bundle>-no-policy.json` is missing.
- Runs the real `gaze clean --rulepack-bundled <bundle> --audit-db <tmp>` path against `crates/xtask/fixtures/drift-corpus.txt`, then restores emitted tokens to infer byte spans.
- Commits baseline snapshots for `core` and `core-extended` with schema version 1 and no raw values, no `session_blob`, and no audit `created_at`.
- Uses S3's `Rulepack::activated_classes()` as the rulepack-derived class substrate instead of a hand-maintained class list.
- Adds clean/adversarial integration tests, CI workflow on ubuntu-24.04 with fmt check, and docs/README stability anchors.

S1 acceptance criteria coverage:
1. Positive drift fail-closed: integration test mutates an enabled recognizer id in a detached worktree and asserts non-zero output naming `core-extended`, recognizer ids, `custom:ip_address`, and changed count.
2. Negative clean pass: integration test and final gate run pass against committed snapshots.
3. Corpus coverage: fixed corpus includes positive samples for active bundled classes plus tenant-shaped negatives (`Order_*`, `Subscriber_*`, `Customer_*`, version shape, non-postal 5-digit shape, long tenant numerics, URL fragments, timestamps/digit runs/ULID-like IDs, cross-locale postal-like strings, email-local-part numerics) using synthetic/non-reachable phone fixtures only.
4. Strict ACK enforcement: `--verify-ack` requires both a changed `// drift-ack:` source/test comment and `[bundle-tokenization-drift]` under `[Unreleased] ### Changed` naming changed bundles; no soft fallback.
5. Token-shape-only snapshots: snapshots include recognizer id, class, byte span, family, token shape, count, and stats only; no raw fixture values, session blob, or audit timestamp.
6. Rulepack glob fail-closed: embedded TOML discovery drives required snapshot paths.
7. S3 substrate: emitted classes are checked against `Rulepack::activated_classes()`.

Adversarial proof:
- Temporarily added enabled recognizer `drift.canary` to `core-extended.toml`.
- `cargo run -p xtask -- bundle-tokenization-drift` failed closed: `bundle core-extended changed detections 7 -> 8` and reported `recognizer=drift.canary class=custom:drift_canary ... count=1`.
- Temporary TOML edit was reverted before push.

Verification:
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo run -p xtask -- bundle-tokenization-drift`
- `cargo run -p xtask -- bundle-tokenization-drift --verify-ack`

Axis impact:
- Strengthens axis 4 trust by making bundled no-policy tokenization drift explicit, deterministic, auditable, and ACK-gated.
- Also strengthens reliability/reversibility by asserting clean -> restore round trip before snapshot comparison.
