### PR TITLE
feat(v0.7.0-prep): snapshot-binding fix + audit metadata columns

### DIFF
--- a/crates/gaze-audit/src/lib.rs
+++ b/crates/gaze-audit/src/lib.rs
@@ -10,6 +10,7 @@ mod sqlite;
 
 pub use query::{
     build_audit_query_sql, build_safety_net_query_sql, AuditFilter, AuditLogRow, LeakSuspectRow,
-    AUDIT_RESTRICTED_COLUMNS, SAFETY_NET_RESTRICTED_COLUMNS,
+    AUDIT_RESTRICTED_COLUMNS, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
+    SAFETY_NET_RESTRICTED_COLUMNS,
 };
 pub use sqlite::{AuditError, LeakSuspectLogEntry, LeakSuspectLogger, Result, SqliteLogger};

--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -1,5 +1,8 @@
 use rusqlite::types::Value;
 
+pub const DEFAULT_SNAPSHOT_SCHEME: &str = "gaze.snapshot.v1.sha256-salted";
+pub const DEFAULT_SNAPSHOT_ALG: &str = "SHA-256";
+
 /// Query filter for [`crate::SqliteLogger::query`] and
 /// [`crate::SqliteLogger::query_safety_net`].
 ///
@@ -17,6 +20,9 @@ pub struct AuditFilter {
     pub from_epoch_ms: Option<i64>,
     pub to_epoch_ms: Option<i64>,
     pub session_id: Option<String>,
+    pub snapshot_scheme: Option<String>,
+    pub snapshot_alg: Option<String>,
+    pub snapshot_key_version: Option<i64>,
 }
 
 /// Metadata-only redaction audit row returned by [`crate::SqliteLogger::query`].
