### PR TITLE
feat(recognizers): v0.6.5 P1 validator bundle — Ipv4Parse + Ipv6Parse + EthEip55 (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [bundle-tokenization-drift] `eth.address` and parser-backed IP validator fixtures refreshed `core` and `core-extended` no-policy snapshots.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Ipv4Parse`, `Ipv6Parse`, and `EthEip55` validator kinds for parser-backed
+  IP address validation and EIP-55 Ethereum address checksums. Closes #440.
+- `eth.address` in `core-extended`, emitting `custom:eth_address` for
+  EIP-55-valid Ethereum addresses.
+- New dependency: `sha3 = "0.10"` for Keccak-256 checksum validation.
+
 ### Changed
 
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "sha3",
  "tempfile",
  "thiserror 1.0.69",
  "tokenizers",
@@ -1079,6 +1080,15 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1951,6 +1961,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+sha3 = "0.10"
 thiserror = "1"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 tracing = "0.1"

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -190,6 +190,25 @@ priority = 80
 [recognizers.token]
 
 [[recognizers]]
+id = "eth.address"
+class = "custom:eth_address"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b0x[0-9a-fA-F]{40}\b'''
+
+[recognizers.validator]
+kind = "eth_eip55"
+
+[recognizers.scoring]
+base = 0.70
+priority = 80
+
+[recognizers.token]
+
+[[recognizers]]
 id = "postal.de"
 class = "custom:postal_code"
 cooperates_with = ["postal.us"]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -130,6 +130,9 @@ locales = ["global"]
 kind = "regex"
 pattern = '''\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b'''
 
+[recognizers.validator]
+kind = "ipv4_parse"
+
 [recognizers.scoring]
 base = 0.70
 priority = 80
@@ -176,6 +179,9 @@ pattern = '''(?ix)
 (?:$|[^0-9a-f:.]|\.(?:$|[^0-9]))
 '''
 capture_groups = [1]
+
+[recognizers.validator]
+kind = "ipv6_parse"
 
 [recognizers.scoring]
 base = 0.70

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -67,7 +67,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 9);
+        assert_eq!(rulepack.recognizers.len(), 10);
         assert_eq!(rulepack.recognizers[0].id, "phone.structural");
         assert_eq!(rulepack.recognizers[1].id, "phone.national.de");
         assert_eq!(rulepack.recognizers[2].id, "phone.national.us");
@@ -75,8 +75,9 @@ mod tests {
         assert_eq!(rulepack.recognizers[4].id, "card.structural");
         assert_eq!(rulepack.recognizers[5].id, "ip.v4");
         assert_eq!(rulepack.recognizers[6].id, "ip.v6");
-        assert_eq!(rulepack.recognizers[7].id, "postal.de");
-        assert_eq!(rulepack.recognizers[8].id, "postal.us");
+        assert_eq!(rulepack.recognizers[7].id, "eth.address");
+        assert_eq!(rulepack.recognizers[8].id, "postal.de");
+        assert_eq!(rulepack.recognizers[9].id, "postal.us");
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -14,6 +14,10 @@ pub enum ValidatorKind {
     E164PhoneNational(Region),
     Luhn,
     IbanMod97,
+    /// Strict decimal dotted-quad IPv4 parser.
+    Ipv4Parse,
+    /// RFC 4291 / RFC 5952 IPv6 textual parser.
+    Ipv6Parse,
 }
 
 #[cfg(feature = "phone-parser")]
@@ -35,6 +39,8 @@ impl ValidatorKind {
             "e164_phone_national_us" => Ok(Self::E164PhoneNational(Region::Us)),
             "luhn" => Ok(Self::Luhn),
             "iban_mod97" => Ok(Self::IbanMod97),
+            "ipv4_parse" => Ok(Self::Ipv4Parse),
+            "ipv6_parse" => Ok(Self::Ipv6Parse),
             // With phone-parser disabled, phone validators fall through here so
             // rulepack construction fails closed instead of silently dropping candidates.
             other => Err(RecognizerError::UnsupportedValidator {
@@ -52,6 +58,8 @@ impl ValidatorKind {
             Self::E164PhoneNational(region) => validate_phone_national(region, input).is_some(),
             Self::Luhn => luhn_check(input),
             Self::IbanMod97 => iban_mod97_check(input),
+            Self::Ipv4Parse => ipv4_parse_check(input),
+            Self::Ipv6Parse => ipv6_parse_check(input),
         }
     }
 }
@@ -376,6 +384,14 @@ fn iban_mod97_check(input: &str) -> bool {
         }
     }
     remainder == 1
+}
+
+fn ipv4_parse_check(input: &str) -> bool {
+    input.parse::<std::net::Ipv4Addr>().is_ok()
+}
+
+fn ipv6_parse_check(input: &str) -> bool {
+    input.parse::<std::net::Ipv6Addr>().is_ok()
 }
 
 #[cfg(test)]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -2,6 +2,7 @@ use gaze_types::{
     Candidate, ConflictTier, DetectContext, Detection, Detector, LocaleTag, PiiClass, Recognizer,
 };
 use regex::Regex;
+use sha3::{Digest, Keccak256};
 
 use crate::{RecognizerError, Result};
 
@@ -18,6 +19,8 @@ pub enum ValidatorKind {
     Ipv4Parse,
     /// RFC 4291 / RFC 5952 IPv6 textual parser.
     Ipv6Parse,
+    /// EIP-55 Ethereum address checksum validator.
+    EthEip55,
 }
 
 #[cfg(feature = "phone-parser")]
@@ -41,6 +44,7 @@ impl ValidatorKind {
             "iban_mod97" => Ok(Self::IbanMod97),
             "ipv4_parse" => Ok(Self::Ipv4Parse),
             "ipv6_parse" => Ok(Self::Ipv6Parse),
+            "eth_eip55" => Ok(Self::EthEip55),
             // With phone-parser disabled, phone validators fall through here so
             // rulepack construction fails closed instead of silently dropping candidates.
             other => Err(RecognizerError::UnsupportedValidator {
@@ -60,6 +64,7 @@ impl ValidatorKind {
             Self::IbanMod97 => iban_mod97_check(input),
             Self::Ipv4Parse => ipv4_parse_check(input),
             Self::Ipv6Parse => ipv6_parse_check(input),
+            Self::EthEip55 => eth_eip55_check(input),
         }
     }
 }
@@ -392,6 +397,41 @@ fn ipv4_parse_check(input: &str) -> bool {
 
 fn ipv6_parse_check(input: &str) -> bool {
     input.parse::<std::net::Ipv6Addr>().is_ok()
+}
+
+fn eth_eip55_check(input: &str) -> bool {
+    let Some(address) = input.strip_prefix("0x") else {
+        return false;
+    };
+    if address.len() != 40 || !address.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return false;
+    }
+    if address
+        .bytes()
+        .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_lowercase())
+        || address
+            .bytes()
+            .all(|byte| !byte.is_ascii_alphabetic() || byte.is_ascii_uppercase())
+    {
+        return true;
+    }
+
+    let lowercase = address.to_ascii_lowercase();
+    let hash = Keccak256::digest(lowercase.as_bytes());
+    for (index, byte) in address.bytes().enumerate() {
+        if byte.is_ascii_digit() {
+            continue;
+        }
+        let hash_nibble = if index % 2 == 0 {
+            hash[index / 2] >> 4
+        } else {
+            hash[index / 2] & 0x0f
+        };
+        if (hash_nibble > 7) != byte.is_ascii_uppercase() {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -115,6 +115,10 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
             Action::Tokenize,
         ))
         .rule(ClassRule::new(
+            PiiClass::Custom("eth_address".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
             PiiClass::Custom("postal_code".to_string()),
             Action::Tokenize,
         ))
@@ -387,6 +391,58 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         let input = "Forwarding ::ffff:198.51.100.7 to upstream";
         let matches = detect_recognizer(&rulepack, "ip.v6", input, LocaleTag::EnUs);
         assert_eq!(matches, vec!["::ffff:198.51.100.7".to_string()]);
+    }
+    // Source: EIP-55 "Test Cases". Mixed-case addresses must pass only when
+    // the Keccak-256 case checksum is correct; all-lower legacy form is
+    // accepted per the EIP.
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "eth.address",
+            "Wallet 0x52908400098527886E0F7030069857D2E4169EE7.",
+            LocaleTag::EnUs
+        ),
+        vec!["0x52908400098527886E0F7030069857D2E4169EE7".to_string()]
+    );
+    assert!(
+        detect_recognizer(
+            &rulepack,
+            "eth.address",
+            "Wallet 0x52908400098527886e0F7030069857D2E4169EE7.",
+            LocaleTag::EnUs
+        )
+        .is_empty(),
+        "eth.address must reject mixed-case checksum mutants"
+    );
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "eth.address",
+            "Wallet 0xde709f2102306220921060314715629080e2fb77.",
+            LocaleTag::EnUs
+        ),
+        vec!["0xde709f2102306220921060314715629080e2fb77".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(
+            &rulepack,
+            "eth.address",
+            "Pair 0x52908400098527886E0F7030069857D2E4169EE7;0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+            LocaleTag::EnUs
+        ),
+        vec![
+            "0x52908400098527886E0F7030069857D2E4169EE7".to_string(),
+            "0x8617E340B3D01FA5F11F306F4090FD50E238070D".to_string(),
+        ]
+    );
+    {
+        let input = "Wallet 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 approved";
+        let matches = detect_recognizer(&rulepack, "eth.address", input, LocaleTag::EnUs);
+        assert_eq!(
+            matches,
+            vec!["0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359".to_string()],
+            "EthEip55 must preserve original matched bytes verbatim"
+        );
     }
     assert_eq!(
         detect_recognizer(&rulepack, "postal.de", "Berlin 10115", LocaleTag::DeDe),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -392,6 +392,8 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         let matches = detect_recognizer(&rulepack, "ip.v6", input, LocaleTag::EnUs);
         assert_eq!(matches, vec!["::ffff:198.51.100.7".to_string()]);
     }
+    // drift-ack: v0.6.5 validator bundle adds eth.address and parser-backed
+    // IP fixture coverage to the core/core-extended no-policy drift snapshots.
     // Source: EIP-55 "Test Cases". Mixed-case addresses must pass only when
     // the Keccak-256 case checksum is correct; all-lower legacy form is
     // accepted per the EIP.

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -310,6 +310,16 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         detect_recognizer(&rulepack, "ip.v4", "Host 192.168.1.1.", LocaleTag::EnUs),
         vec!["192.168.1.1".to_string()]
     );
+    // Source: RFC 6943 Section 3.1.1. Parser-backed validation must reject
+    // non-decimal and out-of-range IPv4 candidates even if regexes change later.
+    assert!(
+        detect_recognizer(&rulepack, "ip.v4", "Host 192.000.2.1.", LocaleTag::EnUs).is_empty(),
+        "ip.v4 must reject leading-zero octets via Ipv4Parse"
+    );
+    assert!(
+        detect_recognizer(&rulepack, "ip.v4", "Host 256.0.0.1.", LocaleTag::EnUs).is_empty(),
+        "ip.v4 must reject out-of-range octets"
+    );
     assert_eq!(
         detect_recognizer(&rulepack, "ip.v6", "Loopback ::1.", LocaleTag::EnUs),
         vec!["::1".to_string()]
@@ -350,6 +360,34 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         ),
         vec!["::ffff:5.6.7.8".to_string()]
     );
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let cleaned = clean_text(
+        &pipeline,
+        &session,
+        "Server ::ffff:192.0.2.1 logged",
+        LocaleTag::EnUs,
+    );
+    assert_eq!(
+        restore_tokens(&session, &cleaned),
+        "Server ::ffff:192.0.2.1 logged",
+        "IPv4-embedded IPv6 wrapper must redact and restore as one unit"
+    );
+    assert!(
+        !cleaned.contains("192.0.2.1"),
+        "cleaned text leaked inner IPv4 octets: {cleaned:?}"
+    );
+
+    {
+        let input = "Server 192.0.2.1 logged";
+        let matches = detect_recognizer(&rulepack, "ip.v4", input, LocaleTag::EnUs);
+        assert_eq!(matches, vec!["192.0.2.1".to_string()]);
+    }
+    {
+        let input = "Forwarding ::ffff:198.51.100.7 to upstream";
+        let matches = detect_recognizer(&rulepack, "ip.v6", input, LocaleTag::EnUs);
+        assert_eq!(matches, vec!["::ffff:198.51.100.7".to_string()]);
+    }
     assert_eq!(
         detect_recognizer(&rulepack, "postal.de", "Berlin 10115", LocaleTag::DeDe),
         vec!["10115".to_string()]

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -4,6 +4,7 @@ use gaze::{
 #[cfg(not(feature = "phone-parser"))]
 use gaze_recognizers::RecognizerError;
 use gaze_recognizers::{NormalizerKind, RegexDetector, ValidatorKind};
+use sha3::{Digest, Sha3_256};
 
 fn validator_pipeline(
     pattern: &str,
@@ -170,6 +171,79 @@ fn ipv6_parse_accepts_rfc3849_documentation_addresses_and_ipv4_embedded() {
 fn ipv6_parse_kind_token_round_trips() {
     let kind = ValidatorKind::parse("ipv6_parse").expect("parse ipv6_parse");
     assert_eq!(kind, ValidatorKind::Ipv6Parse);
+}
+
+#[test]
+fn eth_eip55_accepts_spec_vectors_and_rejects_mutants() {
+    // Source: EIP-55 "Test Cases".
+    for input in [
+        "0x52908400098527886E0F7030069857D2E4169EE7",
+        "0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+        "0xde709f2102306220921060314715629080e2fb77",
+        "0x27b1fdb04752bbc536007a920d24acb045561c26",
+        "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+        "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+        "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+        "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+    ] {
+        assert!(ValidatorKind::EthEip55.validates(input), "{input}");
+    }
+
+    for input in [
+        "0x52908400098527886e0F7030069857D2E4169EE7",
+        "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d358",
+        "52908400098527886E0F7030069857D2E4169EE7",
+        "0x52908400098527886E0F7030069857D2E4169EE",
+        "0x52908400098527886E0F7030069857D2E4169EE7Z",
+        "",
+    ] {
+        assert!(!ValidatorKind::EthEip55.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn eth_eip55_kind_token_round_trips() {
+    let kind = ValidatorKind::parse("eth_eip55").expect("parse eth_eip55");
+    assert_eq!(kind, ValidatorKind::EthEip55);
+}
+
+#[test]
+fn eth_eip55_spec_vectors_fail_under_nist_sha3_256() {
+    // Source: EIP-55 "Test Cases"; NIST SHA3-256 uses different padding than
+    // Keccak-256 and must not be substituted for the checksum hash.
+    for input in [
+        "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+        "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359",
+        "0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB",
+        "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+    ] {
+        assert!(!eth_eip55_check_with_nist_sha3_256(input), "{input}");
+    }
+}
+
+fn eth_eip55_check_with_nist_sha3_256(input: &str) -> bool {
+    let Some(address) = input.strip_prefix("0x") else {
+        return false;
+    };
+    if address.len() != 40 || !address.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return false;
+    }
+    let lowercase = address.to_ascii_lowercase();
+    let hash = Sha3_256::digest(lowercase.as_bytes());
+    for (index, byte) in address.bytes().enumerate() {
+        if byte.is_ascii_digit() {
+            continue;
+        }
+        let hash_nibble = if index % 2 == 0 {
+            hash[index / 2] >> 4
+        } else {
+            hash[index / 2] & 0x0f
+        };
+        if (hash_nibble > 7) != byte.is_ascii_uppercase() {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(not(feature = "phone-parser"))]

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -100,6 +100,78 @@ fn iban_mod97_accepts_spec_examples_and_rejects_check_digit_mutants() {
     }
 }
 
+#[test]
+fn ipv4_parse_accepts_rfc5737_documentation_addresses_and_rejects_malformed() {
+    // Source: RFC 5737 documentation prefixes 192.0.2.0/24,
+    // 198.51.100.0/24, and 203.0.113.0/24.
+    for input in [
+        "192.0.2.1",
+        "198.51.100.10",
+        "203.0.113.255",
+        "0.0.0.0",
+        "255.255.255.255",
+    ] {
+        assert!(ValidatorKind::Ipv4Parse.validates(input), "{input}");
+    }
+    for input in [
+        // Source: RFC 6943 Section 3.1.1 warns against non-decimal IPv4 forms.
+        "192.000.2.1",
+        "01.2.3.4",
+        "0xC0.0x00.0x02.0x01",
+        "192.168.1",
+        "192.168",
+        "256.0.0.1",
+        "192.0.2.300",
+        "192.0.2.1.",
+        " 192.0.2.1",
+        "",
+    ] {
+        assert!(!ValidatorKind::Ipv4Parse.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn ipv4_parse_kind_token_round_trips() {
+    let kind = ValidatorKind::parse("ipv4_parse").expect("parse ipv4_parse");
+    assert_eq!(kind, ValidatorKind::Ipv4Parse);
+}
+
+#[test]
+fn ipv6_parse_accepts_rfc3849_documentation_addresses_and_ipv4_embedded() {
+    // Source: RFC 3849 documentation prefix 2001:db8::/32 and RFC 4291
+    // Section 2.2 textual forms, including IPv4-embedded form 3.
+    for input in [
+        "2001:db8::1",
+        "::1",
+        "::",
+        "fe80::1",
+        "2001:db8:0:0:0:0:0:1",
+        "::ffff:192.0.2.128",
+        "::192.0.2.1",
+        "2001:db8::192.0.2.1",
+        "fe80::ffff:1.2.3.4",
+        "0:0:0:0:0:ffff:192.0.2.1",
+    ] {
+        assert!(ValidatorKind::Ipv6Parse.validates(input), "{input}");
+    }
+    for input in [
+        "2001::1::2",
+        "[2001:db8::1]",
+        "fe80::1%eth0",
+        "::ffff:256.0.0.1",
+        "",
+        " 2001:db8::1",
+    ] {
+        assert!(!ValidatorKind::Ipv6Parse.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn ipv6_parse_kind_token_round_trips() {
+    let kind = ValidatorKind::parse("ipv6_parse").expect("parse ipv6_parse");
+    assert_eq!(kind, ValidatorKind::Ipv6Parse);
+}
+
 #[cfg(not(feature = "phone-parser"))]
 #[test]
 fn e164_phone_fails_closed_when_phone_parser_feature_disabled() {

--- a/crates/gaze/src/resolver.rs
+++ b/crates/gaze/src/resolver.rs
@@ -18,7 +18,7 @@ pub fn resolve_candidates(mut candidates: Vec<Candidate>) -> Vec<Candidate> {
     for candidate in candidates {
         insert_candidate(&mut resolved, candidate);
     }
-    resolved.sort_by(|a, b| a.span.start.cmp(&b.span.start));
+    resolved.sort_by_key(|candidate| candidate.span.start);
     resolved
 }
 

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -742,6 +742,7 @@ license = "Apache-2.0"
                 PiiClass::custom("iban"),
                 PiiClass::custom("credit_card"),
                 PiiClass::custom("ip_address"),
+                PiiClass::custom("eth_address"),
                 PiiClass::custom("postal_code"),
             ])
         );

--- a/crates/xtask/fixtures/drift-corpus.txt
+++ b/crates/xtask/fixtures/drift-corpus.txt
@@ -10,6 +10,9 @@ Extended IBAN sample GB82WEST12345698765432 is synthetic.
 Test card 4111 1111 1111 1111 is a Luhn fixture.
 Documentation IP 192.0.2.44 is reserved for examples.
 IPv6 documentation host 2001:db8:85a3::8a2e:370:7334 is reserved.
+IPv4 parser fixture 198.51.100.7 is reserved for examples.
+IPv6 embedded fixture ::ffff:192.0.2.128 is reserved for examples.
+Ethereum EIP-55 fixture 0x52908400098527886E0F7030069857D2E4169EE7 is from the public checksum specification.
 US postal fixture 94103-1234 is synthetic in this corpus.
 DE postal fixture 10115 is synthetic in this corpus.
 

--- a/crates/xtask/snapshots/core-extended-no-policy.json
+++ b/crates/xtask/snapshots/core-extended-no-policy.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "bundle": "core-extended",
   "rulepack_version": "0.5.1",
-  "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
+  "fixtures_sha256": "7720e1730e5e23f4af5fc78615e702f050e85dca7a786aa2134ce64596ea754a",
   "entries": [
     {
       "recognizer_id": "card.structural",
@@ -13,6 +13,17 @@
       },
       "family": "session_custom_counter",
       "token_shape": "<session:Custom:credit_card_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "eth.address",
+      "class": "custom:eth_address",
+      "byte_span": {
+        "start": 701,
+        "len": 42
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:eth_address_{N}>",
       "count": 1
     },
     {
@@ -38,11 +49,33 @@
       "count": 1
     },
     {
+      "recognizer_id": "ip.v4",
+      "class": "custom:ip_address",
+      "byte_span": {
+        "start": 571,
+        "len": 12
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:ip_address_{N}>",
+      "count": 1
+    },
+    {
       "recognizer_id": "ip.v6",
       "class": "custom:ip_address",
       "byte_span": {
         "start": 509,
         "len": 28
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:ip_address_{N}>",
+      "count": 1
+    },
+    {
+      "recognizer_id": "ip.v6",
+      "class": "custom:ip_address",
+      "byte_span": {
+        "start": 632,
+        "len": 18
       },
       "family": "session_custom_counter",
       "token_shape": "<session:Custom:ip_address_{N}>",
@@ -74,7 +107,7 @@
       "recognizer_id": "postal.us",
       "class": "custom:postal_code",
       "byte_span": {
-        "start": 569,
+        "start": 805,
         "len": 10
       },
       "family": "session_custom_counter",
@@ -85,7 +118,7 @@
       "recognizer_id": "postal.us",
       "class": "custom:postal_code",
       "byte_span": {
-        "start": 627,
+        "start": 863,
         "len": 5
       },
       "family": "session_custom_counter",
@@ -94,11 +127,12 @@
     }
   ],
   "stats": {
-    "detections": 8,
+    "detections": 11,
     "classes": {
       "custom:credit_card": 1,
+      "custom:eth_address": 1,
       "custom:iban": 1,
-      "custom:ip_address": 2,
+      "custom:ip_address": 4,
       "custom:phone": 2,
       "custom:postal_code": 2
     }

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "bundle": "core",
   "rulepack_version": "0.5.1",
-  "fixtures_sha256": "af37516341714906350a84bcf202dfb7040489f565212c341dd699d349398b00",
+  "fixtures_sha256": "7720e1730e5e23f4af5fc78615e702f050e85dca7a786aa2134ce64596ea754a",
   "entries": [
     {
       "recognizer_id": "email.global",
@@ -30,7 +30,7 @@
       "recognizer_id": "email.global",
       "class": "Email",
       "byte_span": {
-        "start": 1379,
+        "start": 1615,
         "len": 23
       },
       "family": "session_builtin_counter",

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -514,6 +514,9 @@ kind = "luhn"
 | `e164_phone_national_us` | US national or international phone candidates | Parser-backed US validation with NANPA 555-0100 through 555-0199 fixture allowance. |
 | `luhn` | Credit-card-like numeric candidates | Mod 10 checksum. ASCII whitespace is ignored; any other non-digit fails validation. |
 | `iban_mod97` | IBAN-like alphanumeric candidates | ISO 7064 mod-97 check. Input is canonicalized as uppercase with ASCII whitespace removed before validation. |
+| `ipv4_parse` | IPv4-like candidates | `std::net::Ipv4Addr` parser validation. Rejects leading-zero octets, hex forms, short forms, and out-of-range octets. |
+| `ipv6_parse` | IPv6-like candidates | `std::net::Ipv6Addr` parser validation for RFC 4291 textual forms, including IPv4-embedded addresses. Rejects bracketed URI literals and zone-id suffixes. |
+| `eth_eip55` | Ethereum address candidates | EIP-55 checksum validation using Keccak-256. Mixed-case addresses must satisfy the checksum; all-lower and all-upper legacy forms are accepted. |
 
 Validator-backed regex candidates fail closed: a regex match whose validator
 returns false emits no detection. This is intentionally stricter than emitting


### PR DESCRIPTION
## Summary

Implements todo #440 (v0.6.5 P1 validator bundle): adds three new closed-enum `ValidatorKind` variants — `Ipv4Parse`, `Ipv6Parse`, `EthEip55` — providing validator-tier defense-in-depth for IP/ETH recognizers. Plan: scratchpad 930 rev 2 (counselors r1 patched).

### Validator-tier additions

- **`Ipv4Parse`** — strict-decimal IPv4 via `std::net::Ipv4Addr::from_str` (zero-dep). Rejects leading zeros, hex, and octal-like forms.
- **`Ipv6Parse`** — full RFC 4291 form coverage via `std::net::Ipv6Addr::from_str` (zero-dep). Defense-in-depth for `core-extended.toml` IPv6 recognition and CIDR composition support per research M9.
- **`EthEip55`** — Keccak-256 mixed-case checksum per EIP-55 spec. New dep: `sha3 = "0.10"` (RustCrypto family, MIT/Apache-2.0, already allowlisted in `deny.toml`).

### Commits

1. `Ipv4Parse` + `Ipv6Parse` validators wired to `ip.v4` + `ip.v6` recognizers (atomic to avoid reopening #419-style inversion at an intermediate state).
2. `EthEip55` validator wired to `eth.address` recognizer + `sha3` dep + Sha3_256 mis-import guard.
3. Pre-push clippy cleanup in `gaze` resolver sort.
4. Drift snapshot acknowledgement for validator bundle fixture changes.

### Axis-2 invariant

Per todo #448 (M1 lost-span): validators ratify/reject only — they MUST NOT mutate `Detection.span`. Span-preservation integration tests added per validator-backed recognizer.

## Test plan

- [x] `cargo test --workspace --all-features` green before phase commits and after full bundle
- [x] xtask gates green: `symmetric-potemkin`, `class-map-override-safety`, `recognizer-composition-validator`, `fixture-citation-lint`
- [x] Pre-push hook clean on pushed HEAD (fmt, clippy all-targets, drift gates, feature matrix, deny, all-targets tests)
- [x] Per-validator span-preservation assertion: `&input[detection.span.range()] == matched_bytes`
- [x] EIP-55 spec vectors: mixed-case checksummed, all-lower, all-upper, plus Sha3_256 mis-import guard
- [x] RFC 5737 IPv4 docs prefixes accepted; leading-zero/hex rejected
- [x] RFC 3849 IPv6 docs prefix + RFC 4291 IPv4-embedded form accepted
- [x] No clippy warnings
- [x] No `--no-verify`, no force push

## Cross-refs

- Plan: solo://proj/19/scratchpad/930 (rev 2)
- Counselors r1: solo://proj/19/scratchpad/935 (verdict: PATCH PLAN → applied → DISPATCH IMPL)
- Sequencing: solo://proj/19/scratchpad/864
- Brainstorm dialogue: 925 (Codex) + 926 (Claude) → 927 (synth)
- Closed-via-shipped (separate): #419 via `a9215c9`
- Strategy session: drawer `c5cf4d0f7ee5618bace207b6`

Closes #440.