### PR TITLE
docs: OSS-readiness — SECURITY.md + CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at security@empiretwo.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Gaze — whether a
+PII leak, a recognizer bypass, a manifest-restore divergence, or a
+chokepoint escape — please report it privately. **Do not open a public
+GitHub issue.**
+
+Email: **security@empiretwo.dev**
+PGP: optional; request a key via the same address.
+
+We will acknowledge receipt within 72 hours and aim to provide a triage
+verdict within 7 days.
+
+## Scope
+
+In scope:
+
+- Any path through `gaze-mcp-core`, `gaze-mcp-rmcp`, the `gaze` (umbrella)
+  / `gaze-pii` runtime, `gaze-recognizers`, `gaze-cli`, or `gaze-assembly`
+  that allows PII to reach an LLM outside the manifest contract.
+- Restore-path divergences that produce different bytes than the original
+  source (manifest contract requires byte-for-byte round-trip on lossless
+  classes).
+- Audit-sink isolation bypasses (the `gaze_module_isolation` Dylint gate).
+- Recognizer fail-open regressions on the protected default,
+  `--no-default-features`, and safety-net feature graphs.
+- Tier-isolation bypasses in MCP tool dispatch (caller-tier vs tool-tier).
+
+Out of scope:
+
+- Issues only reproducible in adopter code that bypasses the documented
+  `Pipeline` / MCP `ToolCtx` chokepoints.
+- Performance-only regressions with no reliability impact.
+- Issues in `gaze-lens` (separate repo: `EmpireTwo/gaze-lens`) — please
+  report there.
+
+## Supported versions
+
+We currently support security fixes only on the latest minor of the `0.6.x`
+series and (when released) the latest minor of `0.7.x`. Earlier versions
+do not receive backports.
+
+## Coordinated disclosure
+
+For high-severity findings we follow a 90-day coordinated-disclosure
+window from the date of acknowledgment, extendable by mutual agreement.
+We will credit reporters in the security advisory and CHANGELOG unless
+they request anonymity.
+
+## Bug bounty
+
+There is no formal bug bounty program at this time.


### PR DESCRIPTION
## Summary
- Add SECURITY.md with private vulnerability reporting and supported-version policy.
- Add Contributor Covenant 2.1 CODE_OF_CONDUCT.md with security@empiretwo.dev enforcement contact.
- Update GitHub repo description to: Reversible PII pseudonymization runtime for agentic LLM workflows.

OSS-readiness prep for private-to-public repo flip.

## Test plan
review-only — no code changes