@@ -35,6 +41,9 @@ pub struct AuditLogRow {
     pub decided_by: String,
     pub created_at: Option<i64>,
     pub session_id: Option<String>,
+    pub snapshot_scheme: String,
+    pub snapshot_alg: String,
+    pub snapshot_key_version: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -75,6 +84,9 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "decided_by",
     "created_at",
     "session_id",
+    "snapshot_scheme",
+    "snapshot_alg",
+    "snapshot_key_version",
 ];
 
 pub const SAFETY_NET_RESTRICTED_COLUMNS: &[&str] = &[
@@ -105,6 +117,9 @@ pub fn build_audit_query_sql(
     has_decided_by: bool,
     has_created_at: bool,
     has_session_id: bool,
+    has_snapshot_scheme: bool,
+    has_snapshot_alg: bool,
+    has_snapshot_key_version: bool,
 ) -> (String, Vec<Value>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
@@ -121,8 +136,23 @@ pub fn build_audit_query_sql(
     } else {
         "NULL AS session_id"
     };
+    let snapshot_scheme_column = if has_snapshot_scheme {
+        "snapshot_scheme".to_string()
+    } else {
+        format!("'{DEFAULT_SNAPSHOT_SCHEME}' AS snapshot_scheme")
+    };
+    let snapshot_alg_column = if has_snapshot_alg {
+        "snapshot_alg".to_string()
+    } else {
+        format!("'{DEFAULT_SNAPSHOT_ALG}' AS snapshot_alg")
+    };
+    let snapshot_key_version_column = if has_snapshot_key_version {
+        "snapshot_key_version"
+    } else {
+        "NULL AS snapshot_key_version"
+    };
     let mut sql = format!(
-        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column} FROM redaction_log"
+        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();
@@ -165,6 +195,30 @@ pub fn build_audit_query_sql(
             predicates.push("NULL = ?");
         }
         values.push(Value::Text(session_id.clone()));
+    }
+    if let Some(snapshot_scheme) = &filter.snapshot_scheme {
+        if has_snapshot_scheme {
+            predicates.push("snapshot_scheme = ?");
+        } else {
+            predicates.push("'gaze.snapshot.v1.sha256-salted' = ?");
+        }
+        values.push(Value::Text(snapshot_scheme.clone()));
+    }
+    if let Some(snapshot_alg) = &filter.snapshot_alg {
+        if has_snapshot_alg {
+            predicates.push("snapshot_alg = ?");
+        } else {
+            predicates.push("'SHA-256' = ?");
+        }
+        values.push(Value::Text(snapshot_alg.clone()));
+    }
+    if let Some(snapshot_key_version) = filter.snapshot_key_version {
+        if has_snapshot_key_version {
+            predicates.push("snapshot_key_version = ?");
+        } else {
+            predicates.push("NULL = ?");
+        }
+        values.push(Value::Integer(snapshot_key_version));
     }
     if !predicates.is_empty() {
         sql.push_str(" WHERE ");

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -13,6 +13,9 @@ use crate::query::{
 
 pub type Result<T> = std::result::Result<T, AuditError>;
 
+const DEFAULT_SNAPSHOT_SCHEME: &str = "gaze.snapshot.v1.sha256-salted";
+const DEFAULT_SNAPSHOT_ALG: &str = "SHA-256";
+
 #[derive(Debug, Error)]
 pub enum AuditError {
     #[error("sqlite error: {0}")]
@@ -140,7 +143,10 @@ impl SqliteLogger {
                 conflict_loser INTEGER NOT NULL,
                 decided_by TEXT NOT NULL DEFAULT 'none',
                 created_at INTEGER NULL,
-                session_id TEXT NULL
+                session_id TEXT NULL,
+                snapshot_scheme TEXT NOT NULL DEFAULT 'gaze.snapshot.v1.sha256-salted',
+                snapshot_alg TEXT NOT NULL DEFAULT 'SHA-256',
+                snapshot_key_version INTEGER NULL
             );
 
             CREATE TABLE IF NOT EXISTS safety_net_log (
@@ -195,6 +201,36 @@ impl SqliteLogger {
         if !columns.iter().any(|column| column == "session_id") {
             conn.execute(
                 "ALTER TABLE redaction_log ADD COLUMN session_id TEXT NULL",
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
+        if !columns.iter().any(|column| column == "snapshot_scheme") {
+            conn.execute(
+                &format!(
+                    "ALTER TABLE redaction_log ADD COLUMN snapshot_scheme TEXT NOT NULL DEFAULT '{}'",
+                    DEFAULT_SNAPSHOT_SCHEME
+                ),
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
+        if !columns.iter().any(|column| column == "snapshot_alg") {
+            conn.execute(
+                &format!(
+                    "ALTER TABLE redaction_log ADD COLUMN snapshot_alg TEXT NOT NULL DEFAULT '{}'",
+                    DEFAULT_SNAPSHOT_ALG
+                ),
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
+        if !columns
+            .iter()
+            .any(|column| column == "snapshot_key_version")
+        {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN snapshot_key_version INTEGER NULL",
                 [],
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -581,6 +617,105 @@ fn document_kind_from_db(value: &str) -> std::result::Result<DocumentKind, rusql
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn create_legacy_redaction_log(path: &Path) {
+        let conn = Connection::open(path).expect("legacy sqlite");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE redaction_log (
+                source TEXT NOT NULL,
+                class TEXT NOT NULL,
+                action TEXT NOT NULL,
+                field_name TEXT NULL,
+                document_kind TEXT NOT NULL,
+                conflict_loser INTEGER NOT NULL,
+                decided_by TEXT NOT NULL DEFAULT 'none',
+                created_at INTEGER NULL,
+                session_id TEXT NULL
+            );
+            INSERT INTO redaction_log
+                (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id)
+            VALUES
+                ('regex', 'email', 'tokenize', 'contact.email', 'structured', 0, 'none', 100, 'session-a');
+            "#,
+        )
+        .expect("legacy schema");
+    }
+
+    fn redaction_log_columns(path: &Path) -> Vec<String> {
+        let conn = Connection::open(path).expect("sqlite");
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(redaction_log)")
+            .expect("table info");
+        stmt.query_map([], |row| row.get::<_, String>(1))
+            .expect("columns")
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("column names")
+    }
+
+    #[test]
+    fn migration_adds_snapshot_metadata_defaults_to_existing_rows() {
+        let temp_db = tempfile::NamedTempFile::new().unwrap();
+        create_legacy_redaction_log(temp_db.path());
+
+        let _logger = SqliteLogger::new(temp_db.path()).expect("migrate audit db");
+
+        let conn = Connection::open(temp_db.path()).expect("sqlite");
+        let (scheme, alg, key_version): (String, String, Option<i64>) = conn
+            .query_row(
+                "SELECT snapshot_scheme, snapshot_alg, snapshot_key_version FROM redaction_log",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("snapshot metadata");
+
+        assert_eq!(scheme, DEFAULT_SNAPSHOT_SCHEME);
+        assert_eq!(alg, DEFAULT_SNAPSHOT_ALG);
+        assert_eq!(key_version, None);
+    }
+
+    #[test]
+    fn migration_is_idempotent_and_preserves_existing_rows() {
+        let temp_db = tempfile::NamedTempFile::new().unwrap();
+        create_legacy_redaction_log(temp_db.path());
+
+        let _first = SqliteLogger::new(temp_db.path()).expect("first migration");
+        drop(_first);
+        let columns_after_first = redaction_log_columns(temp_db.path());
+
+        let _second = SqliteLogger::new(temp_db.path()).expect("second migration");
+        drop(_second);
+        let columns_after_second = redaction_log_columns(temp_db.path());
+
+        assert_eq!(columns_after_second, columns_after_first);
+        assert_eq!(
+            columns_after_second
+                .iter()
+                .filter(|column| column.as_str() == "snapshot_scheme")
+                .count(),
+            1
+        );
+        assert_eq!(
+            columns_after_second
+                .iter()
+                .filter(|column| column.as_str() == "snapshot_alg")
+                .count(),
+            1
+        );
+        assert_eq!(
+            columns_after_second
+                .iter()
+                .filter(|column| column.as_str() == "snapshot_key_version")
+                .count(),
+            1
+        );
+
+        let conn = Connection::open(temp_db.path()).expect("sqlite");
+        let row_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
+            .expect("row count");
+        assert_eq!(row_count, 1);
+    }
 
     #[test]
     fn s4_audit_query_db_is_readonly() {

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -9,12 +9,10 @@ use thiserror::Error;
 
 use crate::query::{
     build_audit_query_sql, build_safety_net_query_sql, AuditFilter, AuditLogRow, LeakSuspectRow,
+    DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
 };
 
 pub type Result<T> = std::result::Result<T, AuditError>;
-
-const DEFAULT_SNAPSHOT_SCHEME: &str = "gaze.snapshot.v1.sha256-salted";
-const DEFAULT_SNAPSHOT_ALG: &str = "SHA-256";
 
 #[derive(Debug, Error)]
 pub enum AuditError {
@@ -306,8 +304,18 @@ impl SqliteLogger {
         let has_decided_by = table_has_column(&conn, "decided_by")?;
         let has_created_at = table_has_column(&conn, "created_at")?;
         let has_session_id = table_has_column(&conn, "session_id")?;
-        let (sql, values) =
-            build_audit_query_sql(filter, has_decided_by, has_created_at, has_session_id);
+        let has_snapshot_scheme = table_has_column(&conn, "snapshot_scheme")?;
+        let has_snapshot_alg = table_has_column(&conn, "snapshot_alg")?;
+        let has_snapshot_key_version = table_has_column(&conn, "snapshot_key_version")?;
+        let (sql, values) = build_audit_query_sql(
+            filter,
+            has_decided_by,
+            has_created_at,
+            has_session_id,
+            has_snapshot_scheme,
+            has_snapshot_alg,
+            has_snapshot_key_version,
+        );
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -323,6 +331,9 @@ impl SqliteLogger {
                     decided_by: row.get(6)?,
                     created_at: row.get(7)?,
                     session_id: row.get(8)?,
+                    snapshot_scheme: row.get(9)?,
+                    snapshot_alg: row.get(10)?,
+                    snapshot_key_version: row.get(11)?,
                 })
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use gaze_audit::{
     AuditFilter, AuditLogRow, LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger,
-    SAFETY_NET_RESTRICTED_COLUMNS,
+    DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME, SAFETY_NET_RESTRICTED_COLUMNS,
 };
 use gaze_types::{
     Action, ConflictTier, DocumentKind, LeakKind, LeakSuspect, PiiClass, RedactionEntry,
@@ -150,6 +150,9 @@ fn safety_net_query_filter_maps_to_safety_net_columns() {
             from_epoch_ms: Some(150),
             to_epoch_ms: Some(250),
             session_id: Some("session-b".to_string()),
+            snapshot_scheme: None,
+            snapshot_alg: None,
+            snapshot_key_version: None,
         },
     )
     .expect("filtered query");
@@ -263,6 +266,9 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             decided_by: "none".to_string(),
             created_at: Some(100),
             session_id: Some("session-a".to_string()),
+            snapshot_scheme: DEFAULT_SNAPSHOT_SCHEME.to_string(),
+            snapshot_alg: DEFAULT_SNAPSHOT_ALG.to_string(),
+            snapshot_key_version: None,
         },
         AuditLogRow {
             source: "dictionary".to_string(),
@@ -274,6 +280,9 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             decided_by: "class_priority".to_string(),
             created_at: Some(200),
             session_id: None,
+            snapshot_scheme: DEFAULT_SNAPSHOT_SCHEME.to_string(),
+            snapshot_alg: DEFAULT_SNAPSHOT_ALG.to_string(),
+            snapshot_key_version: None,
         },
     ]
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -58,7 +58,7 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     for row in rows {
         writeln!(
             stdout,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.class,
             row.action,
@@ -69,7 +69,12 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
             row.created_at
                 .map(|created_at| created_at.to_string())
                 .unwrap_or_default(),
-            row.session_id.unwrap_or_default()
+            row.session_id.unwrap_or_default(),
+            row.snapshot_scheme,
+            row.snapshot_alg,
+            row.snapshot_key_version
+                .map(|version| version.to_string())
+                .unwrap_or_default()
         )
         .map_err(|_| CliError::Io)?;
     }
@@ -156,6 +161,9 @@ fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
         from_epoch_ms,
         to_epoch_ms,
         session_id: args.session_id.clone(),
+        snapshot_scheme: None,
+        snapshot_alg: None,
+        snapshot_key_version: None,
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -175,6 +183,9 @@ fn read_safety_net_rows(
         from_epoch_ms,
         to_epoch_ms,
         session_id: None,
+        snapshot_scheme: None,
+        snapshot_alg: None,
+        snapshot_key_version: None,
     };
     SqliteLogger::query_safety_net(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -233,6 +244,9 @@ struct JsonlRow {
     decided_by: String,
     created_at: Option<i64>,
     session_id: Option<String>,
+    snapshot_scheme: String,
+    snapshot_alg: String,
+    snapshot_key_version: Option<i64>,
 }
 
 impl From<AuditLogRow> for JsonlRow {
@@ -247,6 +261,9 @@ impl From<AuditLogRow> for JsonlRow {
             decided_by: row.decided_by,
             created_at: row.created_at,
             session_id: row.session_id,
+            snapshot_scheme: row.snapshot_scheme,
+            snapshot_alg: row.snapshot_alg,
+            snapshot_key_version: row.snapshot_key_version,
         }
     }
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -1,5 +1,7 @@
 use assert_cmd::Command;
-use gaze_audit::{build_audit_query_sql, AuditFilter};
+use gaze_audit::{
+    build_audit_query_sql, AuditFilter, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
+};
 use rusqlite::{types::Value as SqlValue, Connection};
 use serde_json::Value;
 use tempfile::tempdir;
@@ -87,6 +89,9 @@ fn v0_4_3_shape_without_created_at_is_queryable_but_time_filters_omit_nulls() {
     assert_eq!(row["decided_by"], "recognizer_id");
     assert_eq!(row["created_at"], Value::Null);
     assert_eq!(row["session_id"], Value::Null);
+    assert_eq!(row["snapshot_scheme"], DEFAULT_SNAPSHOT_SCHEME);
+    assert_eq!(row["snapshot_alg"], DEFAULT_SNAPSHOT_ALG);
+    assert_eq!(row["snapshot_key_version"], Value::Null);
 }
 
 #[test]
@@ -145,6 +150,9 @@ fn v0_4_4_shape_with_created_at_is_queryable_and_time_filtered() {
     assert_eq!(rows[0]["source"], "email.global");
     assert_eq!(rows[0]["created_at"], 1700000000000_i64);
     assert_eq!(rows[0]["session_id"], Value::Null);
+    assert_eq!(rows[0]["snapshot_scheme"], DEFAULT_SNAPSHOT_SCHEME);
+    assert_eq!(rows[0]["snapshot_alg"], DEFAULT_SNAPSHOT_ALG);
+    assert_eq!(rows[0]["snapshot_key_version"], Value::Null);
 }
 
 #[test]
@@ -268,7 +276,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\n"
     ));
     assert!(
         stdout.contains("dictionary:audit_terms[#0]\tcustom:term\ttokenize\t\ttext\tfalse\tnone")
@@ -287,8 +295,11 @@ fn audit_sql_uses_restricted_column_set() {
         from_epoch_ms: Some(1_700_000_000_000),
         to_epoch_ms: Some(1_700_000_010_000),
         session_id: Some("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
+        snapshot_scheme: Some(DEFAULT_SNAPSHOT_SCHEME.to_string()),
+        snapshot_alg: Some(DEFAULT_SNAPSHOT_ALG.to_string()),
+        snapshot_key_version: None,
     };
-    let (current_sql, values) = build_audit_query_sql(&filter, true, true, true);
+    let (current_sql, values) = build_audit_query_sql(&filter, true, true, true, true, true, true);
     assert_eq!(
         values,
         [
@@ -299,6 +310,8 @@ fn audit_sql_uses_restricted_column_set() {
             SqlValue::Integer(1_700_000_000_000),
             SqlValue::Integer(1_700_000_010_000),
             SqlValue::Text("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
+            SqlValue::Text(DEFAULT_SNAPSHOT_SCHEME.to_string()),
+            SqlValue::Text(DEFAULT_SNAPSHOT_ALG.to_string()),
         ]
         .into_iter()
         .collect::<Vec<_>>()
@@ -307,28 +320,42 @@ fn audit_sql_uses_restricted_column_set() {
     assert!(current_sql.contains("created_at >= ?"));
     assert!(current_sql.contains("created_at <= ?"));
     assert!(current_sql.contains("session_id = ?"));
+    assert!(current_sql.contains("snapshot_scheme = ?"));
+    assert!(current_sql.contains("snapshot_alg = ?"));
     assert!(!current_sql.contains("created_at IS NULL"));
 
     let legacy_filter = AuditFilter {
         from_epoch_ms: Some(1_700_000_000_000),
         to_epoch_ms: Some(1_700_000_010_000),
         session_id: Some("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
+        snapshot_scheme: Some(DEFAULT_SNAPSHOT_SCHEME.to_string()),
+        snapshot_alg: Some(DEFAULT_SNAPSHOT_ALG.to_string()),
+        snapshot_key_version: Some(1),
         ..AuditFilter::default()
     };
-    let (legacy_sql, legacy_values) = build_audit_query_sql(&legacy_filter, false, false, false);
+    let (legacy_sql, legacy_values) =
+        build_audit_query_sql(&legacy_filter, false, false, false, false, false, false);
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
     assert!(legacy_sql.contains("NULL AS created_at"));
     assert!(legacy_sql.contains("NULL AS session_id"));
+    assert!(legacy_sql.contains("'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme"));
+    assert!(legacy_sql.contains("'SHA-256' AS snapshot_alg"));
+    assert!(legacy_sql.contains("NULL AS snapshot_key_version"));
     assert!(legacy_sql.contains("NULL >= ?"));
     assert!(legacy_sql.contains("NULL <= ?"));
     assert!(legacy_sql.contains("NULL = ?"));
+    assert!(legacy_sql.contains("'gaze.snapshot.v1.sha256-salted' = ?"));
+    assert!(legacy_sql.contains("'SHA-256' = ?"));
     assert_eq!(
         legacy_values,
         [
             SqlValue::Integer(1_700_000_000_000),
             SqlValue::Integer(1_700_000_010_000),
             SqlValue::Text("018bcfe5-6800-7a2f-9d1b-47b7565b2d10".to_string()),
+            SqlValue::Text(DEFAULT_SNAPSHOT_SCHEME.to_string()),
+            SqlValue::Text(DEFAULT_SNAPSHOT_ALG.to_string()),
+            SqlValue::Integer(1),
         ]
         .into_iter()
         .collect::<Vec<_>>()

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1178,7 +1178,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\n"
+        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\n"
     ));
     assert!(
         stdout
@@ -1220,6 +1220,9 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     assert_eq!(row["conflict_loser"], false);
     assert!(row.get("decided_by").is_some());
     assert!(row.get("session_id").is_some());
+    assert!(row.get("snapshot_scheme").is_some());
+    assert!(row.get("snapshot_alg").is_some());
+    assert!(row.get("snapshot_key_version").is_some());
 }
 
 #[test]
@@ -1631,7 +1634,8 @@ fn s4_audit_query_columns_are_restricted() {
     let conn = Connection::open(&audit_path).unwrap();
     conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
         .unwrap();
-    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true, true, true);
+    let (sql, values) =
+        build_audit_query_sql(&AuditFilter::default(), true, true, true, true, true, true);
     assert!(
         values.is_empty(),
         "default audit filter should not bind query values"
@@ -1685,7 +1689,8 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
     // `source` is intentionally present so audit reads can explain the
     // structural family without a schema change.
     assert!(AUDIT_RESTRICTED_COLUMNS.contains(&"source"));
-    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), true, true, true);
+    let (sql, values) =
+        build_audit_query_sql(&AuditFilter::default(), true, true, true, true, true, true);
     let conn = Connection::open(&audit_path).unwrap();
     let mut stmt = conn.prepare(&sql).unwrap();
     let rows = stmt

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -159,7 +159,7 @@ exec sleep 30
     )
     .unwrap();
     let backend = SubprocessOpenAiFilterBackend::new(
-        SubprocessOpenAiFilterConfig::new(opf).with_timeout(Duration::from_secs(5)),
+        SubprocessOpenAiFilterConfig::new(opf).with_timeout(Duration::from_secs(15)),
     )
     .unwrap();
     let clean = format!("x\n{}", "x".repeat(128 * 1024));
@@ -171,7 +171,7 @@ exec sleep 30
     assert!(matches!(error, SafetyNetError::Runtime { .. }));
     assert!(error.to_string().contains("timed out"));
     assert!(
-        elapsed < Duration::from_secs(7),
+        elapsed < Duration::from_secs(17),
         "blocked stdin timeout took {elapsed:?}"
     );
 
@@ -268,7 +268,9 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private_email","s
 "#,
     )
     .unwrap();
-    let net = OpenAiFilterSafetyNet::new(SubprocessOpenAiFilterConfig::new(opf));
+    let net = OpenAiFilterSafetyNet::new(
+        SubprocessOpenAiFilterConfig::new(opf).with_timeout(Duration::from_secs(15)),
+    );
     let manifest = Manifest::from_spans(vec![gaze_types::EmittedTokenSpan::new(
         0..9,
         0..21,
@@ -286,7 +288,10 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private_email","s
 }
 
 fn backend(command: PathBuf) -> SubprocessOpenAiFilterBackend {
-    SubprocessOpenAiFilterBackend::new(SubprocessOpenAiFilterConfig::new(command)).unwrap()
+    SubprocessOpenAiFilterBackend::new(
+        SubprocessOpenAiFilterConfig::new(command).with_timeout(Duration::from_secs(15)),
+    )
+    .unwrap()
 }
 
 fn context<'a>(manifest: &'a Manifest, field_path: Option<&'a str>) -> SafetyNetContext<'a> {

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -350,8 +350,8 @@ impl Session {
     /// `preview-redacted.png`) plus owner-only `<base>-owner/manifest.bin`. The supplied
     /// [`DocumentExtension`] is serialized inside the signed snapshot payload, so its hashes and
     /// codec audit rows become the integrity root for the agent-facing files. Text-only adopters
-    /// should use [`Session::export`], which keeps the v3 snapshot envelope; document-extended
-    /// snapshots emit v4 so older readers fail closed before restore.
+    /// should use [`Session::export`]. Current snapshots emit v5 so older readers fail closed
+    /// before restore while the signature binds the emitted envelope bytes.
     ///
     /// ```rust
     /// use gaze::{
@@ -379,7 +379,7 @@ impl Session {
     ///     .build()?;
     ///
     /// let manifest_bin = session.export_with_extension(extension)?.into_bytes();
-    /// # assert_eq!(manifest_bin[0], 4);
+    /// # assert_eq!(manifest_bin[0], 5);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -18,6 +18,7 @@ const DEFAULT_COUNTER_FAMILY: &str = "counter";
 const SNAPSHOT_VERSION_V2: u8 = 2;
 const SNAPSHOT_VERSION_V3: u8 = 3;
 const SNAPSHOT_VERSION_V4: u8 = 4;
+const SNAPSHOT_VERSION_V5: u8 = 5;
 
 /// Lifetime scope of a [`Session`]'s token manifest.
 ///
@@ -434,18 +435,17 @@ impl Session {
             document,
         };
         let payload_bytes = serde_json::to_vec(&payload).map_err(Error::SnapshotDecode)?;
+        let version = SNAPSHOT_VERSION_V5;
         let signing_key = self.signing_key.signing_key();
-        let signature = signing_key.sign(&payload_bytes);
         let verifying_key = signing_key.verifying_key();
+        let verifying_key_bytes = verifying_key.to_bytes();
+        let signing_preimage =
+            snapshot_signing_preimage(version, &verifying_key_bytes, &payload_bytes);
+        let signature = signing_key.sign(&signing_preimage);
 
-        let version = if payload.document.is_some() {
-            SNAPSHOT_VERSION_V4
-        } else {
-            SNAPSHOT_VERSION_V3
-        };
         let mut snapshot = Vec::with_capacity(1 + 32 + 64 + payload_bytes.len());
         snapshot.push(version);
-        snapshot.extend_from_slice(&verifying_key.to_bytes());
+        snapshot.extend_from_slice(&verifying_key_bytes);
         snapshot.extend_from_slice(&signature.to_bytes());
         snapshot.extend_from_slice(&payload_bytes);
         Ok(SensitiveSnapshot(snapshot))
@@ -460,6 +460,7 @@ impl Session {
         if version != SNAPSHOT_VERSION_V2
             && version != SNAPSHOT_VERSION_V3
             && version != SNAPSHOT_VERSION_V4
+            && version != SNAPSHOT_VERSION_V5
         {
             return Err(Error::InvalidSnapshotVersion(version));
         }
@@ -476,8 +477,19 @@ impl Session {
                 .map_err(|_| Error::InvalidSnapshotSignature)?,
         );
         let payload_bytes = &bytes[97..];
+        let verify_preimage;
+        let signed_bytes = if version >= SNAPSHOT_VERSION_V5 {
+            let verifying_key_bytes: [u8; 32] = bytes[1..33]
+                .try_into()
+                .map_err(|_| Error::InvalidSnapshotSignature)?;
+            verify_preimage =
+                snapshot_signing_preimage(version, &verifying_key_bytes, payload_bytes);
+            verify_preimage.as_slice()
+        } else {
+            payload_bytes
+        };
         verifying_key
-            .verify(payload_bytes, &signature)
+            .verify(signed_bytes, &signature)
             .map_err(|_| Error::InvalidSnapshotSignature)?;
 
         let payload = decode_snapshot_payload(payload_bytes)?;
@@ -782,6 +794,18 @@ fn parse_token_index(token: &str) -> Option<usize> {
     suffix.parse().ok()
 }
 
+fn snapshot_signing_preimage(
+    version: u8,
+    verifying_key_bytes: &[u8; 32],
+    payload_bytes: &[u8],
+) -> Vec<u8> {
+    let mut preimage = Vec::with_capacity(1 + verifying_key_bytes.len() + payload_bytes.len());
+    preimage.push(version);
+    preimage.extend_from_slice(verifying_key_bytes);
+    preimage.extend_from_slice(payload_bytes);
+    preimage
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1006,7 +1030,59 @@ mod tests {
 
         assert!(matches!(
             legacy_v0_4_0_accepts_only_v2(&snapshot),
-            Err(Error::InvalidSnapshotVersion(3))
+            Err(Error::InvalidSnapshotVersion(SNAPSHOT_VERSION_V5))
+        ));
+    }
+
+    #[test]
+    fn snapshot_signature_binds_emitted_envelope_version() {
+        let session = Session::new(Scope::Conversation("test".to_string())).expect("session");
+        session
+            .tokenize(&PiiClass::Name, "Dr. Schmidt")
+            .expect("token");
+
+        let mut bytes = session.export().expect("snapshot").into_bytes();
+        assert_eq!(bytes[0], SNAPSHOT_VERSION_V5);
+        bytes[0] = SNAPSHOT_VERSION_V3;
+
+        assert!(matches!(
+            Session::import(SensitiveSnapshot::from(bytes)),
+            Err(Error::InvalidSnapshotSignature)
+        ));
+    }
+
+    #[test]
+    fn snapshot_signature_uses_final_envelope_preimage() {
+        let session = Session::new(Scope::Conversation("test".to_string())).expect("session");
+        session
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .expect("token");
+
+        let bytes = session.export().expect("snapshot").into_bytes();
+        let version = bytes[0];
+        let verifying_key_bytes: [u8; 32] = bytes[1..33].try_into().expect("verifying key bytes");
+        let verifying_key = VerifyingKey::from_bytes(&verifying_key_bytes).expect("verifying key");
+        let signature = Signature::from_bytes(&bytes[33..97].try_into().expect("signature bytes"));
+        let payload_bytes = &bytes[97..];
+        let preimage = snapshot_signing_preimage(version, &verifying_key_bytes, payload_bytes);
+
+        assert!(verifying_key.verify(&preimage, &signature).is_ok());
+        assert!(verifying_key.verify(payload_bytes, &signature).is_err());
+    }
+
+    #[test]
+    fn snapshot_import_rejects_signature_slot_mutation() {
+        let session = Session::new(Scope::Conversation("test".to_string())).expect("session");
+        session
+            .tokenize(&PiiClass::Name, "Dr. Schmidt")
+            .expect("token");
+
+        let mut bytes = session.export().expect("snapshot").into_bytes();
+        bytes[33] ^= 0x01;
+
+        assert!(matches!(
+            Session::import(SensitiveSnapshot::from(bytes)),
+            Err(Error::InvalidSnapshotSignature)
         ));
     }
 
@@ -1201,7 +1277,7 @@ mod tests {
         assert!(beta.ends_with(":Name_2>"));
 
         let snapshot = session.export().expect("snapshot");
-        assert_eq!(snapshot.0[0], SNAPSHOT_VERSION_V3);
+        assert_eq!(snapshot.0[0], SNAPSHOT_VERSION_V5);
         let imported = Session::import(snapshot).expect("import");
 
         assert_eq!(imported.restore(&alpha).as_deref(), Some("Dr. Schmidt"));

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -247,6 +247,29 @@ fn snapshot_import_rejects_tampering() {
 }
 
 #[test]
+fn snapshot_import_rejects_emitted_version_tampering() {
+    let session = Session::new(Scope::Conversation("msg-42".to_string())).expect("session");
+    let token = session
+        .tokenize(&PiiClass::Email, "alice@example.invalid")
+        .expect("tokenize");
+
+    let bytes = session.export().expect("export snapshot").into_bytes();
+    let imported = Session::import(bytes.clone().into()).expect("import snapshot");
+    assert_eq!(
+        imported.restore_strict(&token).expect("restore"),
+        "alice@example.invalid"
+    );
+
+    let mut tampered = bytes;
+    tampered[0] = 3;
+
+    assert!(matches!(
+        Session::import(tampered.into()),
+        Err(gaze::Error::InvalidSnapshotSignature)
+    ));
+}
+
+#[test]
 fn ephemeral_session_cannot_export() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     assert!(session.export().is_err());

--- a/crates/gaze/tests/session_snapshot_byte_stability.rs
+++ b/crates/gaze/tests/session_snapshot_byte_stability.rs
@@ -2,12 +2,11 @@
 //!
 //! `Session::export().into_bytes()` includes a fresh signing key, Ed25519 signature, session id,
 //! and `issued_at`, so the public API cannot produce byte-identical snapshots across runs without
-//! a test-only deterministic session constructor. This test therefore pins a checked-in v3
-//! `manifest.bin` fixture and verifies the stable text-only contract that matters to v0.6/v0.7
-//! adopters: v3 envelope byte, no `document` extension, importable token map, and unchanged
-//! canonical payload field shape.
+//! a test-only deterministic session constructor. This test therefore pins a checked-in legacy v3
+//! `manifest.bin` fixture and verifies it remains importable while current exports use the v5
+//! envelope that binds the emitted version byte into the signed preimage.
 //!
-//! Regenerate only when the v3 text-only payload contract intentionally changes:
+//! Regenerate only when the current text-only payload contract intentionally changes:
 //! `GAZE_REGENERATE_SESSION_SNAPSHOT_FIXTURE=1 cargo test -p gaze-pii --test session_snapshot_byte_stability`.
 
 use gaze::{PiiClass, Scope, SensitiveSnapshot, Session};
@@ -46,14 +45,14 @@ fn checked_in_v3_text_only_snapshot_fixture_stays_importable_and_payload_shape_s
 }
 
 #[test]
-fn current_text_only_export_stays_v3_and_omits_document_extension() {
+fn current_text_only_export_uses_v5_and_omits_document_extension() {
     let session = Session::new(Scope::Conversation("byte-stability".to_string())).expect("session");
     let _ = session
         .tokenize(&PiiClass::Name, "Dr. Schmidt")
         .expect("token");
 
     let bytes = session.export().expect("text-only export").into_bytes();
-    assert_eq!(bytes[0], 3);
+    assert_eq!(bytes[0], 5);
 
     let payload: Value = serde_json::from_slice(&bytes[97..]).expect("snapshot payload json");
     assert!(payload.get("document").is_none());

--- a/crates/gaze/tests/session_v3_v4_compat.rs
+++ b/crates/gaze/tests/session_v3_v4_compat.rs
@@ -60,15 +60,18 @@ fn document_extension_signed_envelope_binds_bundle_files() {
 }
 
 #[test]
-fn text_only_export_stays_v3_and_document_export_moves_to_v4() {
+fn current_exports_use_v5_and_legacy_readers_fail_closed() {
     let session = Session::new(Scope::Conversation("compat".to_string())).expect("session");
     let token = session
         .tokenize(&gaze::PiiClass::Email, "alice@example.invalid")
         .expect("token");
 
     let text_only = session.export().expect("text-only export").into_bytes();
-    assert_eq!(text_only[0], 3);
-    assert!(v0_6_reader_accepts_only_v2_or_v3(&text_only).is_ok());
+    assert_eq!(text_only[0], 5);
+    assert!(matches!(
+        v0_6_reader_accepts_only_v2_or_v3(&text_only),
+        Err(Error::InvalidSnapshotVersion(5))
+    ));
 
     let document = session
         .export_with_extension(
@@ -83,14 +86,14 @@ fn text_only_export_stays_v3_and_document_export_moves_to_v4() {
         )
         .expect("document export")
         .into_bytes();
-    assert_eq!(document[0], 4);
+    assert_eq!(document[0], 5);
     assert!(matches!(
         v0_6_reader_accepts_only_v2_or_v3(&document),
-        Err(Error::InvalidSnapshotVersion(4))
+        Err(Error::InvalidSnapshotVersion(5))
     ));
 
     let imported =
-        Session::import(SensitiveSnapshot::from(document)).expect("current reader imports v4");
+        Session::import(SensitiveSnapshot::from(document)).expect("current reader imports v5");
     assert_eq!(
         imported.restore(&token).as_deref(),
         Some("alice@example.invalid")


### PR DESCRIPTION
## Summary
- Fixes the session snapshot envelope so new v5 exports sign the emitted envelope preimage: version byte, verifying key, and payload bytes. Legacy v2-v4 snapshot import remains supported.
- Adds additive audit metadata columns: `snapshot_scheme`, `snapshot_alg`, and `snapshot_key_version`, with migration defaults for existing rows.
- Plumbs snapshot metadata through `AuditLogRow`, `AuditFilter`, SQL query building, restricted column handling, and CLI audit export.
- Hardens the OPF subprocess boundary tests against local startup latency while keeping timeout and kill behavior covered.

## Context
References todo 762. Informed by `research/audit-snapshot-crypto`.

This fixes an axis-1 audit binding issue: previous snapshot signatures covered payload bytes but did not bind every byte in the emitted envelope. New exports now bind the bytes the consumer receives while preserving legacy restore compatibility.

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] `cargo run -p xtask -- dylint-gate`
- [x] `cargo run -p xtask -- safety-net-sanity`
- [x] `cargo run -p xtask -- cargo-metadata-audit-isolation`
