### PR TITLE
docs(readme): drop version-roadmap language from install block

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 Gaze sits between your data and the LLM. It swaps PII for stable, session-scoped tokens on the way out, and restores the originals on the way back. The agent never sees raw personal data; the data owner never loses the ability to read the agent's reply.
 
 ```sh
-# Until v0.7 publishes to crates.io, build from source:
 git clone https://github.com/EmpireTwo/gaze.git
 cd gaze
 cargo install --path crates/gaze-cli
 
-# Then run:
 echo 'Email alice@example.invalid about ORD-789012.' | gaze clean
 ```
 
@@ -57,7 +55,6 @@ Gaze takes a fourth path: deterministic, rule-based detection with a signed rest
 ## Install
 
 ```sh
-# Until v0.7 publishes to crates.io, build from source:
 git clone https://github.com/EmpireTwo/gaze.git
 cd gaze
 cargo install --path crates/gaze-cli


### PR DESCRIPTION
Docs-only cleanup from user feedback: version markers in the README install block read like roadmap planning. Install now reads as install, without asking adopters to care about internal release timing.