### PR TITLE
fix: default-Tokenize + RecognizerError passthrough (audit MED-2, MED-3)

### DIFF
--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -136,6 +136,8 @@ fn class_rules_from_rulepacks(rulepacks: &[Rulepack]) -> Vec<RuleSpec> {
         .flat_map(|rulepack| rulepack.recognizers.iter())
         .filter(|recognizer| recognizer.enabled)
     {
+        // note: MED-3 investigated 2026-05-08; loaded rulepack recognizer classes,
+        // including core-extended custom classes, receive explicit Tokenize rules here.
         if seen.insert(recognizer.class.clone()) {
             rules.push(RuleSpec::Class {
                 class: recognizer.class.clone(),

--- a/crates/gaze-assembly/src/error.rs
+++ b/crates/gaze-assembly/src/error.rs
@@ -15,8 +15,8 @@ pub enum BuildError {
         recognizer_id: String,
         bucket: String,
     },
-    #[error("unknown recognizer error variant: {variant}")]
-    UnknownRecognizerError { variant: String },
+    #[error("recognizer error: {0}")]
+    Recognizer(gaze_recognizers::RecognizerError),
 }
 
 impl From<gaze_recognizers::RecognizerError> for BuildError {
@@ -25,15 +25,7 @@ impl From<gaze_recognizers::RecognizerError> for BuildError {
             gaze_recognizers::RecognizerError::InvalidRegex(err) => {
                 Self::Pipeline(gaze::Error::InvalidRegex(err))
             }
-            gaze_recognizers::RecognizerError::UnsupportedValidator { kind } => {
-                Self::Rulepack(gaze::RulepackError::UnsupportedValidator { kind })
-            }
-            gaze_recognizers::RecognizerError::UnsupportedNormalizer { kind } => {
-                Self::Rulepack(gaze::RulepackError::UnsupportedNormalizer { kind })
-            }
-            _ => Self::UnknownRecognizerError {
-                variant: format!("{:?}", err),
-            },
+            err => Self::Recognizer(err),
         }
     }
 }

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -6,7 +6,8 @@ use gaze::{
     SessionPolicy,
 };
 use gaze_recognizers::{
-    AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape, RegexDetector,
+    AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape, RecognizerError,
+    RegexDetector,
 };
 use std::sync::{Arc, Mutex};
 
@@ -329,6 +330,20 @@ fn unknown_bundled_rulepack_fails_closed() {
         BuildError::Policy(PolicyError::BundledRulepackUnknown { value })
             if value == "missing-core-addon"
     ));
+}
+
+#[test]
+fn recognizer_error_passthrough_preserves_non_matcher_variant() {
+    let err = BuildError::from(RecognizerError::UnsupportedValidator {
+        kind: "future_model_loader".to_string(),
+    });
+
+    match err {
+        BuildError::Recognizer(RecognizerError::UnsupportedValidator { kind }) => {
+            assert_eq!(kind, "future_model_loader");
+        }
+        other => panic!("expected recognizer passthrough, got {other:?}"),
+    }
 }
 
 #[derive(Clone, Default)]

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -55,8 +55,8 @@ pub(crate) fn build_pipeline_from_policy(
         gaze_assembly::BuildError::UnknownLocaleBucket { bucket, .. } => {
             map_policy_error(PolicyError::UnknownLocaleBucket { name: bucket })
         }
-        gaze_assembly::BuildError::UnknownRecognizerError { variant } => {
-            CliError::PolicyConfigDetail(format!("unknown recognizer error variant: {variant}"))
+        gaze_assembly::BuildError::Recognizer(err) => {
+            CliError::PolicyConfigDetail(format!("recognizer error: {err}"))
         }
     })
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2670,7 +2670,11 @@ fn rulepack_rejects_unknown_validator_kind() {
     assert_eq!(out.status.code(), Some(2));
     assert_eq!(
         parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
+        json!({
+            "error": "PolicyConfig",
+            "exit": 2,
+            "detail": "recognizer error: unsupported validator: iban_modxx"
+        })
     );
 }
 
@@ -2689,7 +2693,11 @@ fn rulepack_rejects_unknown_normalizer_kind() {
     assert_eq!(out.status.code(), Some(2));
     assert_eq!(
         parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
+        json!({
+            "error": "PolicyConfig",
+            "exit": 2,
+            "detail": "recognizer error: unsupported normalizer: iban_canonicalx"
+        })
     );
 }
 
@@ -2708,7 +2716,11 @@ fn rulepack_rejects_typo_validator_kind() {
     assert_eq!(out.status.code(), Some(2));
     assert_eq!(
         parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
+        json!({
+            "error": "PolicyConfig",
+            "exit": 2,
+            "detail": "recognizer error: unsupported validator: email_rfx"
+        })
     );
 }
 


### PR DESCRIPTION
## Summary
- MED-3 investigation verdict: false-positive on current CorePipelineConfig; loaded rulepack recognizer classes are converted into explicit RuleSpec::Class Tokenize rules before the default Preserve fallback is appended.
- Added a code note documenting the MED-3 investigation in crates/gaze-assembly/src/defaults.rs.
- Fixed MED-2 by replacing lossy UnknownRecognizerError string bucketing with typed BuildError::Recognizer(RecognizerError) passthrough for non-regex recognizer errors.
- Updated CLI mapping/tests so surfaced policy errors include the underlying recognizer message.

## North-star fit
- A1 Reliability: MED-3 verified no current pass-through leak for core-extended recognizer classes under the low-friction assembly path.
- A4 Trust: MED-2 now preserves typed recognizer diagnostics instead of collapsing future/non-matcher variants into a misleading bucket.

## Test plan
- cargo fmt --all
- cargo build --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- safety-net-sanity
- cargo run -p xtask -- cargo-metadata-audit-isolation
- cargo run -p xtask -- ci-feature-matrix

Source: scratchpad 1386 section MEDIUM.