### PR TITLE
v0.6 anchored_match recognizer + locale cue bundles (partial through P4)

### DIFF
--- a/crates/gaze-assembly/src/detector_wiring.rs
+++ b/crates/gaze-assembly/src/detector_wiring.rs
@@ -4,7 +4,9 @@ use gaze::{
     Context, DetectorKind, PiiClass, PipelineBuilder, PolicyError, RawMatch, Rulepack,
     RulepackError,
 };
-use gaze_recognizers::{DictionaryRecognizer, NormalizerKind, RegexDetector, ValidatorKind};
+use gaze_recognizers::{
+    AnchoredMatchRecognizer, DictionaryRecognizer, NormalizerKind, RegexDetector, ValidatorKind,
+};
 
 use crate::{class_map::class_for_dictionary, template::lower_regex_pattern, BuildError};
 
@@ -167,10 +169,74 @@ pub(crate) fn register_rulepack_recognizers(
             RawMatch::Ner { .. } => {
                 return Err(RulepackError::UnsupportedMatcher("Ner".to_string()).into())
             }
+            RawMatch::AnchoredMatch {
+                cues_bucket,
+                boundary,
+                right_window_chars,
+                name_shape,
+                cue_position,
+            } => {
+                let Some(cues) = locale_vocab
+                    .get(&cues_bucket)
+                    .filter(|cues| !cues.is_empty())
+                else {
+                    return Err(BuildError::UnknownLocaleBucket {
+                        recognizer_id: recognizer.id.clone(),
+                        bucket: cues_bucket,
+                    });
+                };
+                let source_short_label = derive_source_short_label(&recognizer.id, &cues_bucket);
+                builder = builder.recognizer(AnchoredMatchRecognizer::new(
+                    recognizer.id,
+                    cues.clone(),
+                    convert_boundary(&boundary),
+                    right_window_chars,
+                    convert_name_shape(&name_shape),
+                    convert_cue_position(&cue_position),
+                    source_short_label,
+                    recognizer.scoring.base,
+                    recognizer.scoring.priority,
+                ));
+            }
         }
     }
 
     Ok(builder)
