### PR TITLE
docs(gaze-recognizers): feature flag table + recognizer inline docs

### DIFF
--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -8,6 +8,15 @@ use gaze_types::{
     Candidate, ConflictTier, DetectContext, DictionaryEntry, LocaleTag, PiiClass, Recognizer,
 };
 
+/// Lookup-based [`Recognizer`] for tenant-specific PII.
+///
+/// Matches exact strings from a runtime-supplied dictionary: order IDs, song
+/// titles, customer codes, or any domain-specific identifiers that regex cannot
+/// reliably detect.
+///
+/// Supply dictionaries at runtime via [`DetectContext`] or the CLI's
+/// `--context-json` wiring. Dictionary entries are session-scoped detection
+/// inputs and are not stored in the audit log.
 pub struct DictionaryRecognizer {
     id: String,
     class: PiiClass,

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -1,4 +1,18 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+//! Built-in recognizer backends for the Gaze pseudonymization pipeline.
+//!
+//! ## Feature flags
+//!
+//! | Feature | Default | What it enables |
+//! |---------|---------|-----------------|
+//! | `phone-parser` | yes | Parser-backed E.164 and national phone validation via `phonenumber` |
+//! | `safety-net` | no | `NerSafetyNet` observer pass |
+//! | `safety-net-openai` | no | OpenAI-filter safety net subprocess; also enables `safety-net` |
+//! | `test-support` | no | Fixture helpers for safety-net tests; not for production use |
+//!
+//! With `phone-parser` disabled, parser-backed phone validators fail closed. There is
+//! no silent regex-only fallback, so phone spans that require parser validation are not
+//! detected.
 
 mod anchored_match;
 mod dictionary;

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -96,6 +96,16 @@ impl NormalizerKind {
     }
 }
 
+/// Regex-backed [`Recognizer`] implementation.
+///
+/// Construct via [`RegexDetector::emails`] for the bundled email recognizer, or
+/// supply a custom pattern through the rulepack mechanism. Patterns use Rust
+/// regex syntax: no lookahead, lookbehind, or backreferences. Prefer TOML
+/// literal strings (`'...'`) in policy files to avoid double-escaping.
+///
+/// [`Candidate::span`] uses byte ranges, not char indices.
+///
+/// [`Candidate::span`]: gaze_types::Candidate::span
 pub struct RegexDetector {
     regex: Regex,
     class: PiiClass,


### PR DESCRIPTION
## Summary
Task 9 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2).

Crate-level feature flag table (\`phone-parser\`, \`safety-net\`, \`safety-net-openai\`, \`test-support\`). Inline docs on \`RegexDetector\` (byte-span semantics) and \`DictionaryRecognizer\` (DetectContext wiring).

Feature flag drift: \`bundled-recognizers\` is not present in \`crates/gaze-recognizers/Cargo.toml\`; embedded rulepacks are available without that feature flag.

## Test plan
- [x] \`cargo doc -p gaze-recognizers --no-deps --all-features\`
- [x] \`cargo test -p gaze-recognizers --doc --all-features\`
- [x] Local pre-push gates green