### PR TITLE
[agent] Prepare v0.5.0-rc.1 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.0-rc.1] - 2026-04-27
+
+### Added
+
 - **v0.5 Phase B — `gaze-types` crate (PR #74, commit `4675b79`):** new shared-contract crate hosts `Recognizer`, `Detection`, `PiiClass`, `Action`, `RedactionEntry`, `LocaleTag` / `LocaleChain` / `LocaleError`, `RawDocument`, `CleanDocument`, `DictionaryBundle`, and the token-related value types. Adopters now get a serde-only contract crate without `ort`/`tokenizers`/`ndarray` ML deps in their dependency tree. `gaze` re-exports the contracts under their previous paths for source-compatibility.
 - **v0.5 Phase B — `bundled-recognizers` feature gate (PR #74):** `gaze` no longer pulls `ort`/`tokenizers`/`ndarray`/`onig` in `--no-default-features` builds. Default features remain unchanged, so existing CLI / library consumers see no behavior change.
 - **v0.5 Phase B — `DictionaryBundleExt` extension trait (PR #74):** `bundle.from_context(&ctx)` now requires `use gaze::DictionaryBundleExt;` (or import from `gaze-types`). The split keeps `gaze-types::DictionaryBundle` a pure value type while preserving the convenience constructor for `gaze` callers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gaze"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.4.6" }
-gaze-types = { path = "crates/gaze-types", version = "0.4.6" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.5.0-rc.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.5.0-rc.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.4.6"
+version = "0.5.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.5.0-rc.1
- Migrate Unreleased changelog to [0.5.0-rc.1] - 2026-04-27

## Test plan
- [x] cargo test --workspace
- [x] cargo metadata reports 0.5.0-rc.1 across workspace crates

Origin: solo todo #266. Mirrors v0.4.6 release pattern (commit d4bec8c).