+}
+
+pub(crate) fn derive_source_short_label(recognizer_id: &str, bucket: &str) -> String {
+    let _ = bucket;
+    recognizer_id
+        .strip_prefix("name.")
+        .unwrap_or(recognizer_id)
+        .rsplit('.')
+        .next()
+        .unwrap_or(recognizer_id)
+        .to_string()
+}
+
+fn convert_boundary(boundary: &str) -> gaze_recognizers::AnchoredBoundary {
+    match boundary {
+        "punctuation" => gaze_recognizers::AnchoredBoundary::Punctuation,
+        "whitespace" => gaze_recognizers::AnchoredBoundary::Whitespace,
+        "line_end" => gaze_recognizers::AnchoredBoundary::LineEnd,
+        _ => unreachable!("rulepack validation rejects unknown anchored_match boundary"),
+    }
+}
+
+fn convert_name_shape(name_shape: &str) -> gaze_recognizers::NameShape {
+    match name_shape {
+        "person_name" => gaze_recognizers::NameShape::PersonName,
+        _ => unreachable!("rulepack validation rejects unknown anchored_match name_shape"),
+    }
+}
+
+fn convert_cue_position(cue_position: &str) -> gaze_recognizers::CuePosition {
+    match cue_position {
+        "before" => gaze_recognizers::CuePosition::Before,
+        "after" => gaze_recognizers::CuePosition::After,
+        _ => unreachable!("rulepack validation rejects unknown anchored_match cue_position"),
+    }
 }
 
 pub(crate) fn register_context_dictionaries(

--- a/crates/gaze-assembly/src/detector_wiring.rs
+++ b/crates/gaze-assembly/src/detector_wiring.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use gaze::{
-    Context, DetectorKind, PiiClass, PipelineBuilder, PolicyError, RawMatch, Rulepack,
-    RulepackError,
+    Context, DetectorKind, LocaleChain, LocaleTag, PiiClass, PipelineBuilder, PolicyError,
+    RawMatch, Rulepack, RulepackError,
 };
 use gaze_recognizers::{
     AnchoredMatchRecognizer, DictionaryRecognizer, NormalizerKind, RegexDetector, ValidatorKind,
@@ -61,6 +61,7 @@ pub(crate) fn register_rulepack_recognizers(
     policy: &gaze::Policy,
     context: &Context,
     rulepacks: &[Rulepack],
+    active_locales: &LocaleChain,
     locale_vocab: &HashMap<String, Vec<String>>,
     registered_dictionaries: &mut BTreeSet<String>,
 ) -> Result<PipelineBuilder, BuildError> {
@@ -176,10 +177,19 @@ pub(crate) fn register_rulepack_recognizers(
                 name_shape,
                 cue_position,
             } => {
-                let Some(cues) = locale_vocab
-                    .get(&cues_bucket)
-                    .filter(|cues| !cues.is_empty())
-                else {
+                if !recognizer_matches_active_locale(&recognizer.locales, active_locales) {
+                    continue;
+                }
+                let Some(cues) = locale_vocab.get(&cues_bucket) else {
+                    if is_optional_builtin_cue_bucket(&cues_bucket) {
+                        continue;
+                    }
+                    return Err(BuildError::UnknownLocaleBucket {
+                        recognizer_id: recognizer.id.clone(),
+                        bucket: cues_bucket,
+                    });
+                };
+                if cues.is_empty() {
                     return Err(BuildError::UnknownLocaleBucket {
                         recognizer_id: recognizer.id.clone(),
                         bucket: cues_bucket,
@@ -202,6 +212,23 @@ pub(crate) fn register_rulepack_recognizers(
     }
 
     Ok(builder)
+}
+
+fn recognizer_matches_active_locale(locales: &[LocaleTag], active_locales: &LocaleChain) -> bool {
+    locales.iter().any(|locale| {
+        *locale == LocaleTag::Global
+            || active_locales
+                .as_slice()
+                .iter()
+                .any(|active| active == locale)
+    })
+}
+
+fn is_optional_builtin_cue_bucket(bucket: &str) -> bool {
+    matches!(
+        bucket,
+        "forward_markers" | "agent_recipient_cues" | "footer_cues"
+    )
 }
 
 pub(crate) fn derive_source_short_label(recognizer_id: &str, bucket: &str) -> String {

--- a/crates/gaze-assembly/src/error.rs
+++ b/crates/gaze-assembly/src/error.rs
@@ -8,6 +8,11 @@ pub enum BuildError {
     Rulepack(#[from] gaze::RulepackError),
     #[error("pipeline error: {0}")]
     Pipeline(#[from] gaze::Error),
+    #[error("unknown locale bucket '{bucket}' for recognizer '{recognizer_id}'")]
+    UnknownLocaleBucket {
+        recognizer_id: String,
+        bucket: String,
+    },
 }
 
 impl From<gaze_recognizers::RecognizerError> for BuildError {

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -36,6 +36,7 @@ pub fn build_pipeline(
         policy,
         context,
         rulepacks,
+        active_locales,
         &locale_vocab,
         &mut registered_dictionaries,
     )?;

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -39,6 +39,13 @@ fn empty_context() -> Context {
     }
 }
 
+fn embedded_rulepack(name: &str) -> Rulepack {
+    Rulepack::load(gaze::RulepackSource::Embedded(
+        gaze_recognizers::embedded(name).expect("embedded rulepack"),
+    ))
+    .expect("rulepack")
+}
+
 fn policy_with_registered_dictionary(rules: Vec<RuleSpec>) -> gaze::Policy {
     gaze::Policy {
         session: SessionPolicy {
@@ -251,6 +258,105 @@ fn pattern_template_lowers_correctly_under_locale_chain_de() {
             .unwrap()
             .is_match(&text)
     );
+}
+
+#[test]
+fn merged_vocab_for_de_de_loads_only_locale_de_buckets() {
+    let core = embedded_rulepack("core");
+    let de = embedded_rulepack("locale-de");
+    let en = embedded_rulepack("locale-en");
+    let active_locales = LocaleChain::merge_policy_and_cli(Some(&[LocaleTag::DeDe]), None);
+    let vocab = merged_locale_vocab(&[core, de, en], &active_locales);
+
+    let forward_markers = vocab
+        .get("forward_markers")
+        .expect("locale-de forward markers");
+    assert_eq!(
+        forward_markers,
+        &vec![
+            "Weitergeleitete Nachricht von".to_string(),
+            "Forwarded message from".to_string(),
+            "Begin forwarded message from".to_string(),
+            "----- Forwarded message".to_string(),
+        ]
+    );
+    assert!(
+        !forward_markers.contains(&"Begin forwarded message".to_string()),
+        "de-DE chain must not merge locale-en-only buckets; English safety cues are duplicated into locale-de deliberately"
+    );
+    assert_eq!(
+        vocab
+            .get("agent_recipient_cues")
+            .expect("agent recipient cues"),
+        &vec![
+            "antwortest".to_string(),
+            "antworte".to_string(),
+            "schreibst".to_string(),
+            "reply to".to_string(),
+            "respond to".to_string(),
+            "draft for".to_string(),
+            "draft to".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn merged_vocab_for_en_us_loads_only_locale_en_buckets() {
+    let core = embedded_rulepack("core");
+    let de = embedded_rulepack("locale-de");
+    let en = embedded_rulepack("locale-en");
+    let active_locales = LocaleChain::merge_policy_and_cli(Some(&[LocaleTag::EnUs]), None);
+    let vocab = merged_locale_vocab(&[core, de, en], &active_locales);
+
+    assert_eq!(
+        vocab
+            .get("forward_markers")
+            .expect("locale-en forward markers"),
+        &vec![
+            "Forwarded message from".to_string(),
+            "Begin forwarded message".to_string(),
+            "----- Forwarded message".to_string(),
+        ]
+    );
+    assert!(
+        !vocab
+            .get("agent_recipient_cues")
+            .expect("agent recipient cues")
+            .contains(&"antwortest".to_string()),
+        "en-US chain must not merge locale-de cues"
+    );
+}
+
+#[test]
+#[ignore = "passes after Phase 4"]
+fn markus_default_pipeline_repro_locks_in_v0_6_closure() {
+    let policy = policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let von_header_pattern =
+        regex::Regex::new(r"^Von: <[0-9a-f]{8}:Name_\d+> <[a-z0-9._%+\-]+@example\.invalid>$")
+            .expect("regex");
+    for rulepacks in [
+        vec![embedded_rulepack("core"), embedded_rulepack("locale-de")],
+        vec![
+            embedded_rulepack("core"),
+            embedded_rulepack("locale-de"),
+            embedded_rulepack("locale-en"),
+        ],
+    ] {
+        let pipeline = build_pipeline(&policy, &empty_context(), &rulepacks, &active_locales, None)
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = pipeline
+            .redact(
+                &session,
+                RawDocument::Text("Von: Alice Example <alice@example.invalid>".to_string()),
+            )
+            .expect("redact");
+        let CleanDocument::Text(text) = clean else {
+            panic!("expected text");
+        };
+        assert!(von_header_pattern.is_match(&text));
+    }
 }
 
 #[test]

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -46,6 +46,22 @@ fn embedded_rulepack(name: &str) -> Rulepack {
     .expect("rulepack")
 }
 
+fn clean_with_rulepacks(rulepacks: &[Rulepack], locales: &[LocaleTag], input: &str) -> String {
+    let mut policy = policy();
+    policy.locale = Some(locales.to_vec());
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let pipeline = build_pipeline(&policy, &empty_context(), rulepacks, &active_locales, None)
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = pipeline
+        .redact(&session, RawDocument::Text(input.to_string()))
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text");
+    };
+    text
+}
+
 fn policy_with_registered_dictionary(rules: Vec<RuleSpec>) -> gaze::Policy {
     gaze::Policy {
         session: SessionPolicy {
@@ -357,6 +373,58 @@ fn markus_default_pipeline_repro_locks_in_v0_6_closure() {
         };
         assert!(von_header_pattern.is_match(&text));
     }
+}
+
+#[test]
+fn paren_display_name_from_header_tokenizes_single_address() {
+    // Matrix row 5 / R2-Patch-9: paren display name beside a header email.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-en")],
+        &[LocaleTag::EnUs],
+        "From: alice@example.invalid (Alice Example)",
+    );
+
+    assert!(
+        regex::Regex::new(r"^From: alice@example\.invalid \(<[0-9a-f]{8}:Name_\d+>\)$")
+            .unwrap()
+            .is_match(&text)
+    );
+}
+
+#[test]
+fn paren_display_name_von_header_tokenizes_under_de_locale_chain() {
+    // Matrix row 5 / R2-Patch-9: DE locale bucket lowers `Von`.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-de")],
+        &[LocaleTag::DeDe],
+        "Von: alice@example.invalid (Alice Example)",
+    );
+
+    assert!(
+        regex::Regex::new(r"^Von: alice@example\.invalid \(<[0-9a-f]{8}:Name_\d+>\)$")
+            .unwrap()
+            .is_match(&text)
+    );
+}
+
+#[test]
+fn paren_display_name_from_header_tokenizes_multi_address_line() {
+    // Matrix row 5 / R2-Patch-9: regex.rs uses captures_iter, so after the
+    // first header-anchored address the comma arm walks the second paren form.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-en")],
+        &[LocaleTag::EnUs],
+        "From: bob@example.invalid (Bob B), alice@example.invalid (Alice A)",
+    );
+
+    assert!(
+        regex::Regex::new(
+            r"^From: bob@example\.invalid \(<[0-9a-f]{8}:Name_\d+>\), alice@example\.invalid \(<[0-9a-f]{8}:Name_\d+>\)$"
+        )
+        .unwrap()
+        .is_match(&text)
+    );
+    assert_eq!(text.matches(":Name_").count(), 2);
 }
 
 #[test]

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::template::lower_pattern_template;
+use crate::{detector_wiring::derive_source_short_label, template::lower_pattern_template};
 use gaze::{
     Action, CleanDocument, DetectorKind, LocaleTag, PiiClass, PolicyError, RawDocument,
     RulepackError, Scope, Session, SessionPolicy, SessionScope,
@@ -449,4 +449,180 @@ pattern_template = '''{unknown_placeholder}: (.+)'''
             ..
         }) if placeholder == "unknown_placeholder"
     ));
+}
+
+#[test]
+fn anchored_match_missing_bucket_fails_closed_with_recognizer_id() {
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "bad-anchored"
+rulepack_version = "0.6.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "missing_bucket"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+"#,
+    )
+    .expect("parse");
+    let policy = policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+
+    let err = match build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    ) {
+        Ok(_) => panic!("missing anchored_match bucket must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        BuildError::UnknownLocaleBucket {
+            recognizer_id,
+            bucket,
+        } if recognizer_id == "name.forward_marker" && bucket == "missing_bucket"
+    ));
+}
+
+#[test]
+fn anchored_match_empty_bucket_fails_closed_with_recognizer_id() {
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "bad-anchored"
+rulepack_version = "0.6.0"
+default_locales = ["global"]
+
+[locale.empty_bucket]
+names = []
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "empty_bucket"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+"#,
+    )
+    .expect("parse");
+    let policy = policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+
+    let err = match build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    ) {
+        Ok(_) => panic!("empty anchored_match bucket must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        BuildError::UnknownLocaleBucket {
+            recognizer_id,
+            bucket,
+        } if recognizer_id == "name.forward_marker" && bucket == "empty_bucket"
+    ));
+}
+
+#[test]
+fn anchored_match_builds_with_constructor_owned_cues() {
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "anchored"
+rulepack_version = "0.6.0"
+default_locales = ["global"]
+
+[locale.forward_markers]
+names = ["Forwarded message from"]
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "forward_markers"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.scoring]
+base = 0.95
+priority = 60
+"#,
+    )
+    .expect("parse");
+    let policy = policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let pipeline = build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    )
+    .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = pipeline
+        .redact(
+            &session,
+            RawDocument::Text("Forwarded message from Alice Example:".to_string()),
+        )
+        .expect("redact");
+
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text");
+    };
+    assert!(
+        regex::Regex::new(r"^Forwarded message from <[0-9a-f]{8}:Name_\d+>:$")
+            .unwrap()
+            .is_match(&text)
+    );
+}
+
+#[test]
+fn source_short_label_derivation_handles_builtin_and_adopter_shapes() {
+    assert_eq!(
+        derive_source_short_label("name.agent_recipient", "agent_recipient_cues"),
+        "agent_recipient"
+    );
+    assert_eq!(
+        derive_source_short_label("name.forward_marker", "forward_markers"),
+        "forward_marker"
+    );
+    assert_eq!(
+        derive_source_short_label("name.auto_footer", "footer_cues"),
+        "auto_footer"
+    );
+    assert_eq!(
+        derive_source_short_label("name.x.team_handoff", "team_handoff_cues"),
+        "team_handoff"
+    );
 }

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -1,9 +1,14 @@
 use super::*;
 use crate::{detector_wiring::derive_source_short_label, template::lower_pattern_template};
 use gaze::{
-    Action, CleanDocument, DetectorKind, LocaleTag, PiiClass, PolicyError, RawDocument,
-    RulepackError, Scope, Session, SessionPolicy, SessionScope,
+    Action, CleanDocument, ConflictTier, DetectorKind, LocaleTag, PiiClass, PolicyError,
+    RawDocument, RedactionEntry, RedactionLogger, RulepackError, Scope, Session, SessionPolicy,
+    SessionScope,
 };
