### PR TITLE
docs: add docs.rs metadata to all published crates

### DIFF
--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Policy-to-pipeline assembly for Gaze"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 gaze = { path = "../gaze" }
 gaze-recognizers = { path = "../gaze-recognizers" }

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use std::collections::BTreeSet;
 
 use gaze::{

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Passive audit sinks for Gaze metadata-only redaction logs"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 name = "gaze_audit"
 path = "src/lib.rs"

--- a/crates/gaze-audit/src/lib.rs
+++ b/crates/gaze-audit/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Passive audit sinks for Gaze metadata-only redaction logs.
 //!
 //! This crate owns concrete audit storage and query helpers. It depends on

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Gaze command-line interface"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = []
 safety-net-openai = ["gaze-recognizers/safety-net-openai"]

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Gaze CLI — pipe-mode `clean` / `restore` for LLM-facing integrations.
 //!
 //! See `ROADMAP.md` for consolidated roadmap context and host-side

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Built-in recognizers for Gaze"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 # phone-parser feature gates phonenumber dep; default-on for gaze-cli, default-off for raw lib.
 default = ["phone-parser"]

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod anchored_match;
 mod dictionary;
 mod error;

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -6,6 +6,10 @@ rust-version = "1.89"
 license = "Apache-2.0"
 description = "Shared value contracts for Gaze"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 name = "gaze_types"
 path = "src/lib.rs"

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use std::cell::Cell;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -7,6 +7,10 @@ build = "build.rs"
 license = "Apache-2.0"
 description = "Reversible PII pseudonymization runtime for agentic workflows"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lib]
 name = "gaze"
 path = "src/lib.rs"

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod context;
 mod detector;
 mod dictionaries;


### PR DESCRIPTION
## Summary
Task 1 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2).

Adds \`[package.metadata.docs.rs]\` to all six published crates and \`#![cfg_attr(docsrs, feature(doc_cfg))]\` to library/binary roots. Without docs.rs metadata, docs.rs builds with default features only — feature-gated APIs (\`phone-parser\`, \`safety-net\`) would not appear.

This is the **sequenced-first** task; Tasks 2 and 3 are blocked on this PR landing because they edit overlapping Cargo.toml files.

## Test plan
- [ ] \`cargo metadata --format-version 1 --no-deps\` parses
- [ ] \`RUSTDOCFLAGS=\"--cfg docsrs\" cargo +nightly doc -p gaze --all-features --no-deps\` produces no errors (warnings expected, fixed in Tasks 4–9)
- [ ] Local pre-push gates: fmt, clippy, full test --all-features all green