### PR TITLE
chore(deny): close cargo-deny policy gap (closes #283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
  "gaze-types",
  "hex",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rusqlite",
  "secrecy",
@@ -1516,9 +1516,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,19 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    # webpki-roots ships Mozilla's root store under the permissive Community Data License.
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+private = { ignore = true }
+
 [bans]
 workspace-default-features = "allow"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,11 @@
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0089 (atomic-polyfill): unmaintained transitive build dependency via phonenumber -> postcard -> heapless; no safe upgrade is available; revisit after phonenumber moves off heapless 0.7 or by 2026-07-29.
+    "RUSTSEC-2023-0089",
+    # RUSTSEC-2024-0436 (paste): unmaintained transitive dependency via tokenizers/macro_rules_attribute; no safe upgrade is available; revisit after tokenizers drops paste or by 2026-07-29.
+    "RUSTSEC-2024-0436",
+]
+
 [licenses]
 allow = [
     "Apache-2.0",


### PR DESCRIPTION
## Summary

Closes solo todo #283 (cargo-deny preexisting policy gap blocking v0.6 P5-7).

deny.toml now has:
- `[licenses] allow = [...]` covering all transitive licenses in the workspace dep graph (industry-standard permissive only — no GPL/LGPL/AGPL). Includes `CDLA-Permissive-2.0` for `webpki-roots` / Mozilla root-store data.
- `[advisories] ignore = [...]` for 2 transitive unmaintained advisories that can't be cleared by dep bump, each with rationale comment + RUSTSEC ID.

Workspace deps bumped:
- rand: 0.8.5 → 0.8.6 (clears RUSTSEC-2026-0097)
- rustls-webpki: 0.103.11 → 0.103.13 (clears RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104)

## North-star axis impact

- **Axis 4 (trust — auditable + deterministic):** every advisory ignore carries written rationale tied to its RUSTSEC ID; license allow-list is explicit + reviewable.
- Unblocks **#284** (v0.6 #87 follow-up impl P5/P6/P7) which needs full `cargo deny check` green.

## Test plan

- [x] cargo fmt + clippy + test --workspace --all-features
- [x] cargo deny check (full) — NEW, was failing
- [x] All other xtask gates remain green (bundle-tokenization-drift, fixture-citation-lint, no-tenant-knowledge, cargo-metadata-audit-isolation)

## Closes

- solo #283

## Unblocks (next dispatch)

- solo #284 (v0.6 #87 follow-up impl P5/P6/P7)