### PR TITLE
chore: bump workspace to 0.6.5 (docs+CI release)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -29,11 +29,11 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1.0.4
         id: cargo-auth
 
-      - name: Publish workspace crates (topological order)
+      - name: Publish workspace crates (topological order, skip already-published)
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
         run: |
-          set -eux
+          set -eu
           DRY_RUN=""
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
             DRY_RUN="--dry-run"
@@ -43,7 +43,17 @@ jobs:
           # published as gaze-pii while its library target remains `gaze`.
           for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-cli; do
             echo "=== publishing $crate ==="
-            cargo publish $DRY_RUN -p "$crate" --locked
+            rc=0
+            out=$(cargo publish $DRY_RUN -p "$crate" --locked 2>&1) || rc=$? && rc=${rc:-0}
+            echo "$out"
+            if [ "$rc" -ne 0 ]; then
+              if echo "$out" | grep -qiE "crate version .* is already uploaded|already exists|version .* has already been published"; then
+                echo "  [warn] $crate already on crates.io at this version; skipping (not a failure)"
+              else
+                echo "  [error] $crate publish failed (exit $rc), aborting"
+                exit "$rc"
+              fi
+            fi
             # Give the crates.io index time to propagate before publishing
             # dependents. Dry-runs do not touch the index.
             [ -z "$DRY_RUN" ] && sleep 30 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.6.5] - 2026-05-09
+
+### Added
+
+- `SECURITY.md` — vulnerability disclosure policy with scoped in/out-of-scope
+  criteria for the chokepoint runtime, audit-sink isolation, and recognizer
+  fail-open regressions.
+- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1.
+- `.github/workflows/publish-crates.yml` — crates.io trusted-publisher OIDC
+  workflow, with no long-lived token, for workspace publishes on tag push or
+  manual dry-run dispatch.
+- README badges for crates.io, license, docs.rs, CI, and GitHub stars, plus an
+  "Available on crates.io" section listing all published workspace crate names.
+- Placeholder publishes on crates.io at 0.6.5 for `gaze-pii`, `gaze-types`,
+  `gaze-audit`, `gaze-recognizers`, `gaze-assembly`, `gaze-cli`,
+  `gaze-mcp-core`, and `gaze-mcp-rmcp` to reserve namespace ahead of the v0.7
+  real publish. Each placeholder mirrors the canonical project README and
+  declares the same internal dependency topology the real workspace will
+  publish.
+
+### Changed
+
+- README rewrite: tighter lede, copy-paste build-from-source install snippet
+  until v0.7, token format example matched to runtime output, license section,
+  and no v0.7 roadmap language in install instructions.
+- Repo description changed from "GDPR-compliant debugging proxy between AI
+  agents and production data" to "Reversible PII pseudonymization runtime for
+  agentic LLM workflows."
+- Adopter attribution in CHANGELOG and the `gaze-recognizers` NER module docs
+  now uses neutral "an adopter" phrasing instead of named individuals.
+- Repository visibility changed from private to public.
+
+### Notes
+
+- No code changes in this release. Detection contracts, audit-sink isolation,
+  and recognizer behavior are identical to v0.6.4. Adopters pinned to `^0.6.4`
+  resolve to v0.6.5 with no behavioral diff.
+- v0.7.0 is the next functional release; it introduces `gaze-mcp-core`
+  (chokepoint runtime) and `gaze-mcp-rmcp` (rmcp transport adapter) as full
+  implementations.
+
 ## [0.6.4] - 2026-04-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.6.4" }
