### PR TITLE
chore(cleanup): post-v0.5.1 hygiene sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [bundle-tokenization-drift] v0.5.1 rulepack_version sync refreshed `core` and `core-extended` no-policy snapshots; only the `rulepack_version` field changed.
-
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Every design, implementation, and review decision is evaluated against these fiv
 4. **Trust (auditable + deterministic).** Rule-based detectors preferred; every token emission traceable to a rule or recognizer.
 5. **Adopter ergonomics.** Low-friction framework adapters; adopter picks Gaze up in under a day without deep PII expertise.
 
-## Install (v0.5.0)
+## Install (v0.5.1)
 
-v0.5.0 is the current stable release.
+v0.5.1 is the current stable release.
 
 Apple Silicon macOS via release asset:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.0/gaze-aarch64-apple-darwin
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.1/gaze-aarch64-apple-darwin
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -59,7 +59,7 @@ Public `brew install piinuts/tap/gaze` documentation should wait until a public 
 Linux x86_64 binary download from the release assets:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.0/gaze-x86_64-unknown-linux-gnu
+curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.1/gaze-x86_64-unknown-linux-gnu
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,14 +23,13 @@ Art. 4(5) term for reversible substitution with tokens, chosen over
 
 ## Now (in flight)
 
-v0.5.0 shipped 2026-04-27 (gaze-types extraction, gaze-audit passive sink with
-the one-minor `audit` feature shim, dylint-based `gaze_module_isolation` lint
-replacing the syn-walker `audit_metadata_only` gate, `bundled-recognizers`
-feature gate). v0.4.6 shipped 2026-04-26.
-
-A v0.5.1 patch is in flight on a separate branch to bump the bundled
-`rulepack_version` from `0.4.6` to `0.5.0` in the four embedded TOMLs that
-release prep missed (todo #267). Once merged, v0.5.1 closes out the v0.5 line.
+v0.5.1 shipped 2026-04-29 (bundled `rulepack_version` sync — the four embedded
+TOMLs now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 contract
+that bundled rulepacks track `gaze-recognizers`; todo #267). v0.5.0 shipped
+2026-04-27 (gaze-types extraction, gaze-audit passive sink with the one-minor
+`audit` feature shim, dylint-based `gaze_module_isolation` lint replacing the
+syn-walker `audit_metadata_only` gate, `bundled-recognizers` feature gate).
+v0.4.6 shipped 2026-04-26. The v0.5 line is closed.
 
 No v0.6 implementation scope is locked in this roadmap yet. The next cycle
 should start with brainstorm → plan → multi-review before dispatching
@@ -53,8 +52,6 @@ brainstorm:
 - **`RedactionLogger` trait → `gaze-types`** — todo #252 (low). Hygiene
   follow-on from v0.5 Phases B/C; pairs with the `audit` feature shim
   decommission planned for v0.6.
-- **v0.5.1 patch — bundled `rulepack_version` sync** — todo #267 (high). In
-  flight on a separate branch; remove from this list once shipped.
 
 The following entries are still tagged `v0.5` from the v0.5 design wave but did
 not block the v0.5.0 ship; the v0.6 brainstorm should decide whether to fold
@@ -77,12 +74,12 @@ them into v0.6, defer further, or close:
 
 | Version | Date | Highlights |
 |---|---:|---|
+| v0.5.1 | 2026-04-29 | Bundled `rulepack_version` sync (todo #267) — `core`, `core-extended`, `locale-de`, `locale-en` embedded TOMLs now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 contract that bundled rulepacks track `gaze-recognizers` |
 | v0.5.0 | 2026-04-27 | `gaze-types` extraction, `gaze-audit` passive sink with one-minor `audit` feature shim, dylint-based `gaze_module_isolation` lint replaces syn-walker `audit_metadata_only` gate, `bundled-recognizers` feature gate frees `gaze` core from `ort` / `tokenizers` / `ndarray` ML deps |
 | v0.4.6 | 2026-04-26 | Bundle-tokenization-drift xtask gate, fixture-citation lint, rulepack-derived bundle classes, DE national-phone recall broaden, no-feature phone parser fail-closed regression, Homebrew tap decision |
 | v0.4.5 | 2026-04-26 | DE+US national phones, audit retention purge + `audit_metadata_only` gate, `--session` audit filter, ClassMapOverrideSafety extension, rulepack version bump validation, `gaze-assembly` split |
 | v0.4.4 | 2026-04-26 | ClassMapOverrideSafety gate, audit schema v2 with `--from` / `--to`, parser-backed E.164 phone validation, Date-as-PII posture memo |
 | v0.4.3 | 2026-04-26 | Luhn + IBAN MOD-97 validators, `core-extended` Phase 2 for IBAN + credit cards, `no_tenant_knowledge` gate, audit query/export |
-| v0.4.2 | 2026-04-25 | macOS aarch64 + Linux x86_64 binaries, `core-extended` Phase 1, audit log persistence, three-surfaces CLI backfill, v0.5 design stub |
 
 Older versions are tracked in `CHANGELOG.md`.
 
@@ -108,4 +105,4 @@ changes.
 - `CLAUDE.md` — Claude Code-specific addenda
 - `docs/research/gaze-first-principles-vision.md` — north star locked 2026-04-24
 - `docs/research/v0.5-dylint-audit-gate.md` — v0.5 architectural pivot stub
-- `docs/architecture/xtask.md` — `audit_metadata_only` gate coverage + limitations
+- `docs/architecture/xtask.md` — current xtask gate inventory; `audit_metadata_only` is decommissioned as of v0.5 Phase E and is documented for historical context only

--- a/dist/homebrew/gaze.rb
+++ b/dist/homebrew/gaze.rb
@@ -8,7 +8,7 @@ class Gaze < Formula
     on_arm do
       url "https://github.com/piinuts/gaze/releases/download/v0.5.1/gaze-aarch64-apple-darwin",
           using: :nounzip
-      sha256 "TBD-after-release-run"
+      sha256 "161c43e50d838935aeefb02c764240792942e5226e63a18207294a02d4262671"
     end
   end
 


### PR DESCRIPTION
## Summary

Post-v0.5.1 docs hygiene. Three files refreshed; no runtime/code changes.

- **ROADMAP.md** — v0.5.1 shipped 2026-04-29 (was "in flight"); added v0.5.1 row to Shipped table (drops v0.4.2 to keep last 5); removed v0.5.1 candidate bullet from Next; refreshed See-also description for `docs/architecture/xtask.md` to note `audit_metadata_only` is decommissioned (Phase E).
- **README.md** — install snippet bumps v0.5.0 → v0.5.1 download URLs (Apple Silicon + Linux x86_64).
- **CHANGELOG.md** — cleared stale `[Unreleased] ### Changed` bundle-tokenization-drift entry that's already captured under `[0.5.1] - 2026-04-29`.

## Cleanup scope verification

- `docs/research/*` — every file still load-bearing: cited (`v0.4.4-phonenumber-audit`, `v0.4.4-date-posture`, `v0.5-dylint-audit-gate`, `ner-library-evaluation`), foundational (`gaze-first-principles-vision` — protected, `gaze-threat-model`, `privacy-conformant-agent-patterns`), or recent audit (`v0.4.5-classmap-coverage` ties to active `class-map-override-safety` xtask gate). None removed.
- `docs/architecture/*` — current; `xtask.md`'s `audit_metadata_only` mention is correct historical context (decommissioned).
- `done/` archives — purpose-built, kept.
- `agents/` counselor + dispatch artifacts — historical archive, kept.
- `.superpowers/brainstorm/{12442,12572,34534}-*` stale dirs — removed locally (gitignored, dead PIDs/server.log).
- `docs/plans/`, `docs/roadmap/` — already absent (#191 cleanup confirmed).

## Test plan

- [x] `git diff --stat` shows only CHANGELOG.md, README.md, ROADMAP.md
- [ ] Docs render correctly on GitHub (links + tables)
- [ ] CI green (no code changes — docs-only)