+use gaze_recognizers::{
+    AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape, RegexDetector,
+};
+use std::sync::{Arc, Mutex};
 
 fn policy() -> gaze::Policy {
     gaze::Policy {
@@ -49,8 +54,16 @@ fn embedded_rulepack(name: &str) -> Rulepack {
 fn clean_with_rulepacks(rulepacks: &[Rulepack], locales: &[LocaleTag], input: &str) -> String {
     let mut policy = policy();
     policy.locale = Some(locales.to_vec());
+    clean_with_policy_and_rulepacks(&policy, rulepacks, input)
+}
+
+fn clean_with_policy_and_rulepacks(
+    policy: &gaze::Policy,
+    rulepacks: &[Rulepack],
+    input: &str,
+) -> String {
     let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
-    let pipeline = build_pipeline(&policy, &empty_context(), rulepacks, &active_locales, None)
+    let pipeline = build_pipeline(policy, &empty_context(), rulepacks, &active_locales, None)
         .expect("pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
     let clean = pipeline
@@ -60,6 +73,46 @@ fn clean_with_rulepacks(rulepacks: &[Rulepack], locales: &[LocaleTag], input: &s
         panic!("expected text");
     };
     text
+}
+
+fn name_email_policy(locales: Vec<LocaleTag>) -> gaze::Policy {
+    let mut policy = policy();
+    policy.locale = Some(locales);
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: PiiClass::Name,
+            action: Action::Tokenize,
+        },
+        RuleSpec::Class {
+            class: PiiClass::Email,
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+    policy
+}
+
+#[derive(Clone, Default)]
+struct MemoryLogger {
+    entries: Arc<Mutex<Vec<RedactionEntry>>>,
+}
+
+impl MemoryLogger {
+    fn entries(&self) -> Vec<RedactionEntry> {
+        self.entries.lock().expect("entries lock").clone()
+    }
+}
+
+impl RedactionLogger for MemoryLogger {
+    fn log(&self, entry: &RedactionEntry) -> gaze::Result<()> {
+        self.entries
+            .lock()
+            .expect("entries lock")
+            .push(entry.clone());
+        Ok(())
+    }
 }
 
 fn policy_with_registered_dictionary(rules: Vec<RuleSpec>) -> gaze::Policy {
@@ -344,13 +397,26 @@ fn merged_vocab_for_en_us_loads_only_locale_en_buckets() {
 }
 
 #[test]
-#[ignore = "passes after Phase 4"]
 fn markus_default_pipeline_repro_locks_in_v0_6_closure() {
-    let policy = policy();
-    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
-    let von_header_pattern =
-        regex::Regex::new(r"^Von: <[0-9a-f]{8}:Name_\d+> <[a-z0-9._%+\-]+@example\.invalid>$")
-            .expect("regex");
+    let policy = name_email_policy(vec![LocaleTag::DeDe]);
+    let fixtures = [
+        (
+            "Von: Alice Example <alice@example.invalid>",
+            r"^Von: <[0-9a-f]{8}:Name_\d+> <<[0-9a-f]{8}:Email_\d+>>$",
+        ),
+        (
+            "From: alice@example.invalid (Alice Example)",
+            r"^From: <[0-9a-f]{8}:Email_\d+> \(<[0-9a-f]{8}:Name_\d+>\)$",
+        ),
+        (
+            "Forwarded message from Alice Example:",
+            r"^Forwarded message from <[0-9a-f]{8}:Name_\d+>:$",
+        ),
+        (
+            "Du antwortest als Artistfy-Support an Alice Example.",
+            r"^Du antwortest als Artistfy-Support an <[0-9a-f]{8}:Name_\d+>\.$",
+        ),
+    ];
     for rulepacks in [
         vec![embedded_rulepack("core"), embedded_rulepack("locale-de")],
         vec![
@@ -359,19 +425,13 @@ fn markus_default_pipeline_repro_locks_in_v0_6_closure() {
             embedded_rulepack("locale-en"),
         ],
     ] {
-        let pipeline = build_pipeline(&policy, &empty_context(), &rulepacks, &active_locales, None)
-            .expect("pipeline");
-        let session = Session::new(Scope::Ephemeral).expect("session");
-        let clean = pipeline
-            .redact(
-                &session,
-                RawDocument::Text("Von: Alice Example <alice@example.invalid>".to_string()),
-            )
-            .expect("redact");
-        let CleanDocument::Text(text) = clean else {
-            panic!("expected text");
-        };
-        assert!(von_header_pattern.is_match(&text));
+        for (input, expected) in fixtures {
+            let text = clean_with_policy_and_rulepacks(&policy, &rulepacks, input);
+            assert!(
+                regex::Regex::new(expected).unwrap().is_match(&text),
+                "{input} produced {text}"
+            );
+        }
     }
 }
 
@@ -425,6 +485,136 @@ fn paren_display_name_from_header_tokenizes_multi_address_line() {
         .is_match(&text)
     );
     assert_eq!(text.matches(":Name_").count(), 2);
+}
+
+#[test]
+fn anchored_footer_catches_sender_name_without_org_suffix() {
+    // Matrix row 3 / R2-Patch-8: max-greedy captures `Alice Example`;
+    // single-component `Mailgun` and organization-shaped `Acme Corp` stay out.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-en")],
+        &[LocaleTag::EnUs],
+        "Sent by Alice Example via Mailgun on behalf of Acme Corp",
+    );
+
+    assert!(regex::Regex::new(
+        r"^Sent by <[0-9a-f]{8}:Name_\d+> via Mailgun on behalf of Acme Corp$"
+    )
+    .unwrap()
+    .is_match(&text));
+    assert_eq!(text.matches(":Name_").count(), 1);
+}
+
+#[test]
+fn anchored_agent_recipient_catches_german_prompt_preamble() {
+    // Matrix row 4 / R2-Patch-11: cue is literal `antwortest`; the 48-char
+    // window walks past `als Artistfy-Support an `, while the 2-component
+    // minimum skips the product-role fragment and captures `Alice Example`.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-de")],
+        &[LocaleTag::DeDe],
+        "Du antwortest als Artistfy-Support an Alice Example.",
+    );
+
+    assert!(
+        regex::Regex::new(r"^Du antwortest als Artistfy-Support an <[0-9a-f]{8}:Name_\d+>\.$")
+            .unwrap()
+            .is_match(&text)
+    );
+}
+
+#[test]
+fn anchored_forward_marker_catches_single_path() {
+    // Matrix row 6 / R2-Patch-13: fixture is covered by anchored_match only.
+    let text = clean_with_rulepacks(
+        &[embedded_rulepack("core"), embedded_rulepack("locale-en")],
+        &[LocaleTag::EnUs],
+        "Forwarded message from Alice Example:",
+    );
+
+    assert!(
+        regex::Regex::new(r"^Forwarded message from <[0-9a-f]{8}:Name_\d+>:$")
+            .unwrap()
+            .is_match(&text)
+    );
+    assert_eq!(text.matches(":Name_").count(), 1);
+}
+
+#[test]
+fn deferred_and_not_caught_rows_do_not_emit_name_tokens() {
+    for (locale, input) in [
+        (LocaleTag::EnUs, "Re: ticket update from Alice Example"),
+        (
+            LocaleTag::EnUs,
+            "Cc: bob@example.invalid, alice@example.invalid",
+        ),
+        (LocaleTag::EnUs, "Schedule a call with Alice next Tuesday"),
+    ] {
+        let text = clean_with_rulepacks(
+            &[embedded_rulepack("core"), embedded_rulepack("locale-en")],
+            &[locale],
+            input,
+        );
+        assert!(!text.contains(":Name_"), "{input} produced {text}");
+    }
+}
+
+#[test]
+fn same_span_structural_name_overlap_logs_loser() {
+    let logger = MemoryLogger::default();
+    let pipeline = gaze::Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                r"reply to alice@example\.invalid \(([^)]+)\)",
+                PiiClass::Name,
+                "email.header.name.paren",
+                vec![LocaleTag::Global],
+                0.85,
+                100,
+                "name.counter",
+                Some(vec![1]),
+                Vec::new(),
+                None,
+                None,
+            )
+            .expect("regex recognizer"),
+        )
+        .recognizer(AnchoredMatchRecognizer::new(
+            "name.agent_recipient".to_string(),
+            vec!["reply to alice@example.invalid".to_string()],
+            AnchoredBoundary::Punctuation,
+            48,
+            NameShape::PersonName,
+            CuePosition::Before,
+            "agent_recipient".to_string(),
+            0.88,
+            110,
+        ))
+        .rule(gaze::ClassRule::new(PiiClass::Name, Action::Tokenize))
+        .rule(gaze::DefaultRule::new(Action::Preserve))
+        .redaction_logger(logger.clone())
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = pipeline
+        .redact(
+            &session,
+            RawDocument::Text("reply to alice@example.invalid (Alice Example)".to_string()),
+        )
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text");
+    };
+
+    assert!(text.contains(":Name_"));
+    let entries = logger.entries();
+    assert_eq!(entries.len(), 2, "{entries:?}");
+    let loser = entries
+        .iter()
+        .find(|entry| entry.conflict_loser)
+        .expect("loser");
+    assert_eq!(loser.source, "email.header.name.paren");
+    assert_eq!(loser.decided_by, ConflictTier::Merged);
 }
 
 #[test]

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -50,6 +50,9 @@ pub(crate) fn build_pipeline_from_policy(
         gaze_assembly::BuildError::Policy(err) => gaze::Error::Policy(err),
         gaze_assembly::BuildError::Rulepack(err) => gaze::Error::Rulepack(err),
         gaze_assembly::BuildError::Pipeline(err) => err,
+        gaze_assembly::BuildError::UnknownLocaleBucket { bucket, .. } => {
+            gaze::Error::Policy(PolicyError::UnknownLocaleBucket { name: bucket })
+        }
     })
 }
 

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -58,3 +58,22 @@ capture_groups = [1, 2]
 [recognizers.scoring]
 base = 0.85
 priority = 100
