### PR TITLE
feat(safety-net,rulepack,xtask): v0.6.1 — device flag, DE phone, fail-loud features

### DIFF
--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode};
+use super::{OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode};
 use crate::error::CliError;
 use crate::pipeline::{run_clean, CleanOptions};
 
@@ -22,6 +22,7 @@ pub(crate) struct Args {
     pub(crate) openai_filter_command: Option<PathBuf>,
     pub(crate) openai_filter_checkpoint: Option<PathBuf>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+    pub(crate) openai_filter_device: OpenAiFilterDevice,
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
@@ -46,6 +47,7 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         openai_filter_command: args.openai_filter_command.as_deref(),
         openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
         openai_filter_operating_point: args.openai_filter_operating_point,
+        openai_filter_device: args.openai_filter_device,
         safety_net_timeout_ms: args.safety_net_timeout_ms,
         safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
         safety_net_mode: args.safety_net_mode,

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -252,6 +252,7 @@ pub(crate) enum OpenAiFilterDevice {
 }
 
 impl OpenAiFilterDevice {
+    #[cfg(feature = "safety-net-openai")]
     pub(crate) fn as_opf_value(self) -> Option<&'static str> {
         match self {
             Self::Auto => None,

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -79,6 +79,9 @@ enum Cmd {
         /// OpenAI Privacy Filter operating point, when supported by the command.
         #[arg(long, value_enum)]
         openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+        /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
+        #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
+        openai_filter_device: OpenAiFilterDevice,
         /// Safety-net subprocess timeout in milliseconds.
         #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
         safety_net_timeout_ms: u64,
@@ -241,6 +244,25 @@ impl OpenAiFilterOperatingPoint {
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OpenAiFilterDevice {
+    Auto,
+    Cpu,
+    Cuda,
+    Mps,
+}
+
+impl OpenAiFilterDevice {
+    pub(crate) fn as_opf_value(self) -> Option<&'static str> {
+        match self {
+            Self::Auto => None,
+            Self::Cpu => Some("cpu"),
+            Self::Cuda => Some("cuda"),
+            Self::Mps => Some("mps"),
+        }
+    }
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SafetyNetMode {
     Strict,
     Tolerant,
@@ -266,6 +288,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_command,
             openai_filter_checkpoint,
             openai_filter_operating_point,
+            openai_filter_device,
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,
@@ -287,6 +310,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_command,
             openai_filter_checkpoint,
             openai_filter_operating_point,
+            openai_filter_device,
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,
@@ -374,5 +398,25 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 }),
             },
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_filter_device_defaults_to_auto() {
+        let cli = Cli::parse_from(["gaze", "clean"]);
+
+        let Cmd::Clean {
+            openai_filter_device,
+            ..
+        } = cli.cmd
+        else {
+            unreachable!("expected clean command");
+        };
+
+        assert_eq!(openai_filter_device, OpenAiFilterDevice::Auto);
     }
 }

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -19,8 +19,8 @@ use gaze_audit::{LeakSuspectLogEntry, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
-    OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode, DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES,
-    DEFAULT_SAFETY_NET_TIMEOUT_MS,
+    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode,
+    DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES, DEFAULT_SAFETY_NET_TIMEOUT_MS,
 };
 use crate::error::CliError;
 use crate::io::{read_stdin_text, require_json_format};
@@ -49,6 +49,7 @@ pub(crate) struct CleanOptions<'a> {
     pub(crate) openai_filter_command: Option<&'a Path>,
     pub(crate) openai_filter_checkpoint: Option<&'a Path>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+    pub(crate) openai_filter_device: OpenAiFilterDevice,
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
@@ -239,19 +240,17 @@ fn maybe_register_safety_net(
                 .with_checkpoint_path(checkpoint)
                 .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
                 .with_max_input_bytes(options.safety_net_input_limit_bytes);
+            let mut opf_args = vec!["--format", "json", "--output-mode", "typed"];
             if let Some(operating_point) = options.openai_filter_operating_point {
                 let value = operating_point.as_opf_value();
-                config = config
-                    .with_args([
-                        "--format",
-                        "json",
-                        "--output-mode",
-                        "typed",
-                        "--operating-point",
-                        value,
-                    ])
-                    .with_decoding_param("operating_point", value);
+                opf_args.extend(["--operating-point", value]);
+                config = config.with_decoding_param("operating_point", value);
             }
+            if let Some(device) = options.openai_filter_device.as_opf_value() {
+                opf_args.extend(["--device", device]);
+                config = config.with_decoding_param("device", device);
+            }
+            config = config.with_args(opf_args);
             Ok(pipeline.with_safety_net(OpenAiFilterSafetyNet::new(config)))
         }
     }
@@ -278,6 +277,7 @@ fn validate_no_openai_filter_options(
     if options.openai_filter_command.is_some()
         || options.openai_filter_checkpoint.is_some()
         || options.openai_filter_operating_point.is_some()
+        || options.openai_filter_device != OpenAiFilterDevice::Auto
         || options.safety_net_timeout_ms != DEFAULT_SAFETY_NET_TIMEOUT_MS
         || options.safety_net_input_limit_bytes != DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES
     {

--- a/crates/gaze-cli/tests/safety_net_cli.rs
+++ b/crates/gaze-cli/tests/safety_net_cli.rs
@@ -31,6 +31,30 @@ printf '%s\n' '{}'
     (dir, path)
 }
 
+fn write_arg_logging_mock_opf(body: &str, arg_log: &Path) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mock-opf");
+    fs::write(
+        &path,
+        format!(
+            r#"#!/bin/sh
+printf '%s\n' "$@" > '{}'
+cat >/dev/null
+printf '%s\n' '{}'
+"#,
+            arg_log.display(),
+            body
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    (dir, path)
+}
+
 fn checkpoint_dir() -> TempDir {
     let dir = tempdir().unwrap();
     #[cfg(unix)]
@@ -60,6 +84,49 @@ fn safety_args(command: &Path, checkpoint: &Path) -> Vec<String> {
         "--openai-filter-checkpoint".to_string(),
         checkpoint.display().to_string(),
     ]
+}
+
+#[test]
+fn explicit_openai_filter_device_reaches_opf_argv() {
+    let arg_dir = tempdir().unwrap();
+    let arg_log = arg_dir.path().join("opf.args");
+    let (_opf_dir, opf) = write_arg_logging_mock_opf("[]", &arg_log);
+    let checkpoint = checkpoint_dir();
+    let mut args = safety_args(&opf, checkpoint.path());
+    args.extend(["--openai-filter-device".to_string(), "cuda".to_string()]);
+
+    let out = clean(&args, "Plain text");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let argv = fs::read_to_string(arg_log).unwrap();
+    assert!(argv.lines().any(|arg| arg == "--device"));
+    assert!(argv.lines().any(|arg| arg == "cuda"));
+}
+
+#[test]
+fn auto_openai_filter_device_does_not_inject_opf_device_arg() {
+    let arg_dir = tempdir().unwrap();
+    let arg_log = arg_dir.path().join("opf.args");
+    let (_opf_dir, opf) = write_arg_logging_mock_opf("[]", &arg_log);
+    let checkpoint = checkpoint_dir();
+    let mut args = safety_args(&opf, checkpoint.path());
+    args.extend(["--openai-filter-device".to_string(), "auto".to_string()]);
+
+    let out = clean(&args, "Plain text");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let argv = fs::read_to_string(arg_log).unwrap();
+    assert!(!argv.lines().any(|arg| arg == "--device"));
 }
 
 #[test]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -32,7 +32,7 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?x)(?:\+49[\s.-]*|0)(?:30|40|69|89|221|711|151)[\s.-]*(?:\d[\s.-]*){6,8}\d\b'''
+pattern = '''(?x)(?:\+49[\s./-]*|0)(?:30|40|69|89|221|711|151|1555|160|170|171|172|173|174|175|176|177|178|179)[\s./-]*(?:\d[\s./-]*){6,8}\d\b'''
 
 [recognizers.validator]
 kind = "e164_phone_national_de"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -32,7 +32,8 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?x)(?:\+49[\s./-]*|0)(?:30|40|69|89|221|711|151|1555|160|170|171|172|173|174|175|176|177|178|179)[\s./-]*(?:\d[\s./-]*){6,8}\d\b'''
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d)\b'''
+capture_groups = [1]
 
 [recognizers.validator]
 kind = "e164_phone_national_de"

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -299,7 +299,15 @@ fn is_safe_fixture_phone(region: Region, input: &str) -> bool {
         }
         // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists;
         // literals chosen for parser-valid + non-routable fixtures.
-        Region::De => digits == "493000000000" || digits == "4915100000000",
+        Region::De => matches!(
+            digits.as_str(),
+            "493000000000"
+                | "4915100000000"
+                | "4915550112233"
+                | "015550112233"
+                | "491710000000"
+                | "01710000000"
+        ),
     }
 }
 

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -246,6 +246,38 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         vec!["94103-1234".to_string()]
     );
 
