### PR TITLE
docs: inline docs on Policy + PiiClass/Action/RawDocument/CleanDocument

### DIFF
--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -22,7 +22,7 @@
 //! let session = Session::new(Scope::Conversation("s1".into()))?;
 //! let CleanDocument::Text(_clean) = core.pipeline().redact(
 //!     &session,
-//!     RawDocument::Text("alice@example.invalid".into()),
+//!     RawDocument::Text("alice@example.invalid".into()), // fixture-cited(crates/gaze-assembly/src/lib.rs:tests::core_pipeline_config_tokenizes_synthetic_email)
 //! )? else {
 //!     panic!("text variant expected");
 //! };

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -14,7 +14,33 @@ pub trait Detector: Send + Sync {
     fn detect(&self, input: &str) -> Vec<Detection>;
 }
 
-/// PII class vocabulary used by detectors, recognizers, policy, and audit metadata.
+/// The category of a detected PII span.
+///
+/// Built-in variants: `Email`, `Name`, `Location`, `Organization`. Tenant-specific PII
+/// (order IDs, song titles, internal codes) is carried as `PiiClass::Custom(String)`.
+/// **There is no `Phone` variant** -- phone detection is provided by recognizers in
+/// `gaze-recognizers` and surfaces as either a `Custom("phone")` class or a class
+/// defined by a rulepack.
+///
+/// `PiiClass` is `#[non_exhaustive]`. Always include a wildcard arm:
+///
+/// ```rust
+/// use gaze_types::PiiClass;
+///
+/// fn label(class: &PiiClass) -> &'static str {
+///     match class {
+///         PiiClass::Email        => "email",
+///         PiiClass::Name         => "name",
+///         PiiClass::Location     => "location",
+///         PiiClass::Organization => "org",
+///         PiiClass::Custom(_)    => "pii",
+///         _                      => "pii",
+///     }
+/// }
+/// ```
+///
+/// Policy TOML uses the lowercase forms `email` / `name` / `location` / `organization`,
+/// and tenant classes are spelled `custom:order_id` (lowercase, snake_case).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum PiiClass {
@@ -590,7 +616,19 @@ pub enum SafetyNetError {
     },
 }
 
-/// Policy action vocabulary for handling detected PII.
+/// Disposition applied to a detected PII span.
+///
+/// | Variant | Restorable | Output shape |
+/// |---------|------------|--------------|
+/// | `Tokenize` | Yes | Opaque token: `<hex:Class_N>` |
+/// | `FormatPreserve` | Yes | Realistic-looking pseudonym (e.g., `email1.hex@gaze-fake.invalid`) |
+/// | `Redact` | No | Literal `[REDACTED]` -- original value is gone |
+/// | `Generalize` | No | Class label (e.g., `[Email]`) -- original value is gone |
+/// | `Preserve` | - | Passes through unchanged |
+///
+/// `Action` is `#[non_exhaustive]`. Use a wildcard arm in exhaustive matches.
+/// When restore is required, use `Tokenize` or `FormatPreserve` -- `Redact` and
+/// `Generalize` are irreversible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Action {
@@ -908,7 +946,15 @@ impl fmt::Display for LocaleTag {
     }
 }
 
-/// Input document before pseudonymization.
+/// The input document submitted for pseudonymization.
+///
+/// `RawDocument::Text(String)` for plain or semi-structured text (most LLM workflows).
+/// `RawDocument::Structured(BTreeMap<String, Value>)` for JSON-shaped data where
+/// column-aware rules apply -- `ColumnRule`s only take effect on structured input.
+///
+/// `Detection::span` and recognizer candidate spans use **byte** ranges, not char indices.
+///
+/// `RawDocument` is `#[non_exhaustive]`. Match with a wildcard arm.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RawDocument {
@@ -918,7 +964,24 @@ pub enum RawDocument {
     Text(String),
 }
 
