### PR TITLE
feat(tooling): tracked pre-push hook for local gate verification

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# .githooks/pre-push — run local gate matrix before allowing push.
+# Bypass: git push --no-verify (requires justification in commit/PR).
+# Fast mode: GAZE_PREPUSH_FAST=1 git push (skips xtask gates except on main).
+# See CONTRIBUTING.md + CLAUDE.md for full discipline.
+
+remote_name="${1:-origin}"
+
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1 && [[ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]]; then
+    bold="$(tput bold)"
+    dim="$(tput dim)"
+    red="$(tput setaf 1)"
+    green="$(tput setaf 2)"
+    yellow="$(tput setaf 3)"
+    blue="$(tput setaf 4)"
+    reset="$(tput sgr0)"
+else
+    bold=""
+    dim=""
+    red=""
+    green=""
+    yellow=""
+    blue=""
+    reset=""
+fi
+
+start_time="$(date +%s)"
+zero_sha="0000000000000000000000000000000000000000"
+
+BASE_XTASK_GATES=(
+    "bundle-tokenization-drift"
+    "bundle-tokenization-drift --verify-ack"
+    "cargo-metadata-audit-isolation"
+    "class-map-override-safety"
+    "fixture-citation-lint"
+    "ci-feature-matrix"
+    "no-tenant-knowledge"
+    "symmetric-potemkin"
+    "recognizer-composition-validator"
+    "dylint-gate"
+)
+
+log() {
+    printf '%b\n' "$*"
+}
+
+elapsed() {
+    local now
+    now="$(date +%s)"
+    printf '%ss' "$((now - start_time))"
+}
+
+is_main_push() {
+    local local_ref="$1"
+    [[ "$local_ref" == "refs/heads/main" ]]
+}
+
+resolve_base_ref() {
+    local local_sha="$1"
+    local upstream=""
+
+    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+    if [[ -n "$upstream" ]] && git rev-parse --verify -q "$upstream" >/dev/null; then
+        printf '%s' "$upstream"
+        return 0
+    fi
+
+    if git rev-parse --verify -q "${remote_name}/HEAD" >/dev/null; then
+        printf '%s' "${remote_name}/HEAD"
+        return 0
+    fi
+
+    if git rev-parse --verify -q "${remote_name}/main" >/dev/null; then
+        printf '%s' "${remote_name}/main"
+        return 0
+    fi
+
+    git rev-list --max-parents=0 "$local_sha" | tail -n 1
+}
+
+changed_files_for_update() {
+    local local_ref="$1"
+    local local_sha="$2"
+    local remote_sha="$3"
+    local base_ref
+    local base_sha
+
+    if [[ "$local_sha" == "$zero_sha" ]]; then
+        return 0
+    fi
+
+    if [[ "$remote_sha" != "$zero_sha" ]]; then
+        git diff --name-only "${remote_sha}..${local_sha}"
+        return 0
+    fi
+
+    base_ref="$(resolve_base_ref "$local_sha")"
+    if base_sha="$(git merge-base "$base_ref" "$local_sha" 2>/dev/null)"; then
+        git diff --name-only "${base_sha}..${local_sha}"
+    else
+        git diff --name-only "${base_ref}..${local_sha}"
+    fi
+}
+
+is_doc_only_push() {
+    local local_ref="$1"
+    local local_sha="$2"
+    local remote_sha="$3"
+    local files
+
+    if is_main_push "$local_ref"; then
+        return 1
+    fi
+
+    files="$(changed_files_for_update "$local_ref" "$local_sha" "$remote_sha")"
+    [[ -n "$files" ]] || return 1
+
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        case "$path" in
+            *.md|*.txt|docs/*|CHANGELOG.md)
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done <<<"$files"
+
+    return 0
+}
+
+discover_xtask_gates() {
+    local gate
+    local known
+    local help_output
+
+    help_output="$(cargo run -p xtask -- --help 2>/dev/null || true)"
+    printf '%s\n' "$help_output" \
+        | awk '/^  [a-z0-9][a-z0-9-]+[[:space:]]*/ { print $1 }' \
+        | while IFS= read -r gate; do
+            [[ "$gate" != "help" ]] || continue
+            known="false"
+            for configured in "${BASE_XTASK_GATES[@]}"; do
+                if [[ "$configured" == "$gate" || "$configured" == "$gate "* ]]; then
+                    known="true"
+                    break
+                fi
+            done
+            if [[ "$known" == "false" ]]; then
+                printf '%s\n' "$gate"
+            fi
+        done
+}
+
+run_gate() {
+    local index="$1"
+    local total="$2"
+    local label="$3"
+    shift 3
+    local stderr_file
+    local status
+
+    stderr_file="$(mktemp -t gaze-pre-push-stderr.XXXXXX)"
+    log "${blue}${bold}[$index/$total]${reset} ${bold}${label}${reset}"
+
+    set +e
+    "$@" 2> >(tee "$stderr_file" >&2)
+    status=$?
+    set -e
+
+    if [[ "$status" -ne 0 ]]; then
+        log "${red}${bold}pre-push gate failed:${reset} $label"
+        log "${yellow}first 2KB of stderr:${reset}"
+        head -c 2048 "$stderr_file" >&2 || true
+        printf '\n' >&2
+        rm -f "$stderr_file"
+        exit "$status"
+    fi
+
+    rm -f "$stderr_file"
+}
+
+local_updates=()
+main_push="false"
+doc_only_candidates=0
+doc_only_matches=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [[ -n "${local_ref:-}" ]] || continue
+    local_updates+=("${local_ref}|${local_sha}|${remote_ref}|${remote_sha}")
+    if is_main_push "$local_ref"; then
+        main_push="true"
+    fi
+    if [[ "$local_sha" != "$zero_sha" ]]; then
+        doc_only_candidates=$((doc_only_candidates + 1))
+        if is_doc_only_push "$local_ref" "$local_sha" "$remote_sha"; then
+            doc_only_matches=$((doc_only_matches + 1))
+        fi
+    fi
+done
+
+if [[ "${#local_updates[@]}" -gt 0 && "$doc_only_candidates" -gt 0 && "$doc_only_candidates" -eq "$doc_only_matches" ]]; then
+    log "${green}doc-only push detected, skipping gates${reset}"
+    exit 0
+fi
+
+xtask_gates=("${BASE_XTASK_GATES[@]}")
+while IFS= read -r discovered_gate; do
+    [[ -n "$discovered_gate" ]] || continue
+    xtask_gates+=("$discovered_gate")
+done < <(discover_xtask_gates)
+
+commands=(
+    "cargo fmt --all -- --check"
+    "cargo test --workspace --all-features"
+)
+
+if [[ "${GAZE_PREPUSH_FAST:-0}" == "1" && "$main_push" != "true" ]]; then
+    log "${yellow}GAZE_PREPUSH_FAST=1: running cargo fmt + cargo test only${reset}"
+elif [[ "${GAZE_PREPUSH_FAST:-0}" == "1" && "$main_push" == "true" ]]; then
+    log "${yellow}main push detected: ignoring GAZE_PREPUSH_FAST=1 and running full gates${reset}"
+    for gate in "${xtask_gates[@]}"; do
+        commands+=("cargo run -p xtask -- $gate")
+    done
+else
+    for gate in "${xtask_gates[@]}"; do
+        commands+=("cargo run -p xtask -- $gate")
+    done
+fi
+
+total="${#commands[@]}"
+log "${bold}Gaze pre-push gates:${reset} $total gate(s), fail-fast enabled"
+
+for i in "${!commands[@]}"; do
+    run_gate "$((i + 1))" "$total" "${commands[$i]}" bash -c "${commands[$i]}"
+done
+
+log "${green}${bold}pre-push gates passed${reset} ${dim}(elapsed: $(elapsed))${reset}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Tracked `.githooks/pre-push` runs full local gate matrix (cargo fmt + tests + xtask gates) before allowing push. Doc-only pushes fast-path. `GAZE_PREPUSH_FAST=1` skips xtask gates when CI is healthy. One-time setup: `git config core.hooksPath .githooks` per clone.
 - **v0.6 GH#24 / todo #87 anchored_match recognizer kind:** cue-anchored
   `Name` detection now covers email forward headers, agent reply preambles, and
   auto-footers through deterministic structural rules. The default `core`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,16 @@ All design, implementation, and review decisions in this repo must be evaluated 
 
 Full rationale (including what the north star rejects and how drift is measured) lives in [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24).
 
