### PR TITLE
feat(gaze-document): opt-in mcp feature with gaze_read_file + gaze_read_text Tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: cargo clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+      - name: cargo test gaze-document mcp feature
+        run: cargo test -p gaze-document --features mcp --no-fail-fast
       - name: cargo test
         run: cargo test --workspace --all-features --no-fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ambiguity_record`, `collision_family`, and `collision_variant`; CLI audit
   queries can filter ambiguity and collision metadata. See
   `docs/architecture/ambiguity-side-channel.md`.
+- `gaze-document` opt-in `mcp` feature exposes `gaze_read_file` and
+  `gaze_read_text` Tool impls that route document ingestion through
+  `PiiEnvelope::dispatch`. Returns `{ clean_markdown, manifest_id,
+  file_metadata }`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,16 +1067,22 @@ name = "gaze-document"
 version = "0.0.1"
 dependencies = [
  "ab_glyph",
+ "async-trait",
+ "gaze-mcp-core",
+ "gaze-mcp-rmcp",
  "gaze-pii",
  "gaze-recognizers",
  "gaze-types",
  "image",
  "imageproc",
  "pdfium-render",
+ "regex",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -36,7 +36,7 @@ image = { version = "0.25", default-features = false, features = ["png"], option
 
 [features]
 default = ["ocr-tesseract", "pdf-input"]
-mcp = ["dep:async-trait", "dep:gaze-mcp-core"]
+mcp = ["dep:async-trait", "dep:gaze-mcp-core", "ocr-tesseract", "pdf-input"]
 ocr-tesseract = []
 pdf-input = ["dep:pdfium-render", "dep:image"]
 extract-docling = []

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -22,8 +22,10 @@ path = "src/lib.rs"
 
 [dependencies]
 gaze = { path = "../gaze", version = "0.7.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.0", optional = true }
 gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.0" }
 gaze-types = { workspace = true }
+async-trait = { version = "0.1", optional = true }
 regex = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -34,6 +36,7 @@ image = { version = "0.25", default-features = false, features = ["png"], option
 
 [features]
 default = ["ocr-tesseract", "pdf-input"]
+mcp = ["dep:async-trait", "dep:gaze-mcp-core"]
 ocr-tesseract = []
 pdf-input = ["dep:pdfium-render", "dep:image"]
 extract-docling = []
@@ -41,10 +44,13 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
+rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 serde_json = { workspace = true }
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
 
 [[example]]
 name = "gen_fixtures"

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -169,12 +169,56 @@ If you observe a new artifact class slipping through, file an issue
 with the OCR output and the expected normalization shape; the fix
 belongs in `ocr::normalize` alongside the existing rules.
 
+## MCP feature
+
+Enable `mcp` to register two agent-tier tools with `gaze-mcp-core`:
+`gaze_read_text` for already-extracted text and `gaze_read_file` for PNG,
+JPG, or PDF paths. Hosts still call them through `PiiEnvelope::dispatch`,
+so args, responses, manifest rows, and auth stay on the MCP chokepoint.
+
+```rust,no_run
+use std::sync::Arc;
+
+use gaze_document::mcp::{self, GazeReadOpts};
+use gaze_mcp_core::ToolRegistry;
+use gaze_mcp_rmcp::{FixedPrincipalResolver, RmcpFrontend};
+
+let mut registry = ToolRegistry::new();
+mcp::register_tools(&mut registry, GazeReadOpts::default())?;
+
+let frontend = RmcpFrontend::stdio(Arc::new(
+    FixedPrincipalResolver::agent("local-stdio"),
+));
+# Ok::<(), gaze_mcp_core::ToolRegistryError>(())
+```
+
+Both tools return a JSON object:
+
+```json
+{
+  "clean_markdown": "# gaze-document safe text\n\n...",
+  "manifest_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "file_metadata": {
+    "source_kind": "text",
+    "ocr_mean_confidence": null,
+    "bundle_version": 1,
+    "page_count": null
+  }
+}
+```
+
+`gaze_read_file` defaults to a 25 MiB input cap. Override it with
+`GazeReadFile::with_max_file_size(bytes)` or `GazeReadOpts`.
+`gaze mcp install` is planned as a separate `gaze-cli` flow; this crate only
+provides the opt-in tool implementations.
+
 ## Feature flags
 
 | Feature           | Default | What it enables                                      |
 |-------------------|---------|------------------------------------------------------|
 | `ocr-tesseract`   | yes     | Tesseract subprocess OCR backend + `clean()` entry.  |
 | `pdf-input`       | yes     | `pdfium-render` PDF rasterization (single page).     |
+| `mcp`             | no      | `gaze_read_file` + `gaze_read_text` Tool impls.      |
 | `extract-docling` | no      | Reserved — future Docling layout adapter.            |
 | `render-image`    | no      | Reserved — future redacted-preview renderer.         |
 

--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -30,15 +30,15 @@ use std::fs;
 #[cfg(feature = "ocr-tesseract")]
 use std::path::Path;
 
-#[cfg(feature = "ocr-tesseract")]
+#[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze::{
     Action, ClassRule, CleanDocument, DefaultRule, LocaleTag, Pipeline, RawDocument, Scope, Session,
 };
-#[cfg(feature = "ocr-tesseract")]
+#[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze_recognizers::{
     AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape, RegexDetector,
 };
-#[cfg(feature = "ocr-tesseract")]
+#[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze_types::{EmittedTokenSpan, PiiClass};
 
 #[cfg(feature = "ocr-tesseract")]
@@ -273,7 +273,7 @@ pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> 
 }
 
 #[cfg(feature = "ocr-tesseract")]
-fn run_ocr(
+pub(crate) fn run_ocr(
     input: &Path,
     kind: InputKind,
 ) -> Result<(OcrResult, Option<i32>, Option<i32>), DocumentError> {
@@ -304,7 +304,8 @@ fn run_ocr(
 }
 
 #[cfg(feature = "ocr-tesseract")]
-fn build_document_pipeline() -> Result<Pipeline, DocumentError> {
+#[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
+pub(crate) fn build_document_pipeline() -> Result<Pipeline, DocumentError> {
     let email = RegexDetector::emails().map_err(|err| pipeline_err("email-regex", err))?;
     // Conservative phone pattern: optional `+CC`, area, exchange, line, with
     // common separators. Synthetic fixture uses `+1-555-0142`-style numbers.
@@ -378,7 +379,7 @@ fn write_bundle(
 }
 
 #[cfg(feature = "ocr-tesseract")]
-fn format_clean_markdown(text: &str, kind: InputKind) -> String {
+pub(crate) fn format_clean_markdown(text: &str, kind: InputKind) -> String {
     let mut out = String::new();
     out.push_str("# gaze-document safe bundle\n\n");
     out.push_str(&format!("Source kind: `{}`\n\n", kind_label(kind)));
@@ -391,7 +392,7 @@ fn format_clean_markdown(text: &str, kind: InputKind) -> String {
 }
 
 #[cfg(feature = "ocr-tesseract")]
-fn kind_label(kind: InputKind) -> &'static str {
+pub(crate) fn kind_label(kind: InputKind) -> &'static str {
     match kind {
         InputKind::Png => "png",
         InputKind::Jpeg => "jpeg",

--- a/crates/gaze-document/src/lib.rs
+++ b/crates/gaze-document/src/lib.rs
@@ -42,6 +42,9 @@
 pub mod bundle;
 pub mod extract;
 pub mod layout;
+#[cfg(feature = "mcp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mcp")))]
+pub mod mcp;
 pub mod ocr;
 pub mod render;
 

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -4,3 +4,567 @@
 //! registered explicitly by adopters. Invocation still happens through
 //! `gaze_mcp_core::PiiEnvelope::dispatch`; this module only provides the
 //! tool bodies and catalog metadata.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use gaze::{CleanDocument, RawDocument};
+use gaze_mcp_core::{
+    Tool, ToolCtx, ToolDescriptor, ToolError, ToolRegistry, ToolRegistryError, ToolResponse,
+};
+use serde::Serialize;
+use serde_json::json;
+
+#[cfg(feature = "ocr-tesseract")]
+use crate::extract::InputKind;
+#[cfg(feature = "ocr-tesseract")]
+use crate::DocumentError;
+
+/// Default `gaze_read_file` input cap: 25 MiB.
+pub const DEFAULT_MAX_FILE_SIZE: u64 = 25 * 1024 * 1024;
+
+/// Options used when registering `gaze-document` MCP tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct GazeReadOpts {
+    /// Maximum accepted input file size in bytes for `gaze_read_file`.
+    pub max_file_size: u64,
+}
+
+impl Default for GazeReadOpts {
+    fn default() -> Self {
+        Self {
+            max_file_size: DEFAULT_MAX_FILE_SIZE,
+        }
+    }
+}
+
+/// Register `gaze_read_text` and `gaze_read_file` with their canonical names.
+pub fn register_tools(
+    registry: &mut ToolRegistry,
+    opts: GazeReadOpts,
+) -> Result<(), ToolRegistryError> {
+    registry.register(GazeReadText::new())?;
+    registry.register(GazeReadFile::with_max_file_size(opts.max_file_size))?;
+    Ok(())
+}
+
+/// MCP tool that tokenizes already-extracted text via the document recognizer set.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct GazeReadText {
+    descriptor: ToolDescriptor,
+}
+
+impl GazeReadText {
+    /// Construct a `gaze_read_text` tool.
+    pub fn new() -> Self {
+        Self {
+            descriptor: ToolDescriptor::agent(
+                "gaze_read_text",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": "Already-extracted text to pseudonymize before model use."
+                        }
+                    },
+                    "required": ["text"]
+                }),
+            )
+            .with_description("Pseudonymize already-extracted text before returning it to an MCP client.")
+            .with_output_schema(response_schema()),
+        }
+    }
+}
+
+impl Default for GazeReadText {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GazeReadText {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.descriptor
+    }
+
+    async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        let text = required_string(ctx.redacted_args(), "text")?;
+        let clean_text = redact_document_text(text, ctx)?;
+        Ok(ToolResponse::json(json!(DocumentToolResponse {
+            clean_markdown: format_text_markdown(&clean_text),
+            manifest_id: ctx.call_id().to_string(),
+            file_metadata: FileMetadata {
+                source_kind: "text".to_string(),
+                ocr_mean_confidence: None,
+                bundle_version: crate::BUNDLE_VERSION,
+                page_count: None,
+            },
+        })))
+    }
+}
+
+/// MCP tool that OCRs an image/PDF file and tokenizes text before model use.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct GazeReadFile {
+    descriptor: ToolDescriptor,
+    max_file_size: u64,
+}
+
+impl GazeReadFile {
+    /// Construct a `gaze_read_file` tool with the default 25 MiB input cap.
+    pub fn new() -> Self {
+        Self::with_max_file_size(DEFAULT_MAX_FILE_SIZE)
+    }
+
+    /// Construct a `gaze_read_file` tool with a caller-supplied input cap.
+    pub fn with_max_file_size(max_file_size: u64) -> Self {
+        Self {
+            descriptor: ToolDescriptor::agent(
+                "gaze_read_file",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Filesystem path to a PNG, JPG, or PDF document."
+                        }
+                    },
+                    "required": ["path"]
+                }),
+            )
+            .with_description(
+                "Read an image or PDF through OCR and Gaze pseudonymization before MCP return.",
+            )
+            .with_output_schema(response_schema()),
+            max_file_size,
+        }
+    }
+}
+
+impl Default for GazeReadFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GazeReadFile {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.descriptor
+    }
+
+    async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        let path = PathBuf::from(required_string(ctx.redacted_args(), "path")?);
+        validate_file(&path, self.max_file_size)?;
+        read_file_response(&path, ctx).map(|response| ToolResponse::json(json!(response)))
+    }
+}
+
+#[derive(Serialize)]
+struct DocumentToolResponse {
+    clean_markdown: String,
+    manifest_id: String,
+    file_metadata: FileMetadata,
+}
+
+#[derive(Serialize)]
+struct FileMetadata {
+    source_kind: String,
+    ocr_mean_confidence: Option<f32>,
+    bundle_version: u32,
+    page_count: Option<u32>,
+}
+
+fn required_string<'a>(args: &'a serde_json::Value, field: &str) -> Result<&'a str, ToolError> {
+    args.get(field)
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| ToolError::InvalidArgs(format!("missing required string field `{field}`")))
+}
+
+fn redact_document_text(text: &str, ctx: &ToolCtx<'_>) -> Result<String, ToolError> {
+    let pipeline = crate::bundle::build_document_pipeline().map_err(map_document_error)?;
+    let clean = pipeline
+        .redact_with_context(
+            ctx.resources().session(),
+            RawDocument::Text(text.to_string()),
+            ctx.resources().locale_chain(),
+        )
+        .map_err(|err| ToolError::BackendFailure(format!("document pipeline failed: {err}")))?;
+    match clean {
+        CleanDocument::Text(text) => Ok(text),
+        _ => Err(ToolError::BackendFailure(
+            "document pipeline returned non-text output".to_string(),
+        )),
+    }
+}
+
+fn validate_file(path: &Path, max_file_size: u64) -> Result<(), ToolError> {
+    let metadata = std::fs::metadata(path).map_err(|err| map_file_metadata_error(path, err))?;
+    if !metadata.is_file() {
+        return Err(ToolError::InvalidArgs(format!(
+            "path `{}` is not a regular file",
+            path.display()
+        )));
+    }
+    if metadata.len() > max_file_size {
+        return Err(ToolError::LimitExceeded(format!(
+            "file `{}` is {} bytes; configured cap is {} bytes",
+            path.display(),
+            metadata.len(),
+            max_file_size
+        )));
+    }
+    Ok(())
+}
+
+fn map_file_metadata_error(path: &Path, err: std::io::Error) -> ToolError {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        ToolError::NotFound(format!("file `{}` not found", path.display()))
+    } else {
+        ToolError::internal(err)
+    }
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn read_file_response(path: &Path, ctx: &ToolCtx<'_>) -> Result<DocumentToolResponse, ToolError> {
+    let kind = InputKind::detect(path).map_err(map_document_error)?;
+    let (ocr_result, pdf_page_count, _) =
+        crate::bundle::run_ocr(path, kind).map_err(map_document_error)?;
+    let normalized = crate::ocr::normalize_ocr_artifacts(&ocr_result.text);
+    let clean_text = redact_document_text(&normalized, ctx)?;
+    Ok(DocumentToolResponse {
+        clean_markdown: crate::bundle::format_clean_markdown(&clean_text, kind),
+        manifest_id: ctx.call_id().to_string(),
+        file_metadata: FileMetadata {
+            source_kind: source_kind(kind).to_string(),
+            ocr_mean_confidence: ocr_result.mean_confidence,
+            bundle_version: crate::BUNDLE_VERSION,
+            page_count: pdf_page_count.and_then(|count| u32::try_from(count).ok()),
+        },
+    })
+}
+
+#[cfg(not(feature = "ocr-tesseract"))]
+fn read_file_response(
+    _path: &PathBuf,
+    _ctx: &ToolCtx<'_>,
+) -> Result<DocumentToolResponse, ToolError> {
+    Err(ToolError::BackendUnavailable(
+        "rebuild gaze-document with `--features ocr-tesseract` to enable `gaze_read_file`"
+            .to_string(),
+    ))
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn source_kind(kind: InputKind) -> &'static str {
+    match crate::bundle::kind_label(kind) {
+        "png" | "jpeg" => "image",
+        "pdf" => "pdf",
+        other => other,
+    }
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn map_document_error(err: DocumentError) -> ToolError {
+    match err {
+        DocumentError::TesseractNotFound(hint) | DocumentError::PdfiumNotFound(hint) => {
+            ToolError::BackendUnavailable(hint)
+        }
+        DocumentError::TesseractFailed { status, stderr } => {
+            ToolError::BackendFailure(format!("tesseract exited with status {status}: {stderr}"))
+        }
+        DocumentError::PdfRasterFailed(detail) => ToolError::BackendFailure(detail),
+        DocumentError::UnsupportedInput { path, reason } => {
+            ToolError::InvalidArgs(format!("unsupported input `{}`: {reason}", path.display()))
+        }
+        other => ToolError::internal(other),
+    }
+}
+
+#[cfg(not(feature = "ocr-tesseract"))]
+fn map_document_error(err: crate::DocumentError) -> ToolError {
+    ToolError::internal(err)
+}
+
+fn format_text_markdown(text: &str) -> String {
+    let mut out = String::new();
+    out.push_str("# gaze-document safe text\n\n");
+    out.push_str("Source kind: `text`\n\n");
+    out.push_str("---\n\n");
+    out.push_str(text);
+    if !text.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn response_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "clean_markdown": { "type": "string" },
+            "manifest_id": { "type": "string" },
+            "file_metadata": {
+                "type": "object",
+                "properties": {
+                    "source_kind": { "type": "string" },
+                    "ocr_mean_confidence": { "type": ["number", "null"] },
+                    "bundle_version": { "type": "integer" },
+                    "page_count": { "type": ["integer", "null"] }
+                },
+                "required": [
+                    "source_kind",
+                    "ocr_mean_confidence",
+                    "bundle_version",
+                    "page_count"
+                ]
+            }
+        },
+        "required": ["clean_markdown", "manifest_id", "file_metadata"]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use gaze_mcp_core::{
+        AuthError, AuthHook, DispatchError, ManifestStore, PiiEnvelope, Principal, SessionIdPolicy,
+    };
+    use gaze_mcp_core::{BeginCallContext, CallHandle, FailureReason, ManifestError, SnapshotRef};
+    use serde_json::json;
+
+    use super::*;
+
+    struct AllowAllAuth;
+
+    #[async_trait]
+    impl AuthHook for AllowAllAuth {
+        async fn authorize_agent(
+            &self,
+            _principal: &Principal,
+            _tool_name: &str,
+        ) -> Result<(), AuthError> {
+            Ok(())
+        }
+
+        async fn authorize_operator(
+            &self,
+            _principal: &Principal,
+            _tool_name: &str,
+        ) -> Result<(), AuthError> {
+            Err(AuthError::Denied("operator tier disabled in test".into()))
+        }
+    }
+
+    struct RecordingManifest {
+        begins: AtomicUsize,
+        finishes: AtomicUsize,
+        failures: AtomicUsize,
+    }
+
+    impl RecordingManifest {
+        fn new() -> Self {
+            Self {
+                begins: AtomicUsize::new(0),
+                finishes: AtomicUsize::new(0),
+                failures: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ManifestStore for RecordingManifest {
+        async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+            self.begins.fetch_add(1, Ordering::SeqCst);
+            Ok(CallHandle::new(ctx.call_id))
+        }
+
+        async fn finish_call(
+            &self,
+            _handle: CallHandle,
+            _snapshot: SnapshotRef,
+        ) -> Result<(), ManifestError> {
+            self.finishes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn fail_call(
+            &self,
+            _handle: CallHandle,
+            _reason: FailureReason,
+        ) -> Result<(), ManifestError> {
+            self.failures.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct Harness {
+        registry: ToolRegistry,
+        auth: AllowAllAuth,
+        manifest: Arc<RecordingManifest>,
+        pipeline: gaze::Pipeline,
+        session: gaze::Session,
+        session_id_policy: SessionIdPolicy,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let mut registry = ToolRegistry::new();
+            register_tools(&mut registry, GazeReadOpts::default()).expect("register tools");
+            Self {
+                registry,
+                auth: AllowAllAuth,
+                manifest: Arc::new(RecordingManifest::new()),
+                pipeline: crate::bundle::build_document_pipeline().expect("pipeline"),
+                session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
+                session_id_policy: SessionIdPolicy::default_strict(),
+            }
+        }
+
+        async fn dispatch(
+            &self,
+            tool_name: &str,
+            args: serde_json::Value,
+        ) -> Result<serde_json::Value, DispatchError> {
+            let envelope = PiiEnvelope::new(
+                &self.registry,
+                &self.auth,
+                self.manifest.as_ref(),
+                &self.pipeline,
+                &self.session,
+                &[gaze::LocaleTag::Global],
+                &self.session_id_policy,
+            );
+            envelope
+                .dispatch(&Principal::new("unit-test"), tool_name, args, None)
+                .await
+                .map(|response| response.payload)
+        }
+    }
+
+    fn assert_no_raw_fixture_values(clean_markdown: &str) {
+        assert!(!clean_markdown.contains("Jane Doe"), "{clean_markdown}");
+        assert!(!clean_markdown.contains("@example.com"), "{clean_markdown}");
+        assert!(!clean_markdown.contains("555-0142"), "{clean_markdown}");
+    }
+
+    #[tokio::test]
+    async fn read_text_dispatch_returns_clean_markdown_and_manifest_id() {
+        let harness = Harness::new();
+        let payload = harness
+            .dispatch(
+                "gaze_read_text",
+                json!({
+                    "text": "Bill to: Jane Doe\nEmail: jane.doe@example.com\nPhone: +1-555-0142"
+                }),
+            )
+            .await
+            .expect("dispatch succeeds");
+
+        let clean_markdown = payload["clean_markdown"].as_str().expect("clean markdown");
+        assert!(clean_markdown.contains(":Email_"), "{clean_markdown}");
+        assert!(clean_markdown.contains(":Name_"), "{clean_markdown}");
+        assert!(
+            clean_markdown.contains(":Custom:phone_"),
+            "{clean_markdown}"
+        );
+        assert_no_raw_fixture_values(clean_markdown);
+        assert!(!payload["manifest_id"].as_str().unwrap().is_empty());
+        assert_eq!(payload["file_metadata"]["source_kind"], "text");
+        assert_eq!(
+            payload["file_metadata"]["ocr_mean_confidence"],
+            serde_json::Value::Null
+        );
+        assert_eq!(harness.manifest.begins.load(Ordering::SeqCst), 1);
+        assert_eq!(harness.manifest.finishes.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_file_missing_path_fails_closed_as_not_found() {
+        let harness = Harness::new();
+        let err = harness
+            .dispatch(
+                "gaze_read_file",
+                json!({ "path": "testdata/does-not-exist.png" }),
+            )
+            .await
+            .expect_err("missing file fails");
+
+        match err {
+            DispatchError::ToolError(ToolError::NotFound(message)) => {
+                assert!(message.contains("not found"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert_eq!(harness.manifest.failures.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_file_limit_fails_closed_before_ocr() {
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(GazeReadFile::with_max_file_size(1))
+            .expect("register file tool");
+        let harness = Harness {
+            registry,
+            auth: AllowAllAuth,
+            manifest: Arc::new(RecordingManifest::new()),
+            pipeline: crate::bundle::build_document_pipeline().expect("pipeline"),
+            session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
+            session_id_policy: SessionIdPolicy::default_strict(),
+        };
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("synthetic_image.png");
+        let err = harness
+            .dispatch("gaze_read_file", json!({ "path": fixture }))
+            .await
+            .expect_err("oversized file fails");
+
+        match err {
+            DispatchError::ToolError(ToolError::LimitExceeded(message)) => {
+                assert!(message.contains("configured cap is 1 bytes"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "ocr-tesseract")]
+    #[tokio::test]
+    async fn read_file_dispatch_returns_clean_markdown_for_fixture_when_backend_available() {
+        let harness = Harness::new();
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata")
+            .join("synthetic_image.png");
+        let payload = match harness
+            .dispatch("gaze_read_file", json!({ "path": fixture }))
+            .await
+        {
+            Ok(payload) => payload,
+            Err(DispatchError::ToolError(ToolError::BackendUnavailable(message))) => {
+                eprintln!("SKIP: document backend unavailable: {message}");
+                return;
+            }
+            Err(other) => panic!("unexpected dispatch error: {other:?}"),
+        };
+
+        let clean_markdown = payload["clean_markdown"].as_str().expect("clean markdown");
+        assert!(clean_markdown.contains(":Email_"), "{clean_markdown}");
+        assert!(clean_markdown.contains(":Name_"), "{clean_markdown}");
+        assert!(
+            clean_markdown.contains(":Custom:phone_"),
+            "{clean_markdown}"
+        );
+        assert_no_raw_fixture_values(clean_markdown);
+        assert_eq!(payload["file_metadata"]["source_kind"], "image");
+        assert!(!payload["manifest_id"].as_str().unwrap().is_empty());
+    }
+}

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -1,0 +1,6 @@
+//! MCP tool adapters for `gaze-document`.
+//!
+//! Tools in this module are opt-in via the `mcp` feature and must be
+//! registered explicitly by adopters. Invocation still happens through
+//! `gaze_mcp_core::PiiEnvelope::dispatch`; this module only provides the
+//! tool bodies and catalog metadata.

--- a/crates/gaze-document/tests/mcp_stdio.rs
+++ b/crates/gaze-document/tests/mcp_stdio.rs
@@ -1,0 +1,230 @@
+#![cfg(all(feature = "mcp", feature = "ocr-tesseract", feature = "pdf-input"))]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use gaze_mcp_core::manifest::{
+    BeginCallContext, CallHandle, FailureReason, ManifestError, ManifestStore, SnapshotRef,
+};
+use gaze_mcp_core::session_id::SessionIdPolicy;
+use gaze_mcp_core::{
+    AuthError, AuthHook, DispatchError, DispatchHost, PiiEnvelope, Principal, ToolDescriptor,
+    ToolResponse,
+};
+use gaze_mcp_rmcp::{FixedPrincipalResolver, RmcpFrontend};
+use rmcp::model::CallToolRequestParams;
+use rmcp::ServiceExt;
+use serde_json::{json, Value};
+use tokio::io::duplex;
+
+struct AllowAllAuth;
+
+#[async_trait]
+impl AuthHook for AllowAllAuth {
+    async fn authorize_agent(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Ok(())
+    }
+
+    async fn authorize_operator(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Err(AuthError::Denied("operator tier disabled in test".into()))
+    }
+}
+
+struct RecordingManifest {
+    begins: AtomicUsize,
+    finishes: AtomicUsize,
+    fails: AtomicUsize,
+}
+
+impl RecordingManifest {
+    fn new() -> Self {
+        Self {
+            begins: AtomicUsize::new(0),
+            finishes: AtomicUsize::new(0),
+            fails: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl ManifestStore for RecordingManifest {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        self.begins.fetch_add(1, Ordering::SeqCst);
+        Ok(CallHandle::new(ctx.call_id))
+    }
+
+    async fn finish_call(
+        &self,
+        _handle: CallHandle,
+        _snapshot: SnapshotRef,
+    ) -> Result<(), ManifestError> {
+        self.finishes.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn fail_call(
+        &self,
+        _handle: CallHandle,
+        _reason: FailureReason,
+    ) -> Result<(), ManifestError> {
+        self.fails.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+struct EnvelopeHost {
+    registry: gaze_mcp_core::ToolRegistry,
+    auth: AllowAllAuth,
+    manifest: Arc<RecordingManifest>,
+    pipeline: gaze::Pipeline,
+    session: gaze::Session,
+    session_id_policy: SessionIdPolicy,
+}
+
+impl EnvelopeHost {
+    fn new() -> Self {
+        let mut registry = gaze_mcp_core::ToolRegistry::new();
+        gaze_document::mcp::register_tools(
+            &mut registry,
+            gaze_document::mcp::GazeReadOpts::default(),
+        )
+        .expect("register document tools");
+        Self {
+            registry,
+            auth: AllowAllAuth,
+            manifest: Arc::new(RecordingManifest::new()),
+            pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
+            session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
+            session_id_policy: SessionIdPolicy::default_strict(),
+        }
+    }
+}
+
+#[async_trait]
+impl DispatchHost for EnvelopeHost {
+    async fn dispatch(
+        &self,
+        principal: &Principal,
+        tool_name: &str,
+        raw_args: serde_json::Value,
+        external_session_id: Option<&str>,
+    ) -> Result<ToolResponse, DispatchError> {
+        let envelope = PiiEnvelope::new(
+            &self.registry,
+            &self.auth,
+            self.manifest.as_ref(),
+            &self.pipeline,
+            &self.session,
+            &[gaze::LocaleTag::Global],
+            &self.session_id_policy,
+        );
+        envelope
+            .dispatch(principal, tool_name, raw_args, external_session_id)
+            .await
+    }
+
+    fn list_tools(&self) -> Vec<ToolDescriptor> {
+        self.registry.list().into_iter().cloned().collect()
+    }
+}
+
+fn synthetic_image_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join("synthetic_image.png")
+}
+
+fn parse_success_payload(result: rmcp::model::CallToolResult) -> Value {
+    assert_eq!(result.is_error, Some(false));
+    let text = &result.content[0].raw.as_text().unwrap().text;
+    serde_json::from_str(text).expect("tool response json")
+}
+
+fn assert_clean_response(payload: &Value, expect_source_kind: &str) {
+    let clean = payload["clean_markdown"]
+        .as_str()
+        .expect("clean_markdown string");
+    assert!(clean.contains(":Email_"), "{clean}");
+    assert!(clean.contains(":Name_"), "{clean}");
+    assert!(clean.contains(":Custom:phone_"), "{clean}");
+    assert!(!clean.contains("Jane Doe"), "{clean}");
+    assert!(!clean.contains("@example.com"), "{clean}");
+    assert!(!clean.contains("555-0142"), "{clean}");
+    assert!(!payload["manifest_id"].as_str().unwrap().is_empty());
+    assert_eq!(payload["file_metadata"]["source_kind"], expect_source_kind);
+    assert_eq!(payload["file_metadata"]["bundle_version"], json!(1));
+}
+
+#[tokio::test]
+async fn stdio_document_tools_return_clean_payloads() {
+    let host = Arc::new(EnvelopeHost::new());
+    let frontend = RmcpFrontend::stdio(Arc::new(FixedPrincipalResolver::agent("stdio-test")));
+    let handler = frontend.into_server_handler(host.clone());
+    let (client_stream, server_stream) = duplex(64 * 1024);
+
+    let server_task = tokio::spawn(async move {
+        let running = rmcp::serve_server(handler, server_stream)
+            .await
+            .expect("server initializes");
+        running.waiting().await.expect("server task joins")
+    });
+
+    let client = ().serve(client_stream).await.expect("client initializes");
+    let tools = client
+        .list_tools(Default::default())
+        .await
+        .expect("list tools");
+    let tool_names: Vec<_> = tools.tools.iter().map(|tool| tool.name.as_ref()).collect();
+    assert!(tool_names.contains(&"gaze_read_text"));
+    assert!(tool_names.contains(&"gaze_read_file"));
+
+    let text_args = json!({
+        "text": "Bill to: Jane Doe\nEmail: jane.doe@example.com\nPhone: +1-555-0142"
+    })
+    .as_object()
+    .cloned()
+    .expect("arguments are object");
+    let text_result = client
+        .call_tool(CallToolRequestParams::new("gaze_read_text").with_arguments(text_args))
+        .await
+        .expect("text tool call succeeds");
+    let text_payload = parse_success_payload(text_result);
+    assert_clean_response(&text_payload, "text");
+
+    let file_args = json!({ "path": synthetic_image_path() })
+        .as_object()
+        .cloned()
+        .expect("arguments are object");
+    let file_result = client
+        .call_tool(CallToolRequestParams::new("gaze_read_file").with_arguments(file_args))
+        .await
+        .expect("file tool call returns");
+    if file_result.is_error == Some(true) {
+        let text = &file_result.content[0].raw.as_text().unwrap().text;
+        if text.starts_with("backend-unavailable:") {
+            eprintln!("SKIP: {text}");
+            client.cancel().await.expect("client cancels");
+            server_task.await.expect("server finishes");
+            return;
+        }
+        panic!("unexpected file tool error: {text}");
+    }
+    let file_payload = parse_success_payload(file_result);
+    assert_clean_response(&file_payload, "image");
+
+    assert_eq!(host.manifest.begins.load(Ordering::SeqCst), 2);
+    assert_eq!(host.manifest.finishes.load(Ordering::SeqCst), 2);
+    assert_eq!(host.manifest.fails.load(Ordering::SeqCst), 0);
+
+    client.cancel().await.expect("client cancels");
+    server_task.await.expect("server finishes");
+}

--- a/crates/gaze-mcp-core/src/tool.rs
+++ b/crates/gaze-mcp-core/src/tool.rs
@@ -173,6 +173,15 @@ pub enum ToolError {
     /// A resource referenced by the call (table, file, identity) was not found.
     #[error("not found: {0}")]
     NotFound(String),
+    /// The tool rejected work because a documented bound would be exceeded.
+    #[error("limit exceeded: {0}")]
+    LimitExceeded(String),
+    /// A required local backend (OCR engine, rasterizer, database) is unavailable.
+    #[error("backend unavailable: {0}")]
+    BackendUnavailable(String),
+    /// A local backend was available but failed while processing the request.
+    #[error("backend failure: {0}")]
+    BackendFailure(String),
     /// Adopter / backend failure unrelated to argument validation.
     #[error("tool internal error: {0}")]
     Internal(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -185,6 +194,9 @@ impl ToolError {
         match self {
             Self::InvalidArgs(_) => "invalid-args",
             Self::NotFound(_) => "not-found",
+            Self::LimitExceeded(_) => "limit-exceeded",
+            Self::BackendUnavailable(_) => "backend-unavailable",
+            Self::BackendFailure(_) => "backend-failure",
             Self::Internal(_) => "internal",
         }
     }

--- a/crates/gaze-mcp-rmcp/src/adapter.rs
+++ b/crates/gaze-mcp-rmcp/src/adapter.rs
@@ -140,6 +140,9 @@ pub fn error_to_rmcp_call_tool_result(err: ToolError) -> CallToolResult {
     let message = match err {
         ToolError::InvalidArgs(msg) => msg,
         ToolError::NotFound(msg) => msg,
+        ToolError::LimitExceeded(msg) => msg,
+        ToolError::BackendUnavailable(msg) => msg,
+        ToolError::BackendFailure(msg) => msg,
         ToolError::Internal(source) => source.to_string(),
         // `ToolError` is `#[non_exhaustive]`. Future variants fall back to
         // their `class()` string — the chokepoint contract guarantees a

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -68,6 +68,11 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         program: "cargo",
         args: &["test", "-p", "gaze-recognizers", "--no-default-features"],
     },
