### PR TITLE
ci: add docs workflow — cargo doc -D warnings + cargo test --doc on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo doc (warnings as errors)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --all-features --no-deps
+
+      - name: cargo test --doc
+        run: cargo test --doc --workspace --all-features

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -37,19 +37,19 @@ enum Cmd {
         /// Override the persistent session TTL in seconds.
         #[arg(long)]
         session_ttl: Option<u64>,
-        /// Override policy [session].scope.
+        /// Override policy \[session].scope.
         #[arg(long)]
         session_scope: Option<String>,
         /// Active locale fallback chain, comma separated and priority ordered.
         #[arg(long, value_delimiter = ',')]
         locale: Vec<String>,
-        /// Override policy [ner] threshold. Must be between 0.0 and 1.0 inclusive.
+        /// Override policy \[ner] threshold. Must be between 0.0 and 1.0 inclusive.
         #[arg(long)]
         ner_threshold: Option<f32>,
-        /// Override policy [ner].model_dir.
+        /// Override policy \[ner].model_dir.
         #[arg(long)]
         ner_model_dir: Option<PathBuf>,
-        /// Override policy [ner].locale.
+        /// Override policy \[ner].locale.
         #[arg(long)]
         ner_locale: Option<String>,
         /// Override policy.rulepacks.bundled. Comma-separated and repeatable.


### PR DESCRIPTION
## Summary
Wave Pub-2 Task 16 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2). Final task.

Adds .github/workflows/docs.yml — runs on PRs and push to main. Two steps:
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
- cargo test --doc --workspace --all-features

Closes the "no PR-triggered CI" gap noted in the audit (scratchpad 1230) and counselors report (scratchpad 1229 CB3). Makes Tasks 4–9 inline-doc work durable: any future PR that breaks doc-tests or introduces rustdoc warnings fails CI.

## Test plan
- [ ] Both gate commands pass locally on current main BEFORE the workflow file lands
- [ ] CI run on this PR is GREEN