### PR TITLE
[agent] Prepare v0.5.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.5.0-rc.1] - 2026-04-27
+## [0.5.0] - 2026-04-27
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gaze"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.5.0-rc.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.5.0-rc.1" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.5.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.5.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.5.0-rc.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.5.0
- Promote changelog from [0.5.0-rc.1] to [0.5.0] - 2026-04-27

## Test plan
- [x] cargo test --workspace
- [x] cargo metadata reports 0.5.0 across workspace crates

Origin: solo todo #266. Mirrors v0.4.6 release pattern (commit d4bec8c).