### PR TITLE
fix(rulepack): v0.6.3 — DE 10-digit landlines + US boundary consistency

### DIFF
--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -55,7 +55,10 @@ locales = ["en-US"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?x)(?:\+?1[\s.-]+555[\s.-]*01\d{2}|\+?1[\s.-]+(?:\([2-9]\d{2}\)|[2-9]\d{2})[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|\([2-9]\d{2}\)[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|[2-9]\d{2}[\s.-]+[2-9]\d{2}[\s.-]+\d{4}|555[\s.-]*01\d{2})\b'''
+# Mirrors phone.national.de's consuming boundary so identifier-attached
+# numbers reject consistently; see audit scratchpad 778.
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:\+?1[\s.-]+555[\s.-]*01\d{2}|\+?1[\s.-]+(?:\([2-9]\d{2}\)|[2-9]\d{2})[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|\([2-9]\d{2}\)[\s.-]*[2-9]\d{2}[\s.-]*\d{4}|[2-9]\d{2}[\s.-]+[2-9]\d{2}[\s.-]+\d{4}|555[\s.-]*01\d{2}))\b'''
+capture_groups = [1]
 
 [recognizers.validator]
 kind = "e164_phone_national_us"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -12,7 +12,11 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''\+\d{6,15}\b'''
+# Mirrors the national phone consuming boundary so phone.structural cannot
+# re-open identifier-attached E.164 matches rejected by locale recognizers;
+# cross-recognizer asymmetry caught in PR #126 review scratchpad 795.
+pattern = '''(?:^|[^[:alnum:]_+])(\+\d{6,15})\b'''
+capture_groups = [1]
 
 [recognizers.validator]
 kind = "e164_phone"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -32,7 +32,9 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d)\b'''
+# BNetzA Numbering Plan permits 10+ digit national significant numbers; audit
+# scratchpad 778 flagged 10-digit metropolitan landlines as an A1 leak vector.
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){7,13}\d)\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -34,7 +34,9 @@ locales = ["de-DE", "de-AT", "de-CH"]
 kind = "regex"
 # BNetzA Numbering Plan permits 10+ digit national significant numbers; audit
 # scratchpad 778 flagged 10-digit metropolitan landlines as an A1 leak vector.
-pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){7,13}\d)\b'''
+# The short branch is intentionally limited to the audited metro area codes;
+# keeping the generic branch at 11+ digits avoids matching formatted IBAN tails.
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -228,6 +228,22 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ),
         vec!["+1 555 0100".to_string()]
     );
+    for (input, expected) in [
+        ("Order 1-202-555-0100", "1-202-555-0100"),
+        ("Phone (415) 555-0101", "(415) 555-0101"),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, "phone.national.us", input, LocaleTag::EnUs),
+            vec![expected.to_string()],
+            "{input}"
+        );
+    }
+    for input in ["Order_15551234567", "Customer+12025550100"] {
+        assert!(
+            detect_recognizer(&rulepack, "phone.national.us", input, LocaleTag::EnUs).is_empty(),
+            "phone.national.us must not fire for {input}"
+        );
+    }
     assert_eq!(
         detect_recognizer(&rulepack, "ip.v4", "Host 192.168.1.1.", LocaleTag::EnUs),
         vec!["192.168.1.1".to_string()]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -195,6 +195,13 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
     );
     // drift-ack: S4 DE national phone broaden — internal recall per gaze-laravel
     for (input, expected) in [
+        // Regression fixtures from #414: common DE metropolitan landline
+        // shapes that must not fall below the national recognizer floor.
+        ("Phone 040 1234567", "040 1234567"),
+        ("Phone 089 12345678", "089 12345678"),
+        ("Phone 069 1234567", "069 1234567"),
+        ("Phone 030 12345678", "030 12345678"),
+        ("Phone +49 89 1234567", "+49 89 1234567"),
         // Source: synthetic-non-reachable; Germany has no official fictional
         // range equivalent to NANPA 555-01XX, so these literals are
         // parser-valid but intentionally non-routable-looking test shapes.
@@ -303,6 +310,8 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         "Build finished at 01:55:50.112233",
         "Order 0171-0000000X",
         "Customer_4915550112233",
+        "Order_4915550112233",
+        "0911 1234",
     ] {
         assert!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe).is_empty(),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -198,8 +198,10 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         // Regression fixtures from #414: common DE metropolitan landline
         // shapes that must not fall below the national recognizer floor.
         ("Phone 040 1234567", "040 1234567"),
+        ("Phone 089 1234567", "089 1234567"),
         ("Phone 089 12345678", "089 12345678"),
         ("Phone 069 1234567", "069 1234567"),
+        ("Phone 030 1234567", "030 1234567"),
         ("Phone 030 12345678", "030 12345678"),
         ("Phone +49 89 1234567", "+49 89 1234567"),
         // Source: synthetic-non-reachable; Germany has no official fictional
@@ -328,6 +330,7 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         "Customer_4915550112233",
         "Order_4915550112233",
         "0911 1234",
+        "IBAN DE89 3704 0044 0532 0130 00",
     ] {
         assert!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe).is_empty(),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -168,6 +168,53 @@ fn assert_custom_token(clean: &str, class: &str) {
 }
 
 #[test]
+fn full_pipeline_rejects_identifier_attached_e164_phone_candidates() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+    let extended = core_extended();
+    let mut builder = Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("phone".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve));
+
+    let email_spec = core
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "email.global")
+        .expect("email.global");
+    builder = builder.recognizer(regex_from_spec(email_spec));
+    for spec in &extended.recognizers {
+        if spec.enabled {
+            builder = builder.recognizer(regex_from_spec(spec));
+        }
+    }
+
+    let pipeline = builder.build().expect("pipeline");
+
+    for input in ["Customer+12025550100", "Order_+12025550100"] {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+        assert_eq!(clean, input, "unexpected tokenization for {input}: {clean}");
+        assert!(
+            !clean.contains(":Custom:phone_"),
+            "custom:phone must not fire for {input}: {clean}"
+        );
+    }
+
+    for input in ["Phone +12025550100", "+12025550100 logged at startup"] {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+        assert!(
+            clean.contains(":Custom:phone_1>"),
+            "missing Custom:phone token in {clean}"
+        );
+        assert_eq!(restore_tokens(&session, &clean), input);
+    }
+}
+
+#[test]
 fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
     let rulepack = core_extended();
 


### PR DESCRIPTION
## Summary
v0.6.3 patch wave bundling two rulepack hardening fixes:

- **DE 10-digit metropolitan landlines** (closes #414, north-star A1). Previously, common DE landlines like Hamburg \`040 1234567\`, Munich \`089 1234567\`, Frankfurt \`069 1234567\`, Berlin \`030 1234567\` (10 digits total) fell below the regex's 11-digit floor and were NOT tokenized — direct A1 leak vector at adopter time. Regex extended to cover audited 10-digit metropolitan NSN forms per BNetzA Numbering Plan while preserving the broader 11+ digit branch to avoid formatted IBAN-tail false positives.
- **US consuming-boundary mirror** (closes #415). The DE regex uses \`(?:^|[^[:alnum:]_+])\` consuming-boundary to reject identifier-attached numbers (e.g. \`Order_4915550112233\`). The US regex used only \`\\b\`, an asymmetry that leaves \`Order_15551234567\` accepted on US side. Defensive consistency fix; no known active leak.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\`
- [x] Live xtask gate matrix
- [x] DE: 10-digit landlines (Hamburg/Munich/Frankfurt/Berlin) tokenize in full; existing positives unchanged; existing negatives still reject
- [x] US: \`Order_15551234567\` and \`Customer+12025550100\` reject; existing positives unchanged
- [x] Regression: formatted IBAN \`DE89 3704 0044 0532 0130 00\` remains an IBAN-only match and does not emit a phone token

## North star
Axis A1 (never leak) primary driver on phase 1. A4 (auditable + deterministic) on phase 2 — symmetry between DE and US recognizer boundaries simplifies future audit.

## Notes
First push attempt completed the pre-push hook cleanly but SSH closed before branch creation; retry with SSH keepalives succeeded without bypassing hooks.

v0.6.3 tag follows after merge.