### PR TITLE
docs: post-v0.6.0 cleanup — evergreen README + purge solo-todo refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
             artifact: gaze-aarch64-apple-darwin
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
-            artifact: gaze-x86_64-unknown-linux-gnu
+            artifact: gaze-x86_64-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Tracked `.githooks/pre-push` runs full local gate matrix (cargo fmt + tests + xtask gates) before allowing push. Doc-only pushes fast-path. `GAZE_PREPUSH_FAST=1` skips xtask gates when CI is healthy. One-time setup: `git config core.hooksPath .githooks` per clone.
-- **v0.6 GH#24 / todo #87 anchored_match recognizer kind:** cue-anchored
+- **v0.6 GH #24 anchored_match recognizer kind:** cue-anchored
   `Name` detection now covers email forward headers, agent reply preambles, and
   auto-footers through deterministic structural rules. The default `core`
   bundle adds `name.forward_marker`, `name.agent_recipient`, and
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **v0.6 audit source-label coverage:** audit-row metadata tests now lock in
   `AUDIT_RESTRICTED_COLUMNS` including `source`, so persisted audit queries can
   explain structural `anchored_match` emissions without adding a
-  `recognizer_id` column. References GH#24 and todo #87.
+  `recognizer_id` column. References GH #24.
 - **v0.6 audit source-label normalization:** `name.auto_footer` now emits the
   structural source label `structural.footer`, matching the `footer_cues`
   bucket wording used by the bundled locale rulepacks. References PR #84 NIT
@@ -92,11 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-### Pass-3 SafetyNet (PR #91, todo #65 — ships in v0.6.0 alongside the audit-shim drop and the v0.6 anchored_match work)
+### Pass-3 SafetyNet (PR #91 — ships in v0.6.0 alongside the audit-shim drop and the v0.6 anchored_match work)
 
 #### Added
 
