### PR TITLE
docs(gaze-audit): inline docs on SqliteLogger + audit query surface

### DIFF
--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -1,5 +1,11 @@
 use rusqlite::types::Value;
 
+/// Query filter for [`crate::SqliteLogger::query`] and
+/// [`crate::SqliteLogger::query_safety_net`].
+///
+/// Construct with `AuditFilter::default()` for all rows, or set fields to
+/// narrow by class, source, action, document kind, raw safety-net label, field
+/// path, epoch-millisecond time range, or session ID.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AuditFilter {
     pub class: Option<String>,
@@ -13,6 +19,11 @@ pub struct AuditFilter {
     pub session_id: Option<String>,
 }
 
+/// Metadata-only redaction audit row returned by [`crate::SqliteLogger::query`].
+///
+/// This row mirrors the approved audit export surface. It is safe for audit
+/// display and reporting, but it is not restore material and contains no
+/// original PII or token values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditLogRow {
     pub source: String,
@@ -47,6 +58,13 @@ pub struct LeakSuspectRow {
     pub telemetry_kind: Option<String>,
 }
 
+/// The approved metadata-only column set exported by `audit export` and queried
+/// by [`crate::SqliteLogger::query`].
+///
+/// Columns that would expose raw PII, token values, or document content are
+/// excluded. The `audit export` CLI command selects only from this set, and the
+/// `gaze_module_isolation` Dylint lint prevents the clean path from routing raw
+/// values into the audit path.
 pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "source",
     "class",

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -19,6 +19,56 @@ pub enum AuditError {
     Sqlite(String),
 }
 
+/// SQLite-backed [`gaze_types::RedactionLogger`] implementation.
+///
+/// Appends redaction metadata rows to a local SQLite database. The schema is
+/// append-only: rows are inserted and optionally purged by TTL, never updated
+/// in place.
+///
+/// `SqliteLogger` is **not** `Clone`. Build it where the pipeline is
+/// constructed and pass ownership directly. Querying happens through the static
+/// [`SqliteLogger::query`] and [`SqliteLogger::query_safety_net`] functions.
+/// They take a [`Path`], so the database file can be queried after the logger
+/// has been moved into the pipeline.
+///
+/// # Audit log is metadata-only
+///
+/// Records class, action, source, field name, document kind, conflict status,
+/// decision tier, timestamp, and session ID. It never stores original PII or
+/// token values. **Do not use as a restore source**: restore requires the
+/// `gaze::SensitiveSnapshot` exported from a `gaze::Session`.
+///
+/// # Isolation
+///
+/// `gaze` core has no compile-time dependency on `gaze-audit`. Wire
+/// `SqliteLogger` in your application layer only. See the Dylint isolation gate
+/// in `docs/architecture/`.
+///
+/// # Example
+///
+/// ```rust
+/// use std::path::Path;
+/// use gaze_audit::SqliteLogger;
+///
+/// let logger = SqliteLogger::new(Path::new("audit.db"))?;
+/// # let _ = logger;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// In an application that depends on both `gaze` and `gaze-audit`, pass the
+/// logger into the pipeline builder once:
+///
+/// ```rust,ignore
+/// use std::path::Path;
+/// use gaze::Pipeline;
+/// use gaze_audit::SqliteLogger;
+///
+/// let logger = SqliteLogger::new(Path::new("audit.db"))?;
+/// let pipeline = Pipeline::builder()
+///     .redaction_logger(logger)
+///     .build()?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
 pub struct SqliteLogger {
     conn: Mutex<Connection>,
 }
@@ -210,6 +260,11 @@ impl SqliteLogger {
         Ok(entries)
     }
 
+    /// Queries metadata-only redaction audit rows from a SQLite database file.
+    ///
+    /// This is a static function, not a method on `SqliteLogger`. Call it with
+    /// the database [`Path`] and an [`AuditFilter`] after the logger has been
+    /// moved into a pipeline or dropped.
     pub fn query(path: &Path, filter: &AuditFilter) -> Result<Vec<AuditLogRow>> {
         let conn = open_audit_query_connection(path)?;
         let has_decided_by = table_has_column(&conn, "decided_by")?;
@@ -243,6 +298,10 @@ impl SqliteLogger {
         Ok(entries)
     }
 
+    /// Queries metadata-only safety-net audit rows from a SQLite database file.
+    ///
+    /// Returned rows include labels, classes, span lengths, and replay hashes,
+    /// never suspect text bytes or emitted placeholder bytes.
     pub fn query_safety_net(path: &Path, filter: &AuditFilter) -> Result<Vec<LeakSuspectRow>> {
         let conn = open_audit_query_connection(path)?;
         let (sql, values) = build_safety_net_query_sql(filter);


### PR DESCRIPTION
## Summary
Task 7 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2).

Inline rustdoc on \`SqliteLogger\`, \`AuditFilter\`, \`AUDIT_RESTRICTED_COLUMNS\`. Establishes audit-log-as-metadata-only contract and the static \`query\` shape.

## Test plan
- [x] \`cargo test -p gaze-audit --doc\`
- [x] Local pre-push gates green