### PR TITLE
chore: bump workspace to 0.6.6 (per-crate READMEs on crates.io)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -43,17 +43,27 @@ jobs:
           # published as gaze-pii while its library target remains `gaze`.
           for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-cli; do
             echo "=== publishing $crate ==="
-            rc=0
-            out=$(cargo publish $DRY_RUN -p "$crate" --locked 2>&1) || rc=$? && rc=${rc:-0}
-            echo "$out"
-            if [ "$rc" -ne 0 ]; then
+            attempt=1
+            while true; do
+              rc=0
+              out=$(cargo publish $DRY_RUN -p "$crate" --locked 2>&1) || rc=$? && rc=${rc:-0}
+              echo "$out"
+              if [ "$rc" -eq 0 ]; then
+                break
+              fi
               if echo "$out" | grep -qiE "crate version .* is already uploaded|already exists|version .* has already been published"; then
                 echo "  [warn] $crate already on crates.io at this version; skipping (not a failure)"
+                break
+              fi
+              if [ -z "$DRY_RUN" ] && [ "$attempt" -lt 10 ] && echo "$out" | grep -qiE "failed to select a version|could not find .* in registry|no matching package named"; then
+                echo "  [warn] crates.io index not ready for $crate dependencies; retrying in 30s ($attempt/10)"
+                attempt=$((attempt + 1))
+                sleep 30
               else
                 echo "  [error] $crate publish failed (exit $rc), aborting"
                 exit "$rc"
               fi
-            fi
+            done
             # Give the crates.io index time to propagate before publishing
             # dependents. Dry-runs do not touch the index.
             [ -z "$DRY_RUN" ] && sleep 30 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.6.6] - 2026-05-09
+
+### Fixed
+
+- Each crates.io page for `gaze-pii`, `gaze-types`, `gaze-audit`, `gaze-recognizers`, `gaze-assembly`, and `gaze-cli` now renders its own per-crate README. Previously, the v0.6.5 placeholder publish mirrored the project root README to all 8 placeholder stubs, so adopters landing on `crates.io/crates/gaze-types` saw the umbrella project README instead of the gaze-types-specific content.
+
+### Changed
+
+- Real workspace crates publish to crates.io at v0.6.6 via the trusted-publisher OIDC workflow. Placeholder stubs at v0.6.5 remain as version history.
+
+### Notes
+
+- `gaze-mcp-core` and `gaze-mcp-rmcp` stay at v0.6.5 placeholder content until their feature branches merge in v0.7. The v0.7.0 release publishes both as real crates with their own per-crate READMEs.
+- No code changes vs v0.6.5. Detection contracts, audit-sink isolation, and recognizer behavior are identical.
+
 ## [0.6.5] - 2026-05-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.6.5" }
-gaze-types = { path = "crates/gaze-types", version = "0.6.5" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.6.6" }
+gaze-types = { path = "crates/gaze-types", version = "0.6.6" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.6.5", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5" }
+gaze = { path = "../gaze", version = "0.6.6", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.6" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,10 +27,10 @@ path = "src/main.rs"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
-gaze = { path = "../gaze", version = "0.6.5", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.6.5" }
+gaze = { path = "../gaze", version = "0.6.6", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.6.6" }
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.6" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -40,7 +40,7 @@ tracing = "0.1"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.6", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.5", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.6.6", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"


### PR DESCRIPTION
## Summary
- bump the six published workspace crates and internal dependency pins to 0.6.6
- add the 0.6.6 changelog entry for per-crate README rendering on crates.io
- harden publish-crates.yml with retry handling for crates.io index propagation between topological publishes

## Verification
- verified all six per-crate README.md files exist and differ from the project root README
- verified all six package file lists include README.md
- cargo publish --dry-run --allow-dirty -p gaze-types --locked
- cargo fmt --all -- --check
- cargo build --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo run -p xtask -- ci-feature-matrix

## Publish note
Dependent crate dry-runs cannot fully verify before 0.6.6 dependency crates exist on crates.io because v0.6.5 registry entries are namespace placeholders with stub APIs. The tag workflow publishes in dependency order and now retries transient registry/index resolution failures between crates.