### PR TITLE
docs: stale-ref cleanup + SHA256SUMS clarity (audit MED-4, MED-5, todo #629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Required files:
 - `tokenizer.json`
 - `config.json`
 - `labels.json`
-- `SHA256SUMS`
+- `SHA256SUMS.ner` release artifact, installed locally by the fetch script as `SHA256SUMS`
 
 See [crates/gaze/testdata/ner/README.md](crates/gaze/testdata/ner/README.md) and [docs/research/ner-library-evaluation.md](docs/research/ner-library-evaluation.md).
 

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 /// Structured CLI error. Each variant maps to an exit code; only the variant
 /// name reaches stderr so raw input or plaintext blob entries never leak into
-/// caller logs (see `ROADMAP.md` for roadmap context).
+/// caller logs.
 #[derive(Debug)]
 pub(crate) enum CliError {
     StdinParse,

--- a/crates/gaze-cli/src/logger.rs
+++ b/crates/gaze-cli/src/logger.rs
@@ -1,7 +1,7 @@
 /// Install a panic hook that prints a sanitized error line and exits 3.
 /// Without this, a panic in `ort`, `regex`, or any other dep would leak a raw
-/// backtrace to stderr whenever `RUST_BACKTRACE` is set — violating the
-/// stderr discipline captured in `ROADMAP.md`.
+/// backtrace to stderr whenever `RUST_BACKTRACE` is set, violating the CLI
+/// stderr discipline.
 pub(crate) fn install_panic_hook() {
     std::panic::set_hook(Box::new(|_info| {
         eprintln!(r#"{{"error":"Pipeline","exit":3}}"#);

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -2,8 +2,7 @@
 
 //! Gaze CLI — pipe-mode `clean` / `restore` for LLM-facing integrations.
 //!
-//! See `ROADMAP.md` for consolidated roadmap context and host-side
-//! integration history.
+//! See the changelog for shipped integration history.
 
 use std::process::ExitCode;
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -288,7 +288,7 @@ impl Session {
     ///
     /// Intended for restore-side callers that need to build an exact-literal
     /// alternation regex over the session map (Pass 1 of the two-pass restore
-    /// strategy documented in `ROADMAP.md`): replacing token-shaped strings via
+    /// strategy): replacing token-shaped strings via
     /// a class-shape regex alone is unsafe because it either (a) straddles
     /// word boundaries into adjacent text, or (b) misses lowercase
     /// FormatPreserve shapes like `location_1`. Feeding these exact strings


### PR DESCRIPTION
## Summary

- MED-4: drop stale ROADMAP.md doc-comment refs from 4+ shipped sources (per scratchpad 1386 §MEDIUM).
- MED-5: clarify README SHA256SUMS.ner artifact name vs on-disk SHA256SUMS rename (per scratchpad 1386 §MEDIUM).
- Closes solo todo #629 (carried over from PR #133 audit).

North-star fit:
- Trust (axis 4): doc surface stops referencing a deleted file — adopters reading the published crate on docs.rs no longer hit dead intra-doc refs.
- Adopter ergonomics (axis 5): release-artifact name in README matches reality.

## Test plan
- [x] cargo build --workspace --all-features (no source-behavior change; sanity)
- [x] cargo doc -p gaze-pii --no-deps (rendered without broken intra-doc warnings)
- [x] manual rg ROADMAP.md across crates + README — zero hits

Source: scratchpad 1386 §MEDIUM (MED-4 / MED-5), todo #629.