+    MatrixCommand {
+        label: "cargo test -p gaze-document --features mcp",
+        program: "cargo",
+        args: &["test", "-p", "gaze-document", "--features", "mcp"],
+    },
     // The removed hook called `xtask ci-feature-matrix`; omit it here to avoid
     // recursive self-execution while preserving the actual gate coverage.
     MatrixCommand {


### PR DESCRIPTION
## Summary

Adds an opt-in `mcp` feature to `gaze-document` with two agent-tier Tool implementations:

- `gaze_read_text` for already-extracted text/transcripts.
- `gaze_read_file` for PNG/JPG/PDF filesystem paths, with a default 25 MiB cap.

Both tools are registered explicitly via `gaze_document::mcp::register_tools`, return `{ clean_markdown, manifest_id, file_metadata }`, and are exercised through `PiiEnvelope::dispatch` in unit and rmcp stdio integration coverage.

## Locked-decision sources

- Scratchpad 1831 counselor verdicts: tool names `gaze_read_file` / `gaze_read_text`, fold into `gaze-document`, honest chokepoint is `PiiEnvelope::dispatch`.
- Roadmap scratchpad 1541 next-wave entry: PR-X document MCP tools before PR-Y `gaze mcp install` / `doctor`.
- Scratchpad 1835 fix patterns / PR #186 doctrine: reuse OCR + Name pipeline behavior and negative leak assertions.

## North-star axis check

- Axis 1 reliability: tools fail closed on missing files, input size limit, missing OCR/pdfium backends, and backend failures; tests assert no raw `Jane Doe`, `@example.com`, or `555-0142` in tool output.
- Axis 2 reversibility: document tool tokenization uses the shared MCP `gaze::Session`, and returns a `manifest_id` tied to the dispatch call.
- Axis 3 agentic-first: output shape is model-friendly clean Markdown plus structured metadata.
- Axis 4 trust: new typed `ToolError` classes cover limit exceeded, backend unavailable, and backend failure instead of collapsing those cases into opaque internal errors.
- Axis 5 adopter ergonomics: feature is opt-in, registration is one helper call, default non-MCP adopters see no behavior change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
