### PR TITLE
ci: add test workflow + swap docs-workflow badge for test badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      - name: cargo test
+        run: cargo test --workspace --all-features --no-fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.github/workflows/publish-crates.yml` — crates.io trusted-publisher OIDC
   workflow, with no long-lived token, for workspace publishes on tag push or
   manual dry-run dispatch.
-- README badges for crates.io, license, docs.rs, CI, and GitHub stars, plus an
+- README badges for crates.io, license, docs.rs, tests, and GitHub stars, plus an
   "Available on crates.io" section listing all published workspace crate names.
+- `.github/workflows/test.yml` — fmt + clippy + workspace test suite on PRs
+  and main push.
 - Placeholder publishes on crates.io at 0.6.5 for `gaze-pii`, `gaze-types`,
   `gaze-audit`, `gaze-recognizers`, `gaze-assembly`, `gaze-cli`,
   `gaze-mcp-core`, and `gaze-mcp-rmcp` to reserve namespace ahead of the v0.7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gaze
 
-[![Crates.io](https://img.shields.io/crates/v/gaze-pii.svg)](https://crates.io/crates/gaze-pii) [![License](https://img.shields.io/crates/l/gaze-pii.svg)](https://github.com/EmpireTwo/gaze#license) [![docs.rs](https://docs.rs/gaze-pii/badge.svg)](https://docs.rs/gaze-pii) [![CI](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml/badge.svg)](https://github.com/EmpireTwo/gaze/actions/workflows/docs.yml) [![GitHub stars](https://img.shields.io/github/stars/EmpireTwo/gaze?style=social)](https://github.com/EmpireTwo/gaze/stargazers)
+[![Crates.io](https://img.shields.io/crates/v/gaze-pii.svg)](https://crates.io/crates/gaze-pii) [![License](https://img.shields.io/crates/l/gaze-pii.svg)](https://github.com/EmpireTwo/gaze#license) [![docs.rs](https://docs.rs/gaze-pii/badge.svg)](https://docs.rs/gaze-pii) [![Tests](https://github.com/EmpireTwo/gaze/actions/workflows/test.yml/badge.svg)](https://github.com/EmpireTwo/gaze/actions/workflows/test.yml) [![GitHub stars](https://img.shields.io/github/stars/EmpireTwo/gaze?style=social)](https://github.com/EmpireTwo/gaze/stargazers)
 
 **Reversible PII pseudonymization for agentic LLM workflows.**
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -590,7 +590,7 @@ fn advise_dontdump(_ptr: *const u8, _len: usize) {
         }
         let page_size = page_size as usize;
         let start = (ptr as usize) & !(page_size - 1);
-        let end = ((ptr as usize + len + page_size - 1) / page_size) * page_size;
+        let end = (ptr as usize + len).div_ceil(page_size) * page_size;
         let aligned_len = end.saturating_sub(start);
         if aligned_len == 0 {
             return;


### PR DESCRIPTION
Adds a dedicated test workflow that runs fmt, clippy, and the workspace test suite on PRs and main pushes.

Drops the redundant docs.yml workflow badge from the README and replaces it with a Tests badge for a clearer trust signal. docs.rs badge remains the adopter-facing docs signal.

No behavioral change.