### PR TITLE
chore(release): v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.6.4] - 2026-04-30
+
+### Added
+
+- `phone.national.de` rulepack class extended with DE 3-digit and 4-digit
+  area-code metro alternations. Closes #420.
+
+### Changed
+
+- Removed bogus `891` ONK from the 3-digit alternation; BNetzA
+  Vorwahlverzeichnis source URL and as-of date are pinned in test fixture
+  comments.
+- Test fixtures use synthetic non-reachable subscriber shapes
+  (zero-exchange-code per `CONTRIBUTING.md:42`) instead of real-looking
+  BNetzA-assigned numbers.
+- Pre-push hook gains a docs-only fast-path for allowlisted documentation
+  paths, from PR #120 by external contributor @naoray.
+
+### Fixed
+
+- IBAN-shape mod-97-failing input now has test coverage documenting the
+  class-misattribution behavior while preserving manifest restore and avoiding
+  leaks.
+
 ## [0.6.3] - 2026-04-30
 
 ### Added
@@ -693,7 +717,12 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/piinuts/gaze/compare/v0.4.6...HEAD
+[Unreleased]: https://github.com/piinuts/gaze/compare/v0.6.4...HEAD
+[0.6.4]: https://github.com/piinuts/gaze/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/piinuts/gaze/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/piinuts/gaze/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/piinuts/gaze/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/piinuts/gaze/compare/v0.5.1...v0.6.0
 [0.4.6]: https://github.com/piinuts/gaze/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/piinuts/gaze/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/piinuts/gaze/compare/v0.4.3...v0.4.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "gaze"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "gaze",
  "gaze-recognizers",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -2927,8 +2927,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[patch.unused]]
 name = "gaze"
-version = "0.4.6"
+version = "0.6.0"
 
 [[patch.unused]]
 name = "gaze-recognizers"
-version = "0.4.6"
+version = "0.6.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,8 +2927,8 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[patch.unused]]
 name = "gaze"
-version = "0.6.0"
+version = "0.4.6"
 
 [[patch.unused]]
 name = "gaze-recognizers"
-version = "0.6.0"
+version = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.6.3" }
-gaze-types = { path = "crates/gaze-types", version = "0.6.3" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.6.4" }
+gaze-types = { path = "crates/gaze-types", version = "0.6.4" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"


### PR DESCRIPTION
## Summary
Release prep for v0.6.4. Bumps workspace + member versions; finalizes CHANGELOG.

## Highlights
- Closes #420: phone.national.de extended with DE 3-/4-digit area code metro alternations
- 891 ONK removed; BNetzA source URL+as-of pinned
- Test fixtures use zero-exchange-code synthetic subscribers (CONTRIBUTING.md:42)
- IBAN-shape class-misattribution documented via test
- Pre-push hook fast-path for docs-only pushes (PR #120, @naoray)

## Test plan
- [x] Local gate matrix all green
- [ ] CI green
- [ ] Cross-build artefacts attached to GitHub release
