### PR TITLE
chore(rulepack): migrate core.toml to {locale.email_headers} (closes #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **v0.6 closes #114 — generic locale-bucket placeholder syntax adopted in
+  bundled `core` rulepack:** the shipped `email.header.name` recognizer now uses
+  the canonical `{locale.email_headers}` placeholder. The legacy
+  `{locale_email_headers}` underscore alias still parses for back-compat (one
+  more rev cycle, scheduled to drop in v0.7) — adopter rulepacks should migrate
+  to the dotted form. No detection or token-shape change.
 - **v0.6 adopter migration for GH#24:** v0.5.1 adopters can load
   `["core", "locale-de"]` under `[locale].active = ["de-DE"]` to tokenize the
   Markus prompt/header/footer leak shapes without changing existing custom

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -53,7 +53,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern_template = '''(?m)^(?:{locale_email_headers}):\s*(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+<[^>]+>'''
+pattern_template = '''(?m)^(?:{locale.email_headers}):\s*(?:"([^"]+)"|([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}))\s+<[^>]+>'''
 capture_groups = [1, 2]
 
 [recognizers.scoring]


### PR DESCRIPTION
## Summary

- Switch the bundled `email.header.name` recognizer (the only remaining shipped recognizer using the legacy `{locale_email_headers}` underscore alias) to the canonical `{locale.<bucket>}` syntax.
- Closes #114 — the generic bucket-lookup lowering, fail-closed unknown-bucket error (`PolicyError::UnknownLocaleBucket`), and back-compat alias all already shipped in v0.4.2/v0.5; this PR aligns the shipped recognizer.
- Legacy `{locale_email_headers}` parse-time alias is preserved one more rev cycle (scheduled to drop in v0.7) so adopter custom rulepacks have a migration window.

## North-star axes

- **Adopter ergonomics (axis 5):** removes the last in-tree usage of the legacy syntax, so adopters reading the bundled rulepacks see only the canonical form.
- **Trust / determinism (axis 4):** no detection or token-shape change — `bundle-tokenization-drift` confirms the lowered regex is byte-identical, so all downstream snapshots, restore manifests, and audit rows are unaffected.
- **No domain codification:** companion to the architectural principle locked in 2026-04-25 — the bundled rulepack now uses the same generic placeholder syntax that adopters use for their own buckets.

## Test plan

- [x] `cargo test --workspace --all-features` — all green, including the legacy-alias coverage.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo run -p xtask -- bundle-tokenization-drift` — passed; lowered regex unchanged.
- [x] `cargo run -p xtask -- fixture-citation-lint` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)