### PR TITLE
ci: add publish-crates.yml workflow for trusted-publisher OIDC

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,50 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (no actual publish)"
+        type: boolean
+        default: true
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write # required for OIDC trusted-publisher
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Optional: add `environment: crates-io-publish` if that environment was
+    # configured on the crates.io trusted publisher.
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate to crates.io via OIDC
+        uses: rust-lang/crates-io-auth-action@v1.0.4
+        id: cargo-auth
+
+      - name: Publish workspace crates (topological order)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
+        run: |
+          set -eux
+          DRY_RUN=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN="--dry-run"
+          fi
+
+          # Topological order, dependency crates first. The core package is
+          # published as gaze-pii while its library target remains `gaze`.
+          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-cli; do
+            echo "=== publishing $crate ==="
+            cargo publish $DRY_RUN -p "$crate" --locked
+            # Give the crates.io index time to propagate before publishing
+            # dependents. Dry-runs do not touch the index.
+            [ -z "$DRY_RUN" ] && sleep 30 || true
+          done

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ The crate is published as `gaze-pii` because the bare `gaze` name is in transfer
 - Minimal example and the API surface table: [`crates/gaze/README.md`](crates/gaze/README.md) (also rendered on [`crates.io/crates/gaze-pii`](https://crates.io/crates/gaze-pii)).
 - Full walk-through with structured documents, tenant-specific recognizers, and policy TOML: [`docs/getting-started.md`](docs/getting-started.md).
 
+## Publishing
+
+The workspace publishes via the `publish-crates.yml` GitHub Actions workflow using crates.io trusted-publisher OIDC auth; it does not need a long-lived `CARGO_REGISTRY_TOKEN` secret.
+
+- **Tag push** (`git tag v<version> && git push --tags`) runs a real publish on every workspace crate in topological order.
+- **Manual dispatch** with `dry_run=true` packages each crate without publishing, useful for catching metadata or dependency issues before a release tag.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Repository gates (xtask + Dylint) enforce the contracts in [`docs/architecture/`](docs/architecture/). Run them locally before pushing:


### PR DESCRIPTION
## Summary
- Add .github/workflows/publish-crates.yml for the crates.io trusted publisher configured for EmpireTwo/gaze.
- Authenticate cargo publish through rust-lang/crates-io-auth-action using GitHub OIDC, with no long-lived CARGO_REGISTRY_TOKEN secret.
- Publish real workspace crates only in dependency order: gaze-types, gaze-audit, gaze-recognizers, gaze-pii, gaze-assembly, gaze-cli.
- Document tag-push and manual dry-run trigger paths in README.

## Test plan
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-crates.yml"); puts "yaml ok"'\n- git diff --check\n- Manual post-merge check: run workflow_dispatch with dry_run=true on the merged commit.\n\nNote: actionlint is not installed in this worktree, so local actionlint was skipped.