### PR TITLE
feat(recognizers): postal-collision lint at rulepack load (todo #441, axis-1)

### DIFF
--- a/crates/gaze-recognizers/embedded/core-extended.toml
+++ b/crates/gaze-recognizers/embedded/core-extended.toml
@@ -209,6 +209,12 @@ priority = 80
 
 [recognizers.token]
 
+# Postal collision warning (research-855 §Collision matrix conclusion):
+# `postal.de` and `postal.us` both accept naked five-digit numeric strings.
+# This is safe only when active locale chains keep DE and US projections apart.
+# Avoid broad chains such as [global, en-US, de-DE] for postal-only workflows.
+# Prefer a single active country locale, or split processing by locale_chain.
+# Loader lint warns or fails strict mode when this collision class can co-fire.
 [[recognizers]]
 id = "postal.de"
 class = "custom:postal_code"
@@ -226,6 +232,12 @@ priority = 70
 
 [recognizers.token]
 
+# Postal collision warning (research-855 §Collision matrix conclusion):
+# `postal.de` and `postal.us` both accept naked five-digit numeric strings.
+# This is safe only when active locale chains keep DE and US projections apart.
+# Avoid broad chains such as [global, en-US, de-DE] for postal-only workflows.
+# Prefer a single active country locale, or split processing by locale_chain.
+# Loader lint warns or fails strict mode when this collision class can co-fire.
 [[recognizers]]
 id = "postal.us"
 class = "custom:postal_code"

--- a/crates/gaze-recognizers/tests/rulepack_lint.rs
+++ b/crates/gaze-recognizers/tests/rulepack_lint.rs
@@ -44,6 +44,52 @@ pattern = '''\b\d{{5}}(-\d{{4}})?\b'''
     )
 }
 
+fn prefixed_shape_rulepack(
+    class: &str,
+    first_id: &str,
+    first_pattern: &str,
+    second_id: &str,
+    second_pattern: &str,
+    strict: bool,
+) -> String {
+    let lint = if strict {
+        "[recognizers.lint]\nstrict_locale_overlap = true\n"
+    } else {
+        ""
+    };
+    format!(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "prefixed-shape-test"
+rulepack_version = "0.6.5"
+default_locales = ["global", "de-DE", "fr-FR"]
+
+{lint}
+[[recognizers]]
+id = "{first_id}"
+class = "{class}"
+cooperates_with = ["{second_id}"]
+enabled = true
+locales = ["de-DE"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''{first_pattern}'''
+
+[[recognizers]]
+id = "{second_id}"
+class = "{class}"
+cooperates_with = ["{first_id}"]
+enabled = true
+locales = ["fr-FR"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''{second_pattern}'''
+"#
+    )
+}
+
 fn capture_rulepack_parse_logs(raw: &str) -> (Result<Rulepack, RulepackError>, Vec<String>) {
     let logs = Arc::new(Mutex::new(Vec::new()));
     let subscriber = CaptureSubscriber { logs: logs.clone() };
@@ -129,6 +175,68 @@ fn lint_strict_mode_rejects_overlap() {
             && recognizer_ids == &vec!["postal.de".to_string(), "postal.us".to_string()]
             && locale_overlap == &vec![LocaleTag::DeDe, LocaleTag::EnUs]
     ));
+}
+
+#[test]
+#[serial]
+fn lint_does_not_fire_on_same_class_different_shape_pair() {
+    let raw = prefixed_shape_rulepack(
+        "custom:postal_code",
+        "postal.de",
+        r"\bDE\d{5}\b",
+        "postal.fr",
+        r"\bFR\d{5}\b",
+        false,
+    );
+    let (result, logs) = capture_rulepack_parse_logs(&raw);
+
+    result.expect("country-prefixed shapes should not warn");
+    assert!(
+        logs.iter()
+            .all(|line| !line.contains("recognizers share class with naked-shape regex")),
+        "unexpected postal collision warning in logs: {logs:?}"
+    );
+
+    let strict_raw = prefixed_shape_rulepack(
+        "custom:postal_code",
+        "postal.de",
+        r"\bDE\d{5}\b",
+        "postal.fr",
+        r"\bFR\d{5}\b",
+        true,
+    );
+    Rulepack::parse(&strict_raw).expect("strict mode should allow prefixed shapes");
+}
+
+#[test]
+#[serial]
+fn lint_does_not_fire_on_anchored_iban_shape_pair() {
+    let raw = prefixed_shape_rulepack(
+        "custom:iban",
+        "iban.de",
+        r"\bDE\d{2}[A-Z0-9]+\b",
+        "iban.fr",
+        r"\bFR\d{2}[A-Z0-9]+\b",
+        false,
+    );
+    let (result, logs) = capture_rulepack_parse_logs(&raw);
+
+    result.expect("country-prefixed IBAN shapes should not warn");
+    assert!(
+        logs.iter()
+            .all(|line| !line.contains("recognizers share class with naked-shape regex")),
+        "unexpected IBAN collision warning in logs: {logs:?}"
+    );
+
+    let strict_raw = prefixed_shape_rulepack(
+        "custom:iban",
+        "iban.de",
+        r"\bDE\d{2}[A-Z0-9]+\b",
+        "iban.fr",
+        r"\bFR\d{2}[A-Z0-9]+\b",
+        true,
+    );
+    Rulepack::parse(&strict_raw).expect("strict mode should allow prefixed IBAN shapes");
 }
 
 #[test]

