### PR TITLE
Expose default core pipeline API

### DIFF
--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use gaze::{
+    Action, CleanDocument, Context, LocaleChain, LocaleTag, PiiClass, Pipeline, Policy,
+    PolicyError, RawDocument, RuleSpec, Rulepack, RulepackPolicy, RulepackSource, Session,
+    SessionPolicy, SessionScope,
+};
+
+use crate::{build_pipeline, BuildError};
+
+const CORE_BUNDLED_RULEPACK: &str = "core";
+
+#[derive(Debug, Clone, Default)]
+pub struct CorePipelineConfig {
+    locale: Option<Vec<LocaleTag>>,
+    extra_bundled: Vec<String>,
+    extra_rulepack_paths: Vec<PathBuf>,
+}
+
+pub struct CorePipeline {
+    pipeline: Pipeline,
+    locale_chain: LocaleChain,
+}
+
+impl CorePipelineConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_locale(mut self, locale: &[LocaleTag]) -> Self {
+        self.locale = Some(locale.to_vec());
+        self
+    }
+
+    pub fn with_bundled_rulepack(mut self, id: &str) -> Self {
+        self.extra_bundled.push(id.to_string());
+        self
+    }
+
+    pub fn with_rulepack_path(mut self, path: PathBuf) -> Self {
+        self.extra_rulepack_paths.push(path);
+        self
+    }
+
+    pub fn build(self) -> Result<CorePipeline, BuildError> {
+        let rulepacks = self.load_rulepacks()?;
+        let rulepack_defaults = merged_rulepack_default_locales(&rulepacks);
+        let locale_chain = LocaleChain::merge_cli_policy_rulepack_default(
+            None,
+            self.locale.as_deref(),
+            Some(&rulepack_defaults),
+        );
+        let policy = default_policy(self.locale, class_rules_from_rulepacks(&rulepacks));
+        let context = Context {
+            dictionaries: std::collections::HashMap::new(),
+            class_map: std::collections::HashMap::new(),
+            fields: serde_json::Map::new(),
+        };
+        let pipeline = build_pipeline(&policy, &context, &rulepacks, &locale_chain, None)?;
+
+        Ok(CorePipeline {
+            pipeline,
+            locale_chain,
+        })
+    }
+
+    fn load_rulepacks(&self) -> Result<Vec<Rulepack>, BuildError> {
+        let mut rulepacks = Vec::new();
+        let contents = load_embedded_rulepack_contents(CORE_BUNDLED_RULEPACK)?;
+        rulepacks.push(Rulepack::load(RulepackSource::Embedded(contents))?);
+
+        for bundled in &self.extra_bundled {
+            let contents = load_embedded_rulepack_contents(bundled)?;
+            rulepacks.push(Rulepack::load(RulepackSource::Embedded(contents))?);
+        }
+        for path in &self.extra_rulepack_paths {
+            rulepacks.push(Rulepack::load(RulepackSource::Path(path.clone()))?);
+        }
+
+        Ok(rulepacks)
+    }
+}
+
+impl CorePipeline {
+    pub fn pipeline(&self) -> &Pipeline {
+        &self.pipeline
+    }
+
+    pub fn locale_chain(&self) -> &LocaleChain {
+        &self.locale_chain
+    }
+
+    pub fn into_pipeline(self) -> Pipeline {
+        self.pipeline
+    }
+
+    pub fn redact_text(
+        &self,
+        session: &Session,
+        input: impl Into<String>,
+    ) -> Result<CleanDocument, gaze::Error> {
+        self.pipeline.redact_with_context(
+            session,
+            RawDocument::Text(input.into()),
+            self.locale_chain.as_slice(),
+        )
+    }
+}
+
+fn load_embedded_rulepack_contents(id: &str) -> Result<&'static str, BuildError> {
+    gaze_recognizers::embedded(id).ok_or_else(|| {
+        BuildError::Policy(PolicyError::BundledRulepackUnknown {
+            value: id.to_string(),
+        })
+    })
+}
+
+fn merged_rulepack_default_locales(rulepacks: &[Rulepack]) -> Vec<LocaleTag> {
+    let mut locales = Vec::new();
+    for rulepack in rulepacks {
+        for locale in &rulepack.default_locales {
+            if !locales.iter().any(|existing| existing == locale) {
+                locales.push(locale.clone());
+            }
+        }
+    }
+    locales
+}
+
+fn class_rules_from_rulepacks(rulepacks: &[Rulepack]) -> Vec<RuleSpec> {
+    let mut seen = BTreeSet::<PiiClass>::new();
+    let mut rules = Vec::new();
+
+    for recognizer in rulepacks
+        .iter()
+        .flat_map(|rulepack| rulepack.recognizers.iter())
+        .filter(|recognizer| recognizer.enabled)
+    {
+        if seen.insert(recognizer.class.clone()) {
+            rules.push(RuleSpec::Class {
+                class: recognizer.class.clone(),
+                action: Action::Tokenize,
+            });
+        }
+    }
+
+    rules.push(RuleSpec::Default {
+        action: Action::Preserve,
+    });
+    rules
+}
+
+fn default_policy(locale: Option<Vec<LocaleTag>>, rules: Vec<RuleSpec>) -> Policy {
+    Policy {
+        session: SessionPolicy {
+            scope: SessionScope::Ephemeral,
+            ttl_secs: None,
+        },
+        detectors: Vec::new(),
+        dictionaries: Vec::new(),
+        rules,
+        ner: None,
+        rulepacks: RulepackPolicy {
+            bundled: Vec::new(),
+            paths: Vec::new(),
+        },
+        locale,
+    }
+}