+## Pre-push hook discipline
+
+Install tracked hooks once per clone with `git config core.hooksPath .githooks`.
+All coding workers SHOULD run local gates before declaring `IMPL DONE`; the
+pre-push hook is defense in depth and is critical when CI is unavailable.
+`git push --no-verify` is allowed only as an exceptional bypass with written
+justification in the commit body or PR description. `GAZE_PREPUSH_FAST=1` is
+acceptable for routine feature-branch pushes only when CI is healthy; pushes to
+`main` still run the full gate matrix.
+
 ## v0.5 architecture primer
 
 As of v0.5 dev complete (`[Unreleased]`) the repo is split into six published-shape crates plus one internal `xtask` crate. v0.5 dev introduced two new crates (`gaze-types`, `gaze-audit`) and replaced the syn-walker audit-isolation gate with a Dylint resolver-based gate. Detection contract is unchanged from v0.4. Always `cargo test --workspace --all-features` (the `--all-features` flag enables `gaze`'s `audit` feature shim that the dev-dep compatibility tests rely on).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,34 @@
 # Contributing
 
+## Setup
+
+Install the tracked git hooks once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The tracked `.githooks/pre-push` hook runs the local gate matrix before
+allowing `git push`: `cargo fmt --all -- --check`,
+`cargo test --workspace --all-features`, and the repository xtask gates. It is
+defense in depth for normal PR work and critical when GitHub Actions is
+unavailable.
+
+Doc-only pushes skip the gate run when the pushed diff contains only `*.md`,
+`*.txt`, files under `docs/**`, or `CHANGELOG.md`. Pushes to `main` always run
+the full gates.
+
+For routine feature-branch pushes while CI is healthy, use:
+
+```bash
+GAZE_PREPUSH_FAST=1 git push
+```
+
+Fast mode runs only formatting and workspace tests. It is ignored for pushes to
+`main`. Standard `git push --no-verify` bypasses the hook, but that is
+exceptional and requires a written justification in the commit body or PR
+description.
+
 ## Workspace shape
 
 As of v0.5 dev complete (`[Unreleased]`):


### PR DESCRIPTION
## Summary

Adds `.githooks/pre-push` running the full local gate matrix before allowing `git push`. Defense-in-depth + critical when CI is unavailable (e.g. GHA billing block per todo #308).

Defaults baked in:
- Scope: all branches.
- Gates: cargo fmt + cargo test + xtask gates matching `.github/workflows/*.yml`, plus discovered no-arg xtask commands (`recognizer-composition-validator`) and bundle drift verify-ack.
- Doc-only pushes (`*.md`, `*.txt`, `docs/**`, `CHANGELOG.md`) skip the gate run.
- `--no-verify` allowed but exceptional; document justification in commit/PR.
- `GAZE_PREPUSH_FAST=1` env var skips xtask gates (cargo fmt + test only). For healthy-CI mode.
- Main branch pushes never honor fast-mode skip.

## One-time setup per clone

```bash
git config core.hooksPath .githooks
```

CONTRIBUTING.md updated to document this.

## North-star

- A1 (never leak): catches regressions before push, not after.
- A4 (auditable): hook output IS the local audit trail when CI is down.
- A5 (adopter ergonomics): pre-push hook prevents broken pushes that block adapter consumers.

## Test plan

- [x] Hook fires on push to feature branch.
- [x] All xtask gates run + PASS on clean main-derived branch.
- [x] Doc-only push skips gates.
- [x] `GAZE_PREPUSH_FAST=1` skips xtask gates.
- [x] `--no-verify` bypass works (with documented justification expected).
- [x] Hook fails fast on first gate failure via fail-fast runner path.

Verification notes:
- Direct simulated hook run passed 12 gates: fmt, all-feature workspace tests, bundle drift, bundle drift verify-ack, cargo metadata audit isolation, class-map override safety, fixture citation lint, ci-feature-matrix, no-tenant-knowledge, symmetric-potemkin, recognizer-composition-validator, dylint-gate.
- Real `git push -u origin agent-pre-push-hook` ran the same 12 gates and passed; GitHub SSH closed during the long local hook, so the network push was retried with SSH keepalives and `GAZE_PREPUSH_FAST=1` after the full matrix had passed twice.
- Temporary verification branches for doc-only, fast mode, and no-verify were pushed and then deleted.
