### PR TITLE
test: original-span-preserved invariant lock (todo #448, axis-2)

### DIFF
--- a/crates/gaze-recognizers/tests/invariants.rs
+++ b/crates/gaze-recognizers/tests/invariants.rs
@@ -1,0 +1,115 @@
+#![cfg(feature = "phone-parser")]
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, Pipeline, RawDocument, RawMatch, RecognizerSpec,
+    Rulepack, RulepackSource, Scope, Session,
+};
+use gaze_recognizers::{embedded, NormalizerKind, RegexDetector, ValidatorKind};
+use gaze_types::{LocaleTag, PiiClass};
+
+fn core_extended() -> Rulepack {
+    Rulepack::load(RulepackSource::Embedded(
+        embedded("core-extended").expect("core-extended embedded rulepack"),
+    ))
+    .expect("core-extended loads")
+}
+
+fn regex_from_spec(spec: &RecognizerSpec) -> RegexDetector {
+    let RawMatch::Regex {
+        pattern,
+        pattern_template: None,
+        capture_groups,
+    } = &spec.matcher
+    else {
+        panic!("expected plain regex recognizer {}", spec.id);
+    };
+
+    RegexDetector::with_rulepack_fields(
+        pattern.as_deref().expect("regex pattern"),
+        spec.class.clone(),
+        &spec.id,
+        spec.locales.clone(),
+        spec.scoring.base,
+        spec.scoring.priority,
+        spec.token.family.as_deref().unwrap_or("counter"),
+        capture_groups.clone(),
+        spec.context
+            .as_ref()
+            .map(|context| context.exclusions.clone())
+            .unwrap_or_default(),
+        spec.validator
+            .as_ref()
+            .map(|validator| ValidatorKind::parse(&validator.kind).expect("validator kind")),
+        spec.normalizer
+            .as_ref()
+            .map(|normalizer| NormalizerKind::parse(&normalizer.kind).expect("normalizer kind")),
+    )
+    .expect("regex detector")
+}
+
+fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
+    let mut builder = Pipeline::builder()
+        .rule(ClassRule::new(
+            PiiClass::Custom("phone".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("iban".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("credit_card".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve));
+
+    for spec in &rulepack.recognizers {
+        if spec.enabled {
+            builder = builder.recognizer(regex_from_spec(spec));
+        }
+    }
+
+    builder.build().expect("pipeline")
+}
+
+fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: LocaleTag) -> String {
+    let clean = pipeline
+        .redact_with_context(
+            session,
+            RawDocument::Text(input.to_string()),
+            &[locale, LocaleTag::Global],
+        )
+        .expect("clean");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+    text
+}
+
+fn restore_tokens(session: &Session, clean: &str) -> String {
+    gaze::token_shape::pattern()
+        .replace_all(clean, |captures: &regex::Captures<'_>| {
+            session.restore_strict(&captures[0]).expect("known token")
+        })
+        .to_string()
+}
+
+/// Locks research-855 §Rulepack > Normalization, todo #448, and audit
+/// scratchpad 862 §M1: recognizer normalizers may canonicalize validator input,
+/// but restore must preserve the original byte span byte-for-byte.
+#[test]
+fn original_span_preserved_through_normalizer_roundtrip() {
+    let rulepack = core_extended();
+    let pipeline = pipeline_from_rulepack(&rulepack);
+
+    for (input, locale) in [
+        ("IBAN: GB82 WEST 1234 5698 7654 32", LocaleTag::EnUs),
+        ("card 4242-4242-4242-4242", LocaleTag::EnUs),
+        ("phone +49 30 1234567", LocaleTag::DeDe),
+    ] {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, locale);
+        assert_ne!(clean, input, "expected tokenized output for {input}");
+        assert_eq!(restore_tokens(&session, &clean), input);
+    }
+}

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -315,6 +315,8 @@ impl Session {
         &self.audit_session_id
     }
 
+    // Original byte spans are preserved by recognizer normalizers per
+    // research-855 §Rulepack > Normalization (axis-2 invariant).
     pub fn restore_strict(&self, token: &str) -> Result<String> {
         self.value_by_token
             .get(token)

--- a/docs/recognizer-policy.md
+++ b/docs/recognizer-policy.md
@@ -1,0 +1,16 @@
+# Recognizer Policy
+
+## Original-span-preserved invariant
+
+Recognizer normalizers MUST NOT mutate the original byte span emitted to the
+manifest. Normalizers operate on the value passed to validators, checksums, and
+parsers; the original span is preserved for restore.
+
+Research-855 source line 33 is the governing rule:
+
+> "Strip spaces, dashes, and full-width variants before checksum validation; **keep original span for redaction**. Most standards define logical value first and presentation second."
+
+This is an axis-2 reversibility invariant. If a recognizer validates a
+normalized canonical value, it must still persist the exact input bytes covered
+by the match so `Session` restore can reconstruct the owner-side text
+byte-for-byte.


### PR DESCRIPTION
## Summary
- Documents the original-span-preserved invariant in docs/recognizer-policy.md with the research-855 source line 33 normalization quote.
- Adds original_span_preserved_through_normalizer_roundtrip for formatted IBAN, hyphenated card, and DE phone fixtures through Pipeline clean + Session restore.
- Adds a restore-path cross-link in Session; no recognizer behavior changed.

## Invariant
Recognizer normalizers may canonicalize values for validators, checksums, and parsers, but they must not mutate the byte span persisted to the manifest. Restore must preserve the owner-side input byte-for-byte.

## Sources
- todo #448
- research-855 §Rulepack > Normalization, source line 33
- audit scratchpad 862 §M1

## North-star fit
A2 reversibility: locks existing correct behavior so normalized validator values do not break manifest restore. A4 auditability: makes the invariant written and test-enforced.

## Test plan
- cargo fmt --all
- cargo build --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- safety-net-sanity
- cargo run -p xtask -- ci-feature-matrix