-gaze-types = { path = "crates/gaze-types", version = "0.6.4" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.6.5" }
+gaze-types = { path = "crates/gaze-types", version = "0.6.5" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Gaze
 
+[![Crates.io](https://img.shields.io/crates/v/gaze-pii.svg)](https://crates.io/crates/gaze-pii) [![License](https://img.shields.io/crates/l/gaze-pii.svg)](https://github.com/EmpireTwo/gaze#license) [![docs.rs](https://docs.rs/gaze-pii/badge.svg)](https://docs.rs/gaze-pii) [![CI](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml/badge.svg)](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml) [![GitHub stars](https://img.shields.io/github/stars/EmpireTwo/gaze?style=social)](https://github.com/EmpireTwo/gaze/stargazers)
+
 **Reversible PII pseudonymization for agentic LLM workflows.**
 
 Gaze sits between your data and the LLM. It swaps PII for stable, session-scoped tokens on the way out, and restores the originals on the way back. The agent never sees raw personal data; the data owner never loses the ability to read the agent's reply.
-
-[![Crates.io](https://img.shields.io/crates/v/gaze-pii.svg)](https://crates.io/crates/gaze-pii) [![License](https://img.shields.io/crates/l/gaze-pii.svg)](https://github.com/EmpireTwo/gaze#license) [![docs.rs](https://docs.rs/gaze-pii/badge.svg)](https://docs.rs/gaze-pii) [![CI](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml/badge.svg)](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml) [![GitHub stars](https://img.shields.io/github/stars/EmpireTwo/gaze?style=social)](https://github.com/EmpireTwo/gaze/stargazers)
 
 ```sh
 git clone https://github.com/EmpireTwo/gaze.git

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The audit DB is opened read-only by `query` and `export`. The exported column se
 
 ## Status
 
-- **Version:** v0.6.4 (2026-05).
+- **Version:** v0.6.5 (2026-05).
 - **MSRV:** Rust 1.89.
 - **License:** dual `Apache-2.0 OR MIT`.
 - **crates.io:** published as `gaze-pii`. The bare `gaze` name is in transfer; until that completes, depend on `gaze-pii`. Source-compat is preserved via `[lib].name = "gaze"`.

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.6.4", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.4" }
+gaze = { path = "../gaze", version = "0.6.5", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -1,6 +1,12 @@
 # gaze-assembly
 
-Policy-to-pipeline assembly for Gaze.
+[![Crates.io](https://img.shields.io/crates/v/gaze-assembly.svg)](https://crates.io/crates/gaze-assembly)
+[![docs.rs](https://docs.rs/gaze-assembly/badge.svg)](https://docs.rs/gaze-assembly)
+[![License](https://img.shields.io/crates/l/gaze-assembly.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Policy-to-pipeline assembly for Gaze
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 This crate joins the core `gaze` policy model with the built-in recognizers
 from `gaze-recognizers`. It exists to keep the dependency direction clean:
@@ -16,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.6.4"
-gaze-assembly = "0.6.4"
-gaze-recognizers = "0.6.4"
+gaze-pii = "0.6.5"
+gaze-assembly = "0.6.5"
+gaze-recognizers = "0.6.5"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -1,6 +1,12 @@
 # gaze-audit
 
-Audit sink for the [gaze-pii](https://crates.io/crates/gaze-pii) PII pseudonymization runtime.
+[![Crates.io](https://img.shields.io/crates/v/gaze-audit.svg)](https://crates.io/crates/gaze-audit)
+[![docs.rs](https://docs.rs/gaze-audit/badge.svg)](https://docs.rs/gaze-audit)
+[![License](https://img.shields.io/crates/l/gaze-audit.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Passive audit sinks for Gaze metadata-only redaction logs
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 Provides `SqliteLogger` - the concrete `RedactionLogger` implementation that writes
 session-scoped redaction metadata to a local SQLite database. The audit log is

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,10 +27,10 @@ path = "src/main.rs"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
-gaze = { path = "../gaze", version = "0.6.4", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.6.4" }
+gaze = { path = "../gaze", version = "0.6.5", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.6.5" }
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.4" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -40,7 +40,7 @@ tracing = "0.1"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.4", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -1,6 +1,12 @@
 # gaze-cli
 
-Command-line interface for Gaze.
+[![Crates.io](https://img.shields.io/crates/v/gaze-cli.svg)](https://crates.io/crates/gaze-cli)
+[![docs.rs](https://docs.rs/gaze-cli/badge.svg)](https://docs.rs/gaze-cli)
+[![License](https://img.shields.io/crates/l/gaze-cli.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Gaze command-line interface
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 This crate publishes the `gaze` binary. It is the process boundary used by
 shell integrations and language adapters that should not link the Rust library

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -1,6 +1,12 @@
 # gaze-recognizers
 
-Built-in recognizer backends and bundled rulepacks for Gaze.
+[![Crates.io](https://img.shields.io/crates/v/gaze-recognizers.svg)](https://crates.io/crates/gaze-recognizers)
+[![docs.rs](https://docs.rs/gaze-recognizers/badge.svg)](https://docs.rs/gaze-recognizers)
+[![License](https://img.shields.io/crates/l/gaze-recognizers.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Built-in recognizers for Gaze
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 This crate depends on `gaze` and implements concrete `gaze::Recognizer`
 backends. Keeping it separate lets the core crate expose a small, stable
@@ -11,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.6.4"
-gaze-recognizers = "0.6.4"
+gaze-pii = "0.6.5"
+gaze-recognizers = "0.6.5"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -20,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.6.4", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.6.5", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -1,6 +1,12 @@
 # gaze-types
 
-Shared value contracts for the [gaze-pii](https://crates.io/crates/gaze-pii) PII pseudonymization runtime.
+[![Crates.io](https://img.shields.io/crates/v/gaze-types.svg)](https://crates.io/crates/gaze-types)
+[![docs.rs](https://docs.rs/gaze-types/badge.svg)](https://docs.rs/gaze-types)
+[![License](https://img.shields.io/crates/l/gaze-types.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Shared value contracts for Gaze
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 Serde-only — no ML, no SQLite, no ONNX. This crate exists so that:
 - Restore-side adapters can take `gaze-types` without pulling in `ort` / `tokenizers` / `ndarray`

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.4", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -1,6 +1,12 @@
 # gaze-pii
 
-**Reversible PII pseudonymization for agentic LLM workflows.**
+[![Crates.io](https://img.shields.io/crates/v/gaze-pii.svg)](https://crates.io/crates/gaze-pii)
+[![docs.rs](https://docs.rs/gaze-pii/badge.svg)](https://docs.rs/gaze-pii)
+[![License](https://img.shields.io/crates/l/gaze-pii.svg)](https://github.com/EmpireTwo/gaze#license)
+
+Reversible PII pseudonymization runtime for agentic workflows
+
+Part of the [Gaze](https://github.com/EmpireTwo/gaze) workspace — a reversible PII pseudonymization runtime for agentic LLM workflows.
 
 `gaze-pii` is the runtime crate for [Gaze](https://github.com/EmpireTwo/gaze). It owns the contracts that must stay stable for adopters: `Pipeline`, `Session`, `Policy`, `RecognizerRegistry`, the rulepack schema, token shape, and the signed restore manifest.
 


### PR DESCRIPTION
## Why
Align GitHub with crates.io. Placeholder crates landed at 0.6.5, while the repo was still at 0.6.4.

## What ships
- Bumps workspace crate manifests and lockfile to 0.6.5.
- Adds CHANGELOG 0.6.5 docs+CI release entry.
- Moves root README badges directly under the H1.
- Adds per-crate crates.io/docs.rs/license badges.
- Hardens publish-crates.yml to skip already-published versions and abort on real publish errors.

No code changes. Detection contracts, audit-sink isolation, and recognizer behavior match v0.6.4.

## Test plan
- cargo fmt --all -- --check
- cargo build --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo run -p xtask -- ci-feature-matrix

## Notes
- publish-crates.yml now tolerates placeholder collisions on crates.io.
- Do not tag v0.6.5. A v0.6.5 tag would trigger publish-crates.yml against already-published placeholder versions.
