### PR TITLE
chore: audit MED follow-ups (dead code + wildcards)

### DIFF
--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -380,29 +380,6 @@ pub enum LeakKind {
     },
 }
 
-/// Stable tag for leak-kind aggregation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
-pub enum LeakKindTag {
-    /// `LeakKind::Uncovered`.
-    Uncovered,
-    /// `LeakKind::PartialBleed`.
-    PartialBleed,
-    /// `LeakKind::ClassMismatch`.
-    ClassMismatch,
-}
-
-impl LeakKind {
-    /// Returns the stable aggregation tag.
-    pub fn tag(&self) -> LeakKindTag {
-        match self {
-            Self::Uncovered => LeakKindTag::Uncovered,
-            Self::PartialBleed { .. } => LeakKindTag::PartialBleed,
-            Self::ClassMismatch { .. } => LeakKindTag::ClassMismatch,
-        }
-    }
-}
-
 /// Bytes-free telemetry emitted by safety-net orchestration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 [features]
 default = ["bundled-recognizers"]
 bundled-recognizers = ["dep:gaze-recognizers"]
-safety-net = []
+safety-net = ["gaze-recognizers/safety-net"]
 
 [dependencies]
 anyhow = "1"

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -27,9 +27,9 @@ pub use dictionaries::{
     DictionaryLoadError, DictionarySource, DictionaryStats, RulepackDict,
 };
 pub use gaze_types::{
-    EmittedTokenSpan, LeakKind, LeakKindTag, LeakReport, LeakReportStats, LeakReportTelemetry,
-    LeakSuspect, Manifest, OpenAiPrivateLabel, RedactionLogError, RedactionLogger, SafetyNet,
-    SafetyNetContext, SafetyNetError, SafetyNetPiiClass,
+    EmittedTokenSpan, LeakKind, LeakReport, LeakReportStats, LeakReportTelemetry, LeakSuspect,
+    Manifest, OpenAiPrivateLabel, RedactionLogError, RedactionLogger, SafetyNet, SafetyNetContext,
+    SafetyNetError, SafetyNetPiiClass,
 };
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{Error, Pipeline, PipelineBuilder, Result};

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -883,10 +883,7 @@ mod tests {
     #[test]
     fn generalize_token_custom_class_preserves_identity() {
         // Regression guard: custom classes must not collapse to an indistinct [PII].
-        assert_eq!(
-            generalize_token(&PiiClass::Custom("foo".into())),
-            "[FOO]"
-        );
+        assert_eq!(generalize_token(&PiiClass::Custom("foo".into())), "[FOO]");
     }
 
     #[test]

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -881,6 +881,15 @@ mod tests {
     }
 
     #[test]
+    fn generalize_token_custom_class_preserves_identity() {
+        // Regression guard: custom classes must not collapse to an indistinct [PII].
+        assert_eq!(
+            generalize_token(&PiiClass::Custom("foo".into())),
+            "[FOO]"
+        );
+    }
+
+    #[test]
     fn stacked_ner_detectors_resolve_via_span_conflict() {
         // Input: "Alice Smith works here" — byte spans: Alice=0..5, full name=0..11.
         let text = "Alice Smith works here";


### PR DESCRIPTION
## Summary

Three MEDIUM follow-ups from scratchpad 1386 (audit since v0.6.4):

- MED-7: drop unused `LeakKindTag` / `LeakKind::tag()` (axis: adopter ergonomics)
- MED-6: wire the dead `safety-net` Cargo feature to `gaze-recognizers/safety-net` (axis: adopter ergonomics)
- MED-1: preserve class identity in `generalize_token` wildcard (axis: trust)

North-star fit:
- Trust (axis 4): custom `PiiClass` generalization is now covered by a regression test so class identity cannot drift into indistinguishable `[PII]` output.
- Adopter ergonomics (axis 5): public surface stays honest — no orphan re-exports, no lying feature flag.

Note: MED-1 audit text expected a wildcard arm, but current `main` already had an explicit `PiiClass::Custom(name)` arm and `PiiClass` is not `#[non_exhaustive]`. This PR keeps scope mechanical by adding the requested invariant test for `Custom("foo") -> [FOO]`.

## Test plan
- [x] cargo build --workspace --all-features
- [x] cargo test --workspace --all-features
- [x] cargo build -p gaze-pii --features safety-net
- [x] cargo build -p gaze-pii --no-default-features
- [x] cargo run -p xtask -- safety-net-sanity
- [x] cargo run -p xtask -- cargo-metadata-audit-isolation
- [x] new unit test in pipeline.rs covering generalize_token custom-class identity

Source: scratchpad 1386 §MEDIUM, MED-1 / MED-6 / MED-7.