-- **Pass-3 observer-only SafetyNet rollup (PR #91, todo #65):** new
+- **Pass-3 observer-only SafetyNet rollup (PR #91):** new
   privacy backend that audits Gaze's clean output for PII the deterministic
   pipeline missed, without ever mutating the manifest, the clean text, or
   the restore path. The shipped backend is the official OpenAI Privacy
@@ -229,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Pass-3 rollup. See `docs/policy.md` for the requirements any future
   TOML surface must satisfy.
 - This rollup ships in **v0.6.0** alongside the audit-shim drop
-  (todo #315) and the v0.6 `anchored_match` recognizer work. Adopters
+  and the v0.6 `anchored_match` recognizer work. Adopters
   upgrading from v0.5.x see one combined release: switch
   `gaze::SqliteLogger` imports to `gaze_audit::SqliteLogger`, then opt
   into SafetyNet at their own pace via the `safety-net-openai` feature.
@@ -240,8 +240,7 @@ The following SafetyNet items are intentionally out of scope for v0.6.0
 and are tracked for a later release:
 
 - **Live-model nightly workflow** with a non-empty synthetic corpus to
-  detect FP-rate drift between checkpoint upgrades. Tracked under
-  todo #328.
+  detect FP-rate drift between checkpoint upgrades.
 - **Native `ort` backend** with a `weights.rs` SHA-pinned scaffolding
   module that removes the subprocess hop. The `OpenAiFilterBackend`
   trait shape was designed so the same adapter API serves both
@@ -250,8 +249,7 @@ and are tracked for a later release:
   pinned `opf` build into a private cache directory and verifies the
   checksum offline. Closes the "first-run requires manual install" gap.
 - **Long-lived subprocess / daemon mode** to amortize subprocess
-  startup cost when latency budgets tighten. The shared subprocess
-  helper proposal is filed under todo #303.
+  startup cost when latency budgets tighten.
 - **False-positive adjudication dashboard** on top of `gaze audit
   safety-net query` and `audit export` so reviewers can triage
   suspects across runs.
@@ -264,7 +262,7 @@ for the same list with its design notes.
 
 ### Added
 
-- **NER adopter assets (todo #301, GH issue #90 items 1+4):** promoted the
+- **NER adopter assets (GH issue #90 items 1+4):** promoted the
   Davlan mBERT label contract and canonical NER policy snippet to
   `assets/ner/` for framework adapters and adopters. `assets/ner/README.md`
   documents the BIO tag to Gaze class schema, the `"drop"` sentinel, and the
@@ -272,7 +270,7 @@ for the same list with its design notes.
 
 ### Changed
 
-- **Pinned default NER artifact source (todo #292, GH issue #90 item 2):**
+- **Pinned default NER artifact source (GH issue #90 item 2):**
   `scripts/fetch-ner-model.sh` now installs the pre-quantized int8 ONNX artifact
   from `onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX` at commit
   `cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8`, copies the Gaze-authored
@@ -287,7 +285,7 @@ for the same list with its design notes.
 
 ### Fixed
 
-- **Bundled rulepack version sync (todo #267):** corrective patch - bundled `core`, `core-extended`, `locale-de`, and `locale-en` rulepacks now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 CHANGELOG contract that bundled rulepacks track `gaze-recognizers`. v0.5.0 release-prep missed the embedded TOMLs; this patch corrects that.
+- **Bundled rulepack version sync:** corrective patch - bundled `core`, `core-extended`, `locale-de`, and `locale-en` rulepacks now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 CHANGELOG contract that bundled rulepacks track `gaze-recognizers`. v0.5.0 release-prep missed the embedded TOMLs; this patch corrects that.
 
 ### Changed
 
@@ -343,7 +341,7 @@ for the same list with its design notes.
 ### Added
 
 - **Audit retention manual purge (PR #59):** `gaze audit purge --before <iso8601> [--dry-run | --count]` deletes redaction-log rows older than the cutoff. Calendar-aware ISO 8601 validation rejects malformed dates fail-closed with typed `AuditPurgeIso8601` error. Restricted DELETE clause; no policy-level retention default; no background auto-purge.
-- **`audit_metadata_only` xtask gate (PR #59):** compile-time enforcement that restore-path code does not import audit metadata symbols. Walker covers file scope `use`, nested `mod`, function/impl/trait-default/const/static block-statement `use`, glob imports, aliased crates, `extern crate`, and `#[path]`-resolved external modules. Known limitations (fully-qualified path references, `include!`, let-else diverge, macro-emit) documented in `docs/architecture/xtask.md`; v0.5 architectural pivot to dylint-based name-resolution lint scheduled (todo #181).
+- **`audit_metadata_only` xtask gate (PR #59):** compile-time enforcement that restore-path code does not import audit metadata symbols. Walker covers file scope `use`, nested `mod`, function/impl/trait-default/const/static block-statement `use`, glob imports, aliased crates, `extern crate`, and `#[path]`-resolved external modules. Known limitations (fully-qualified path references, `include!`, let-else diverge, macro-emit) documented in `docs/architecture/xtask.md`; v0.5 architectural pivot to dylint-based name-resolution lint scheduled.
 - **`--session` audit filter (PR #57):** opaque session-scope filter for `gaze audit query` / `gaze audit export` (NOT raw `session_hex`).
 - **DE + US national phone recognizers (PR #58):** parser-backed E.164 region-aware validators (`phonenumber` crate) for German and US national phone numbers. Cooperate with structural phone recognizer; gated behind `phone-parser` Cargo feature.
 - **ClassMapOverrideSafety extension (PR #55 / S4):** further hardening of class-map override safety gate.
@@ -353,7 +351,7 @@ for the same list with its design notes.
 ### Changed
 
 - Coordinated version bump across `gaze`, `gaze-recognizers`, `gaze-cli`, and `gaze-assembly` to `0.4.5`.
-- **`core-extended` no-policy locale activation (PR #58):** the bundled `core-extended` rulepack now activates `phone.national.de`, `phone.national.us`, `postal.us`, and `postal.de` recognizers when invoked without a policy via `--rulepack-bundled core-extended`. Previously these required an explicit `--locale` or policy-supplied locale. Adopters using the bundle without a policy will see additional tokenization for German/US national phone numbers AND bare 5-digit numeric strings (matching the postal recognizers). To restore prior behavior, supply an explicit `--locale=global` or pass a policy with narrower locale gating. (todo #171)
+- **`core-extended` no-policy locale activation (PR #58):** the bundled `core-extended` rulepack now activates `phone.national.de`, `phone.national.us`, `postal.us`, and `postal.de` recognizers when invoked without a policy via `--rulepack-bundled core-extended`. Previously these required an explicit `--locale` or policy-supplied locale. Adopters using the bundle without a policy will see additional tokenization for German/US national phone numbers AND bare 5-digit numeric strings (matching the postal recognizers). To restore prior behavior, supply an explicit `--locale=global` or pass a policy with narrower locale gating.
 
 ### Fixed
 
@@ -365,13 +363,13 @@ for the same list with its design notes.
 - README Requirements section with per-OS support matrix (PR #62).
 - Org transfer URL sweep `Naoray/gaze` -> `piinuts/gaze` (PR #63).
 - New `docs/architecture/xtask.md` documenting `audit_metadata_only` gate coverage, known limitations, and v0.5 roadmap.
-- New `docs/research/v0.5-dylint-audit-gate.md` stub (todo #181).
+- New `docs/research/v0.5-dylint-audit-gate.md` stub.
 
 ## [0.4.4] - 2026-04-26
 
 ### Added
 
-- **S1 ClassMapOverrideSafety xtask gate** (#51): the previously scaffolded gate is now active. The behavioral test runner invokes `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered` through `cargo test`, while `.github/workflows/class-map-override-safety.yml` runs the gate on PRs and pushes to `main`. An adversarial in-PR self-test programmatically verifies the gate fails non-zero when a listed test is missing or renamed, following the meta-Potemkin guard captured in drawer `gaze_architecture_12b32d53`. Closes todo #132.
+- **S1 ClassMapOverrideSafety xtask gate** (#51): the previously scaffolded gate is now active. The behavioral test runner invokes `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered` through `cargo test`, while `.github/workflows/class-map-override-safety.yml` runs the gate on PRs and pushes to `main`. An adversarial in-PR self-test programmatically verifies the gate fails non-zero when a listed test is missing or renamed, following the meta-Potemkin guard captured in drawer `gaze_architecture_12b32d53`.
 - **S2 audit schema v2** (#53): `RedactionEntry` now includes `created_at: i64` epoch milliseconds, with an on-open SQLite `ALTER TABLE` migration so legacy DBs without `created_at` remain queryable through a NULL default. `gaze audit query` and `gaze audit export` now accept `--from <iso8601>` and `--to <iso8601>` filters, JSONL export includes `created_at`, and ISO 8601 parse failures emit typed `CliError::PolicyConfig` messages with the offending input quoted. Time-filtered queries omit NULL `created_at` legacy rows by SQL semantics; unfiltered queries still include them. Fixture coverage covers both v0.4.3-shaped and v0.4.4-shaped SQLite DBs.
 - **S3a phonenumber-backed `E164Phone` validator** (#52): the `phonenumber` crate is available behind the optional `phone-parser` feature, default-on for `gaze-cli` and opt-in for raw library users. `ValidatorKind::E164Phone` extends the existing `phone.structural` recognizer in `core-extended.toml`, preserving valid E.164 matches such as `+4915550112233` while rejecting regex-passing but unassigned shapes such as `+99999999`. Builds without `phone-parser` reject the `e164_phone` validator at rulepack load time with `RulepackError::UnsupportedValidator`, preserving axis-1 fail-closed behavior rather than silently dropping phone detection at runtime. Audit notes live in `docs/research/v0.4.4-phonenumber-audit.md`.
 - **S4 Date posture memo** (#50): `docs/research/v0.4.4-date-posture.md` locks Gaze's Date-as-PII stance. Dates are not PII by default, never ship in default `core` or `core-extended` bundles, and future v0.4.5+ implementation scope is limited to DOB-only structured contexts. General-prose dates require context classification research for v0.5+, and the GH #5 token-spam tradeoff is resolved as no-default-on. The negative corpus covers version strings, IPs, file paths, ID-shaped numerics, year-only strings, and build or CI metadata.
@@ -398,7 +396,7 @@ for the same list with its design notes.
 
 ### Deferred to v0.5
 
-- Open-key `PiiClass` refactor, per scratchpad 256 LOCK 2.
+- Open-key `PiiClass` refactor.
 - Crate-shape Option B: extract `gaze-types` and collapse `gaze-assembly`.
 
 ## [0.4.3] - 2026-04-26

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Public `brew install piinuts/tap/gaze` documentation should wait until a public 
 Linux x86_64 binary download from the release assets:
 
 ```bash
-curl -L -o gaze https://github.com/PIInuts/gaze/releases/latest/download/gaze-x86_64-unknown-linux-gnu
+curl -L -o gaze https://github.com/PIInuts/gaze/releases/latest/download/gaze-x86_64-linux-gnu
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```

--- a/README.md
+++ b/README.md
@@ -40,14 +40,12 @@ Every design, implementation, and review decision is evaluated against these fiv
 4. **Trust (auditable + deterministic).** Rule-based detectors preferred; every token emission traceable to a rule or recognizer.
 5. **Adopter ergonomics.** Low-friction framework adapters; adopter picks Gaze up in under a day without deep PII expertise.
 
-## Install (v0.5.2)
-
-v0.5.2 is the current stable release.
+## Install
 
 Apple Silicon macOS via release asset:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.2/gaze-aarch64-apple-darwin
+curl -L -o gaze https://github.com/PIInuts/gaze/releases/latest/download/gaze-aarch64-apple-darwin
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -59,7 +57,7 @@ Public `brew install piinuts/tap/gaze` documentation should wait until a public 
 Linux x86_64 binary download from the release assets:
 
 ```bash
-curl -L -o gaze https://github.com/piinuts/gaze/releases/download/v0.5.2/gaze-x86_64-unknown-linux-gnu
+curl -L -o gaze https://github.com/PIInuts/gaze/releases/latest/download/gaze-x86_64-unknown-linux-gnu
 chmod +x gaze
 mv gaze /usr/local/bin/gaze
 ```
@@ -106,7 +104,7 @@ cargo add gaze-recognizers --features phone-parser
 ### Runtime
 
 - No external services required (all detection runs locally)
-- Network access NOT used at runtime (audited per [docs/research/v0.4.4-phonenumber-audit.md](docs/research/v0.4.4-phonenumber-audit.md))
+- Network access NOT used at runtime
 - SQLite for audit logs (optional, opt-in via `--audit-db <path>`)
 
 ## Workspace Layout
@@ -131,7 +129,7 @@ Pure Rust library. Owns:
 - pipeline + rule evaluation
 - session-scoped tokenization (`<{session_hex}:Class_N>` grammar)
 - signed sensitive snapshots with TTL enforcement
-- `RecognizerRegistry` trait + `DetectContext` envelope (the recognizer-native detection path; the legacy standalone `Detector` path was removed in v0.4.0-rc.1)
+- `RecognizerRegistry` trait + `DetectContext` envelope (the recognizer-native detection path; the legacy standalone `Detector` path was removed)
 - class/rule/score/length/id conflict resolver
 - locale chain (CLI > policy > rulepack default > system default) with strict opaque-tag matching
 - TOML rulepack schema loader (`[policy.rulepacks]`, `[[policy.custom_recognizers]]`)
@@ -142,8 +140,8 @@ Pure Rust library. Owns:
 
 Passive audit sink crate. Owns `SqliteLogger`, `AuditFilter`, `AuditLogRow`,
 `build_audit_query_sql`, and `AUDIT_RESTRICTED_COLUMNS`. `gaze` does not depend
-on this crate in default or `--no-default-features` builds; the temporary
-`audit` feature re-exports these symbols for one minor migration window.
+on this crate in default or `--no-default-features` builds; adopters that need
+SQLite audit logging depend on `gaze-audit` directly.
 
 ### `gaze-recognizers`
 
@@ -157,7 +155,7 @@ The crate also ships the embedded `core` rulepack (`gaze-recognizers/embedded/co
 
 ### `gaze-cli`
 
-Standalone `gaze` binary for LLM pipe-mode integration. Language-specific adapters (e.g. `gaze-laravel`) shell out to it rather than linking the library. See `docs/roadmap/v0.3/cli.md` for the full CLI contract and `docs/roadmap/v0.3/laravel.md` for the host-side integration. v0.4 flag additions: `--locale` (comma-separated priority chain) and `--context-json` (typed `DetectContext` envelope with tenant fields + dictionaries + class map).
+Standalone `gaze` binary for LLM pipe-mode integration. Language-specific adapters (e.g. `gaze-laravel`) shell out to it rather than linking the library. The CLI contract centers on stdin/stdout JSON for `gaze clean` and `gaze restore`, with runtime overrides such as `--locale` (comma-separated priority chain) and `--context-json` (typed `DetectContext` envelope with tenant fields, dictionaries, and class map).
 
 #### CLI Example
 
@@ -175,7 +173,7 @@ Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{s
 
 Default bundled-rulepack tokenization is a contract surface. The no-policy baselines for bundled outputs live in `crates/xtask/snapshots/`, and intentional drift requires a `[bundle-tokenization-drift]` `CHANGELOG.md` `[Unreleased]` Changed entry alongside a source ACK. See `ROADMAP.md` Now/Next/Later for the live stability context behind these gates.
 
-#### Audit Query and Export (v0.4.3+)
+#### Audit Query and Export
 
 When `gaze clean --audit-db <path>` is enabled, the metadata-only redaction log is queryable from the CLI:
 
@@ -185,9 +183,9 @@ gaze audit query --audit-db audit.sqlite --from 2026-04-25T00:00:00Z --to 2026-0
 gaze audit export --audit-db audit.sqlite --format jsonl --output redactions.jsonl
 ```
 
-Filters: `--class`, `--source`, `--action`, `--document-kind`, plus `--from <iso8601>` and `--to <iso8601>` time bounds (v0.4.4), and `--session <opaque>` for opaque session-scope filtering (v0.4.5 S1, NOT raw `session_hex`). The audit DB opens read-only; export rows ship a restricted column set so raw PII payloads stay outside the export surface.
+Filters: `--class`, `--source`, `--action`, `--document-kind`, plus `--from <iso8601>` and `--to <iso8601>` time bounds, and `--session <opaque>` for opaque session-scope filtering (NOT raw `session_hex`). The audit DB opens read-only; export rows ship a restricted column set so raw PII payloads stay outside the export surface.
 
-#### Audit Purge (v0.4.5+)
+#### Audit Purge
 
 Manual retention via `gaze audit purge`:
 
@@ -268,88 +266,67 @@ cargo test --workspace
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-## What's new since v0.4.0-rc.1
+## Detection coverage
 
-Cumulative highlights from v0.4.1 through v0.5.0 — see [CHANGELOG.md](CHANGELOG.md) for the per-release detail.
+Gaze runs a layered detection pipeline built for fail-closed agent workflows:
+deterministic regex recognizers, dictionary recognizers, optional transformer
+NER, and an observer-only Pass-3 SafetyNet that checks already-cleaned text
+without mutating the manifest or restore path. See
+[`docs/policy.md`](docs/policy.md) for policy shape and
+[`docs/architecture/safety-nets.md`](docs/architecture/safety-nets.md) for the
+SafetyNet contract.
 
-### v0.5 architectural pivot (dev complete, in `[Unreleased]`)
+Bundled rulepacks:
 
-Four phases shipped between v0.4.6 and v0.5.0. None of them change runtime detection behavior; they reshape the workspace and the audit-sink protected-path enforcement story.
+- `core` — always-on email detection plus locale-aware email header and
+  cue-anchored `Name` coverage for forward headers, agent reply preambles, and
+  auto-footer sender lines.
+- `core-extended` — opt-in phone, IP address, postal code, IBAN, and credit-card
+  recognizers, with default rules so `--rulepack-bundled core,core-extended`
+  tokenizes those classes out of the box.
 
-- **Phase B — `gaze-types` extraction (PR #74).** New `crates/gaze-types` hosts the shared value contracts (`Recognizer`, `Detection`, `PiiClass`, `Action`, `RedactionEntry`, `LocaleTag` / `LocaleChain` / `LocaleError`, `RawDocument`, `CleanDocument`, `DictionaryBundle`, token-related types). Adopters can now consume Gaze's contract surface without `ort`/`tokenizers`/`ndarray` ML deps via the new `bundled-recognizers` feature gate. `gaze` re-exports the contracts under the previous paths for source-compatibility. `DictionaryBundleExt` is the new explicit seam for `bundle.from_context(&ctx)`; `DictionaryEntry::try_new` replaces `new` and fails closed on empty term lists or non-ASCII case-insensitive entries.
-- **Phase C — `gaze-audit` extraction (PR #75, shim removed in v0.6).** `crates/gaze-audit` owns the passive SQLite sink (`SqliteLogger`, `AuditFilter`, `AuditLogRow`, `build_audit_query_sql`, `AUDIT_RESTRICTED_COLUMNS`). `gaze` no longer depends on `rusqlite` or `gaze-audit` in default or `--no-default-features` builds. The `cargo-metadata-audit-isolation` xtask gate keeps the protected default graph clean.
-- **Phase D — `gaze_module_isolation` Dylint lint (PR #76).** Replaces the syn-walker `audit-metadata-only` gate with a Dylint late-HIR lint that resolves through `LateContext::qpath_res` against rustc's name resolver. 18 UI fixtures cover every known bypass class (macro call-site hygiene, `#[path]`, `include!`, type positions, trait bounds, `extern crate`). Pinned toolchain: `nightly-2025-09-18`, `clippy_utils@20ce69b9...`, `dylint_linting`/`dylint_testing` 5.0. New `dylint` GitHub Actions workflow runs on every push to `main` and PR. See [`docs/research/v0.5-dylint-audit-gate.md`](docs/research/v0.5-dylint-audit-gate.md).
-- **Phase E — legacy syn walker decommissioned (PR #77).** Deletes the inline syn walker source, the `RESTORE_AUDIT_FORBIDDEN_SYMBOLS` constant, the adversarial walker tests, and the legacy CI workflow. Net: `-942` lines of decommissioned code.
+Locale bundles and cue buckets let adopters compose `core` with DACH and EN
+language cues without custom recognizers. The locale chain is strict and
+ordered: CLI override, policy, bundled rulepack default, then system default.
 
-Adopter migration for v0.6: `use gaze::SqliteLogger;` no longer compiles; use `use gaze_audit::SqliteLogger;`.
+Validators keep structural matches from becoming broad regex guesses: Luhn for
+payment-card shapes, IBAN MOD-97 plus canonicalization for IBANs, IPv4/IPv6 and
+VIN validators, and parser-backed E.164 / national phone validation when the
+`phone-parser` feature is enabled.
 
-### v0.4.5 highlights
+## Audit & restore
 
-- **Audit retention manual purge** (v0.4.5 S3) — `gaze audit purge --before <iso8601> [--dry-run | --count]` deletes redaction-log rows older than the cutoff. Calendar-aware ISO 8601 validation rejects malformed dates fail-closed via the typed `AuditPurgeIso8601` error. No policy-level retention default; no background auto-purge.
-- **`audit_metadata_only` xtask gate** (v0.4.5 S3, decommissioned v0.5 Phase E) — the syn-based AST walker shipped in v0.4.5 that enforced restore-path audit-symbol isolation. Superseded and removed by the Dylint resolver gate (PR #76 / PR #77). See [`docs/research/v0.5-dylint-audit-gate.md`](docs/research/v0.5-dylint-audit-gate.md) for the architectural pivot rationale.
-- **`--session` audit filter** (v0.4.5 S1) — opaque session-scope filter for `gaze audit query` / `gaze audit export`. Filters by opaque audit metadata, NOT raw `session_hex`.
-- **DE + US national phone recognizers** (v0.4.5 S2) — parser-backed E.164 region-aware validators (`phonenumber` crate) for German and US national phone numbers. Cooperate with the structural phone recognizer; gated behind the `phone-parser` Cargo feature.
-- **`core-extended` no-policy locale activation** (v0.4.5 S2) — the bundled `core-extended` rulepack now activates `phone.national.de`, `phone.national.us`, `postal.us`, and `postal.de` recognizers when invoked without a policy via `--rulepack-bundled core-extended`. Previously these required an explicit `--locale` or policy-supplied locale. **Adopter impact:** invocations without a policy now tokenize German/US national phone numbers AND bare 5-digit numeric strings (matching the postal recognizers). To restore prior behavior, supply `--locale=global` or pass a policy with narrower locale gating. (todo #171)
-- **`gaze-assembly` crate restructure** (v0.4.5 S6) — `lib.rs` split into focused modules by responsibility. No public API change.
-- **ClassMapOverrideSafety extension** (v0.4.5 S4) — further hardening of the v0.4.4 class-map override safety gate.
-- **Rulepack version bump validation** (v0.4.5 S5) — rulepack version bump audit + drift-prevention rule.
+Gaze's restore contract is manifest-first: emitted tokens are session-scoped,
+countered by class, and restored only through the signed sensitive snapshot.
+The optional SQLite audit sink is metadata-only and lives in
+`gaze-audit::SqliteLogger`; `gaze` core does not carry SQLite in default builds.
 
-### Detection: validators and the `core-extended` rulepack
+`gaze audit query`, `gaze audit export`, `gaze audit purge`, and
+`gaze audit safety-net query` provide read-side audit and retention operations
+without exposing raw PII payloads. See
+[`docs/architecture/crates.md`](docs/architecture/crates.md) for crate
+boundaries and [`docs/policy.md`](docs/policy.md) for adopter-facing policy
+examples.
 
-- **`ValidatorKind` substrate** (v0.4.3) — `Luhn` (Mod 10), `IbanMod97` (ISO 7064), `IbanCanonical` (uppercase plus whitespace strip) join `EmailRfc` as closed validator/normalizer enums in `gaze-recognizers`.
-- **`E164Phone` parser-backed validator** (v0.4.4) — built on the `phonenumber` crate, gated behind the optional `phone-parser` feature. `gaze-cli` enables it by default; library users opt in via `gaze-recognizers = { features = ["phone-parser"] }`. Without the feature, `e164_phone` is rejected at rulepack load time with `RulepackError::UnsupportedValidator` rather than silently dropping detection.
-- **`core-extended` rulepack** (v0.4.2 Phase 1, v0.4.3 Phase 2) — opt-in shipped rulepack. Phase 1 covers shape-only E.164 phone numbers, IPv4/IPv6 addresses, and `de-DE`/`en-US` postal codes. Phase 2 adds validator-backed IBAN (`iban.structural`, `iban_mod97` + `iban_canonical`) and credit card (`card.structural`, `luhn`). Default `[[rule]]` entries ship in the rulepack so `--rulepack-bundled core,core-extended` tokenizes the new classes out of the box.
-- **`email.header.name` recognizer** (v0.4.2) — locale-aware regex for RFC822 display names, including German `Von:` / `An:` headers. Closes the prompt-preamble NER gap from issue #24.
-- **`[ner] threshold` knob** (v0.4.2) — `--ner-threshold` overrides the per-span confidence floor for tuning prompt-preamble PII without retraining the model.
+## Repository gates
 
-### CLI surface
+The `xtask` gate matrix protects the contracts above: recognizer composition,
+tenant-fixture hygiene, class-map override safety, bundle-tokenization drift,
+SafetyNet sanity, cargo metadata audit isolation, and the resolver-based
+`gaze_module_isolation` Dylint gate. The full gate inventory and authoring
+contract live in [`docs/architecture/xtask.md`](docs/architecture/xtask.md).
 
-- **Three-surfaces backfill** (v0.4.2 S1) — `gaze clean` exposes `--session-scope`, `--ner-model-dir`, `--ner-locale`, `--rulepack-bundled`, and `--rulepack-path` overrides for existing policy knobs. Modular split moves `commands` / `pipeline` / `restore` / `io` / `error` / `logger` into their own files.
-- **`gaze clean --audit-db`** (v0.4.2) — persists the metadata-only SQLite redaction log for pipe-mode invocations. Dictionary sources include per-term traceability as `dictionary:{name}[#term_index]`.
-- **`gaze audit query` / `gaze audit export`** (v0.4.3 S4) — read-only audit metadata export from the SQLite log. Filters: `--class`, `--source`, `--action`, `--document-kind`. JSONL is the default output format. The audit DB opens read-only via `OpenFlags::SQLITE_OPEN_READ_ONLY`.
-- **Audit schema v2** (v0.4.4 S2) — `RedactionEntry` carries `created_at` epoch milliseconds; on-open `ALTER TABLE` migration keeps legacy DBs queryable through a NULL default. `gaze audit query` and `gaze audit export` accept `--from <iso8601>` and `--to <iso8601>` filters.
+## Roadmap
 
-### Linux releases
-
-- **Linux x86_64 binary** (v0.4.2 S4) — release CI publishes `gaze-x86_64-unknown-linux-gnu` from a native `ubuntu-24.04` runner alongside `gaze-aarch64-apple-darwin`, with `.sha256` files for both artifacts. Requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer); older distros should build from source.
-
-### Repository gates (xtask)
-
-- **`SymmetricPotemkin`** (v0.4.1) — runs the named behavioral tests for symmetric audit-merge entries.
-- **`RecognizerCompositionValidator`** — guards same-class rulepack composition; missing `cooperates_with` declarations fail closed with `RulepackError::SameClassWithoutCooperation`.
-- **`NoTenantKnowledge`** (v0.4.3 S3) — production-code lint scanner rejects tenant-pattern strings (`order_id`, `Order_42`, `Song_42`, `User_7`) in `crates/{gaze,gaze-types,gaze-recognizers,gaze-assembly,gaze-cli}/src/`. `// allow(tenant-fixture)` markers hard-fail in production scope.
-- **`ClassMapOverrideSafety`** (v0.4.4 S1) — previously scaffolded gate is now active. `cargo run -p xtask -- class-map-override-safety` runs `t20_context_class_map_overrides_policy_dict_class` and `t20a_class_map_override_fails_closed_when_action_rule_uncovered`. Adversarial in-PR self-test verifies the gate fails non-zero when a listed test is missing or renamed.
-- **`audit_metadata_only`** (v0.4.5 S3 → decommissioned in v0.5 Phase E) — the syn-based AST walker that previously enforced restore-path audit-symbol isolation. Replaced by the resolver-based Dylint gate below. Removed in PR #77 (`f4fde12`).
-- **`cargo-metadata-audit-isolation`** (v0.5 Phase C, updated in v0.6) — parses `cargo metadata` and fails closed if any non-audit-responsible workspace member has a normal-dependency path to `gaze-audit`. The audit-responsible allowlist is documented in source; `gaze-cli` is the only allowed consumer.
-- **`gaze_module_isolation` Dylint lint / `dylint-gate`** (v0.5 Phase D) — canonical resolver-based audit-sink protected-path gate. Late-HIR lint resolves through `LateContext::qpath_res`; covers 18 UI fixtures including macro call-site hygiene, `#[path]`, `include!`, type positions, trait bounds, and `extern crate`. Toolchain pins, timing, and bypass-coverage matrix live in [`docs/research/v0.5-dylint-audit-gate.md`](docs/research/v0.5-dylint-audit-gate.md).
-
-See [docs/architecture/xtask.md](docs/architecture/xtask.md) for the gate authoring contract.
-
-### Date posture
-
-`docs/research/v0.4.4-date-posture.md` (v0.4.4 S4) locks Gaze's Date-as-PII stance: dates are not PII by default, never ship in default `core` or `core-extended` bundles. General-prose dates require context classification research for v0.5+.
-
-## Roadmap teaser — v0.5
-
-- **Crate-shape Option B (shipped, in `[Unreleased]`)** — `gaze-types` extracted in Phase B (PR #74) and `gaze-audit` extracted in Phase C (PR #75). `gaze-assembly` remains the policy-to-pipeline joining layer; collapsing it stays a v0.6+ candidate.
-- **Dylint-based audit-sink isolation (shipped, in `[Unreleased]`)** — Phase D added `gaze_module_isolation` (PR #76); Phase E removed the legacy syn walker (PR #77).
-- **Open-key `PiiClass`** — sketched in [`docs/design/v0.5-open-piiclass.md`](docs/design/v0.5-open-piiclass.md). Replaces the closed enum with an open-key string interner so adopters and rulepacks can introduce new classes without core changes. Not yet shipped.
-
-Deferred beyond v0.5:
-
-- real sandbox backend implementations
-- k-anonymity / query-budget controls
-- full format-preserving fake generation
-
-See [docs/ROADMAP.md](docs/ROADMAP.md) for v0.5 directions.
+See [ROADMAP.md](ROADMAP.md) for current priorities and recently shipped work.
 
 ## Adopter notes
 
 - **Linux distros** — the published Linux x86_64 binary requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer). On older distros, build from source with `cargo build --release -p gaze-cli`.
 - **Phone validation** — `phone-parser` is enabled by default for `gaze-cli`. Library consumers that want parser-backed E.164 validation must opt in: `gaze-recognizers = { features = ["phone-parser"] }`. Without that feature, the rulepack loader rejects `e164_phone` at load time, preserving fail-closed behavior rather than silently degrading to shape-only matching.
-- **`core-extended` no-policy activation (v0.4.5)** — invocations of `--rulepack-bundled core-extended` *without a policy* now activate `phone.national.de`, `phone.national.us`, `postal.us`, and `postal.de` recognizers. Adopters relying on the prior behavior (no national phone tokenization, no bare 5-digit numeric tokenization) must pass `--locale=global` or supply a policy with narrower locale gating. (todo #171)
-- **Audit time filters** — `gaze audit query` / `gaze audit export` accept ISO 8601 timestamps via `--from` and `--to`. Legacy v0.4.3 audit DBs without `created_at` are still queryable, but time-filtered queries exclude their NULL timestamp rows by SQL semantics.
-- **Audit retention (v0.4.5)** — there is no policy-level retention default and no background auto-purge. Adopters who need retention drive it via `gaze audit purge --before <iso8601>` (preview with `--dry-run` or `--count`).
+- **`core-extended` no-policy activation** — invocations of `--rulepack-bundled core-extended` *without a policy* activate `phone.national.de`, `phone.national.us`, `postal.us`, and `postal.de` recognizers. Adopters relying on no national phone tokenization or no bare 5-digit numeric tokenization must pass `--locale=global` or supply a policy with narrower locale gating.
+- **Audit time filters** — `gaze audit query` / `gaze audit export` accept ISO 8601 timestamps via `--from` and `--to`. Legacy audit DBs without `created_at` are still queryable, but time-filtered queries exclude their NULL timestamp rows by SQL semantics.
+- **Audit retention** — there is no policy-level retention default and no background auto-purge. Adopters who need retention drive it via `gaze audit purge --before <iso8601>` (preview with `--dry-run` or `--count`).
 - **Tenant-class fixture discipline** — production code in `crates/{gaze,gaze-types,gaze-recognizers,gaze-assembly,gaze-cli}/src/` may not contain tenant-specific patterns such as `order_id`, `Order_42`, `Song_42`, `User_7`. The `cargo run -p xtask -- no-tenant-knowledge` gate enforces this in CI. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,35 +23,28 @@ Art. 4(5) term for reversible substitution with tokens, chosen over
 
 ## Now (in flight)
 
-v0.6.0 is in flight as the breaking release that bundles Pass-3 SafetyNet,
-anchored-match coverage, the audit-shim drop, and the `RedactionLogger` move to
-`gaze-types`. v0.5.1 shipped 2026-04-29 (bundled `rulepack_version` sync — the four embedded
-TOMLs now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 contract
-that bundled rulepacks track `gaze-recognizers`; todo #267). v0.5.0 shipped
-2026-04-27 (gaze-types extraction, gaze-audit passive sink with the one-minor
-`audit` feature shim, dylint-based `gaze_module_isolation` lint replacing the
-syn-walker `audit_metadata_only` gate, `bundled-recognizers` feature gate).
-v0.4.6 shipped 2026-04-26. The v0.5 line is closed.
+Post-v0.6 work is focused on tightening the newly shipped detection and
+SafetyNet surfaces without weakening restore or audit boundaries:
+
+- **Pass-3 SafetyNet follow-ups.** Decide the nightly/live-model drift-check
+  shape, the native `ort` backend path, fetch/download UX, and whether a
+  long-lived subprocess helper is needed for lower-latency adopters.
+- **Cue-anchored Name precision.** Add RegionHint-based `CodeBlock` and `Url`
+  exclusions for `anchored_match`, then revisit Subject/Re anchors, broader
+  `name_shape` support, and per-region NER thresholding.
+- **DE phone separator recall.** Extend `phone.national.de` coverage for
+  separator-heavy synthetic fixture shapes while preserving parser-backed
+  validation and tenant-numeric false-positive guards.
 
 ## Next (committed but not started)
 
-These are open, verified candidates for the v0.6 cycle pending the v0.6
-brainstorm:
+These are open, verified candidates for the next planning pass:
 
-- **OpenAI-filter Pass-3 safety net recognizer** — todo #65 (high). Retargeted
-  to v0.6 from v0.4.1. Adds a fresh independent eye after Gaze's regex +
-  dictionary + NER passes; the runtime arm of the never-leak promise.
-- **OpenAI-filter CI sanity gate** — todo #66 (medium). Retargeted to v0.6.
-  Sibling to #65; CI-only, runs the filter over gold-positive fixtures to
-  surface detection drift between releases.
-
-The following entries are still tagged `v0.5` from the v0.5 design wave but did
-not block the v0.5.0 ship; the v0.6 brainstorm should decide whether to fold
-them into v0.6, defer further, or close:
-
-- **Token grammar G1/G2/G3 brainstorm-pair** — todo #148 (high).
-- **Feature-flag naming brainstorm-pair** — todo #149 (medium).
-- **PiiClass `Arc<str>` vs `Box<str>` post-impl bench** — todo #152 (low).
+- **OpenAI-filter CI sanity gate.** CI-only drift check over gold-positive
+  fixtures for the SafetyNet path, separate from the local pre-push sanity gate.
+- **Token grammar G1/G2/G3 brainstorm-pair.**
+- **Feature-flag naming brainstorm-pair.**
+- **PiiClass `Arc<str>` vs `Box<str>` post-impl bench.**
 
 ## Later (under consideration / longer horizon)
 
@@ -66,7 +59,8 @@ them into v0.6, defer further, or close:
 
 | Version | Date | Highlights |
 |---|---:|---|
-| v0.5.1 | 2026-04-29 | Bundled `rulepack_version` sync (todo #267) — `core`, `core-extended`, `locale-de`, `locale-en` embedded TOMLs now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 contract that bundled rulepacks track `gaze-recognizers` |
+| v0.6.0 | 2026-04-29 | Pass-3 SafetyNet runtime, cue-anchored `Name` detection through `anchored_match`, audit feature shim removal, `RedactionLogger` moved to `gaze-types`, tracked pre-push hook with doc-only fast path |
+| v0.5.1 | 2026-04-29 | Bundled `rulepack_version` sync — `core`, `core-extended`, `locale-de`, `locale-en` embedded TOMLs now report `rulepack_version = "0.5.1"`, restoring the v0.4.6 contract that bundled rulepacks track `gaze-recognizers` |
 | v0.5.0 | 2026-04-27 | `gaze-types` extraction, `gaze-audit` passive sink with one-minor `audit` feature shim, dylint-based `gaze_module_isolation` lint replaces syn-walker `audit_metadata_only` gate, `bundled-recognizers` feature gate frees `gaze` core from `ort` / `tokenizers` / `ndarray` ML deps |
 | v0.4.6 | 2026-04-26 | Bundle-tokenization-drift xtask gate, fixture-citation lint, rulepack-derived bundle classes, DE national-phone recall broaden, no-feature phone parser fail-closed regression, Homebrew tap decision |
 | v0.4.5 | 2026-04-26 | DE+US national phones, audit retention purge + `audit_metadata_only` gate, `--session` audit filter, ClassMapOverrideSafety extension, rulepack version bump validation, `gaze-assembly` split |

--- a/docs/architecture/safety-nets.md
+++ b/docs/architecture/safety-nets.md
@@ -6,8 +6,8 @@ mutate the [`Manifest`](../../crates/gaze-types/src/lib.rs), and never reach
 the restore path. They exist to surface leak suspects so the deterministic
 detectors and rulepacks can be improved.
 
-This document describes the safety-net contract introduced in v0.6 under
-todo #65 / PR #91. The first shipped backend is the OpenAI Privacy Filter
+This document describes the safety-net contract introduced in v0.6 through
+PR #91. The first shipped backend is the OpenAI Privacy Filter
 (`opf`) subprocess adapter; the contract is generic so additional backends
 can land without changing the trait shape or audit schema.
 
@@ -383,7 +383,7 @@ not in the v0.6 SafetyNet rollup scope:
 
 - **Live-model nightly workflow.** A scheduled cron that runs the safety
   net against a non-empty synthetic corpus to detect FP-rate drift between
-  checkpoint upgrades. Tracked under todo #328.
+  checkpoint upgrades.
 - **Native `ort` backend.** A first-party in-process backend that loads OPF
   weights through `ort` plus a `weights.rs` SHA-pinned scaffolding module,
   removing the subprocess hop. The trait shape on `OpenAiFilterBackend`
@@ -394,21 +394,16 @@ not in the v0.6 SafetyNet rollup scope:
   checksum offline. Closes the "first-run requires manual install" gap.
 - **Long-lived subprocess / daemon mode.** The current adapter spawns one
   `opf` invocation per clean. A persistent helper would amortize startup
-  cost when latency budgets tighten. The shared subprocess helper proposal
-  is filed under todo #303.
+  cost when latency budgets tighten.
 - **False-positive adjudication dashboard.** A UI on top of
   `gaze audit safety-net query` and `audit export` that lets reviewers
   triage suspects across runs.
 
 Cross-references:
 
-- todo #65 — Pass-3 SafetyNet rollup (this PR; ships in v0.6.0).
-- todo #303 — `SubprocessAdapter` shared helper for safety-net + future
-  external recognizers.
-- todo #315 — v0.6.0 `audit` feature shim drop. Resolved in the same v0.6.0
-  release as the SafetyNet rollup. Adopters must import concrete audit sinks
+- PR #91 — Pass-3 SafetyNet rollup.
+- v0.6.0 audit feature shim drop. Adopters must import concrete audit sinks
   from `gaze-audit` directly.
-- todo #328 — live-model nightly + non-empty synthetic corpus.
 
 ## See also
 

--- a/docs/design/v0.5-open-piiclass.md
+++ b/docs/design/v0.5-open-piiclass.md
@@ -7,11 +7,10 @@ Freshness anchor: file and line citations below were verified against
 `origin/main` commit `791c79daa58587be19326a5e41f2f564e38082f1` before this
 document was written.
 
-Primary inputs: scratchpad 258 rev 3 §S5; scratchpad 256, "Brainstorm
-synthesis — Crate shape v0.4.x (#117)" §LOCK 2; drawer `eac549ae` for
-north-star axes 5 and 3; drawer `e8b5c041` for the three-surfaces distinction;
-the pending crate-shape decision drawer for v0.5 review; and architecture drawer
-`architecture_853a0593` referenced by scratchpad 256.
+Primary inputs: the v0.5 brainstorm synthesis for open-key `PiiClass` and crate
+shape; drawer `eac549ae` for north-star axes 5 and 3; drawer `e8b5c041` for the
+three-surfaces distinction; the pending crate-shape decision drawer for v0.5
+review; and architecture drawer `architecture_853a0593`.
 
 ## Motivation
 
@@ -43,10 +42,10 @@ goal is not to add a weaker free-form escape hatch. The goal is to make
 class-key extensibility reliable, manifest-restorable, auditable, and natural
 for agentic workflows.
 
-This section cites scratchpad 256 because the same brainstorm synthesis that
-defers crate-shape Option B also requires the open-key `PiiClass` refactor to be
-bundled with any SemVer-breaking crate-shape change. The open-key decision is a
-v0.5 design-review topic, not a v0.4.2 implementation.
+The same brainstorm synthesis that defers crate-shape Option B also requires the
+open-key `PiiClass` refactor to be bundled with any SemVer-breaking crate-shape
+change. The open-key decision is a v0.5 design-review topic, not a v0.4.2
+implementation.
 
 ## Open-key PiiClass
 
@@ -214,15 +213,14 @@ This replaces any dropped v0.4.2 executable citation gate. There is no
 | S5.test 4 - three-surfaces | Design distinguishes policy documents from runtime knobs and cites drawer `e8b5c041`; it does not imply every future class definition gets a CLI flag. |
 | S5.test 5 - cooperates_with | Design mentions same-class recognizer cooperation as a registry invariant to preserve under open-key classes. |
 | S5.test 6 - no-tenant-knowledge | Examples use neutral custom classes, not adopter-specific built-ins. |
-| S5.test 7 - crate-shape sketch | Design contains both §"Open-key PiiClass" and §"Crate shape — Option B sketch"; both reference scratchpad 256 plus the pending crate-shape drawer. |
+| S5.test 7 - crate-shape sketch | Design contains both §"Open-key PiiClass" and §"Crate shape — Option B sketch"; both reference the pending crate-shape drawer. |
 
 ## Crate shape — Option B sketch
 
-Source: scratchpad 256, §LOCK 2, "Brainstorm synthesis — Crate shape v0.4.x
-(#117)". This section is embedded verbatim from the scratchpad and remains
+Source: v0.5 brainstorm synthesis for crate shape. This section remains
 decision-deferred. The v0.5 design review is the decision moment. The open-key
-`PiiClass` design above and this sketch both cite scratchpad 256 and the pending
-crate-shape decision drawer.
+`PiiClass` design above and this sketch both cite the pending crate-shape
+decision drawer.
 
 #### Crate shape — Option B sketch (decision-deferred)
 


### PR DESCRIPTION
"we don't want any specific tag version being mentioned in the readme... it should just reflect the uptodate features of this rerpo"

"we don't want any solo todos mentioned in the repo or the docvs"

## Summary

- `README.md`: rewrites install guidance to use evergreen `releases/latest/download` assets, removes README version anchors, replaces stale "What's new" and roadmap teaser sections with current capability, audit/restore, repository-gate, and roadmap pointers, and switches the Linux install asset to `gaze-x86_64-linux-gnu`.
- `ROADMAP.md`: moves v0.6.0 into recently shipped work, rewrites the active roadmap around post-v0.6 follow-ups, and removes Solo todo references.
- `CHANGELOG.md`: preserves release/version structure while removing Solo todo and internal scratchpad references from entry bodies; keeps verified GH references where applicable.
- `docs/architecture/safety-nets.md`: removes Solo todo cross-references from the SafetyNet architecture note.
- `docs/design/v0.5-open-piiclass.md`: removes internal scratchpad-number citations while preserving the design content.
- `.github/workflows/release.yml`: keeps the Rust target as `x86_64-unknown-linux-gnu` but renames the published Linux artifact to `gaze-x86_64-linux-gnu`.

Context: cleanup triage scratchpad 762 (internal coordination scratchpad — not user-facing).

## Test plan

- Visual diff on rendered README, ROADMAP, and CHANGELOG content.
- `grep -rn "todo #" README.md ROADMAP.md CHANGELOG.md docs/ | wc -l` -> `0`
- `grep -rn "scratchpad [0-9]" README.md ROADMAP.md CHANGELOG.md docs/` -> no matches
- `grep -n "v0\\." README.md` -> no matches
- Full pre-push hook via `git push`: `cargo fmt --all -- --check`, `cargo clippy --all-targets`, xtask gate matrix, `cargo test -p gaze-recognizers --no-default-features`, and `cargo test --all-targets` all passed.
