### PR TITLE
docs(roadmap): refresh post v0.5.0 ship

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,33 +23,49 @@ Art. 4(5) term for reversible substitution with tokens, chosen over
 
 ## Now (in flight)
 
-v0.4.6 brainstorm pending.
+v0.5.0 shipped 2026-04-27 (gaze-types extraction, gaze-audit passive sink with
+the one-minor `audit` feature shim, dylint-based `gaze_module_isolation` lint
+replacing the syn-walker `audit_metadata_only` gate, `bundled-recognizers`
+feature gate). v0.4.6 shipped 2026-04-26.
 
-Post-v0.4.5, there is no active implementation scope locked in this roadmap.
-The next cycle should start with brainstorm → plan → multi-review before
-dispatching implementation work.
+A v0.5.1 patch is in flight on a separate branch to bump the bundled
+`rulepack_version` from `0.4.6` to `0.5.0` in the four embedded TOMLs that
+release prep missed (todo #267). Once merged, v0.5.1 closes out the v0.5 line.
+
+No v0.6 implementation scope is locked in this roadmap yet. The next cycle
+should start with brainstorm → plan → multi-review before dispatching
+implementation work. The leading hygiene candidate is the v0.6 decommission of
+the `audit` feature shim on `gaze` (per the v0.5 migration window documented in
+CHANGELOG.md and decision drawer `gaze_decisions_6c60bce3b9f8ed7a4de538d8`),
+optionally landed alongside todo #252.
 
 ## Next (committed but not started)
 
-These items are committed candidates for the v0.4.6 cycle unless the brainstorm
-explicitly reorders them:
+These are open, verified candidates for the v0.6 cycle pending the v0.6
+brainstorm:
 
-- **DE national-phone regex broaden** — todo #167.
-- **Fixture-citation xtask lint** — todo #166.
-- **`audit_metadata_only` follow-ups** — todos #172, #173, #186, #187.
-- **Brew tap location decision** — todo #184.
-- **Bundle class derive from rulepack** — todo #173.
+- **OpenAI-filter Pass-3 safety net recognizer** — todo #65 (high). Retargeted
+  to v0.6 from v0.4.1. Adds a fresh independent eye after Gaze's regex +
+  dictionary + NER passes; the runtime arm of the never-leak promise.
+- **OpenAI-filter CI sanity gate** — todo #66 (medium). Retargeted to v0.6.
+  Sibling to #65; CI-only, runs the filter over gold-positive fixtures to
+  surface detection drift between releases.
+- **`RedactionLogger` trait → `gaze-types`** — todo #252 (low). Hygiene
+  follow-on from v0.5 Phases B/C; pairs with the `audit` feature shim
+  decommission planned for v0.6.
+- **v0.5.1 patch — bundled `rulepack_version` sync** — todo #267 (high). In
+  flight on a separate branch; remove from this list once shipped.
+
+The following entries are still tagged `v0.5` from the v0.5 design wave but did
+not block the v0.5.0 ship; the v0.6 brainstorm should decide whether to fold
+them into v0.6, defer further, or close:
+
+- **Token grammar G1/G2/G3 brainstorm-pair** — todo #148 (high).
+- **Feature-flag naming brainstorm-pair** — todo #149 (medium).
+- **PiiClass `Arc<str>` vs `Box<str>` post-impl bench** — todo #152 (low).
 
 ## Later (under consideration / longer horizon)
 
-- **Crate-shape Option B** — scratchpad 256 locked this as the v0.5 direction:
-  extract `gaze-types` and collapse `gaze-assembly` after the v0.4 line settles.
-- **v0.5 design follow-up dispatches** — todos #148-#152, scratchpad 359.
-- **v0.5 dylint audit gate pivot** — todo #181; replace the current
-  syn-walker `audit_metadata_only` gate with a resolver-backed lint. See
-  `docs/research/v0.5-dylint-audit-gate.md`.
-- **Macro-emitted / `include!` / `let-else` escape coverage** — todos #179,
-  #185, #186, folded into the #181 dylint pivot.
 - **First-party MCP for Gaze** — drawer `gaze_decisions_69b09f17`; open
   question.
 - **PII detection-only thin surface** — drawer `gaze_decisions_92011c25`; open
@@ -61,11 +77,12 @@ explicitly reorders them:
 
 | Version | Date | Highlights |
 |---|---:|---|
+| v0.5.0 | 2026-04-27 | `gaze-types` extraction, `gaze-audit` passive sink with one-minor `audit` feature shim, dylint-based `gaze_module_isolation` lint replaces syn-walker `audit_metadata_only` gate, `bundled-recognizers` feature gate frees `gaze` core from `ort` / `tokenizers` / `ndarray` ML deps |
+| v0.4.6 | 2026-04-26 | Bundle-tokenization-drift xtask gate, fixture-citation lint, rulepack-derived bundle classes, DE national-phone recall broaden, no-feature phone parser fail-closed regression, Homebrew tap decision |
 | v0.4.5 | 2026-04-26 | DE+US national phones, audit retention purge + `audit_metadata_only` gate, `--session` audit filter, ClassMapOverrideSafety extension, rulepack version bump validation, `gaze-assembly` split |
 | v0.4.4 | 2026-04-26 | ClassMapOverrideSafety gate, audit schema v2 with `--from` / `--to`, parser-backed E.164 phone validation, Date-as-PII posture memo |
 | v0.4.3 | 2026-04-26 | Luhn + IBAN MOD-97 validators, `core-extended` Phase 2 for IBAN + credit cards, `no_tenant_knowledge` gate, audit query/export |
 | v0.4.2 | 2026-04-25 | macOS aarch64 + Linux x86_64 binaries, `core-extended` Phase 1, audit log persistence, three-surfaces CLI backfill, v0.5 design stub |
-| v0.4.1 | 2026-04-24 | Markus Phase-1 NER fix, locale-aware email-header names, `[ner] threshold`, rulepack composition validation, snapshot token-family metadata |
 
 Older versions are tracked in `CHANGELOG.md`.
 


### PR DESCRIPTION
## Summary

ROADMAP.md was stuck on "v0.4.6 brainstorm pending" after v0.4.6 + v0.5.0 both shipped (2026-04-26 and 2026-04-27). This refresh:

- Rewrites "Now (in flight)" to reflect post-v0.5.0 state (no scope locked; v0.6 hygiene candidates; v0.5.1 patch in flight on a separate branch).
- Removes shipped candidates from "Next" (DE phone broaden, fixture-citation lint, audit_metadata_only follow-ups, brew tap, bundle class derive — all SHIPPED v0.4.6 or folded into Phase D/E).
- Removes shipped items from "Later" (Crate Option B + dylint pivot both SHIPPED in v0.5).
- Adds v0.5.0 + v0.4.6 to the "Shipped" table; drops the v0.4.1 row to keep "last ~5".

Adopter ergonomics axis fix only — no behavior change. Closes solo #268.

## Test plan

- [x] \`git diff\` confirms ROADMAP.md is the only file touched
- [x] \`grep "brainstorm pending" ROADMAP.md\` returns nothing
- [x] All version references in ROADMAP.md cross-checked against CHANGELOG.md