-/// Cleaned document after pseudonymization.
+/// The pseudonymized output from `Pipeline::redact`.
+///
+/// Mirrors the shape of `RawDocument`: `CleanDocument::Text(String)` or
+/// `CleanDocument::Structured(BTreeMap<String, Value>)`. Destructure with a `let`-else
+/// or `match`; **there is no `.text()` accessor**.
+///
+/// ```rust
+/// use gaze_types::CleanDocument;
+///
+/// fn unwrap_text(doc: CleanDocument) -> Option<String> {
+///     if let CleanDocument::Text(t) = doc { Some(t) } else { None }
+/// }
+/// ```
+///
+/// Contains only tokens or redacted placeholders -- no original PII values.
+/// Send this (or its inner string) to the LLM; never send the original `RawDocument`.
+///
+/// `CleanDocument` is `#[non_exhaustive]`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 #[non_exhaustive]

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -17,7 +17,7 @@ pub trait Detector: Send + Sync {
 /// The category of a detected PII span.
 ///
 /// Built-in variants: `Email`, `Name`, `Location`, `Organization`. Tenant-specific PII
-/// (order IDs, song titles, internal codes) is carried as `PiiClass::Custom(String)`.
+/// (case references, titles, internal codes) is carried as `PiiClass::Custom(String)`.
 /// **There is no `Phone` variant** -- phone detection is provided by recognizers in
 /// `gaze-recognizers` and surfaces as either a `Custom("phone")` class or a class
 /// defined by a rulepack.
@@ -40,7 +40,7 @@ pub trait Detector: Send + Sync {
 /// ```
 ///
 /// Policy TOML uses the lowercase forms `email` / `name` / `location` / `organization`,
-/// and tenant classes are spelled `custom:order_id` (lowercase, snake_case).
+/// and tenant classes are spelled like `custom:case_ref` (lowercase, snake_case).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum PiiClass {

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -10,6 +10,16 @@ use crate::{Action, LocaleTag, PiiClass, RulepackDict};
 
 pub const DEFAULT_NER_THRESHOLD: f32 = 0.3;
 
+/// Loaded redaction policy from a TOML configuration file.
+///
+/// Defines which rulepacks activate, which recognizers are enabled, and the locale chain.
+/// Load with [`Policy::load`] for library use or [`Policy::load_for_cli`] for CLI hosts.
+/// Both signatures take `&std::path::Path`.
+///
+/// Production deployments **must** use a policy -- the no-policy builder path is for
+/// development smoke-testing only and has an unauditable detection posture.
+///
+/// See `docs/policy.md` in the repository for the full TOML schema reference.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
 pub struct Policy {

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -132,7 +132,7 @@ struct SnapshotPayload {
 ///
 /// impl Detector for ExampleEmailDetector {
 ///     fn detect(&self, input: &str) -> Vec<Detection> {
-///         let email = "alice@example.invalid";
+///         let email = "alice@example.invalid"; // fixture-cited(crates/gaze/src/session.rs:session::tests::snapshot_round_trip_two_families_same_class_raw_preserved_under_shared_counter)
 ///         input
 ///             .find(email)
 ///             .map(|start| Detection::new(start..start + email.len(), PiiClass::Email, "docs"))
@@ -150,7 +150,7 @@ struct SnapshotPayload {
 ///
 /// let CleanDocument::Text(clean) = pipeline.redact(
 ///     &session,
-///     RawDocument::Text("alice@example.invalid".into()),
+///     RawDocument::Text("alice@example.invalid".into()), // fixture-cited(crates/gaze/src/session.rs:session::tests::snapshot_round_trip_two_families_same_class_raw_preserved_under_shared_counter)
 /// )? else {
 ///     panic!("text variant expected");
 /// };
@@ -169,7 +169,7 @@ struct SnapshotPayload {
 ///     last = m.end();
 /// }
 /// restored.push_str(&clean[last..]);
-/// assert_eq!(restored, "alice@example.invalid");
+/// assert_eq!(restored, "alice@example.invalid"); // fixture-cited(crates/gaze/src/session.rs:session::tests::snapshot_round_trip_two_families_same_class_raw_preserved_under_shared_counter)
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///


### PR DESCRIPTION
## Summary
Wave Pub-1 Task 5 of Gaze pre-OSS documentation plan (scratchpad 1235, plan r2).

Inline rustdoc on the most-touched public types: `Policy` (gaze), `PiiClass`, `Action`, `RawDocument`, `CleanDocument` (gaze-types). Each enum has explicit `#[non_exhaustive]` matching guidance with wildcard-arm examples — without these docs, adopters matching these enums hit compile errors and file issues.

Also includes hook-required fixture citation markers on existing synthetic rustdoc examples, plus neutralized PiiClass custom-class wording to satisfy no-tenant-knowledge.

## Test plan
- [x] `cargo test -p gaze --doc`
- [x] `cargo test -p gaze-types --doc` (PiiClass label fn doc-test compiles)
- [x] `cargo test -p gaze-assembly --doc` (fixture-citation follow-up)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] Pre-push hook full gate green