--- a/crates/gaze-assembly/src/error.rs
+++ b/crates/gaze-assembly/src/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum BuildError {
+    #[error("no effective recognizers configured")]
+    NoRecognizers,
     #[error("policy error: {0}")]
     Policy(#[from] gaze::PolicyError),
     #[error("rulepack error: {0}")]

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -5,12 +5,14 @@ use gaze::{
 };
 
 mod class_map;
+pub mod defaults;
 mod detector_wiring;
 mod error;
 mod locale;
 mod ner;
 mod template;
 
+pub use defaults::{CorePipeline, CorePipelineConfig};
 pub use error::BuildError;
 pub(crate) use locale::merged_locale_vocab;
 

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -47,6 +47,30 @@ pub fn build_pipeline(
         &registered_dictionaries,
     )?;
 
+    let has_policy_detector = !policy.detectors.is_empty();
+    let has_enabled_rulepack_recognizer = rulepacks.iter().any(|rulepack| {
+        rulepack
+            .recognizers
+            .iter()
+            .any(|recognizer| recognizer.enabled && active_locales.intersects(&recognizer.locales))
+    });
+    let has_usable_ner = policy
+        .ner
+        .as_ref()
+        .is_some_and(|ner| ner.model_dir.is_some());
+    let has_context_dictionary = context
+        .dictionaries
+        .keys()
+        .any(|name| !registered_dictionaries.contains(name));
+
+    if !has_policy_detector
+        && !has_enabled_rulepack_recognizer
+        && !has_usable_ner
+        && !has_context_dictionary
+    {
+        return Err(BuildError::NoRecognizers);
+    }
+
     for rule in &policy.rules {
         builder = match rule {
             RuleSpec::Class { class, action } => {

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{detector_wiring::derive_source_short_label, template::lower_pattern_template};
 use gaze::{
-    Action, CleanDocument, ConflictTier, DetectorKind, LocaleTag, PiiClass, PolicyError,
+    Action, CleanDocument, ConflictTier, DetectorKind, LocaleTag, NerPolicy, PiiClass, PolicyError,
     RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, RulepackError, Scope, Session,
     SessionPolicy, SessionScope,
 };
@@ -44,11 +44,178 @@ fn empty_context() -> Context {
     }
 }
 
+fn empty_policy() -> gaze::Policy {
+    gaze::Policy {
+        session: SessionPolicy {
+            scope: SessionScope::Ephemeral,
+            ttl_secs: None,
+        },
+        detectors: Vec::new(),
+        dictionaries: Vec::new(),
+        rules: Vec::new(),
+        ner: None,
+        rulepacks: gaze::RulepackPolicy {
+            bundled: Vec::new(),
+            paths: Vec::new(),
+        },
+        locale: None,
+    }
+}
+
 fn embedded_rulepack(name: &str) -> Rulepack {
     Rulepack::load(gaze::RulepackSource::Embedded(
         gaze_recognizers::embedded(name).expect("embedded rulepack"),
     ))
     .expect("rulepack")
+}
+
+#[test]
+fn build_pipeline_empty_inputs_returns_no_recognizers() {
+    let policy = empty_policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let err = match build_pipeline(&policy, &empty_context(), &[], &active_locales, None) {
+        Ok(_) => panic!("empty inputs must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, BuildError::NoRecognizers));
+}
+
+#[test]
+fn build_pipeline_all_disabled_rulepack_returns_no_recognizers() {
+    let policy = empty_policy();
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "disabled-only"
+rulepack_version = "0.6.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "disabled.email"
+class = "Email"
+enabled = false
+
+[recognizers.match]
+kind = "regex"
+pattern = '''alice@example\.invalid'''
+"#,
+    )
+    .expect("rulepack");
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let err = match build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    ) {
+        Ok(_) => panic!("all-disabled rulepack must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, BuildError::NoRecognizers));
+}
+
+#[test]
+fn build_pipeline_locale_filtered_rulepack_returns_no_recognizers() {
+    let policy = empty_policy();
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "filtered"
+rulepack_version = "0.6.0"
+default_locales = ["de-DE"]
+
+[[recognizers]]
+id = "filtered.email"
+class = "Email"
+enabled = true
+locales = ["de-DE"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''alice@example\.invalid'''
+"#,
+    )
+    .expect("rulepack");
+    let active_locales = LocaleChain::merge_policy_and_cli(Some(&[LocaleTag::EnUs]), None);
+    let err = match build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    ) {
+        Ok(_) => panic!("locale-filtered rulepack must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, BuildError::NoRecognizers));
+}
+
+#[test]
+fn build_pipeline_ner_without_model_dir_returns_no_recognizers() {
+    let mut policy = empty_policy();
+    policy.ner = Some(NerPolicy {
+        model_dir: None,
+        locale: None,
+        threshold: gaze::DEFAULT_NER_THRESHOLD,
+    });
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let err = match build_pipeline(&policy, &empty_context(), &[], &active_locales, None) {
+        Ok(_) => panic!("threshold-only NER must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, BuildError::NoRecognizers));
+}
+
+#[test]
+fn build_pipeline_context_only_still_succeeds() {
+    let mut policy = empty_policy();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: PiiClass::custom("song"),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+    let context = Context {
+        dictionaries: std::collections::HashMap::from([(
+            "song".to_string(),
+            gaze::ContextDictionary {
+                terms: vec!["context-song-123".to_string()],
+                case_sensitive: true,
+            },
+        )]),
+        class_map: std::collections::HashMap::from([(
+            "song".to_string(),
+            PiiClass::custom("song"),
+        )]),
+        fields: serde_json::Map::new(),
+    };
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    let pipeline = build_pipeline(&policy, &context, &[], &active_locales, None)
+        .expect("context-only assembly must remain supported");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let dictionaries = gaze::dictionary_bundle_from_context(&context);
+    let clean = pipeline
+        .redact_with_detect_context(
+            &session,
+            RawDocument::Text("track context-song-123".to_string()),
+            active_locales.as_slice(),
+            &dictionaries,
+            &serde_json::Map::new(),
+        )
+        .expect("redact");
+
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text");
+    };
+    assert!(text.contains(":Custom:song_"));
 }
 
 fn clean_with_rulepacks(rulepacks: &[Rulepack], locales: &[LocaleTag], input: &str) -> String {

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -325,6 +325,41 @@ fn core_pipeline_config_extended_tokenizes_synthetic_iban() {
     assert!(text.contains(":Custom:iban_"), "{text}");
 }
 
+#[test]
+fn core_pipeline_restore_round_trip() {
+    let core = CorePipelineConfig::new().build().expect("core pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let original = "alice@example.invalid";
+    let text = clean_text(
+        core.redact_text(&session, format!("Email {original}"))
+            .expect("redact"),
+    );
+    let token = regex::Regex::new(r"<[^>]+:Email_\d+>")
+        .expect("token regex")
+        .find(&text)
+        .map(|matched| matched.as_str())
+        .expect("email token");
+
+    assert_eq!(session.restore_strict(token).expect("restore"), original);
+}
+
+#[test]
+fn unknown_bundled_rulepack_fails_closed() {
+    let err = match CorePipelineConfig::new()
+        .with_bundled_rulepack("missing-core-addon")
+        .build()
+    {
+        Ok(_) => panic!("unknown bundled rulepack must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        BuildError::Policy(PolicyError::BundledRulepackUnknown { value })
+            if value == "missing-core-addon"
+    ));
+}
+
 #[derive(Clone, Default)]
 struct MemoryLogger {
     entries: Arc<Mutex<Vec<RedactionEntry>>>,

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -242,6 +242,13 @@ fn clean_with_policy_and_rulepacks(
     text
 }
 
+fn clean_text(clean: CleanDocument) -> String {
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text");
+    };
+    text
+}
+
 fn name_email_policy(locales: Vec<LocaleTag>) -> gaze::Policy {
     let mut policy = policy();
     policy.locale = Some(locales);
@@ -259,6 +266,63 @@ fn name_email_policy(locales: Vec<LocaleTag>) -> gaze::Policy {
         },
     ];
     policy
+}
+
+#[test]
+fn core_pipeline_config_tokenizes_synthetic_email() {
+    let core = CorePipelineConfig::new().build().expect("core pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let text = clean_text(
+        core.redact_text(&session, "Email alice@example.invalid")
+            .expect("redact"),
+    );
+
+    assert!(text.contains(":Email_"), "{text}");
+}
+
+#[test]
+fn core_pipeline_config_core_only_does_not_tokenize_phone() {
+    let core = CorePipelineConfig::new()
+        .with_locale(&[LocaleTag::EnUs])
+        .build()
+        .expect("core pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Phone +12025550100";
+    let text = clean_text(core.redact_text(&session, input).expect("redact"));
+
+    assert_eq!(text, input);
+}
+
+#[test]
+fn core_pipeline_config_extended_tokenizes_synthetic_phone() {
+    let core = CorePipelineConfig::new()
+        .with_locale(&[LocaleTag::EnUs])
+        .with_bundled_rulepack("core-extended")
+        .build()
+        .expect("extended pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let text = clean_text(
+        core.redact_text(&session, "Phone +12025550100")
+            .expect("redact"),
+    );
+
+    assert!(text.contains(":Custom:phone_"), "{text}");
+}
+
+#[test]
+fn core_pipeline_config_extended_tokenizes_synthetic_iban() {
+    let core = CorePipelineConfig::new()
+        .with_locale(&[LocaleTag::DeDe])
+        .with_bundled_rulepack("core-extended")
+        .build()
+        .expect("extended pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let text = clean_text(
+        core.redact_text(&session, "IBAN DE89 3704 0044 0532 0130 00")
+            .expect("redact"),
+    );
+
+    assert!(text.contains(":Custom:iban_"), "{text}");
 }
 
 #[derive(Clone, Default)]

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -48,6 +48,7 @@ pub(crate) fn build_pipeline_from_policy(
         Some(ner_threshold),
     )
     .map_err(|err| match err {
+        gaze_assembly::BuildError::NoRecognizers => gaze::Error::Policy(PolicyError::NoDetectors),
         gaze_assembly::BuildError::Policy(err) => gaze::Error::Policy(err),
         gaze_assembly::BuildError::Rulepack(err) => gaze::Error::Rulepack(err),
         gaze_assembly::BuildError::Pipeline(err) => err,

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -917,13 +917,16 @@ fn clean_echoes_locale_chain_from_cli() {
 fn rulepack_recognizer_is_gated_by_policy_locale() {
     let (_dir, path) =
         write_policy_with_rulepack(&de_email_rulepack("\"de-DE\""), Some("\"en-US\""));
-    let v = clean_json_with_args(
+    let out = clean_raw_with_args(
         &[&format!("--policy={}", path.display())],
         "kennung kundennummer-123",
     );
-
-    assert_eq!(v["clean_text"], "kennung kundennummer-123");
-    assert_eq!(v["stats"]["detections"], 0);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty(), "policy config must not emit stdout");
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
 
     let (_dir, path) =
         write_policy_with_rulepack(&de_email_rulepack("\"de-DE\""), Some("\"de-DE\""));
@@ -942,13 +945,17 @@ fn rulepack_recognizer_is_gated_by_policy_locale() {
 fn rulepack_recognizer_fr_fr_not_gated_by_en_us() {
     let rulepack = de_email_rulepack("\"fr-FR\"").replace("kundennummer", "ticket");
     let (_dir, path) = write_policy_with_rulepack(&rulepack, Some("\"en-US\""));
-    let v = clean_json_with_args(
+    let out = clean_raw_with_args(
         &[&format!("--policy={}", path.display())],
         "kennung ticket-123",
     );
 
-    assert_eq!(v["clean_text"], "kennung ticket-123");
-    assert_eq!(v["stats"]["detections"], 0);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty(), "policy config must not emit stdout");
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
 }
 
 #[test]
@@ -972,12 +979,16 @@ terms = ["Sonnenlied"]
 [recognizers.token]
 "#;
     let (_dir, path) = write_policy_with_rulepack(rulepack, Some("\"en-US\""));
-    let v = clean_json_with_args(
+    let out = clean_raw_with_args(
         &[&format!("--policy={}", path.display())],
         "track Sonnenlied",
     );
-    assert_eq!(v["clean_text"], "track Sonnenlied");
-    assert_eq!(v["stats"]["detections"], 0);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty(), "policy config must not emit stdout");
+    assert_eq!(
+        parse_stderr_variant(&out.stderr),
+        json!({ "error": "PolicyConfig", "exit": 2 })
+    );
 
     let (_dir, path) = write_policy_with_rulepack(rulepack, Some("\"de-DE\""));
     let v = clean_json_with_args(


### PR DESCRIPTION
Adds the reusable default/core assembly API needed by downstream crates without making them duplicate CLI rulepack setup.

What changed:
- `gaze_assembly::build_pipeline` now fails closed with `BuildError::NoRecognizers` when no effective recognizer can run.
- Added `gaze_assembly::defaults::{CorePipelineConfig, CorePipeline}`. `CorePipelineConfig::new()` loads bundled `core`, can add `core-extended`/locale bundles/paths, builds tokenize class rules from enabled rulepack recognizers, and carries the active `LocaleChain` through `CorePipeline::redact_text`.
- Updated CLI error/test expectations for locale-filtered rulepack-only policies to fail closed instead of silently succeeding with zero detections.

Validation:
- `cargo test -p gaze-assembly --all-features` passed.
- `cargo test -p gaze-cli --all-features --test cli_pipe` passed.
- Attempted full workspace validation with `/opt/homebrew/bin/lean-ctx -c 'cargo test --workspace --all-features'`. It was stopped after hanging around 9 minutes in `tests/adversarial_class_map_override_safety.rs` (`class_map_override_safety_gate_fails_when_required_test_is_missing` and `class_map_override_safety_gate_passes_on_baseline` both stuck after the 60s warning). Earlier suites in that run were passing; this was a hang/blocker, not an assertion failure.