### PR TITLE
docs(gaze-types): add crate README

### DIFF
--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
 description = "Shared value contracts for Gaze"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -9,7 +9,6 @@ Serde-only — no ML, no SQLite, no ONNX. This crate exists so that:
 ## When to depend on this crate directly
 
 Use `gaze-types` instead of `gaze` when building:
-- A restore-side adapter that consumes `SensitiveSnapshot`, calls restore, and does not run detection
 - An audit sink implementing `RedactionLogger`
 - A crate that needs `PiiClass`, `Action`, or `RedactionEntry` without the full pipeline
 
@@ -25,6 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 | `CleanDocument` | Cleaned output variant — same shape as `RawDocument` — `#[non_exhaustive]` |
 | `RedactionLogger` | Trait for audit sinks (metadata-only contract) |
 | `RedactionEntry` | One audit row: class, action, span, session, timestamp — no raw PII |
+| `ConflictTier` | Precedence tier for resolving overlapping detections |
 | `SafetyNet` | Observer-only post-clean trait (does not mutate the manifest) |
 | `LeakReport` / `LeakKind` | Suspected-miss report from a `SafetyNet` |
 

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -1,0 +1,57 @@
+# gaze-types
+
+Shared value contracts for the [gaze](https://crates.io/crates/gaze) PII pseudonymization runtime.
+
+Serde-only — no ML, no SQLite, no ONNX. This crate exists so that:
+- Restore-side adapters can take `gaze-types` without pulling in `ort` / `tokenizers` / `ndarray`
+- Audit sinks (`gaze-audit`) share the `RedactionLogger` trait without depending on `gaze` core
+
+## When to depend on this crate directly
+
+Use `gaze-types` instead of `gaze` when building:
+- A restore-side adapter that consumes `SensitiveSnapshot`, calls restore, and does not run detection
+- An audit sink implementing `RedactionLogger`
+- A crate that needs `PiiClass`, `Action`, or `RedactionEntry` without the full pipeline
+
+Otherwise depend on `gaze` — it re-exports the public types from this crate.
+
+## Key types
+
+| Type | Purpose |
+|------|---------|
+| `PiiClass` | PII category vocabulary (`Email`, `Name`, `Location`, `Organization`, `Custom(String)`) — `#[non_exhaustive]` |
+| `Action` | Disposition for a detected span — `#[non_exhaustive]` |
+| `RawDocument` | Input variant — `Text(String)` or `Structured(BTreeMap<String, Value>)` — `#[non_exhaustive]` |
+| `CleanDocument` | Cleaned output variant — same shape as `RawDocument` — `#[non_exhaustive]` |
+| `RedactionLogger` | Trait for audit sinks (metadata-only contract) |
+| `RedactionEntry` | One audit row: class, action, span, session, timestamp — no raw PII |
+| `SafetyNet` | Observer-only post-clean trait (does not mutate the manifest) |
+| `LeakReport` / `LeakKind` | Suspected-miss report from a `SafetyNet` |
+
+`PiiClass` does **not** include a `Phone` variant. Phone detection is supplied by recognizers
+in `gaze-recognizers` (e.g. the `phone-parser` feature) and emitted as `PiiClass::Custom(...)` or
+via rulepack-defined classes — see `docs/policy.md`.
+
+## `#[non_exhaustive]` enums
+
+`PiiClass`, `Action`, `RawDocument`, `CleanDocument`, `LeakKind`, `SafetyNet`-related variants
+are `#[non_exhaustive]`. Always include a wildcard arm in match statements:
+
+```rust
+use gaze_types::PiiClass;
+
+fn label(class: &PiiClass) -> &'static str {
+    match class {
+        PiiClass::Email        => "email",
+        PiiClass::Name         => "name",
+        PiiClass::Location     => "location",
+        PiiClass::Organization => "org",
+        PiiClass::Custom(_)    => "pii",
+        _                      => "pii", // forward-compat fallback
+    }
+}
+```
+
+## MSRV
+
+`rust-version = "1.89"` (matches the workspace).


### PR DESCRIPTION
## Summary
Task 3 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2).

Adds \`crates/gaze-types/README.md\` and wires \`readme = \"README.md\"\` in Cargo.toml so docs.rs picks it up as the landing page. README content verified against actual public API in \`crates/gaze-types/src/lib.rs\`.

## Test plan
- [ ] \`cargo test --doc -p gaze-types --all-features\` (README rust blocks)
- [ ] Local pre-push gates green