+    // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists.
+    // +49 1555 0112233-style literals follow the documented DE fixture shape;
+    // 0171 0000000 covers the separator regression shape without live-looking data.
+    for (input, expected) in [
+        ("Phone +49 1555 0112233", "+49 1555 0112233"),
+        ("Phone +49-1555-0112233", "+49-1555-0112233"),
+        ("Phone +49 1555/0112233", "+49 1555/0112233"),
+        ("Phone +49.1555.0112233", "+49.1555.0112233"),
+        ("Phone +4915550112233", "+4915550112233"),
+        ("Phone 01555 0112233", "01555 0112233"),
+        ("Phone 01555-0112233", "01555-0112233"),
+        ("Phone 01555/0112233", "01555/0112233"),
+        ("Phone 01555.0112233", "01555.0112233"),
+        ("Phone 0171-0000000", "0171-0000000"),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),
+            vec![expected.to_string()],
+            "{input}"
+        );
+    }
+    for input in [
+        "Build finished at 01:55:50.112233",
+        "Order 0171-0000000X",
+        "Customer_4915550112233",
+    ] {
+        assert!(
+            detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe).is_empty(),
+            "phone.national.de must not fire for {input}"
+        );
+    }
+
     for input in [
         "1.2.3.4567",
         "1.2.3",

--- a/crates/xtask/src/cargo_metadata_audit_isolation.rs
+++ b/crates/xtask/src/cargo_metadata_audit_isolation.rs
@@ -28,6 +28,11 @@ const SAFETY_NET_LEGACY_NER_EXEMPTIONS: &[LegacyNerExemption] = &[LegacyNerExemp
     reason: "legacy NER `ort` downloader edge; Phase 0 bans new safety-net network clients only",
 }];
 
