### PR TITLE
feat(rulepack): v0.6.4 — DE 3-digit and 4-digit area code metro coverage

### DIFF
--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -36,10 +36,13 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-# BNetzA Vorwahlverzeichnis lists 2- to 5-digit Ortsnetzkennzahlen. Following
-# the v0.6.3 short-branch precedent, audited metro area codes get literal
-# branches while the generic branch stays at 11+ digits to reject IBAN tails.
-pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)(?:201|203|211|212|214|221|228|231|234|241|261|271|281|291|331|335|341|345|351|361|365|371|375|381|385|391|395|421|441|451|461|471|481|511|531|541|551|561|571|581|591|611|621|631|641|651|661|671|681|711|721|731|741|751|761|771|781|791|821|831|841|851|861|871|881|891|911|921|931|941|951|961|971|981|991)[\s./-]*[1-9](?:\d[\s./-]*){4,5}\d)|(?:(?:\+49[\s./-]*|0)(?:2051|2102|2131|2133|2173|2181|2202|2233|2241|2302|2305|2361|2366|2371|2421|2841|4101|4131|4421|4721|5121|5131|5141|5151|5241|5251|5341|7071|7121|7131|7141|7231)[\s./-]*[1-9](?:\d[\s./-]*){4}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
+# Source: BNetzA Vorwahlverzeichnis (https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/ONRufnr/start.html), as-of 2026-04-29.
+# BNetzA lists 2- to 5-digit Ortsnetzkennzahlen. Following the v0.6.3 short-branch
+# precedent, audited metro area codes get literal branches while the generic
+# branch stays at 11+ digits to reject IBAN tails.
+# ONKs are prefix-free; do not add 3-digit codes whose 2-digit prefix is already
+# a valid ONK like 30/40/69/89.
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)(?:201|203|211|212|214|221|228|231|234|241|261|271|281|291|331|335|341|345|351|361|365|371|375|381|385|391|395|421|441|451|461|471|481|511|531|541|551|561|571|581|591|611|621|631|641|651|661|671|681|711|721|731|741|751|761|771|781|791|821|831|841|851|861|871|881|911|921|931|941|951|961|971|981|991)[\s./-]*[1-9](?:\d[\s./-]*){4,5}\d)|(?:(?:\+49[\s./-]*|0)(?:2051|2102|2131|2133|2173|2181|2202|2233|2241|2302|2305|2361|2366|2371|2421|2841|4101|4131|4421|4721|5121|5131|5141|5151|5241|5251|5341|7071|7121|7131|7141|7231)[\s./-]*[1-9](?:\d[\s./-]*){4}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -36,11 +36,10 @@ locales = ["de-DE", "de-AT", "de-CH"]
 
 [recognizers.match]
 kind = "regex"
-# BNetzA Numbering Plan permits 10+ digit national significant numbers; audit
-# scratchpad 778 flagged 10-digit metropolitan landlines as an A1 leak vector.
-# The short branch is intentionally limited to the audited metro area codes;
-# keeping the generic branch at 11+ digits avoids matching formatted IBAN tails.
-pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
+# BNetzA Vorwahlverzeichnis lists 2- to 5-digit Ortsnetzkennzahlen. Following
+# the v0.6.3 short-branch precedent, audited metro area codes get literal
+# branches while the generic branch stays at 11+ digits to reject IBAN tails.
+pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)(?:201|203|211|212|214|221|228|231|234|241|261|271|281|291|331|335|341|345|351|361|365|371|375|381|385|391|395|421|441|451|461|471|481|511|531|541|551|561|571|581|591|611|621|631|641|651|661|671|681|711|721|731|741|751|761|771|781|791|821|831|841|851|861|871|881|891|911|921|931|941|951|961|971|981|991)[\s./-]*[1-9](?:\d[\s./-]*){4,5}\d)|(?:(?:\+49[\s./-]*|0)(?:2051|2102|2131|2133|2173|2181|2202|2233|2241|2302|2305|2361|2366|2371|2421|2841|4101|4131|4421|4721|5121|5131|5141|5151|5241|5251|5341|7071|7121|7131|7141|7231)[\s./-]*[1-9](?:\d[\s./-]*){4}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -244,13 +244,14 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
     for (input, expected) in [
         // Regression fixtures from #414: common DE metropolitan landline
         // shapes that must not fall below the national recognizer floor.
-        ("Phone 040 1234567", "040 1234567"),
-        ("Phone 089 1234567", "089 1234567"),
-        ("Phone 089 12345678", "089 12345678"),
-        ("Phone 069 1234567", "069 1234567"),
-        ("Phone 030 1234567", "030 1234567"),
-        ("Phone 030 12345678", "030 12345678"),
-        ("Phone +49 89 1234567", "+49 89 1234567"),
+        // The subscriber runs are non-reachable synthetic placeholders.
+        ("Phone 040 1000000", "040 1000000"),
+        ("Phone 089 1000000", "089 1000000"),
+        ("Phone 089 10000000", "089 10000000"),
+        ("Phone 069 1000000", "069 1000000"),
+        ("Phone 030 1000000", "030 1000000"),
+        ("Phone 030 10000000", "030 10000000"),
+        ("Phone +49 89 1000000", "+49 89 1000000"),
         // Source: synthetic-non-reachable; Germany has no official fictional
         // range equivalent to NANPA 555-01XX, so these literals are
         // parser-valid but intentionally non-routable-looking test shapes.
@@ -259,15 +260,15 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ("Phone +49 69 0000 0000", "+49 69 0000 0000"),
         ("Phone +49 221 0000 000", "+49 221 0000 000"),
         ("Phone +49 711 0000 000", "+49 711 0000 000"),
-        // Source: BNetzA Vorwahlverzeichnis; examples use synthetic subscriber
-        // numbers rather than live-looking personal phone numbers.
-        ("Phone 0221 1234567", "0221 1234567"),
-        ("Phone 0711 1234567", "0711 1234567"),
-        ("Phone 0211 123456", "0211 123456"),
-        ("Phone 0911 123456", "0911 123456"),
-        ("Phone +49 221 1234567", "+49 221 1234567"),
-        ("Phone 0341 1234567", "0341 1234567"),
-        ("Phone 02202 123456", "02202 123456"),
+        // Source: BNetzA Vorwahlverzeichnis; subscriber runs are
+        // non-reachable synthetic placeholders.
+        ("Phone 0221 1000000", "0221 1000000"),
+        ("Phone 0711 1000000", "0711 1000000"),
+        ("Phone 0211 100000", "0211 100000"),
+        ("Phone 0911 100000", "0911 100000"),
+        ("Phone +49 221 1000000", "+49 221 1000000"),
+        ("Phone 0341 1000000", "0341 1000000"),
+        ("Phone 02202 100000", "02202 100000"),
     ] {
         assert_eq!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -244,14 +244,14 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
     for (input, expected) in [
         // Regression fixtures from #414: common DE metropolitan landline
         // shapes that must not fall below the national recognizer floor.
-        // The subscriber runs are non-reachable synthetic placeholders.
-        ("Phone 040 1000000", "040 1000000"),
-        ("Phone 089 1000000", "089 1000000"),
-        ("Phone 089 10000000", "089 10000000"),
-        ("Phone 069 1000000", "069 1000000"),
-        ("Phone 030 1000000", "030 1000000"),
-        ("Phone 030 10000000", "030 10000000"),
-        ("Phone +49 89 1000000", "+49 89 1000000"),
+        // The subscriber runs are zero-padded synthetic placeholders.
+        ("Phone 040 0000 0000", "040 0000 0000"),
+        ("Phone 089 0000 0000", "089 0000 0000"),
+        ("Phone 089 0000 0000", "089 0000 0000"),
+        ("Phone 069 0000 0000", "069 0000 0000"),
+        ("Phone 030 0000 0000", "030 0000 0000"),
+        ("Phone 030 0000 0000", "030 0000 0000"),
+        ("Phone +49 89 0000 0000", "+49 89 0000 0000"),
         // Source: synthetic-non-reachable; Germany has no official fictional
         // range equivalent to NANPA 555-01XX, so these literals are
         // parser-valid but intentionally non-routable-looking test shapes.
@@ -260,15 +260,18 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ("Phone +49 69 0000 0000", "+49 69 0000 0000"),
         ("Phone +49 221 0000 000", "+49 221 0000 000"),
         ("Phone +49 711 0000 000", "+49 711 0000 000"),
-        // Source: BNetzA Vorwahlverzeichnis; subscriber runs are
-        // non-reachable synthetic placeholders.
-        ("Phone 0221 1000000", "0221 1000000"),
-        ("Phone 0711 1000000", "0711 1000000"),
-        ("Phone 0211 100000", "0211 100000"),
-        ("Phone 0911 100000", "0911 100000"),
-        ("Phone +49 221 1000000", "+49 221 1000000"),
-        ("Phone 0341 1000000", "0341 1000000"),
-        ("Phone 02202 100000", "02202 100000"),
+        // Source: synthetic-non-reachable per CONTRIBUTING.md:42
+        // (zero-exchange-code carve-out). ONKs are real BNetzA-assigned
+        // values so the 3-/4-digit alternation branches are exercised;
+        // subscriber runs are zero-padded so the full literals are
+        // unambiguously non-routable.
+        ("Phone 0221 0000 0000", "0221 0000 0000"),
+        ("Phone 0711 0000 0000", "0711 0000 0000"),
+        ("Phone 0211 0000 0000", "0211 0000 0000"),
+        ("Phone 0911 0000 0000", "0911 0000 0000"),
+        ("Phone +49 221 0000 000", "+49 221 0000 000"),
+        ("Phone 0341 0000 0000", "0341 0000 0000"),
+        ("Phone 02202 0000 000", "02202 0000 000"),
     ] {
         assert_eq!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -259,6 +259,15 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ("Phone +49 69 0000 0000", "+49 69 0000 0000"),
         ("Phone +49 221 0000 000", "+49 221 0000 000"),
         ("Phone +49 711 0000 000", "+49 711 0000 000"),
+        // Source: BNetzA Vorwahlverzeichnis; examples use synthetic subscriber
+        // numbers rather than live-looking personal phone numbers.
+        ("Phone 0221 1234567", "0221 1234567"),
+        ("Phone 0711 1234567", "0711 1234567"),
+        ("Phone 0211 123456", "0211 123456"),
+        ("Phone 0911 123456", "0911 123456"),
+        ("Phone +49 221 1234567", "+49 221 1234567"),
+        ("Phone 0341 1234567", "0341 1234567"),
+        ("Phone 02202 123456", "02202 123456"),
     ] {
         assert_eq!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),
@@ -374,6 +383,8 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
     for input in [
         "Build finished at 01:55:50.112233",
         "Order 0171-0000000X",
+        "Order 0044 0532 01",
+        "Build at 2026-04-30 0040 12345",
         "Customer_4915550112233",
         "Order_4915550112233",
         "0911 1234",
@@ -562,6 +573,10 @@ fn phase2_formatted_iban_with_spaces_tokenizes_and_round_trips() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let clean = clean_text(&pipeline, &session, input, LocaleTag::DeDe);
     assert_custom_token(&clean, "iban");
+    assert!(
+        !clean.contains(":Custom:phone_"),
+        "phone recognizer must not fire inside formatted DE IBAN: {clean}"
+    );
     assert_eq!(restore_tokens(&session, &clean), input);
 }
 

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -582,6 +582,31 @@ fn phase2_formatted_iban_with_spaces_tokenizes_and_round_trips() {
 }
 
 #[test]
+fn phase2_mod97_failing_iban_shape_can_still_tokenize_phone_tail() {
+    let rulepack = core_extended();
+    let input = "My IBAN DE12 3456 7890 01555 0112233";
+
+    assert!(
+        detect_recognizer(&rulepack, "iban.structural", input, LocaleTag::DeDe).is_empty(),
+        "iban.structural must reject mod-97-failing IBAN shapes"
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),
+        vec!["01555 0112233".to_string()]
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::DeDe);
+    assert_custom_token(&clean, "phone");
+    assert!(
+        !clean.contains(":Custom:iban_"),
+        "invalid IBAN shape must not produce an IBAN token: {clean}"
+    );
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
 fn phase2_formatted_card_with_spaces_tokenizes_and_round_trips() {
     let rulepack = core_extended();
     let input = "Card: 4111 1111 1111 1111";


### PR DESCRIPTION
## Summary
Closes #420. Extends `phone.national.de` short branch to cover BNetzA Vorwahlverzeichnis 3-digit and curated 4-digit area codes for major DE metros.

v0.6.3 added Berlin/Hamburg/Frankfurt/Munich (30/40/69/89). This wave adds Cologne (0221), Stuttgart (0711), Düsseldorf (0211), Nuremberg (0911), Leipzig (0341), Dresden (0351), Bremen (0421), Hannover (0511), Mannheim (0621), and ~70 other 3-digit area-code cities, plus curated 4-digit area codes for cities like Bergisch Gladbach (02202).

## Why
North-star A1 leak axis. Adopter DE production data routinely contains landline numbers with these area codes. Pre-v0.6.4 they fell below the regex's 11-digit floor and were NOT tokenized — direct leak vector.

## IBAN defense preserved
The generic-branch floor stays at 11 digits to prevent IBAN tail over-match (commit `d08f61e` from v0.6.3). New branches only add literal area-code alternations — IBAN tails like `0044 0532 0130 00` still don't match since `0044` is not in any area-code list.

## Test plan
- [x] `cargo fmt` / `clippy` / `cargo test -p gaze-recognizers --all-features`
- [x] Live xtask gates
- [x] DE 3-digit-area-code metros (Cologne/Stuttgart/Düsseldorf/Nuremberg/Leipzig/Dresden/Bremen/Hannover/Mannheim) tokenize in full
- [x] DE 4-digit curated metros (Bergisch Gladbach et al) tokenize in full
- [x] IBAN regression: `DE89 3704 0044 0532 0130 00` does NOT emit phone token
- [x] Pre-existing v0.6.3 metros (Berlin/Hamburg/Frankfurt/Munich) unchanged
- [x] Adversarial backtracking probes complete <5s

## Source
Bundesnetzagentur Vorwahlverzeichnis (Nummernplan ONB). Top-100 metros selected by population.

v0.6.4 tag follows after merge.