### PR TITLE
chore(gha): bump Node-20 actions to Node-24 majors (closes #279)

### DIFF
--- a/.github/workflows/bundle-tokenization-drift.yml
+++ b/.github/workflows/bundle-tokenization-drift.yml
@@ -6,7 +6,7 @@ jobs:
   bundle-tokenization-drift:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting

--- a/.github/workflows/cargo-metadata-audit-isolation.yml
+++ b/.github/workflows/cargo-metadata-audit-isolation.yml
@@ -7,7 +7,7 @@ jobs:
   cargo-metadata-audit-isolation:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo_metadata_audit_isolation gate

--- a/.github/workflows/class-map-override-safety.yml
+++ b/.github/workflows/class-map-override-safety.yml
@@ -6,7 +6,7 @@ jobs:
   class-map-override-safety:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with: { toolchain: stable }
       - run: cargo run -p xtask -- class-map-override-safety

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -8,21 +8,21 @@ jobs:
   dylint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install nightly toolchain for dylint
         run: rustup toolchain install nightly-2025-09-18 --component rustc-dev,rust-src,llvm-tools-preview
       - name: Install cargo-dylint
         run: cargo install --locked cargo-dylint dylint-link
       - name: Cache cargo registry and git
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: dylint-cargo-${{ runner.os }}-${{ hashFiles('xtask/dylint/Cargo.lock') }}
       - name: Cache dylint target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: xtask/dylint/target
           key: dylint-target-${{ runner.os }}-${{ hashFiles('xtask/dylint/Cargo.lock') }}

--- a/.github/workflows/fixture-citation-lint.yml
+++ b/.github/workflows/fixture-citation-lint.yml
@@ -10,7 +10,7 @@ jobs:
   fixture-citation-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting

--- a/.github/workflows/no-phone-parser.yml
+++ b/.github/workflows/no-phone-parser.yml
@@ -10,7 +10,7 @@ jobs:
   no-phone-parser:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting

--- a/.github/workflows/no-tenant-knowledge.yml
+++ b/.github/workflows/no-tenant-knowledge.yml
@@ -10,7 +10,7 @@ jobs:
   no-tenant-knowledge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run no_tenant_knowledge gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             artifact: gaze-x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -34,11 +34,11 @@ jobs:
           cp target/${{ matrix.target }}/release/gaze dist/${{ matrix.artifact }}
           chmod +x dist/${{ matrix.artifact }}
           (cd dist && shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256)
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: dist/*
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.artifact }}
           path: smoke
@@ -89,7 +89,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/symmetric-potemkin.yml
+++ b/.github/workflows/symmetric-potemkin.yml
@@ -7,7 +7,7 @@ jobs:
   symmetric-potemkin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run symmetric_potemkin_gate


### PR DESCRIPTION
## Summary

Bumps first-party GHA actions off Node 20 and onto current Node 24 runtime majors ahead of the 2026-09-16 GitHub deprecation deadline.

Closes solo todo #279.

## Actions bumped

- `.github/workflows/bundle-tokenization-drift.yml:9`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/cargo-metadata-audit-isolation.yml:10`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/class-map-override-safety.yml:9`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/dylint.yml:11`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/dylint.yml:18`: `actions/cache@v4` -> `actions/cache@v5`
- `.github/workflows/dylint.yml:25`: `actions/cache@v4` -> `actions/cache@v5`
- `.github/workflows/fixture-citation-lint.yml:13`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/no-phone-parser.yml:13`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/no-tenant-knowledge.yml:13`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/release.yml:25`: `actions/checkout@v4` -> `actions/checkout@v6`
- `.github/workflows/release.yml:37`: `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
- `.github/workflows/release.yml:41`: `actions/download-artifact@v4` -> `actions/download-artifact@v8`
- `.github/workflows/release.yml:92`: `actions/download-artifact@v4` -> `actions/download-artifact@v8`
- `.github/workflows/symmetric-potemkin.yml:10`: `actions/checkout@v4` -> `actions/checkout@v6`

## Version verification

Verified via GitHub releases and action metadata that these target majors run on `node24`:

- `actions/checkout@v6`
- `actions/cache@v5`
- `actions/upload-artifact@v7`
- `actions/download-artifact@v8`

## Test plan

- [x] All `.github/workflows/*.yml` parse as valid YAML using Ruby's YAML parser. PyYAML was unavailable locally.
- [x] `cargo run -p xtask -- ci-feature-matrix` passes locally.
- [x] CI runs cleanly on PR.

## North-star axis impact

Adopter ergonomics (axis 5): future-proofs CI ahead of forced deprecation. No behavior change intended.