### PR TITLE
fix(gaze-pii): default_policy fallback to Tokenize (axis-1 fail-closed) — closes #687

### DIFF
--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -147,7 +147,7 @@ fn class_rules_from_rulepacks(rulepacks: &[Rulepack]) -> Vec<RuleSpec> {
     }
 
     rules.push(RuleSpec::Default {
-        action: Action::Preserve,
+        action: Action::Tokenize,
     });
     rules
 }
@@ -157,4 +157,29 @@ fn default_policy(locale: Option<Vec<LocaleTag>>, rules: Vec<RuleSpec>) -> Polic
     policy.rules = rules;
     policy.locale = locale;
     policy
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_unseen_class_does_not_preserve() {
+        let core = Rulepack::load(RulepackSource::Embedded(
+            gaze_recognizers::embedded(CORE_BUNDLED_RULEPACK).expect("core rulepack"),
+        ))
+        .expect("core loads");
+        let policy = default_policy(None, class_rules_from_rulepacks(&[core]));
+        let default_action = policy
+            .rules
+            .iter()
+            .find_map(|rule| match rule {
+                RuleSpec::Default { action } => Some(*action),
+                _ => None,
+            })
+            .expect("default rule");
+
+        assert_eq!(default_action, Action::Tokenize);
+        assert_ne!(default_action, Action::Preserve);
+    }
 }


### PR DESCRIPTION
## Summary
- Switch CorePipelineConfig default policy fallback from RuleSpec::Default(Preserve) to RuleSpec::Default(Tokenize).
- Add regression coverage for default_policy_unseen_class_does_not_preserve.
- Keep bundled core and core-extended recognizer classes explicitly tokenized; explicit adopter Preserve rules still require opt-in policy config.

## Axis-1 rationale
Before this change, an unseen detected class could fall through the assembly default as Preserve, silently passing original PII through. That violates the north-star reliability axis: unknown or future PII classes must not leak by default.

After this change, the default assembly fallback tokenizes unmatched classes, preserving reversibility while avoiding silent pass-through.

## Gates
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features