+
+[[recognizers]]
+id = "email.header.name.paren"
+class = "Name"
+cooperates_with = ["email.header.name"]
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern_template = '''(?:(?:{locale.email_headers}):|,)\s*\S+@\S+\s*\(([^)]+)\)'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.85
+priority = 100
+
+[recognizers.token]
+family = "name.counter"

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -47,6 +47,7 @@ license = "Apache-2.0"
 [[recognizers]]
 id = "email.header.name"
 class = "Name"
+cooperates_with = ["email.header.name.paren", "name.forward_marker", "name.agent_recipient", "name.auto_footer"]
 enabled = true
 locales = ["global"]
 
@@ -62,7 +63,7 @@ priority = 100
 [[recognizers]]
 id = "email.header.name.paren"
 class = "Name"
-cooperates_with = ["email.header.name"]
+cooperates_with = ["email.header.name", "name.forward_marker", "name.agent_recipient", "name.auto_footer"]
 enabled = true
 locales = ["global"]
 
@@ -74,6 +75,72 @@ capture_groups = [1]
 [recognizers.scoring]
 base = 0.85
 priority = 100
+
+[recognizers.token]
+family = "name.counter"
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+cooperates_with = ["email.header.name", "email.header.name.paren", "name.agent_recipient", "name.auto_footer"]
+enabled = true
+locales = ["de-DE", "de-AT", "de-CH", "en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "forward_markers"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.scoring]
+base = 0.88
+priority = 110
+
+[recognizers.token]
+family = "name.counter"
+
+[[recognizers]]
+id = "name.agent_recipient"
+class = "Name"
+cooperates_with = ["email.header.name", "email.header.name.paren", "name.forward_marker", "name.auto_footer"]
+enabled = true
+locales = ["de-DE", "de-AT", "de-CH", "en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "agent_recipient_cues"
+boundary = "punctuation"
+right_window_chars = 48
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.scoring]
+base = 0.88
+priority = 110
+
+[recognizers.token]
+family = "name.counter"
+
+[[recognizers]]
+id = "name.auto_footer"
+class = "Name"
+cooperates_with = ["email.header.name", "email.header.name.paren", "name.forward_marker", "name.agent_recipient"]
+enabled = true
+locales = ["de-DE", "de-AT", "de-CH", "en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "footer_cues"
+boundary = "whitespace"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.scoring]
+base = 0.88
+priority = 110
 
 [recognizers.token]
 family = "name.counter"

--- a/crates/gaze-recognizers/embedded/locale-de.toml
+++ b/crates/gaze-recognizers/embedded/locale-de.toml
@@ -6,3 +6,12 @@ default_locales = ["de-DE", "de-AT", "de-CH"]
 # Phase 2 ports DACH structured recognizers.
 [locale.email_headers]
 names = ["Von", "An", "Cc", "Bcc", "Antwort-An", "Absender"]
+
+[locale.forward_markers]
+names = ["Weitergeleitete Nachricht von", "Forwarded message from", "Begin forwarded message from", "----- Forwarded message"]
+
+[locale.agent_recipient_cues]
+names = ["antwortest", "antworte", "schreibst", "reply to", "respond to", "draft for", "draft to"]
+
+[locale.footer_cues]
+names = ["Gesendet von", "Gesendet durch", "Sent by", "Sent via", "On behalf of", "via"]

--- a/crates/gaze-recognizers/embedded/locale-en.toml
+++ b/crates/gaze-recognizers/embedded/locale-en.toml
@@ -6,3 +6,12 @@ default_locales = ["en-US", "en-GB", "en-IE", "en-AU", "en-CA"]
 # Phase 2 ports English locale recognizers.
 [locale.email_headers]
 names = ["From", "To", "Cc", "Bcc", "Reply-To", "Sender"]
+
+[locale.forward_markers]
+names = ["Forwarded message from", "Begin forwarded message", "----- Forwarded message"]
+
+[locale.agent_recipient_cues]
+names = ["reply to", "respond to", "draft for", "draft to"]
+
+[locale.footer_cues]
+names = ["Sent by", "Sent via", "On behalf of"]

--- a/crates/gaze-recognizers/src/anchored_match.rs
+++ b/crates/gaze-recognizers/src/anchored_match.rs
@@ -1,0 +1,509 @@
+use gaze_types::{Candidate, ConflictTier, DetectContext, LocaleTag, PiiClass, Recognizer};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchoredBoundary {
+    Punctuation,
+    Whitespace,
+    LineEnd,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameShape {
+    PersonName,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CuePosition {
+    Before,
+    After,
+}
+
+/// Recognizes person names near literal locale cues.
+///
+/// The `person_name` grammar accepts Unicode letter components with internal
+/// apostrophe or hyphen joins, initials written as a single uppercase letter
+/// followed by `.`, and non-leading particles (`de`, `la`, `van`, `der`) only
+/// when sandwiched between uppercase components. Matching is max-greedy,
+/// capped at four components and 64 bytes.
+pub struct AnchoredMatchRecognizer {
+    id: String,
+    cues: Vec<String>,
+    boundary: AnchoredBoundary,
+    right_window_chars: u16,
+    name_shape: NameShape,
+    cue_position: CuePosition,
+    source: String,
+    score: f32,
+    priority: i32,
+    token_family: String,
+    locales: Vec<LocaleTag>,
+    min_components: usize,
+}
+
+impl AnchoredMatchRecognizer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        cues: Vec<String>,
+        boundary: AnchoredBoundary,
+        right_window_chars: u16,
+        name_shape: NameShape,
+        cue_position: CuePosition,
+        source_short_label: String,
+        score: f32,
+        priority: i32,
+    ) -> Self {
+        let mut cues = cues
+            .into_iter()
+            .filter(|cue| !cue.trim().is_empty())
+            .collect::<Vec<_>>();
+        cues.sort_by_key(|cue| std::cmp::Reverse(cue.chars().count()));
+        let min_components = if source_short_label == "forward_marker" {
+            1
+        } else {
+            2
+        };
+        Self {
+            id,
+            cues,
+            boundary,
+            right_window_chars,
+            name_shape,
+            cue_position,
+            source: format!("structural.{source_short_label}"),
+            score,
+            priority,
+            token_family: "name.counter".to_string(),
+            locales: vec![LocaleTag::Global],
+            min_components,
+        }
+    }
+
+    fn candidate_after_cue(&self, input: &str, cue_end: usize) -> Option<std::ops::Range<usize>> {
+        let window = bounded_window_after(input, cue_end, self.right_window_chars);
+        let window = if matches!(self.boundary, AnchoredBoundary::LineEnd) {
+            window
+                .split_once(['\n', '\r'])
+                .map_or(window, |(line, _)| line)
+        } else {
+            window
+        };
+        let relative = is_person_name_candidate_with_min(window, self.min_components)?;
+        Some((cue_end + relative.start)..(cue_end + relative.end))
+    }
+
+    fn candidate_before_cue(
+        &self,
+        input: &str,
+        cue_start: usize,
+    ) -> Option<std::ops::Range<usize>> {
+        let window = bounded_window_before(input, cue_start, self.right_window_chars);
+        let relative = last_person_name_candidate_with_min(window, self.min_components)?;
+        let window_start = cue_start - window.len();
+        Some((window_start + relative.start)..(window_start + relative.end))
+    }
+}
+
+impl Recognizer for AnchoredMatchRecognizer {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn supported_class(&self) -> &PiiClass {
+        &PiiClass::Name
+    }
+
+    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+        if !matches!(self.name_shape, NameShape::PersonName) {
+            return Vec::new();
+        }
+
+        let mut candidates = Vec::new();
+        for cue in &self.cues {
+            for cue_range in find_cue_ranges(input, cue) {
+                let span = match self.cue_position {
+                    CuePosition::Before => self.candidate_after_cue(input, cue_range.end),
+                    CuePosition::After => self.candidate_before_cue(input, cue_range.start),
+                };
+                let Some(span) = span else {
+                    continue;
+                };
+                if !self.boundary_allows(input, &span) {
+                    continue;
+                }
+                candidates.push(Candidate {
+                    span,
+                    class: PiiClass::Name,
+                    recognizer_id: self.id.clone(),
+                    score: self.score,
+                    priority: self.priority,
+                    canonical_form: None,
+                    token_family: self.token_family.clone(),
+                    source: self.source.clone(),
+                    decided_by: ConflictTier::None,
+                    merged_sources: Vec::new(),
+                });
+            }
+        }
+        candidates.sort_by_key(|candidate| candidate.span.start);
+        candidates.dedup_by(|a, b| a.span == b.span);
+        candidates
+    }
+
+    fn token_family(&self) -> &str {
+        &self.token_family
+    }
+
+    fn locales(&self) -> &[LocaleTag] {
+        &self.locales
+    }
+}
+
+impl AnchoredMatchRecognizer {
+    fn boundary_allows(&self, input: &str, span: &std::ops::Range<usize>) -> bool {
+        match self.boundary {
+            AnchoredBoundary::Punctuation => input[span.end..]
+                .chars()
+                .find(|ch| !ch.is_whitespace())
+                .is_none_or(|ch| matches!(ch, '.' | ',' | ':' | ';' | ')' | ']' | '>' | '\n')),
+            AnchoredBoundary::Whitespace => input[span.end..]
+                .chars()
+                .next()
+                .is_none_or(|ch| ch.is_whitespace() || matches!(ch, '.' | ',' | ':' | ';')),
+            AnchoredBoundary::LineEnd => input[span.end..]
+                .chars()
+                .next()
+                .is_none_or(|ch| ch == '\n' || ch == '\r'),
+        }
+    }
+}
+
+pub fn is_person_name_candidate(input: &str) -> Option<std::ops::Range<usize>> {
+    is_person_name_candidate_with_min(input, 1)
+}
+
+fn is_person_name_candidate_with_min(
+    input: &str,
+    min_components: usize,
+) -> Option<std::ops::Range<usize>> {
+    for (start, _) in input.char_indices().filter(|(_, ch)| ch.is_uppercase()) {
+        if let Some(span) = person_name_at(input, start, min_components) {
+            return Some(span);
+        }
+    }
+    None
+}
+
+fn last_person_name_candidate_with_min(
+    input: &str,
+    min_components: usize,
+) -> Option<std::ops::Range<usize>> {
+    input
+        .char_indices()
+        .filter(|(_, ch)| ch.is_uppercase())
+        .filter_map(|(start, _)| person_name_at(input, start, min_components))
+        .next_back()
+}
+
+fn person_name_at(
+    input: &str,
+    start: usize,
+    min_components: usize,
+) -> Option<std::ops::Range<usize>> {
+    let mut end = start;
+    let mut components = 0usize;
+    let mut uppercase_components = 0usize;
+    let mut pending_particles: Vec<(usize, usize)> = Vec::new();
+    let mut cursor = start;
+
+    while components < 4 {
+        let Some((token_start, token_end)) = next_space_delimited(input, cursor) else {
+            break;
+        };
+        if token_start != cursor && !input[cursor..token_start].chars().all(char::is_whitespace) {
+            break;
+        }
+        let token = trim_trailing_boundary(&input[token_start..token_end]);
+        let effective_end = token_start + token.len();
+        if token.is_empty() {
+            break;
+        }
+
+        if is_upper_component(token) {
+            components += 1;
+            uppercase_components += 1;
+            pending_particles.clear();
+            end = effective_end;
+            cursor = token_end;
+            continue;
+        }
+
+        if components > 0 && is_particle(token) {
+            pending_particles.push((token_start, effective_end));
+            components += 1;
+            cursor = token_end;
+            continue;
+        }
+        break;
+    }
+
+    if !pending_particles.is_empty() {
+        end = pending_particles[0].0.saturating_sub(1);
+        components = components.saturating_sub(pending_particles.len());
+    }
+
+    let candidate = &input[start..end];
+    (components >= min_components
+        && uppercase_components > 0
+        && candidate.len() <= 64
+        && !candidate.is_empty())
+    .then_some(start..end)
+}
+
+fn next_space_delimited(input: &str, cursor: usize) -> Option<(usize, usize)> {
+    let start = input[cursor..]
+        .char_indices()
+        .find(|(_, ch)| !ch.is_whitespace())
+        .map(|(offset, _)| cursor + offset)?;
+    let end = input[start..]
+        .char_indices()
+        .find(|(_, ch)| ch.is_whitespace())
+        .map_or(input.len(), |(offset, _)| start + offset);
+    Some((start, end))
+}
+
+fn trim_trailing_boundary(token: &str) -> &str {
+    if token.len() == 2 {
+        let mut chars = token.chars();
+        if chars.next().is_some_and(|ch| ch.is_uppercase()) && chars.next() == Some('.') {
+            return token;
+        }
+    }
+    token.trim_end_matches(['.', ',', ':', ';', ')', ']', '>'])
+}
+
+fn is_upper_component(token: &str) -> bool {
+    if token.len() == 2 {
+        let mut chars = token.chars();
+        if chars.next().is_some_and(|ch| ch.is_uppercase()) && chars.next() == Some('.') {
+            return true;
+        }
+    }
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_uppercase()
+        && !token.chars().all(|ch| ch.is_uppercase())
+        && token.chars().all(|ch| {
+            ch.is_alphabetic() || matches!(ch, '\'' | '-') || (ch == '.' && token.len() == 2)
+        })
+        && token
+            .split(['\'', '-'])
+            .all(|part| part.chars().next().is_some_and(|ch| ch.is_alphabetic()))
+}
+
+fn is_particle(token: &str) -> bool {
+    matches!(token, "de" | "la" | "van" | "der")
+}
+
+fn find_cue_ranges(input: &str, cue: &str) -> Vec<std::ops::Range<usize>> {
+    let input_lower = input.to_lowercase();
+    let cue_lower = cue.to_lowercase();
+    input_lower
+        .match_indices(&cue_lower)
+        .filter_map(|(start, matched)| {
+            let end = start + matched.len();
+            (is_boundary(input, start, true) && is_boundary(input, end, false))
+                .then_some(start..end)
+        })
+        .collect()
+}
+
+fn is_boundary(input: &str, index: usize, before: bool) -> bool {
+    let ch = if before {
+        input[..index].chars().next_back()
+    } else {
+        input[index..].chars().next()
+    };
+    ch.is_none_or(|ch| !ch.is_alphanumeric() && ch != '_' && ch != '-')
+}
+
+fn bounded_window_after(input: &str, start: usize, max_chars: u16) -> &str {
+    let end = input[start..]
+        .char_indices()
+        .nth(max_chars as usize)
+        .map_or(input.len(), |(offset, _)| start + offset);
+    &input[start..end]
+}
+
+fn bounded_window_before(input: &str, end: usize, max_chars: u16) -> &str {
+    let start = input[..end]
+        .char_indices()
+        .rev()
+        .nth(max_chars as usize)
+        .map_or(0, |(offset, _)| offset);
+    &input[start..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, collections::HashMap};
+
+    use gaze_types::{DictionaryBundle, LocaleTag};
+
+    use super::*;
+
+    #[test]
+    fn person_name_shape_accepts_required_matches() {
+        for value in [
+            "Łukasz Müller",
+            "O'Brien",
+            "Alice de la Cruz",
+            "Jean-Paul Sartre",
+            "Müller-Schmidt",
+            "José María García",
+        ] {
+            assert!(
+                is_person_name_candidate(value).is_some(),
+                "{value} should match"
+            );
+        }
+    }
+
+    #[test]
+    fn person_name_shape_rejects_required_non_matches() {
+        for value in ["IBM", "mailgun", "the alice"] {
+            assert!(
+                is_person_name_candidate(value).is_none(),
+                "{value} should not match"
+            );
+        }
+        assert!(is_person_name_candidate_with_min("Acme Corp", 3).is_none());
+    }
+
+    #[test]
+    fn detects_cue_followed_by_name_with_punctuation_boundary() {
+        let recognizer = test_recognizer(
+            "test.from_cue",
+            vec!["from"],
+            AnchoredBoundary::Punctuation,
+            CuePosition::Before,
+            "from",
+        );
+        let hits = recognizer.detect("Hello from Alice Example, please reply.", &ctx());
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].span, 11..24);
+        assert_eq!(hits[0].recognizer_id, "test.from_cue");
+        assert_eq!(hits[0].source, "structural.from");
+    }
+
+    #[test]
+    fn detects_line_end_and_whitespace_bounded_names() {
+        let line_end = test_recognizer(
+            "test.line",
+            vec!["from"],
+            AnchoredBoundary::LineEnd,
+            CuePosition::Before,
+            "from",
+        );
+        assert_eq!(
+            line_end.detect("Forwarded from Alice Example\nBody", &ctx())[0].span,
+            15..28
+        );
+
+        let whitespace = test_recognizer(
+            "test.ws",
+            vec!["reply to"],
+            AnchoredBoundary::Whitespace,
+            CuePosition::Before,
+            "agent_recipient",
+        );
+        assert_eq!(
+            whitespace.detect("Please reply to Alice Example today", &ctx())[0].span,
+            16..29
+        );
+    }
+
+    #[test]
+    fn detects_cue_after_name_and_rejects_window_overflow() {
+        let recognizer = test_recognizer(
+            "test.after",
+            vec!["sent"],
+            AnchoredBoundary::Whitespace,
+            CuePosition::After,
+            "footer",
+        );
+        assert_eq!(
+            recognizer.detect("Alice Example sent this", &ctx())[0].span,
+            0..13
+        );
+
+        let short = AnchoredMatchRecognizer::new(
+            "test.short".to_string(),
+            vec!["from".to_string()],
+            AnchoredBoundary::Punctuation,
+            4,
+            NameShape::PersonName,
+            CuePosition::Before,
+            "from".to_string(),
+            0.9,
+            10,
+        );
+        assert!(short.detect("from Alice Example.", &ctx()).is_empty());
+    }
+
+    #[test]
+    fn handles_unicode_overlap_and_non_name_rejection() {
+        let recognizer = test_recognizer(
+            "test.forward",
+            vec!["Forwarded", "Forwarded message from"],
+            AnchoredBoundary::Punctuation,
+            CuePosition::Before,
+            "forward_marker",
+        );
+        let hits = recognizer.detect("Forwarded message from Łukasz Müller:", &ctx());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(
+            &"Forwarded message from Łukasz Müller:"[hits[0].span.clone()],
+            "Łukasz Müller"
+        );
+
+        assert!(recognizer
+            .detect("Forwarded message from mailgun:", &ctx())
+            .is_empty());
+    }
+
+    fn test_recognizer(
+        id: &str,
+        cues: Vec<&str>,
+        boundary: AnchoredBoundary,
+        cue_position: CuePosition,
+        source_short_label: &str,
+    ) -> AnchoredMatchRecognizer {
+        AnchoredMatchRecognizer::new(
+            id.to_string(),
+            cues.into_iter().map(str::to_string).collect(),
+            boundary,
+            64,
+            NameShape::PersonName,
+            cue_position,
+            source_short_label.to_string(),
+            0.91,
+            60,
+        )
+    }
+
+    fn ctx() -> DetectContext<'static> {
+        let fields = Box::leak(Box::new(()));
+        let dictionaries = Box::leak(Box::new(DictionaryBundle::from_entries(HashMap::new())));
+        let locale_chain = Box::leak(Box::new([LocaleTag::Global]));
+        DetectContext {
+            locale_chain,
+            dictionaries,
+            fields,
+            degraded: Cell::new(false),
+        }
+    }
+}

--- a/crates/gaze-recognizers/src/anchored_match.rs
+++ b/crates/gaze-recognizers/src/anchored_match.rs
@@ -253,6 +253,9 @@ fn person_name_at(
     }
 
     let candidate = &input[start..end];
+    if has_organization_suffix(candidate) {
+        return None;
+    }
     (components >= min_components
         && uppercase_components > 0
         && candidate.len() <= 64
@@ -305,6 +308,18 @@ fn is_upper_component(token: &str) -> bool {
 
 fn is_particle(token: &str) -> bool {
     matches!(token, "de" | "la" | "van" | "der")
+}
+
+fn has_organization_suffix(candidate: &str) -> bool {
+    candidate
+        .split_whitespace()
+        .next_back()
+        .is_some_and(|last| {
+            matches!(
+                trim_trailing_boundary(last),
+                "Corp" | "Corporation" | "Inc" | "LLC" | "GmbH" | "AG"
+            )
+        })
 }
 
 fn find_cue_ranges(input: &str, cue: &str) -> Vec<std::ops::Range<usize>> {
@@ -379,7 +394,7 @@ mod tests {
                 "{value} should not match"
             );
         }
-        assert!(is_person_name_candidate_with_min("Acme Corp", 3).is_none());
+        assert!(is_person_name_candidate_with_min("Acme Corp", 2).is_none());
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -35,15 +35,20 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 2);
+        assert_eq!(rulepack.recognizers.len(), 3);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
+        assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
         assert!(matches!(
             rulepack.recognizers[0].matcher,
             RawMatch::Regex { .. }
         ));
         assert!(matches!(
             rulepack.recognizers[1].matcher,
+            RawMatch::Regex { .. }
+        ));
+        assert!(matches!(
+            rulepack.recognizers[2].matcher,
             RawMatch::Regex { .. }
         ));
     }

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -1,8 +1,12 @@
+mod anchored_match;
 mod dictionary;
 mod error;
 mod ner;
 mod regex;
 
+pub use anchored_match::{
+    is_person_name_candidate, AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape,
+};
 pub use dictionary::DictionaryRecognizer;
 pub use error::{RecognizerError, Result};
 pub use ner::{

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -35,10 +35,13 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 3);
+        assert_eq!(rulepack.recognizers.len(), 6);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
+        assert_eq!(rulepack.recognizers[3].id, "name.forward_marker");
+        assert_eq!(rulepack.recognizers[4].id, "name.agent_recipient");
+        assert_eq!(rulepack.recognizers[5].id, "name.auto_footer");
         assert!(matches!(
             rulepack.recognizers[0].matcher,
             RawMatch::Regex { .. }
@@ -51,6 +54,9 @@ mod tests {
             rulepack.recognizers[2].matcher,
             RawMatch::Regex { .. }
         ));
+        assert!(rulepack.recognizers[3..]
+            .iter()
+            .all(|recognizer| matches!(recognizer.matcher, RawMatch::AnchoredMatch { .. })));
     }
 
     #[test]

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -42,9 +42,9 @@ pub use registry::{
 pub use resolver::resolve_candidates;
 pub use rule::{Action, ClassRule, ColumnRule, DefaultRule, Rule, RuleContext};
 pub use rulepack::{
-    recognizer_composition_validator, ContextSpec, LocaleBucket, LocaleData, NormalizerSpec,
-    RawMatch, RecognizerSpec, Rulepack, RulepackError, RulepackSource, ScoringSpec, SourceSpec,
-    TokenSpec, ValidatorSpec,
+    recognizer_composition_validator, AnchoredBoundary, ContextSpec, CuePosition, LocaleBucket,
+    LocaleData, NameShape, NormalizerSpec, RawMatch, RecognizerSpec, Rulepack, RulepackError,
+    RulepackSource, ScoringSpec, SourceSpec, TokenSpec, ValidatorSpec,
 };
 pub use sandbox::{
     ExecPolicy, Sandbox, SandboxError, SandboxPlan, UntrustedExecRequest, ValidatedExecRequest,

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -58,6 +58,42 @@ pub enum RawMatch {
     Ner {
         model_ref: String,
     },
+    AnchoredMatch {
+        cues_bucket: String,
+        boundary: String,
+        right_window_chars: u16,
+        name_shape: String,
+        cue_position: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum AnchoredBoundary {
+    Punctuation,
+    Whitespace,
+    LineEnd,
+}
+
+/// Closed enum for the shape of token sequences `anchored_match` extracts.
+///
+/// v0.6 ships a single `PersonName` variant. Future variants
+/// (e.g. `Organization`, `Address`, `LegalEntity`) must justify
+/// why they aren't a locale-bucket lookup before being added here.
+/// Adding variants without that justification regresses the
+/// principle drawer `session-2026-04-25-no-codified-domain-concerns`
+/// (see also `lower_email_header_pattern_template` in pre-v0.4.1 history).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum NameShape {
+    PersonName,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum CuePosition {
+    Before,
+    After,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -127,6 +163,8 @@ pub enum RulepackError {
     UnknownLocale(String),
     #[error("unsupported matcher kind: {0}")]
     UnsupportedMatcher(String),
+    #[error("unsupported anchored_match field '{field}' value '{value}'")]
+    UnsupportedAnchoredMatch { field: String, value: String },
     #[error("unsupported rulepack field '{field}' in B1; planned for {planned_version}")]
     UnsupportedField {
         field: String,
@@ -399,15 +437,62 @@ fn parse_recognizer(
 }
 
 fn validate_matcher(raw: &RawRecognizerSpec) -> Result<(), RulepackError> {
-    if let RawMatch::Regex {
-        pattern,
-        pattern_template,
-        ..
-    } = &raw.matcher
-    {
-        if pattern.is_some() == pattern_template.is_some() {
-            return Err(RulepackError::RegexPatternChoice { id: raw.id.clone() });
+    match &raw.matcher {
+        RawMatch::Regex {
+            pattern,
+            pattern_template,
+            ..
+        } => {
+            if pattern.is_some() == pattern_template.is_some() {
+                return Err(RulepackError::RegexPatternChoice { id: raw.id.clone() });
+            }
         }
+        RawMatch::AnchoredMatch {
+            cues_bucket,
+            boundary,
+            right_window_chars,
+            name_shape,
+            cue_position,
+            ..
+        } => {
+            if cues_bucket.trim().is_empty() {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "cues_bucket".to_string(),
+                    value: cues_bucket.clone(),
+                });
+            }
+            if !(1..=512).contains(right_window_chars) {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "right_window_chars".to_string(),
+                    value: right_window_chars.to_string(),
+                });
+            }
+            if !matches!(boundary.as_str(), "punctuation" | "whitespace" | "line_end") {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "boundary".to_string(),
+                    value: boundary.clone(),
+                });
+            }
+            if name_shape != "person_name" {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "name_shape".to_string(),
+                    value: name_shape.clone(),
+                });
+            }
+            if !matches!(cue_position.as_str(), "before" | "after") {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "cue_position".to_string(),
+                    value: cue_position.clone(),
+                });
+            }
+            if cues_bucket.contains("...") {
+                return Err(RulepackError::UnsupportedAnchoredMatch {
+                    field: "cues_bucket".to_string(),
+                    value: cues_bucket.clone(),
+                });
+            }
+        }
+        RawMatch::Dictionary { .. } | RawMatch::Ner { .. } => {}
     }
     Ok(())
 }
@@ -745,6 +830,59 @@ kind = "regex"
     }
 
     #[test]
+    fn anchored_match_accepts_valid_schema() {
+        let rulepack = Rulepack::parse(&anchored_match_rulepack("")).expect("anchored_match");
+        assert!(matches!(
+            rulepack.recognizers[0].matcher,
+            RawMatch::AnchoredMatch { .. }
+        ));
+    }
+
+    #[test]
+    fn anchored_match_rejects_unknown_boundary() {
+        let err = Rulepack::parse(&anchored_match_rulepack("boundary = \"paragraph\"\n"))
+            .expect_err("unknown boundary fails closed");
+
+        assert_unsupported_anchored_match(err, "boundary", "paragraph");
+    }
+
+    #[test]
+    fn anchored_match_rejects_unknown_name_shape() {
+        let err = Rulepack::parse(&anchored_match_rulepack("name_shape = \"organization\"\n"))
+            .expect_err("unknown name_shape fails closed");
+
+        assert_unsupported_anchored_match(err, "name_shape", "organization");
+    }
+
+    #[test]
+    fn anchored_match_rejects_unknown_cue_position() {
+        let err = Rulepack::parse(&anchored_match_rulepack("cue_position = \"around\"\n"))
+            .expect_err("unknown cue_position fails closed");
+
+        assert_unsupported_anchored_match(err, "cue_position", "around");
+    }
+
+    #[test]
+    fn anchored_match_rejects_missing_cues_bucket() {
+        let err = Rulepack::parse(&anchored_match_rulepack("cues_bucket = \"\"\n"))
+            .expect_err("missing cues_bucket fails closed");
+
+        assert_unsupported_anchored_match(err, "cues_bucket", "");
+    }
+
+    #[test]
+    fn anchored_match_rejects_invalid_window_bounds() {
+        for (value, expected) in [("0", "0"), ("513", "513")] {
+            let err = Rulepack::parse(&anchored_match_rulepack(&format!(
+                "right_window_chars = {value}\n"
+            )))
+            .expect_err("invalid right_window_chars fails closed");
+
+            assert_unsupported_anchored_match(err, "right_window_chars", expected);
+        }
+    }
+
+    #[test]
     fn rulepack_load_fails_when_two_name_recognizers_omit_cooperates_with() {
         let err = Rulepack::parse(
             r#"
@@ -884,6 +1022,51 @@ pattern = ".+"
         )
     }
 
+    fn anchored_match_rulepack(override_line: &str) -> String {
+        let cues_bucket = if override_line.starts_with("cues_bucket") {
+            override_line.to_string()
+        } else {
+            "cues_bucket = \"forward_markers\"\n".to_string()
+        };
+        let boundary = if override_line.starts_with("boundary") {
+            override_line.to_string()
+        } else {
+            "boundary = \"punctuation\"\n".to_string()
+        };
+        let right_window_chars = if override_line.starts_with("right_window_chars") {
+            override_line.to_string()
+        } else {
+            "right_window_chars = 64\n".to_string()
+        };
+        let name_shape = if override_line.starts_with("name_shape") {
+            override_line.to_string()
+        } else {
+            "name_shape = \"person_name\"\n".to_string()
+        };
+        let cue_position = if override_line.starts_with("cue_position") {
+            override_line.to_string()
+        } else {
+            "cue_position = \"before\"\n".to_string()
+        };
+        format!(
+            r#"
+schema_version = "0.1.0"
+rulepack_id = "anchored"
+rulepack_version = "0.6.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+{cues_bucket}{boundary}{right_window_chars}{name_shape}{cue_position}
+"#
+        )
+    }
+
     fn assert_unsupported_field(err: RulepackError, field: &str) {
         assert!(matches!(
             err,
@@ -891,6 +1074,16 @@ pattern = ".+"
                 field: ref actual,
                 planned_version: "v0.4.1",
             } if actual == field
+        ));
+    }
+
+    fn assert_unsupported_anchored_match(err: RulepackError, field: &str, value: &str) {
+        assert!(matches!(
+            err,
+            RulepackError::UnsupportedAnchoredMatch {
+                field: ref actual_field,
+                value: ref actual_value,
+            } if actual_field == field && actual_value == value
         ));
     }
 }

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -678,6 +678,34 @@ license = "Apache-2.0"
     }
 
     #[test]
+    fn embedded_core_loads_full_name_recognizer_cooperation_matrix() {
+        let rulepack = Rulepack::load(RulepackSource::Embedded(
+            gaze_recognizers::embedded("core").expect("core rulepack"),
+        ))
+        .expect("embedded core rulepack");
+        let name_recognizers = rulepack
+            .recognizers
+            .iter()
+            .filter(|recognizer| recognizer.class == PiiClass::Name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(name_recognizers.len(), 5);
+        for recognizer in &name_recognizers {
+            for peer in &name_recognizers {
+                if recognizer.id == peer.id {
+                    continue;
+                }
+                assert!(
+                    recognizer.cooperates_with.contains(&peer.id),
+                    "{} missing cooperates_with {}",
+                    recognizer.id,
+                    peer.id
+                );
+            }
+        }
+    }
+
+    #[test]
     fn embedded_core_extended_activated_classes_match_rulepack_classes() {
         let rulepack = Rulepack::load(RulepackSource::Embedded(
             gaze_recognizers::embedded("core-extended").expect("core-extended rulepack"),


### PR DESCRIPTION
## Summary

Partial implementation for the v0.5 NER context-sensitivity leak class (Markus GH#24, solo todo #87). This PR contains phases 1-4 from `plan/v0.6-ner-context`: the closed `anchored_match` recognizer kind, DE/EN cue buckets, parenthesized display-name header matching, and default core wiring for the Markus prompt-preamble/footer closure matrix.

North-star axes covered so far: **1 reliability** (default-on structural prompt/header coverage), **3 agentic** (agent prompt preamble cues), **5 adopter ergonomics** (bundled locale cue coverage with no policy change for default DE/EN flows).

## Phases Included

- P1: Introduced the `anchored_match` rulepack schema and recognizer implementation with constructor-owned cue buckets and fail-closed assembly errors.
- P2: Added forward-marker, agent-recipient, and footer cue buckets to `locale-de` and `locale-en`, including DE+EN safety coverage under German locale chains.
- P3: Added parenthesized email display-name matching for single and multi-address header lines.
- P4: Wired anchored name recognizers into the embedded core rulepack and completed the `Name` cooperation matrix, including Markus closure fixtures.

## Coverage Matrix So Far

- Row 1 Markus forward-marker shape: covered in P4 by `markus_default_pipeline_repro_locks_in_v0_6_closure`.
- Row 3 German agent-recipient prompt preamble: covered in P4 by `anchored_agent_recipient_catches_german_prompt_preamble` and Markus closure fixture.
- Row 4 German support-recipient prompt preamble: covered in P4 Markus closure fixture.
- Row 5 footer/auto-sender shape: covered in P4 by `anchored_footer_catches_sender_name_without_org_suffix`.
- Row 6 parenthesized display name: covered in P3/P4 by paren header tests and Markus closure fixture.
- Row 2 deferred: preserved as no-token in P4 negative test.
- Row 7 planned no-Name: preserved as no-token in P4 negative test.
- Row 8 deferred: preserved as no-token in P4 negative test.

## Test Plan Completed For P1-P4

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --all-features
- [x] cargo run -p xtask -- bundle-tokenization-drift
- [x] cargo run -p xtask -- fixture-citation-lint
- [x] cargo run -p xtask -- no-tenant-knowledge
- [x] cargo run -p xtask -- cargo-metadata-audit-isolation

## Phase 5 Blocker

P5 was attempted as test-only traceability coverage, but the required full `cargo deny check` failed on existing dependency policy/advisory state unrelated to the P5 diff. The repository `deny.toml` currently configures only bans, so full deny reports broad license rejections and existing advisories (`rand`, `rustls-webpki`, `atomic-polyfill`, `paste`). `cargo deny check bans` passes, and the P5-specific `cargo run -p xtask -- dylint-gate` passed.

Per worker instructions, I removed the uncommitted P5 test draft and opened this as `IMPL PARTIAL` with phases 1-4 only instead of papering over the unrelated deny failure.

## Origin

- Brainstorm pair: scratchpad 555 (Codex), 556 (Claude)
- Synthesis: 558
- Plan: 560 rev 3
- Counselors: 563 (PATCH PLAN, 5 consensus blockers, 18 surgical patches applied + verified resolved)

Closes solo #87 partially through P4; blocked at P5.