### PR TITLE
S7: prepare v0.4.6 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [bundle-tokenization-drift] Baseline snapshot contract added for `core` and `core-extended` no-policy bundled tokenization output; future snapshot drift must carry an explicit source ACK and this Changed-section marker.
-- [bundle-tokenization-drift] `core`/`core-extended` baselines updated for the S4 `core-extended` DE national phone broaden fixture.
+- [bundle-tokenization-drift] Release aggregation refreshed `core` and `core-extended` no-policy snapshots for the v0.4.6 bundled rulepack version bump.
+
+## [0.4.6] - 2026-04-26
+
+### Changed
+
+- Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.6`.
+- Bundled rulepack versions now track `gaze-recognizers` at `0.4.6`.
+- **Bundle-tokenization drift gate:** no-policy `core` and `core-extended` bundled outputs now have checked-in baselines; intentional drift requires an explicit source ACK and changelog marker before release.
+- **Fixture-citation lint:** synthetic fixture policy is now enforced by `xtask`, tightening the no-real-PII discipline for examples and tests.
+- **Rulepack-derived bundle classes:** bundled class listings are derived from rulepacks instead of hand-maintained metadata, reducing release drift for adopter-facing bundle docs and checks.
+- **DE national-phone recall broaden:** `core-extended` recognizes additional documented synthetic German national-phone mobile shapes while preserving parser-backed validation.
+- **CI/no-feature matrix:** `xtask ci-feature-matrix` guards the no-default-feature phone parser path so unsupported parser validators continue to fail closed.
+- **Homebrew tap decision:** README install guidance remains release-asset first until a public tap exists and the release process publishes to it.
 
 ## [0.4.5] - 2026-04-26
 
@@ -316,7 +328,8 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/piinuts/gaze/compare/v0.4.5...HEAD
+[Unreleased]: https://github.com/piinuts/gaze/compare/v0.4.6...HEAD
+[0.4.6]: https://github.com/piinuts/gaze/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/piinuts/gaze/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/piinuts/gaze/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/piinuts/gaze/compare/v0.4.2...v0.4.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gaze"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aho-corasick",
  "criterion",

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Every design, implementation, and review decision is evaluated against these fiv
 4. **Trust (auditable + deterministic).** Rule-based detectors preferred; every token emission traceable to a rule or recognizer.
 5. **Adopter ergonomics.** Low-friction framework adapters; adopter picks Gaze up in under a day without deep PII expertise.
 
-## Install (v0.4.5)
+## Install (v0.4.6)
 
-v0.4.5 is the current stable release.
+v0.4.6 is the current stable release.
 
 Apple Silicon macOS via release asset:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.5/gaze-aarch64-apple-darwin
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.6/gaze-aarch64-apple-darwin
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -57,7 +57,7 @@ Public `brew install piinuts/tap/gaze` documentation should wait until a public 
 Linux x86_64 binary download from the release assets:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.5/gaze-x86_64-unknown-linux-gnu
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.4.6/gaze-x86_64-unknown-linux-gnu
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -259,7 +259,7 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 ## What's new since v0.4.0-rc.1
 
-Cumulative highlights from v0.4.1 through v0.4.5 — see [CHANGELOG.md](CHANGELOG.md) for the per-release detail.
+Cumulative highlights from v0.4.1 through v0.4.6 — see [CHANGELOG.md](CHANGELOG.md) for the per-release detail.
 
 ### v0.4.5 highlights
 

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -179,7 +179,7 @@ fn t20b_rulepack_context_dict_override_fails_closed_when_uncovered() {
         r#"
 schema_version = "0.1.0"
 rulepack_id = "tenant-rulepack"
-rulepack_version = "0.4.5"
+rulepack_version = "0.4.6"
 default_locales = ["global"]
 
 [[recognizers]]

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core-extended"
-rulepack_version = "0.4.5"
+rulepack_version = "0.4.6"
 default_locales = ["en-US", "de-DE", "de-AT", "de-CH", "global"]
 
 [[recognizers]]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core"
-rulepack_version = "0.4.5"
+rulepack_version = "0.4.6"
 default_locales = ["global"]
 
 [locale.email_headers]

--- a/crates/gaze-recognizers/embedded/locale-de.toml
+++ b/crates/gaze-recognizers/embedded/locale-de.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-de"
-rulepack_version = "0.4.5"
+rulepack_version = "0.4.6"
 default_locales = ["de-DE", "de-AT", "de-CH"]
 
 # Phase 2 ports DACH structured recognizers.

--- a/crates/gaze-recognizers/embedded/locale-en.toml
+++ b/crates/gaze-recognizers/embedded/locale-en.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-en"
-rulepack_version = "0.4.5"
+rulepack_version = "0.4.6"
 default_locales = ["en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
 
 # Phase 2 ports English locale recognizers.

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"

--- a/crates/xtask/snapshots/core-extended-no-policy.json
+++ b/crates/xtask/snapshots/core-extended-no-policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "bundle": "core-extended",
-  "rulepack_version": "0.4.5",
+  "rulepack_version": "0.4.6",
   "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "bundle": "core",
-  "rulepack_version": "0.4.5",
+  "rulepack_version": "0.4.6",
   "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {

--- a/crates/xtask/tests/snapshot_ack.rs
+++ b/crates/xtask/tests/snapshot_ack.rs
@@ -1,4 +1,5 @@
 // drift-ack: bundle-tokenization-drift baseline snapshots introduced for S1.
+// drift-ack: v0.4.6 release aggregation refreshes bundle snapshots for rulepack version bump only.
 
 #[test]
 fn drift_ack_marker_is_source_controlled() {


### PR DESCRIPTION
## Summary
- Cut the v0.4.6 changelog section and update compare links.
- Bump published crate versions and bundled rulepack versions from 0.4.5 to 0.4.6.
- Refresh bundle tokenization snapshots for the rulepack version bump and update current-release README install lines.

## Checks
- cargo fmt --all -- --check
- cargo check --workspace --all-features
- cargo run -p xtask -- bundle-tokenization-drift
- cargo run -p xtask -- bundle-tokenization-drift --verify-ack
- cargo run -p xtask -- fixture-citation-lint
- cargo run -p xtask -- ci-feature-matrix

## Notes
- Cargo.lock is limited to the four workspace package version bumps: gaze, gaze-cli, gaze-recognizers, and gaze-assembly.