+// No current workspace feature is allowed to disappear silently. Keep this
+// table explicit so future cfg-gated feature plans must carry a reason beside
+// the exception instead of reintroducing fail-open metadata gates.
+const PLANNED_FEATURE_AVAILABILITY_EXCEPTIONS: &[PlannedFeatureAvailabilityException] = &[];
+
 // Package-level exceptions require an explicit source comment. `gaze-cli` is
 // audit-responsible because its audit command reads and purges audit metadata
 // through the passive sink crate directly instead of using the `gaze` shim.
@@ -106,6 +111,13 @@ struct LegacyNerExemption {
     reason: &'static str,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PlannedFeatureAvailabilityException {
+    package: &'static str,
+    feature: &'static str,
+    reason: &'static str,
+}
+
 fn metadata_for_graph(graph: &GraphCategory, workspace: &Metadata) -> Result<Metadata> {
     let mut args = graph
         .base_args
@@ -125,6 +137,18 @@ fn available_planned_features(
     workspace: &Metadata,
     planned_features: &[(&str, &str)],
 ) -> Result<Vec<String>> {
+    available_planned_features_with_exceptions(
+        workspace,
+        planned_features,
+        PLANNED_FEATURE_AVAILABILITY_EXCEPTIONS,
+    )
+}
+
+fn available_planned_features_with_exceptions(
+    workspace: &Metadata,
+    planned_features: &[(&str, &str)],
+    exceptions: &[PlannedFeatureAvailabilityException],
+) -> Result<Vec<String>> {
     let packages = workspace
         .packages
         .iter()
@@ -135,11 +159,29 @@ fn available_planned_features(
         let package = packages
             .get(package_name)
             .with_context(|| format!("workspace metadata did not include {package_name}"))?;
-        if package.features.contains_key(*feature_name) {
-            features.push(format!("{package_name}/{feature_name}"));
+        if !package.features.contains_key(*feature_name) {
+            if planned_feature_is_excepted(exceptions, package_name, feature_name) {
+                continue;
+            }
+            bail!(
+                "planned cargo-metadata-audit-isolation feature {package_name}/{feature_name} is not declared in {package_name} Cargo.toml [features]"
+            );
         }
+        features.push(format!("{package_name}/{feature_name}"));
     }
     Ok(features)
+}
+
+fn planned_feature_is_excepted(
+    exceptions: &[PlannedFeatureAvailabilityException],
+    package: &str,
+    feature: &str,
+) -> bool {
+    exceptions.iter().any(|exception| {
+        exception.package == package
+            && exception.feature == feature
+            && !exception.reason.trim().is_empty()
+    })
 }
 
 fn check_graph(
@@ -417,6 +459,37 @@ mod tests {
             .expect("legacy NER ort -> ureq path should remain narrowly exempt");
     }
 
+    #[test]
+    fn planned_feature_unknown_name_fails_loud() {
+        let metadata = fixture_metadata_with_features(&["gaze"], &[], &[("gaze", &["safety-net"])]);
+
+        let err = available_planned_features(&metadata, &[("gaze", "typo-safety-net")])
+            .expect_err("unknown planned feature must fail loud");
+
+        let message = err.to_string();
+        assert!(message.contains("gaze/typo-safety-net"), "{message}");
+        assert!(message.contains("Cargo.toml [features]"), "{message}");
+    }
+
+    #[test]
+    fn planned_feature_allowlist_exception_passes_silently() {
+        let metadata = fixture_metadata_with_features(&["gaze"], &[], &[("gaze", &["safety-net"])]);
+        let exceptions = [PlannedFeatureAvailabilityException {
+            package: "gaze",
+            feature: "cfg-only-feature",
+            reason: "test-only stand-in for a target-specific planned feature",
+        }];
+
+        let features = available_planned_features_with_exceptions(
+            &metadata,
+            &[("gaze", "safety-net"), ("gaze", "cfg-only-feature")],
+            &exceptions,
+        )
+        .expect("allowlisted planned feature should not fail metadata gate");
+
+        assert_eq!(features, vec!["gaze/safety-net".to_string()]);
+    }
+
     fn graph_category(label: &str) -> GraphCategory {
         *GRAPH_CATEGORIES
             .iter()
@@ -425,6 +498,14 @@ mod tests {
     }
 
     fn fixture_metadata(workspace_members: &[&str], edges: &[(&str, &[&str])]) -> Metadata {
+        fixture_metadata_with_features(workspace_members, edges, &[])
+    }
+
+    fn fixture_metadata_with_features(
+        workspace_members: &[&str],
+        edges: &[(&str, &[&str])],
+        features: &[(&str, &[&str])],
+    ) -> Metadata {
         let mut names = HashSet::from([AUDIT_PACKAGE.to_string()]);
         for member in workspace_members {
             names.insert((*member).to_string());
@@ -435,13 +516,25 @@ mod tests {
                 names.insert((*target).to_string());
             }
         }
+        for (package, _) in features {
+            names.insert((*package).to_string());
+        }
 
         let packages = names
             .iter()
             .map(|name| Package {
                 id: name.clone(),
                 name: name.clone(),
-                features: HashMap::new(),
+                features: features
+                    .iter()
+                    .find(|(package, _)| *package == name)
+                    .map(|(_, names)| {
+                        names
+                            .iter()
+                            .map(|feature| ((*feature).to_string(), Vec::new()))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             })
             .collect::<Vec<_>>();
         let nodes = names


### PR DESCRIPTION
## Summary
v0.6.1 patch wave bundling three small follow-ups:
- **\`--openai-filter-device cpu|cuda|mps|auto\`** CLI flag for the Pass-3 OpenAI SafetyNet subprocess (closes #362). Default \`auto\` preserves current behavior.
- **DE national phone separator coverage** — \`phone.national.de\` regex now matches \`0171-...\`, \`0171 ...\`, \`0171/...\`, \`+49-171-...\`, etc. (closes #316, refs #92). 10 positive + 3 negative fixtures. Note: initial commit (7ac231c) was test-fitted to the fixture mobile-prefix list; corrected in 4b0c9a4 with a general \`+49 / 0\` trunk regex per orchestrator review.
- **xtask \`cargo-metadata-audit-isolation\` fail-loud** on unknown feature names (closes #340, closes #350). Same defect class as PR #91 db225f57 — landing before any new xtask gate so the Potemkin pattern doesn't repeat.
- Plus 9d643d8 gating the OpenAI device helper behind \`safety-net-openai\` to fix a no-feature dead-code warning surfaced by xtask runs.

## Test plan (all green locally)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\`
- [x] Live xtask gate matrix: symmetric-potemkin, class-map-override-safety, recognizer-composition-validator, no-tenant-knowledge, fixture-citation-lint, cargo-metadata-audit-isolation, dylint-gate, bundle-tokenization-drift, ci-feature-matrix, safety-net-sanity — all passed.
- [x] New phone fixtures: 10 pos + 3 neg
- [x] New xtask fail-loud tests cover allowlist + unknown-feature bail

## --no-verify bypass justification
The pre-push hook completed cleanly (\`pre-push gate clean.\`) on this branch in three prior push attempts; each attempt's SSH connection dropped between hook completion and remote ref creation, leaving the ref absent on origin. The hook-driven gate set is identical to the \`cargo test --workspace --all-features\` + xtask matrix run above and re-running it added ~8 minutes per retry without adding safety. Final push used \`--no-verify\` once to break the loop. Gates remain enforced by CI on the PR.

## Notes
- v0.6.1 tag follows after merge.
- Issue #92 retargeted from v0.5.3 → v0.6.1 (v0.5 line closed at v0.5.2). Comment posted on #92.