### PR TITLE
docs: remove broken links to deleted files (gaze-first-principles-vision.md, ROADMAP.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Every design, implementation, and review decision MUST be evaluated against thes
 4. **Trust (auditable + deterministic).** Rule-based detectors preferred over neural for precise classes. Neural is an addon (safety net, free-text NER), not the floor. Every token emission traceable to a rule or recognizer. Typed exceptions + closed error-variant set. No silent mismatches.
 5. **Adopter ergonomics.** Low-friction integration (Laravel adapter pattern, clear TOML policy, sane defaults). Framework adapters pave the 80% case; library API serves the 20% power case. Adopter can pick Gaze up in under a day without deep PII domain expertise.
 
-Full rationale, reframes of active decisions, what the north star rejects, and drift-measurement protocol live in [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24).
+All design, implementation, and review decisions in this repo are evaluated against the five axes above. If a decision weakens any axis, call it out in the PR description and justify the tradeoff. Correctness axes 1–4 always beat performance.
 
 ## Workspace shape (v0.6)
 

--- a/README.md
+++ b/README.md
@@ -316,10 +316,6 @@ SafetyNet sanity, cargo metadata audit isolation, and the resolver-based
 `gaze_module_isolation` Dylint gate. The full gate inventory and authoring
 contract live in [`docs/architecture/xtask.md`](docs/architecture/xtask.md).
 
-## Roadmap
-
-See [ROADMAP.md](ROADMAP.md) for current priorities and recently shipped work.
-
 ## Adopter notes
 
 - **Linux distros** — the published Linux x86_64 binary requires glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer). On older distros, build from source with `cargo build --release -p gaze-cli`.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ External consumer: [piinuts/gaze-lens](https://github.com/PIInuts/gaze-lens), fo
 
 > **Gaze is the most reliable, reversible PII pseudonymization runtime for agentic workflows. Zero PII leaks between the agent and the data owner — ever. Any byte of PII that reaches an LLM outside the manifest contract is a critical defect.**
 
-"Pseudonymization" is the GDPR Art. 4(5) term for reversible substitution with tokens — that reversibility is the Gaze moat, not one-way redaction. See [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24) for the locked north star and rationale.
+"Pseudonymization" is the GDPR Art. 4(5) term for reversible substitution with tokens — that reversibility is the Gaze moat, not one-way redaction. See [AGENTS.md](AGENTS.md#project-north-star) for the locked north star and rationale.
 
 ## Five Axes
 
-Every design, implementation, and review decision is evaluated against these five axes. Full rationale: [docs/research/gaze-first-principles-vision.md](docs/research/gaze-first-principles-vision.md#north-star-locked-2026-04-24).
+Every design, implementation, and review decision is evaluated against these five axes. Full rationale: [AGENTS.md](AGENTS.md#project-north-star).
 
 1. **Reliability (never leak).** Fail-closed always; defense in depth across regex, NER, dictionary, and optional neural safety net.
 2. **Reversibility.** Manifest-first restore; no one-way primitives in the core contract.
@@ -171,7 +171,7 @@ echo '{"text":"Email <{session_hex}:Email_1> now","session_blob":"<base64>"}' | 
 
 Counter-family tokens (`<{session_hex}:Email_N>`, `<{session_hex}:Name_N>`, `<{session_hex}:Location_N>`, `<{session_hex}:Organization_N>`, `<{session_hex}:Custom:name_N>`) are wrapped in angle brackets so the LLM cannot silently dissolve them into adjacent words. Format-preserving email tokens (`email1.{session_hex}@gaze-fake.invalid`) intentionally stay bare — the whole point is to look like a real email.
 
-Default bundled-rulepack tokenization is a contract surface. The no-policy baselines for bundled outputs live in `crates/xtask/snapshots/`, and intentional drift requires a `[bundle-tokenization-drift]` `CHANGELOG.md` `[Unreleased]` Changed entry alongside a source ACK. See `ROADMAP.md` Now/Next/Later for the live stability context behind these gates.
+Default bundled-rulepack tokenization is a contract surface. The no-policy baselines for bundled outputs live in `crates/xtask/snapshots/`, and intentional drift requires a `[bundle-tokenization-drift]` `CHANGELOG.md` `[Unreleased]` Changed entry alongside a source ACK.
 
 #### Audit Query and Export
 

--- a/docs/architecture/safety-nets.md
+++ b/docs/architecture/safety-nets.md
@@ -414,5 +414,5 @@ Cross-references:
   safety-net feature gates on `gaze`, `gaze-recognizers`, and `gaze-cli`.
 - [`docs/architecture/xtask.md`](xtask.md) — `safety-net-sanity` and
   `class-map-override-safety` gates.
-- [`docs/research/gaze-first-principles-vision.md`](../research/gaze-first-principles-vision.md) —
+- [`AGENTS.md`](../../AGENTS.md#project-north-star) —
   the five-axis north star that the safety-net contract is checked against.


### PR DESCRIPTION
## Summary
Three markdown files pointed at deleted docs. Replaced or removed.

## Broken refs found
- \`docs/research/gaze-first-principles-vision.md\` — deleted in PR #133 (pre-OSS hardening).
  Referenced from README.md (×2), AGENTS.md, docs/architecture/safety-nets.md.
- \`ROADMAP.md\` — deleted earlier (pre-this-session).
  Referenced from README.md (×2 — one inline, one section).

## Changes
- README.md: 2 north-star refs → \`AGENTS.md#project-north-star\`; drop "ROADMAP.md Now/Next/Later" sentence inline; remove the "## Roadmap" section that pointed at deleted ROADMAP.md
- AGENTS.md: self-reference to gaze-first-principles-vision.md → inline summary of the apply-rule (the content was already implicit in the section above)
- docs/architecture/safety-nets.md: north-star ref → \`AGENTS.md#project-north-star\`

## Out of scope
Source files \`crates/gaze-cli/src/{error,logger,main}.rs\` and \`crates/gaze/src/session.rs\` still reference \`ROADMAP.md\` — tracked in todo #629 (Deferred PR #133 audit follow-up: remove stale ROADMAP.md references).

## Test plan
- [x] \`grep -rln 'gaze-first-principles-vision\\|ROADMAP\\.md' --include='*.md'\` returns nothing
- [ ] Docs CI workflow runs green on this PR