--- a/crates/gaze-recognizers/tests/rulepack_lint.rs
+++ b/crates/gaze-recognizers/tests/rulepack_lint.rs
@@ -1,0 +1,146 @@
+use std::sync::{Arc, Mutex};
+
+use gaze::{LocaleTag, PiiClass, Rulepack, RulepackError};
+use serial_test::serial;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Id, Level, Metadata, Subscriber};
+
+fn postal_collision_rulepack(default_locales: &str, strict: bool) -> String {
+    let lint = if strict {
+        "[recognizers.lint]\nstrict_locale_overlap = true\n"
+    } else {
+        ""
+    };
+    format!(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "postal-collision-test"
+rulepack_version = "0.6.5"
+default_locales = [{default_locales}]
+
+{lint}
+[[recognizers]]
+id = "postal.de"
+class = "custom:postal_code"
+cooperates_with = ["postal.us"]
+enabled = true
+locales = ["de-DE"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b\d{{5}}\b'''
+
+[[recognizers]]
+id = "postal.us"
+class = "custom:postal_code"
+cooperates_with = ["postal.de"]
+enabled = true
+locales = ["en-US"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''\b\d{{5}}(-\d{{4}})?\b'''
+"#
+    )
+}
+
+fn capture_rulepack_parse_logs(raw: &str) -> (Result<Rulepack, RulepackError>, Vec<String>) {
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = CaptureSubscriber { logs: logs.clone() };
+    let result = tracing::subscriber::with_default(subscriber, || Rulepack::parse(raw));
+    let logs = logs.lock().expect("logs").clone();
+    (result, logs)
+}
+
+#[derive(Clone)]
+struct CaptureSubscriber {
+    logs: Arc<Mutex<Vec<String>>>,
+}
+
+impl Subscriber for CaptureSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= &Level::WARN
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = CaptureVisitor::default();
+        event.record(&mut visitor);
+        self.logs.lock().expect("logs").push(format!(
+            "{} {}",
+            event.metadata().level(),
+            visitor.fields.join(" ")
+        ));
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Default)]
+struct CaptureVisitor {
+    fields: Vec<String>,
+}
+
+impl Visit for CaptureVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields.push(format!("{}={value:?}", field.name()));
+    }
+}
+
+#[test]
+#[serial]
+fn lint_warns_on_postal_collision_with_overlapping_chain() {
+    let raw = postal_collision_rulepack(r#""global", "en-US", "de-DE""#, false);
+    let (result, logs) = capture_rulepack_parse_logs(&raw);
+
+    result.expect("overlap is warn-only by default");
+    assert!(
+        logs.iter().any(|line| {
+            line.contains("recognizers share class with naked-shape regex")
+                && line.contains("postal.de")
+                && line.contains("postal.us")
+                && line.contains("Custom:postal_code")
+        }),
+        "missing postal collision warning in logs: {logs:?}"
+    );
+}
+
+#[test]
+fn lint_strict_mode_rejects_overlap() {
+    let raw = postal_collision_rulepack(r#""global", "en-US", "de-DE""#, true);
+    let err = Rulepack::parse(&raw).expect_err("strict mode must reject overlap");
+
+    assert!(matches!(
+        err,
+        RulepackError::ConflictingLocaleProjection {
+            class: PiiClass::Custom(ref class),
+            ref recognizer_ids,
+            ref locale_overlap,
+        } if class == "postal_code"
+            && recognizer_ids == &vec!["postal.de".to_string(), "postal.us".to_string()]
+            && locale_overlap == &vec![LocaleTag::DeDe, LocaleTag::EnUs]
+    ));
+}
+
+#[test]
+#[serial]
+fn lint_disjoint_locales_load_clean() {
+    let raw = postal_collision_rulepack(r#""de-DE""#, false);
+    let (result, logs) = capture_rulepack_parse_logs(&raw);
+
+    result.expect("single-locale projection should load");
+    assert!(
+        logs.iter()
+            .all(|line| !line.contains("recognizers share class with naked-shape regex")),
+        "unexpected postal collision warning in logs: {logs:?}"
+    );
+}

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -212,6 +212,14 @@ pub enum RulepackError {
         recognizer_a: String,
         recognizer_b: String,
     },
+    #[error(
+        "recognizers {recognizer_ids:?} share class {class:?} with equivalent regex shape and overlapping locale projection {locale_overlap:?}"
+    )]
+    ConflictingLocaleProjection {
+        class: PiiClass,
+        recognizer_ids: Vec<String>,
+        locale_overlap: Vec<LocaleTag>,
+    },
 }
 
 impl Rulepack {
@@ -226,8 +234,9 @@ impl Rulepack {
     }
 
     pub fn parse(raw: &str) -> Result<Rulepack, RulepackError> {
-        let raw: RawRulepack = toml::from_str(raw).map_err(RulepackError::Toml)?;
-        raw.try_into()
+        let (raw, lint) = extract_recognizer_lint_config(raw);
+        let raw: RawRulepack = toml::from_str(&raw).map_err(RulepackError::Toml)?;
+        RawRulepackWithLint { raw, lint }.try_into()
     }
 
     pub fn activated_classes(&self) -> BTreeSet<PiiClass> {
@@ -251,6 +260,17 @@ struct RawRulepack {
     locale: Option<RawLocaleData>,
     #[serde(default)]
     recognizers: Vec<RawRecognizerSpec>,
+}
+
+#[derive(Debug, Default)]
+struct RawRecognizerLintConfig {
+    strict_locale_overlap: bool,
+}
+
+#[derive(Debug)]
+struct RawRulepackWithLint {
+    raw: RawRulepack,
+    lint: RawRecognizerLintConfig,
 }
 
 #[derive(Debug, Deserialize)]
@@ -349,6 +369,19 @@ impl TryFrom<RawRulepack> for Rulepack {
     type Error = RulepackError;
 
     fn try_from(raw: RawRulepack) -> Result<Self, Self::Error> {
+        RawRulepackWithLint {
+            raw,
+            lint: RawRecognizerLintConfig::default(),
+        }
+        .try_into()
+    }
+}
+
+impl TryFrom<RawRulepackWithLint> for Rulepack {
+    type Error = RulepackError;
+
+    fn try_from(raw_with_lint: RawRulepackWithLint) -> Result<Self, Self::Error> {
+        let raw = raw_with_lint.raw;
         if !raw.schema_version.starts_with(SUPPORTED_SCHEMA_MAJOR_MINOR) {
             return Err(RulepackError::SchemaVersion {
                 found: raw.schema_version,
@@ -362,7 +395,7 @@ impl TryFrom<RawRulepack> for Rulepack {
             .into_iter()
             .map(|recognizer| parse_recognizer(recognizer, &default_locales))
             .collect::<Result<Vec<_>, _>>()?;
-        recognizer_composition_validator(&recognizers)?;
+        validate_rulepack_recognizers(&recognizers, &default_locales, &raw_with_lint.lint)?;
         let locale = raw.locale.map(LocaleData::from);
         reject_anchored_match_ellipsis_cues(&recognizers, locale.as_ref())?;
 
@@ -375,6 +408,35 @@ impl TryFrom<RawRulepack> for Rulepack {
             recognizers,
         })
     }
+}
+
+fn extract_recognizer_lint_config(raw: &str) -> (String, RawRecognizerLintConfig) {
+    let mut sanitized = String::with_capacity(raw.len());
+    let mut lint = RawRecognizerLintConfig::default();
+    let mut in_lint = false;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[recognizers.lint]" {
+            in_lint = true;
+            continue;
+        }
+        if in_lint && trimmed.starts_with('[') {
+            in_lint = false;
+        }
+        if in_lint {
+            if let Some((key, value)) = trimmed.split_once('=') {
+                if key.trim() == "strict_locale_overlap" {
+                    lint.strict_locale_overlap = value.trim().eq_ignore_ascii_case("true");
+                }
+            }
+            continue;
+        }
+        sanitized.push_str(line);
+        sanitized.push('\n');
+    }
+
+    (sanitized, lint)
 }
 
 impl From<RawLocaleData> for LocaleData {
@@ -586,6 +648,190 @@ pub fn recognizer_composition_validator(
         }
     }
     Ok(())
+}
+
+fn validate_rulepack_recognizers(
+    recognizers: &[RecognizerSpec],
+    active_locales: &[LocaleTag],
+    lint: &RawRecognizerLintConfig,
+) -> Result<(), RulepackError> {
+    recognizer_composition_validator(recognizers)?;
+    lint_locale_projection_collisions(recognizers, active_locales, lint)?;
+    lint_global_naked_patterns(recognizers);
+    Ok(())
+}
+
+fn lint_locale_projection_collisions(
+    recognizers: &[RecognizerSpec],
+    active_locales: &[LocaleTag],
+    lint: &RawRecognizerLintConfig,
+) -> Result<(), RulepackError> {
+    for (index, first) in recognizers.iter().enumerate() {
+        if !first.enabled {
+            continue;
+        }
+        let Some(first_shape) = regex_structural_shape(&first.matcher) else {
+            continue;
+        };
+        let first_projection = locale_projection(&first.locales, active_locales);
+        if first_projection.is_empty() {
+            continue;
+        }
+
+        for second in recognizers.iter().skip(index + 1) {
+            if !second.enabled || first.class != second.class {
+                continue;
+            }
+            if regex_structural_shape(&second.matcher).as_ref() != Some(&first_shape) {
+                continue;
+            }
+            let second_projection = locale_projection(&second.locales, active_locales);
+            if second_projection.is_empty() {
+                continue;
+            }
+
+            let recognizer_ids = vec![first.id.clone(), second.id.clone()];
+            let locale_overlap = merged_locale_projection(&first_projection, &second_projection);
+            if lint.strict_locale_overlap {
+                return Err(RulepackError::ConflictingLocaleProjection {
+                    class: first.class.clone(),
+                    recognizer_ids,
+                    locale_overlap,
+                });
+            }
+            tracing::warn!(
+                class = %first.class.class_name(),
+                recognizer_ids = ?recognizer_ids,
+                locale_overlap = ?locale_overlap,
+                "recognizers share class with naked-shape regex and non-disjoint locale projection"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn lint_global_naked_patterns(recognizers: &[RecognizerSpec]) {
+    for recognizer in recognizers {
+        if !recognizer.enabled || recognizer.locales != [LocaleTag::Global] {
+            continue;
+        }
+        let Some(shape) = regex_structural_shape(&recognizer.matcher) else {
+            continue;
+        };
+        let RawMatch::Regex {
+            pattern: Some(pattern),
+            ..
+        } = &recognizer.matcher
+        else {
+            continue;
+        };
+        if shape.minimum_match_len < 6 && !has_regex_separator(pattern) {
+            tracing::warn!(
+                recognizer_id = %recognizer.id,
+                class = %recognizer.class.class_name(),
+                minimum_match_len = shape.minimum_match_len,
+                "global recognizer uses short naked regex shape"
+            );
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegexStructuralShape {
+    minimum_match_len: usize,
+    character_class: RegexCharacterClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RegexCharacterClass {
+    Digit,
+}
+
+fn regex_structural_shape(matcher: &RawMatch) -> Option<RegexStructuralShape> {
+    let RawMatch::Regex {
+        pattern: Some(pattern),
+        pattern_template: None,
+        ..
+    } = matcher
+    else {
+        return None;
+    };
+    if has_unescaped_line_anchor(pattern) {
+        return None;
+    }
+    digit_quantifier_minimum(pattern).map(|minimum_match_len| RegexStructuralShape {
+        minimum_match_len,
+        character_class: RegexCharacterClass::Digit,
+    })
+}
+
+fn has_unescaped_line_anchor(pattern: &str) -> bool {
+    let mut escaped = false;
+    let mut in_class = false;
+    for ch in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '[' => in_class = true,
+            ']' => in_class = false,
+            '^' | '$' if !in_class => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+fn digit_quantifier_minimum(pattern: &str) -> Option<usize> {
+    find_digit_quantifier(pattern, r"\d{")
+        .or_else(|| find_digit_quantifier(pattern, "[0-9]{"))
+        .or_else(|| find_digit_quantifier(pattern, "[[:digit:]]{"))
+}
+
+fn find_digit_quantifier(pattern: &str, needle: &str) -> Option<usize> {
+    let start = pattern.find(needle)? + needle.len();
+    let rest = &pattern[start..];
+    let digits = rest
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+fn locale_projection(locales: &[LocaleTag], active_locales: &[LocaleTag]) -> Vec<LocaleTag> {
+    let mut projection = Vec::new();
+    for locale in locales {
+        if *locale == LocaleTag::Global {
+            projection.push(LocaleTag::Global);
+        } else if active_locales.iter().any(|active| active == locale) {
+            projection.push(locale.clone());
+        }
+    }
+    projection
+}
+
+fn merged_locale_projection(left: &[LocaleTag], right: &[LocaleTag]) -> Vec<LocaleTag> {
+    let mut merged = Vec::new();
+    for locale in left.iter().chain(right) {
+        if !merged.iter().any(|existing| existing == locale) {
+            merged.push(locale.clone());
+        }
+    }
+    merged
+}
+
+fn has_regex_separator(pattern: &str) -> bool {
+    pattern.contains('-')
+        || pattern.contains('/')
+        || pattern.contains('.')
+        || pattern.contains('+')
+        || pattern.contains("\\s")
+        || pattern.contains("[:space:]")
 }
 
 pub fn parse_class(input: &str) -> Result<PiiClass, RulepackError> {

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -673,6 +673,9 @@ fn lint_locale_projection_collisions(
         let Some(first_shape) = regex_structural_shape(&first.matcher) else {
             continue;
         };
+        if !is_truly_naked_numeric(&first.matcher) {
+            continue;
+        }
         let first_projection = locale_projection(&first.locales, active_locales);
         if first_projection.is_empty() {
             continue;
@@ -680,6 +683,9 @@ fn lint_locale_projection_collisions(
 
         for second in recognizers.iter().skip(index + 1) {
             if !second.enabled || first.class != second.class {
+                continue;
+            }
+            if !is_truly_naked_numeric(&second.matcher) {
                 continue;
             }
             if regex_structural_shape(&second.matcher).as_ref() != Some(&first_shape) {
@@ -763,6 +769,28 @@ fn regex_structural_shape(matcher: &RawMatch) -> Option<RegexStructuralShape> {
         minimum_match_len,
         character_class: RegexCharacterClass::Digit,
     })
+}
+
+fn is_truly_naked_numeric(matcher: &RawMatch) -> bool {
+    let RawMatch::Regex {
+        pattern: Some(pattern),
+        ..
+    } = matcher
+    else {
+        return false;
+    };
+
+    let mut chars = pattern.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            chars.next();
+            continue;
+        }
+        if ch.is_ascii_alphabetic() {
+            return false;
+        }
+    }
+    true
 }
 
 fn has_unescaped_line_anchor(pattern: &str) -> bool {


### PR DESCRIPTION
## Problem

core-extended ships postal.de and postal.us as locale-scoped postal recognizers, but both include a naked 5-digit numeric shape. Under a broad locale chain, a token like 10115 or 94103 can be eligible for both recognizers with no load-time signal.

## Scope

- Added 6-line warning comments above postal.de and postal.us in core-extended.toml, citing research-855 Collision matrix conclusion and recommending narrower locale_chain posture.
- Added rulepack-load lint for same-class, structurally equivalent regex shapes that can co-fire under the rulepack locale projection. Default behavior logs WARN with class, recognizer ids, and projected locales.
- Added strict mode via [recognizers.lint] strict_locale_overlap = true, failing closed with RulepackError::ConflictingLocaleProjection.
- Added short global naked-pattern WARN lint for global recognizers with min-match < 6 and no separators.

## North-star fit

- A1 reliability: makes postal double-detect risk loud by default and fail-closed when strict mode is enabled.
- A4 trust: collision is visible at rulepack load with typed strict error and explicit recognizer ids.
- A5 adopter ergonomics: diagnoses broad-locale foot-gun before runtime behavior surprises adopters.

No postal.de or postal.us regex behavior changed.

## Test plan

- cargo fmt --all
- cargo build --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- safety-net-sanity
- cargo run -p xtask -- ci-feature-matrix

Source: solo todo #441; research-855 §P1.2, §3, and §Collision matrix.