### PR TITLE
v0.5.1: bundled rulepack_version sync + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.5.1] - 2026-04-29
+
+### Fixed
+
+- **Bundled rulepack version sync (todo #267):** corrective patch - bundled `core`, `core-extended`, `locale-de`, and `locale-en` rulepacks now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 CHANGELOG contract that bundled rulepacks track `gaze-recognizers`. v0.5.0 release-prep missed the embedded TOMLs; this patch corrects that.
+
+### Changed
+
+- Version bump 0.5.0 -> 0.5.1 across `gaze`, `gaze-types`, `gaze-recognizers`, `gaze-audit`, `gaze-cli`, and `gaze-assembly`.
+- [bundle-tokenization-drift] v0.5.1 rulepack_version sync refreshed `core` and `core-extended` no-policy snapshots; only the `rulepack_version` field changed.
+
 ## [0.5.0] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [bundle-tokenization-drift] v0.5.1 rulepack_version sync refreshed `core` and `core-extended` no-policy snapshots; only the `rulepack_version` field changed.
+
 ### Deprecated
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gaze"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.5.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.5.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.5.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.5.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core-extended"
-rulepack_version = "0.4.6"
+rulepack_version = "0.5.1"
 default_locales = ["en-US", "de-DE", "de-AT", "de-CH", "global"]
 
 [[recognizers]]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-core"
-rulepack_version = "0.4.6"
+rulepack_version = "0.5.1"
 default_locales = ["global"]
 
 [locale.email_headers]

--- a/crates/gaze-recognizers/embedded/locale-de.toml
+++ b/crates/gaze-recognizers/embedded/locale-de.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-de"
-rulepack_version = "0.4.6"
+rulepack_version = "0.5.1"
 default_locales = ["de-DE", "de-AT", "de-CH"]
 
 # Phase 2 ports DACH structured recognizers.

--- a/crates/gaze-recognizers/embedded/locale-en.toml
+++ b/crates/gaze-recognizers/embedded/locale-en.toml
@@ -1,6 +1,6 @@
 schema_version = "0.1.0"
 rulepack_id = "gaze-locale-en"
-rulepack_version = "0.4.6"
+rulepack_version = "0.5.1"
 default_locales = ["en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
 
 # Phase 2 ports English locale recognizers.

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"

--- a/crates/xtask/snapshots/core-extended-no-policy.json
+++ b/crates/xtask/snapshots/core-extended-no-policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "bundle": "core-extended",
-  "rulepack_version": "0.4.6",
+  "rulepack_version": "0.5.1",
   "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "bundle": "core",
-  "rulepack_version": "0.4.6",
+  "rulepack_version": "0.5.1",
   "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
   "entries": [
     {

--- a/crates/xtask/tests/snapshot_ack.rs
+++ b/crates/xtask/tests/snapshot_ack.rs
@@ -1,5 +1,6 @@
 // drift-ack: bundle-tokenization-drift baseline snapshots introduced for S1.
 // drift-ack: v0.4.6 release aggregation refreshes bundle snapshots for rulepack version bump only.
+// drift-ack: v0.5.1 rulepack_version sync refreshes bundle snapshots for rulepack version bump only.
 
 #[test]
 fn drift_ack_marker_is_source_controlled() {

--- a/crates/xtask/tests/snapshot_ack.rs
+++ b/crates/xtask/tests/snapshot_ack.rs
@@ -4,6 +4,9 @@
 
 #[test]
 fn drift_ack_marker_is_source_controlled() {
-    let source = std::fs::read_to_string(file!()).expect("snapshot_ack.rs is readable");
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/snapshot_ack.rs"),
+    )
+    .expect("snapshot_ack.rs is readable");
     assert!(source.contains("drift-ack:"));
 }

--- a/crates/xtask/tests/snapshot_ack.rs
+++ b/crates/xtask/tests/snapshot_ack.rs
@@ -4,5 +4,6 @@
 
 #[test]
 fn drift_ack_marker_is_source_controlled() {
-    assert!(true);
+    let source = std::fs::read_to_string(file!()).expect("snapshot_ack.rs is readable");
+    assert!(source.contains("drift-ack:"));
 }

--- a/dist/homebrew/gaze.rb
+++ b/dist/homebrew/gaze.rb
@@ -1,14 +1,14 @@
 class Gaze < Formula
   desc "Channel-agnostic PII redaction CLI for AI pipelines"
   homepage "https://github.com/piinuts/gaze"
-  version "0.4.5"
+  version "0.5.1"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/piinuts/gaze/releases/download/v0.4.5/gaze-aarch64-apple-darwin",
+      url "https://github.com/piinuts/gaze/releases/download/v0.5.1/gaze-aarch64-apple-darwin",
           using: :nounzip
-      sha256 "c739869f3d4d21936872fc92785dbd5be2e794d9bed9e4684805c1f0da054b4f"
+      sha256 "TBD-after-release-run"
     end
   end
 
@@ -18,6 +18,6 @@ class Gaze < Formula
   end
 
   test do
-    assert_match "gaze 0.4.5", shell_output("#{bin}/gaze --version")
+    assert_match "gaze 0.5.1", shell_output("#{bin}/gaze --version")
   end
 end


### PR DESCRIPTION
## Summary

Corrective patch for v0.5.0 release-prep oversight (todo #267): bundled `embedded/*.toml` rulepacks were stuck at `rulepack_version = "0.4.6"` because the v0.5.0 file-list missed them. This patch syncs them to `0.5.1` and bumps all crate versions to match.

Advances the **trust (auditable + deterministic)** north-star axis — the v0.4.6 CHANGELOG locked the contract *"Bundled rulepack versions now track gaze-recognizers"* and this patch restores it.

## Changes

- Workspace + crate versions: 0.5.0 → 0.5.1 (gaze, gaze-types, gaze-recognizers, gaze-audit, gaze-cli, gaze-assembly)
- Embedded rulepack_version: 0.4.6 → 0.5.1 across `core.toml`, `core-extended.toml`, `locale-de.toml`, `locale-en.toml`
- Refreshed `bundle-tokenization-drift` snapshots (rulepack_version field only)
- CHANGELOG entry under [0.5.1]
- Homebrew formula version bump with SHA placeholder for release engineer
- Clippy-cleaned the drift ACK marker test touched by the snapshot refresh

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo run -p xtask -- bundle-tokenization-drift`
- [x] `cargo run -p xtask -- fixture-citation-lint` (current checkout command; requested `fixture-citation` is not present)
- [x] `cargo run -p xtask -- no-tenant-knowledge`
- [x] `cargo run -p xtask -- cargo-metadata-audit-isolation`
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] `cargo run -p xtask -- dylint-gate`
- [x] `ruby -c dist/homebrew/gaze.rb`

## Process gap (per todo #267)

The v0.5 release-prep brief did not include `crates/gaze-recognizers/embedded/*.toml` in the file-list. Add to the orchestrator-mode release-engineer template before next release.

## Follow-up

Once this lands, dispatch release engineer to cut `v0.5.1-rc.1` then `v0.5.1` tags following v0.4.6 / v0.5.0 patterns.

Closes solo todo #267.