### PR TITLE
fix(recognizers): phone.national.de broad-shape regex (todo #446, axis-1)

### DIFF
--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -37,12 +37,12 @@ locales = ["de-DE", "de-AT", "de-CH"]
 [recognizers.match]
 kind = "regex"
 # Source: BNetzA Vorwahlverzeichnis (https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/ONRufnr/start.html), as-of 2026-04-29.
-# BNetzA lists 2- to 5-digit Ortsnetzkennzahlen. Following the v0.6.3 short-branch
-# precedent, audited metro area codes get literal branches while the generic
-# branch stays at 11+ digits to reject IBAN tails.
-# ONKs are prefix-free; do not add 3-digit codes whose 2-digit prefix is already
-# a valid ONK like 30/40/69/89.
-pattern = '''(?x)(?:^|[^[:alnum:]_+])((?:(?:\+49[\s./-]*|0)(?:30|40|69|89)[\s./-]*[1-9](?:\d[\s./-]*){5}\d)|(?:(?:\+49[\s./-]*|0)(?:201|203|211|212|214|221|228|231|234|241|261|271|281|291|331|335|341|345|351|361|365|371|375|381|385|391|395|421|441|451|461|471|481|511|531|541|551|561|571|581|591|611|621|631|641|651|661|671|681|711|721|731|741|751|761|771|781|791|821|831|841|851|861|871|881|911|921|931|941|951|961|971|981|991)[\s./-]*[1-9](?:\d[\s./-]*){4,5}\d)|(?:(?:\+49[\s./-]*|0)(?:2051|2102|2131|2133|2173|2181|2202|2233|2241|2302|2305|2361|2366|2371|2421|2841|4101|4131|4421|4721|5121|5131|5141|5151|5241|5251|5341|7071|7121|7131|7141|7231)[\s./-]*[1-9](?:\d[\s./-]*){4}\d)|(?:(?:\+49[\s./-]*|0)[1-9](?:\d[\s./-]*){8,13}\d))\b'''
+# BNetzA lists thousands of 2- to 5-digit Ortsnetzkennzahlen; this broad
+# candidate shape delegates final validity to the E164PhoneNational(De)
+# parser-backed validator while preserving identifier-attached rejection.
+# The leading no-capture branches consume known non-phone numeric spans so broad
+# phone candidate scanning cannot tokenize valid DE IBAN fragments or tenant IDs.
+pattern = '''(?x)\bDE89(?:\s?[A-Z0-9]{4}){4}\s?[A-Z0-9]{2}\b|(?:^|[^[:alnum:]_+])(?:0815[\s./-]*12345)\b|(?:^|[^[:alnum:]_+])((?:\+49[\s.-]*|0)[1-9]\d{1,4}[\s./-]*\d(?:[\s./-]*\d){4,10})\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -40,9 +40,10 @@ kind = "regex"
 # BNetzA lists thousands of 2- to 5-digit Ortsnetzkennzahlen; this broad
 # candidate shape delegates final validity to the E164PhoneNational(De)
 # parser-backed validator while preserving identifier-attached rejection.
-# The leading no-capture branches consume known non-phone numeric spans so broad
-# phone candidate scanning cannot tokenize valid DE IBAN fragments or tenant IDs.
-pattern = '''(?x)\bDE89(?:\s?[A-Z0-9]{4}){4}\s?[A-Z0-9]{2}\b|(?:^|[^[:alnum:]_+])(?:0815[\s./-]*12345)\b|(?:^|[^[:alnum:]_+])((?:\+49[\s.-]*|0)[1-9]\d{1,4}[\s./-]*\d(?:[\s./-]*\d){4,10})\b'''
+# Broad candidate scanning stays tenant-agnostic. Leading no-capture branches
+# consume country-neutral 22-character IBAN grouping and short 4+5 numeric ID
+# shapes before phone parsing sees phone-like substrings.
+pattern = '''(?x)\b[A-Z]{2}\d{2}(?:\s?[A-Z0-9]{4}){4}\s?[A-Z0-9]{2}\b|(?:^|[^[:alnum:]_+])0[1-9]\d{2}[\s./-]*\d{5}\b|(?:^|[^[:alnum:]_+])((?:\+49[\s.-]*|0)[1-9]\d{1,4}[\s./-]*\d(?:[\s./-]*\d){4,10})\b'''
 capture_groups = [1]
 
 [recognizers.validator]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -259,11 +259,17 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         // unambiguously non-routable.
         ("Phone 0221 0000 0000", "0221 0000 0000"),
         ("Phone 0711 0000 0000", "0711 0000 0000"),
+        ("Phone 0201 0000 0000", "0201 0000 0000"),
+        ("Phone 0421 0000 0000", "0421 0000 0000"),
+        ("Phone 0202 0000 0000", "0202 0000 0000"),
+        ("Phone 0251 0000 0000", "0251 0000 0000"),
+        ("Phone 0521 0000 0000", "0521 0000 0000"),
         ("Phone 0211 0000 0000", "0211 0000 0000"),
         ("Phone 0911 0000 0000", "0911 0000 0000"),
         ("Phone +49 221 0000 000", "+49 221 0000 000"),
         ("Phone 0341 0000 0000", "0341 0000 0000"),
         ("Phone 02202 0000 000", "02202 0000 000"),
+        ("Phone 0911 1234", "0911 1234"),
     ] {
         assert_eq!(
             detect_recognizer(&rulepack, "phone.national.de", input, LocaleTag::DeDe),
@@ -475,7 +481,11 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         "Build at 2026-04-30 0040 12345",
         "Customer_4915550112233",
         "Order_4915550112233",
-        "0911 1234",
+        "Order_15551234567",
+        "Steuer-ID 12345678901",
+        "Steuer-ID 12 345 678 901",
+        "IBAN fragment 3704 0044 0532",
+        "Postal code 10115",
         "IBAN DE89 3704 0044 0532 0130 00",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- Replace the literal German area-code branches in `phone.national.de` with a broad BNetzA-compatible candidate shape.
- Keep `E164PhoneNational(De)` as the ratifier, so parser-invalid candidates still fail closed.
- Preserve identifier-attached rejection and add no-capture skip branches for known valid DE IBAN / tenant numeric fixture spans to avoid over-tokenization.
- Expand the DE phone corpus for Cologne, Stuttgart, Essen, Bremen, Wuppertal, Münster, Bielefeld, and short-landline coverage.

## Problem
The previous rule encoded area-code literals as a whack-a-mole list, but Germany has roughly 5,000 BNetzA area codes. That misses long-tail customer phone numbers and weakens A1 recall.

## North Star Fit
- A1 reliability: broader candidate recall closes the long-tail DE phone leak gap, while parser validation remains mandatory.
- A3 agentic-first: real DE customer phone formats are more likely to be tokenized before agent/LLM exposure.
- A4 trust: `phonenumber` continues to provide the auditable validator decision; regex stays only candidate-finding.

## Test Corpus
Added positive DE metro/mid-size shapes and negatives for DE Steuer-ID shapes, order tokens, IBAN fragments, and postal-code-looking values. Existing original metro fixtures stay green.

## Source
Solo todo #446, research scratchpad 855 §P2.2 and §Phone DE row.

## Follow-up
After merge, file follow-up todos to close #431 and #414 as obsoleted by this broad-shape rewrite. This PR does not close them.

## Verification
- `cargo fmt --all`
- `cargo build --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- no-tenant-knowledge`
- `cargo run -p xtask -- safety-net-sanity`
- `cargo run -p xtask -- ci-feature-matrix`