### PR TITLE
feat(gaze-cli): add MCP install, doctor, and serve commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,7 @@ jobs:
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
       - name: cargo test gaze-document mcp feature
         run: cargo test -p gaze-document --features mcp --no-fail-fast
+      - name: cargo test gaze-cli mcp feature
+        run: cargo test -p gaze-cli --features mcp --no-fail-fast
       - name: cargo test
         run: cargo test --workspace --all-features --no-fail-fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `gaze_read_text` Tool impls that route document ingestion through
   `PiiEnvelope::dispatch`. Returns `{ clean_markdown, manifest_id,
   file_metadata }`.
+- `gaze-cli` opt-in `mcp` feature exposes `gaze mcp install --client=<name>`,
+  `gaze mcp doctor`, and `gaze mcp serve` subcommands. Install writes client
+  JSON with the absolute `current_exe()` path and an idempotent marker-fenced
+  skill section in `AGENTS.md`. Ships claude-code, claude-desktop, and cursor
+  at launch.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,20 +1066,26 @@ name = "gaze-cli"
 version = "0.7.0"
 dependencies = [
  "assert_cmd",
+ "async-trait",
  "base64 0.22.1",
  "chrono",
  "clap",
+ "directories-next",
  "gaze-assembly",
  "gaze-audit",
  "gaze-document",
+ "gaze-mcp-core",
+ "gaze-mcp-rmcp",
  "gaze-pii",
  "gaze-recognizers",
  "gaze-types",
+ "pdfium-render",
  "regex",
  "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 
@@ -1689,6 +1716,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2482,6 +2518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Pre-built binaries for Apple Silicon macOS and Linux x86_64 (glibc 2.39+) are at
 
 For library use — linking the Rust runtime directly instead of shelling out — see [Use from Rust](#use-from-rust) below.
 
+For agent hosts that support MCP, build the CLI with the MCP feature and install
+the stdio server into a client config:
+
+```sh
+cargo install --path crates/gaze-cli --features mcp
+gaze mcp install --client=claude-code
+gaze mcp doctor
+```
+
+The MCP server exposes `gaze_read_file` and `gaze_read_text`, returning
+tokenized content plus a `manifest_id` for authorized restore flows. See
+[`crates/gaze-cli/README.md`](crates/gaze-cli/README.md#mcp-installation) for
+Claude Code, Claude Desktop, and Cursor config paths.
+
 ## Pipeline shape
 
 ```text
@@ -89,7 +103,7 @@ Three deterministic detection passes plus an optional observer pass. The safety 
 
 ## Workspace
 
-Eight published crates. Pick the smallest surface that does the job.
+Published crates. Pick the smallest surface that does the job.
 
 | Crate | Use when |
 |-------|----------|
@@ -99,6 +113,7 @@ Eight published crates. Pick the smallest surface that does the job.
 | [`gaze-audit`](crates/gaze-audit/) | You want SQLite-backed metadata audit logging. Adopt directly; `gaze` core has no `rusqlite` dep in any feature graph. |
 | [`gaze-cli`](crates/gaze-cli/) | You want a process boundary for non-Rust adapters (Laravel, Python, etc.). |
 | [`gaze-types`](crates/gaze-types/) | You want the value contracts (`RedactionLogger`, `Manifest`, `LeakReport`) without ML deps. |
+| [`gaze-document`](crates/gaze-document/) | You want PNG/JPG/PDF document ingestion into SafeBundles or MCP document-read tools. |
 | [`gaze-mcp-core`](crates/gaze-mcp-core/) | You're building an MCP-protocol tool host and want every call to pass through Gaze's redaction chokepoint. |
 | [`gaze-mcp-rmcp`](crates/gaze-mcp-rmcp/) | You want the rmcp transport sink for `gaze-mcp-core` (stdio default, optional streamable HTTP). |
 
@@ -182,7 +197,7 @@ cargo run -p xtask -- ci-feature-matrix
 
 ## Available on crates.io
 
-The Gaze workspace publishes 8 crates. All current versions point at this repository as their canonical source.
+The Gaze workspace publishes crates that point at this repository as their canonical source.
 
 | Crate | Purpose |
 |---|---|
@@ -192,6 +207,7 @@ The Gaze workspace publishes 8 crates. All current versions point at this reposi
 | [`gaze-audit`](https://crates.io/crates/gaze-audit) | Passive SQLite audit sink, isolated from core. |
 | [`gaze-assembly`](https://crates.io/crates/gaze-assembly) | Policy-to-pipeline builder shared by CLI-style adopters. |
 | [`gaze-cli`](https://crates.io/crates/gaze-cli) | Command-line `gaze clean` / `gaze restore` binary. |
+| [`gaze-document`](https://crates.io/crates/gaze-document) | Document SafeBundle pipeline and opt-in MCP document tools. |
 | [`gaze-mcp-core`](https://crates.io/crates/gaze-mcp-core) | MCP chokepoint runtime — Tool / ToolCtx / PiiEnvelope dispatch. |
 | [`gaze-mcp-rmcp`](https://crates.io/crates/gaze-mcp-rmcp) | rmcp transport adapter for `gaze-mcp-core`. |
 

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -19,6 +19,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 safety-net-openai = ["gaze-recognizers/safety-net-openai"]
 document = ["dep:gaze-document"]
+mcp = [
+    "dep:async-trait",
+    "dep:directories-next",
+    "dep:gaze-mcp-core",
+    "dep:gaze-mcp-rmcp",
+    "dep:pdfium-render",
+    "dep:tokio",
+    "document",
+    "gaze-document/mcp",
+]
 
 [[bin]]
 name = "gaze"
@@ -28,15 +38,21 @@ path = "src/main.rs"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
+async-trait = { version = "0.1", optional = true }
+directories-next = { version = "2", optional = true }
 gaze = { path = "../gaze", version = "0.7.0", package = "gaze-pii" }
 gaze-assembly = { path = "../gaze-assembly", version = "0.7.0" }
 gaze-audit = { workspace = true }
 gaze-document = { path = "../gaze-document", version = "0.0.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.0", optional = true }
 gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.0" }
 gaze-types = { workspace = true }
+pdfium-render = { version = "0.9", optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -30,6 +30,12 @@ Build from the workspace root:
 $ cargo build -p gaze-cli
 ```
 
+Build with the MCP installer/server surface:
+
+```console
+$ cargo build -p gaze-cli --features mcp
+```
+
 Run from the workspace root:
 
 ```console
@@ -48,9 +54,68 @@ Current subcommands in [`src/commands/mod.rs`](src/commands/mod.rs):
 | `restore` | Reads `{"session_blob","text"}` JSON from stdin and emits restored `{"text"}` JSON, plus `restore_warning` when tolerant restore allows an unknown token. |
 | `audit query` | Prints filtered audit metadata rows from a `--audit-db` SQLite log, opened read-only. |
 | `audit export` | Exports filtered audit metadata rows in JSONL (default) for downstream processing. |
+| `document clean` | OCRs PNG/JPG/PDF input into a SafeBundle. Requires `--features document`. |
+| `mcp install` | Installs `gaze mcp serve` into supported MCP client configs. Requires `--features mcp`. |
+| `mcp doctor` | Diagnoses MCP runtime dependencies, client config, and AGENTS.md guidance. Requires `--features mcp`. |
+| `mcp serve` | Runs the stdio MCP server exposing `gaze_read_file` and `gaze_read_text`. Requires `--features mcp`. |
 
 Audit logging is captured on `clean` via `--audit-db <path>`; the
 `audit query` and `audit export` subcommands read the same database back.
+
+## MCP installation
+
+The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
+registers `gaze-document` tools:
+
+```console
+$ cargo install gaze-cli --features mcp
+$ gaze mcp install --client=claude-code
+$ gaze mcp doctor
+```
+
+`install` always writes the absolute `std::env::current_exe()` path into the
+client config:
+
+```json
+{
+  "mcpServers": {
+    "gaze": {
+      "command": "/absolute/path/to/gaze",
+      "args": ["mcp", "serve"],
+      "env": {}
+    }
+  }
+}
+```
+
+Supported clients:
+
+| Client | Default config path |
+|--------|---------------------|
+| `claude-code` | `./.mcp.json` in the current project. |
+| `claude-desktop` | macOS `~/Library/Application Support/Claude/claude_desktop_config.json`; Windows `%APPDATA%\Claude\claude_desktop_config.json`; Linux config dir fallback. |
+| `cursor` | `./.cursor/mcp.json` in the current project. |
+| `all` | Updates all supported client paths. |
+
+Use `--agents-md <path>` to choose where the marker-fenced Gaze MCP guidance
+section is written. By default, `install` updates `./AGENTS.md`. Use
+`--skip-agents-md` to update only client JSON, and `--dry-run` to preview
+without writing.
+
+`doctor` checks whether the current binary matches client config entries,
+whether `tesseract` and pdfium are available for `gaze_read_file`, whether the
+manifest directory is writable, and whether the AGENTS.md guidance section is
+present. Warnings do not fail by default; `--strict` exits non-zero on warnings.
+Use `--json` for machine-readable output.
+
+`serve` runs the stdio MCP server:
+
+```console
+$ gaze mcp serve --manifest-dir ~/.local/share/gaze/mcp-manifests --max-file-size 26214400
+```
+
+The server covers the data-source to model path only. It does not filter text
+the user pastes directly into a chat UI.
 
 ## `clean`
 

--- a/crates/gaze-cli/src/commands/mcp/doctor.rs
+++ b/crates/gaze-cli/src/commands/mcp/doctor.rs
@@ -1,0 +1,10 @@
+use crate::error::CliError;
+
+use super::DoctorArgs;
+
+pub(crate) fn run(args: DoctorArgs) -> Result<(), CliError> {
+    let _ = (args.agents_md, args.strict, args.json);
+    Err(CliError::McpDetail(
+        "`gaze mcp doctor` implementation is incomplete".to_string(),
+    ))
+}

--- a/crates/gaze-cli/src/commands/mcp/doctor.rs
+++ b/crates/gaze-cli/src/commands/mcp/doctor.rs
@@ -13,11 +13,12 @@ use super::{default_agents_md, Client, DoctorArgs};
 const BEGIN_MARKER: &str = "<!-- BEGIN GAZE MCP -->";
 
 pub(crate) fn run(args: DoctorArgs) -> Result<(), CliError> {
-    let mut checks = Vec::new();
-    checks.push(check_binary_on_path());
-    checks.push(check_tesseract());
-    checks.push(check_pdfium());
-    checks.push(check_manifest_dir(&default_manifest_dir().join("calls")));
+    let mut checks = vec![
+        check_binary_on_path(),
+        check_tesseract(),
+        check_pdfium(),
+        check_manifest_dir(&default_manifest_dir().join("calls")),
+    ];
     for target in targets(Client::All)? {
         checks.push(check_client(target));
     }

--- a/crates/gaze-cli/src/commands/mcp/doctor.rs
+++ b/crates/gaze-cli/src/commands/mcp/doctor.rs
@@ -1,10 +1,279 @@
+use std::path::{Path, PathBuf};
+
+use pdfium_render::prelude::Pdfium;
+use serde::Serialize;
+use serde_json::Value;
+
 use crate::error::CliError;
 
-use super::DoctorArgs;
+use super::install::{targets, ClientTarget};
+use super::serve::default_manifest_dir;
+use super::{default_agents_md, Client, DoctorArgs};
+
+const BEGIN_MARKER: &str = "<!-- BEGIN GAZE MCP -->";
 
 pub(crate) fn run(args: DoctorArgs) -> Result<(), CliError> {
-    let _ = (args.agents_md, args.strict, args.json);
-    Err(CliError::McpDetail(
-        "`gaze mcp doctor` implementation is incomplete".to_string(),
-    ))
+    let mut checks = Vec::new();
+    checks.push(check_binary_on_path());
+    checks.push(check_tesseract());
+    checks.push(check_pdfium());
+    checks.push(check_manifest_dir(&default_manifest_dir().join("calls")));
+    for target in targets(Client::All)? {
+        checks.push(check_client(target));
+    }
+    checks.push(check_agents_md(
+        args.agents_md.unwrap_or_else(default_agents_md),
+    ));
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&checks)
+                .map_err(|err| CliError::McpDetail(format!("doctor JSON failed: {err}")))?
+        );
+    } else {
+        println!("{:<5}\t{:<28}\tevidence", "state", "check");
+        for check in &checks {
+            println!(
+                "{:<5}\t{:<28}\t{}",
+                check.state.as_str(),
+                check.name,
+                check.evidence
+            );
+        }
+    }
+
+    let has_fail = checks.iter().any(|check| check.state == CheckState::Fail);
+    let has_warn = checks.iter().any(|check| check.state == CheckState::Warn);
+    if has_fail || (args.strict && has_warn) {
+        return Err(CliError::McpDetail(
+            "one or more MCP doctor checks failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Check {
+    name: String,
+    state: CheckState,
+    evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum CheckState {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl CheckState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Warn => "warn",
+            Self::Fail => "fail",
+        }
+    }
+}
+
+fn pass(name: impl Into<String>, evidence: impl Into<String>) -> Check {
+    Check {
+        name: name.into(),
+        state: CheckState::Pass,
+        evidence: evidence.into(),
+    }
+}
+
+fn warn(name: impl Into<String>, evidence: impl Into<String>) -> Check {
+    Check {
+        name: name.into(),
+        state: CheckState::Warn,
+        evidence: evidence.into(),
+    }
+}
+
+fn fail(name: impl Into<String>, evidence: impl Into<String>) -> Check {
+    Check {
+        name: name.into(),
+        state: CheckState::Fail,
+        evidence: evidence.into(),
+    }
+}
+
+fn check_binary_on_path() -> Check {
+    let current = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(err) => return fail("binary on PATH", format!("current_exe failed: {err}")),
+    };
+    let Some(found) = find_on_path("gaze") else {
+        return warn(
+            "binary on PATH",
+            format!(
+                "`gaze` not found on PATH; MCP configs can still use `{}`",
+                current.display()
+            ),
+        );
+    };
+    if paths_match(&current, &found) {
+        pass("binary on PATH", found.display().to_string())
+    } else {
+        warn(
+            "binary on PATH",
+            format!(
+                "PATH resolves `{}` but current executable is `{}`",
+                found.display(),
+                current.display()
+            ),
+        )
+    }
+}
+
+fn check_tesseract() -> Check {
+    match std::process::Command::new("tesseract")
+        .arg("--version")
+        .output()
+    {
+        Ok(output) if output.status.success() => pass("tesseract", "tesseract --version exited 0"),
+        Ok(output) => warn(
+            "tesseract",
+            format!("tesseract --version exited {}", output.status),
+        ),
+        Err(err) => warn(
+            "tesseract",
+            format!("missing or not executable; gaze_read_text still works: {err}"),
+        ),
+    }
+}
+
+fn check_pdfium() -> Check {
+    match Pdfium::bind_to_system_library() {
+        Ok(_) => pass("pdfium dynamic lib", "pdfium system library loaded"),
+        Err(err) => warn(
+            "pdfium dynamic lib",
+            format!("missing; PDF input unavailable until installed: {err}"),
+        ),
+    }
+}
+
+fn check_manifest_dir(path: &Path) -> Check {
+    if !path.exists() {
+        return warn(
+            "manifest dir",
+            format!(
+                "`{}` does not exist yet; serve will create it",
+                path.display()
+            ),
+        );
+    }
+    if !path.is_dir() {
+        return fail(
+            "manifest dir",
+            format!("`{}` is not a directory", path.display()),
+        );
+    }
+    let probe = path.join(".gaze-doctor-write-test");
+    match std::fs::write(&probe, b"ok").and_then(|_| std::fs::remove_file(&probe)) {
+        Ok(()) => pass("manifest dir", format!("`{}` is writable", path.display())),
+        Err(err) => fail(
+            "manifest dir",
+            format!("`{}` is not writable: {err}", path.display()),
+        ),
+    }
+}
+
+fn check_client(target: ClientTarget) -> Check {
+    let label = target.label();
+    let name = format!("{label} config");
+    let path = match target.config_path() {
+        Ok(path) => path,
+        Err(err) => return fail(name, format!("cannot resolve config path: {err:?}")),
+    };
+    if !path.exists() {
+        return warn(name, format!("`{}` does not exist", path.display()));
+    }
+    let root = match read_config(&path) {
+        Ok(root) => root,
+        Err(err) => return fail(name, err),
+    };
+    let Some(server) = root
+        .get("mcpServers")
+        .and_then(|servers| servers.get("gaze"))
+    else {
+        return warn(
+            name,
+            format!("`{}` has no mcpServers.gaze entry", path.display()),
+        );
+    };
+    let Some(command) = server.get("command").and_then(Value::as_str) else {
+        return fail(name, "mcpServers.gaze.command is missing or not a string");
+    };
+    let current = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(err) => return fail(name, format!("current_exe failed: {err}")),
+    };
+    if paths_match(&current, Path::new(command)) {
+        pass(name, format!("gaze entry points at `{command}`"))
+    } else {
+        warn(
+            name,
+            format!(
+                "gaze entry points at `{command}`, current executable is `{}`",
+                current.display()
+            ),
+        )
+    }
+}
+
+fn check_agents_md(path: PathBuf) -> Check {
+    match std::fs::read_to_string(&path) {
+        Ok(content) if content.contains(BEGIN_MARKER) => pass(
+            "AGENTS.md skill section",
+            format!("`{}` contains Gaze MCP section", path.display()),
+        ),
+        Ok(_) => warn(
+            "AGENTS.md skill section",
+            format!("`{}` lacks Gaze MCP section", path.display()),
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => warn(
+            "AGENTS.md skill section",
+            format!("`{}` does not exist", path.display()),
+        ),
+        Err(err) => fail(
+            "AGENTS.md skill section",
+            format!("cannot read `{}`: {err}", path.display()),
+        ),
+    }
+}
+
+fn read_config(path: &Path) -> Result<Value, String> {
+    let bytes =
+        std::fs::read(path).map_err(|err| format!("cannot read `{}`: {err}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|err| format!("cannot parse `{}`: {err}", path.display()))
+}
+
+fn find_on_path(binary: &str) -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&paths) {
+        let candidate = dir.join(binary);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let candidate = dir.join(format!("{binary}.exe"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn paths_match(a: &Path, b: &Path) -> bool {
+    let a = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
+    let b = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
+    a == b
 }

--- a/crates/gaze-cli/src/commands/mcp/install.rs
+++ b/crates/gaze-cli/src/commands/mcp/install.rs
@@ -289,13 +289,13 @@ fn env_path(name: &str) -> Option<PathBuf> {
 fn claude_desktop_config_path() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        return BaseDirs::new().map(|dirs| {
+        BaseDirs::new().map(|dirs| {
             dirs.home_dir()
                 .join("Library")
                 .join("Application Support")
                 .join("Claude")
                 .join("claude_desktop_config.json")
-        });
+        })
     }
     #[cfg(target_os = "windows")]
     {

--- a/crates/gaze-cli/src/commands/mcp/install.rs
+++ b/crates/gaze-cli/src/commands/mcp/install.rs
@@ -1,0 +1,15 @@
+use crate::error::CliError;
+
+use super::InstallArgs;
+
+pub(crate) fn run(args: InstallArgs) -> Result<(), CliError> {
+    let _ = (
+        args.client,
+        args.agents_md,
+        args.dry_run,
+        args.skip_agents_md,
+    );
+    Err(CliError::McpDetail(
+        "`gaze mcp install` implementation is incomplete".to_string(),
+    ))
+}

--- a/crates/gaze-cli/src/commands/mcp/install.rs
+++ b/crates/gaze-cli/src/commands/mcp/install.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "macos")]
 use directories_next::BaseDirs;
 use serde::Serialize;
 use serde_json::{Map, Value};

--- a/crates/gaze-cli/src/commands/mcp/install.rs
+++ b/crates/gaze-cli/src/commands/mcp/install.rs
@@ -1,15 +1,340 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use directories_next::BaseDirs;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
 use crate::error::CliError;
 
-use super::InstallArgs;
+use super::{default_agents_md, Client, InstallArgs};
+
+const BEGIN_MARKER: &str = "<!-- BEGIN GAZE MCP -->";
+const END_MARKER: &str = "<!-- END GAZE MCP -->";
 
 pub(crate) fn run(args: InstallArgs) -> Result<(), CliError> {
-    let _ = (
-        args.client,
-        args.agents_md,
-        args.dry_run,
-        args.skip_agents_md,
-    );
-    Err(CliError::McpDetail(
-        "`gaze mcp install` implementation is incomplete".to_string(),
-    ))
+    let exe = std::env::current_exe()
+        .map_err(|err| CliError::McpDetail(format!("cannot resolve current executable: {err}")))?;
+    let targets = targets(args.client)?;
+    let mut summaries = Vec::new();
+    for target in targets {
+        summaries.push(install_client(target, &exe, args.dry_run)?);
+    }
+
+    let agents_path = args.agents_md.unwrap_or_else(default_agents_md);
+    let agents_summary = if args.skip_agents_md {
+        None
+    } else {
+        Some(update_agents_md(&agents_path, args.dry_run)?)
+    };
+
+    for summary in summaries {
+        println!(
+            "{} {} {}",
+            summary.client.label(),
+            summary.action,
+            summary.path.display()
+        );
+    }
+    if let Some(summary) = agents_summary {
+        println!("agents-md {} {}", summary.action, summary.path.display());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ClientTarget {
+    ClaudeCode,
+    ClaudeDesktop,
+    Cursor,
+}
+
+impl ClientTarget {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::ClaudeDesktop => "claude-desktop",
+            Self::Cursor => "cursor",
+        }
+    }
+
+    pub(crate) fn config_path(self) -> Result<PathBuf, CliError> {
+        match self {
+            Self::ClaudeCode => env_path("GAZE_MCP_CLAUDE_CODE_CONFIG")
+                .or_else(|| Some(std::env::current_dir().ok()?.join(".mcp.json")))
+                .ok_or_else(|| {
+                    CliError::McpDetail(
+                        "cannot resolve Claude Code project config path".to_string(),
+                    )
+                }),
+            Self::ClaudeDesktop => env_path("GAZE_MCP_CLAUDE_DESKTOP_CONFIG")
+                .or_else(claude_desktop_config_path)
+                .ok_or_else(|| {
+                    CliError::McpDetail(
+                        "cannot resolve Claude Desktop config path from home/config dir"
+                            .to_string(),
+                    )
+                }),
+            Self::Cursor => env_path("GAZE_MCP_CURSOR_CONFIG")
+                .or_else(|| {
+                    Some(
+                        std::env::current_dir()
+                            .ok()?
+                            .join(".cursor")
+                            .join("mcp.json"),
+                    )
+                })
+                .ok_or_else(|| {
+                    CliError::McpDetail("cannot resolve Cursor project config path".to_string())
+                }),
+        }
+    }
+}
+
+pub(crate) fn targets(client: Client) -> Result<Vec<ClientTarget>, CliError> {
+    Ok(match client {
+        Client::ClaudeCode => vec![ClientTarget::ClaudeCode],
+        Client::ClaudeDesktop => vec![ClientTarget::ClaudeDesktop],
+        Client::Cursor => vec![ClientTarget::Cursor],
+        Client::All => vec![
+            ClientTarget::ClaudeCode,
+            ClientTarget::ClaudeDesktop,
+            ClientTarget::Cursor,
+        ],
+    })
+}
+
+#[derive(Debug)]
+struct InstallSummary {
+    client: ClientTarget,
+    path: PathBuf,
+    action: &'static str,
+}
+
+#[derive(Debug)]
+struct AgentsSummary {
+    path: PathBuf,
+    action: &'static str,
+}
+
+#[derive(Serialize)]
+struct ServerConfig<'a> {
+    command: &'a str,
+    args: [&'static str; 2],
+    env: BTreeMap<String, String>,
+}
+
+fn install_client(
+    target: ClientTarget,
+    exe: &Path,
+    dry_run: bool,
+) -> Result<InstallSummary, CliError> {
+    let path = target.config_path()?;
+    let mut root = read_json_object(&path)?;
+    let action = upsert_gaze_server(&mut root, exe)?;
+    if !dry_run {
+        write_json_object(&path, &root)?;
+    }
+    Ok(InstallSummary {
+        client: target,
+        path,
+        action,
+    })
+}
+
+fn upsert_gaze_server(root: &mut Map<String, Value>, exe: &Path) -> Result<&'static str, CliError> {
+    let exe = exe
+        .to_str()
+        .ok_or_else(|| CliError::McpDetail("current executable path is not UTF-8".to_string()))?;
+    let desired = serde_json::to_value(ServerConfig {
+        command: exe,
+        args: ["mcp", "serve"],
+        env: BTreeMap::new(),
+    })
+    .map_err(|err| CliError::McpDetail(format!("cannot build MCP server JSON: {err}")))?;
+
+    let servers = root
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(servers) = servers else {
+        return Err(CliError::McpDetail(
+            "`mcpServers` exists but is not a JSON object".to_string(),
+        ));
+    };
+    let action = match servers.get("gaze") {
+        Some(existing) if existing == &desired => "unchanged",
+        Some(_) => "updated",
+        None => "installed",
+    };
+    servers.insert("gaze".to_string(), desired);
+    Ok(action)
+}
+
+fn read_json_object(path: &Path) -> Result<Map<String, Value>, CliError> {
+    if !path.exists() {
+        return Ok(Map::new());
+    }
+    let bytes = std::fs::read(path).map_err(|err| {
+        CliError::McpDetail(format!("cannot read config `{}`: {err}", path.display()))
+    })?;
+    let value: Value = serde_json::from_slice(&bytes).map_err(|err| {
+        CliError::McpDetail(format!("cannot parse config `{}`: {err}", path.display()))
+    })?;
+    match value {
+        Value::Object(object) => Ok(object),
+        _ => Err(CliError::McpDetail(format!(
+            "config `{}` is not a JSON object",
+            path.display()
+        ))),
+    }
+}
+
+fn write_json_object(path: &Path, object: &Map<String, Value>) -> Result<(), CliError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            CliError::McpDetail(format!(
+                "cannot create config directory `{}`: {err}",
+                parent.display()
+            ))
+        })?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(object).map_err(|err| {
+        CliError::McpDetail(format!(
+            "cannot serialize config `{}`: {err}",
+            path.display()
+        ))
+    })?;
+    std::fs::write(&tmp, bytes).map_err(|err| {
+        CliError::McpDetail(format!("cannot write config `{}`: {err}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, path).map_err(|err| {
+        CliError::McpDetail(format!("cannot replace config `{}`: {err}", path.display()))
+    })
+}
+
+fn update_agents_md(path: &Path, dry_run: bool) -> Result<AgentsSummary, CliError> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(err) => {
+            return Err(CliError::McpDetail(format!(
+                "cannot read `{}`: {err}",
+                path.display()
+            )));
+        }
+    };
+    let (next, action) = replace_or_append_section(&existing);
+    if !dry_run && next != existing {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                CliError::McpDetail(format!(
+                    "cannot create AGENTS.md directory `{}`: {err}",
+                    parent.display()
+                ))
+            })?;
+        }
+        std::fs::write(path, next).map_err(|err| {
+            CliError::McpDetail(format!("cannot write `{}`: {err}", path.display()))
+        })?;
+    }
+    Ok(AgentsSummary {
+        path: path.to_path_buf(),
+        action,
+    })
+}
+
+fn replace_or_append_section(existing: &str) -> (String, &'static str) {
+    let section = skill_section();
+    if let Some(start) = existing.find(BEGIN_MARKER) {
+        if let Some(end_rel) = existing[start..].find(END_MARKER) {
+            let end = start + end_rel + END_MARKER.len();
+            let mut next = String::new();
+            next.push_str(&existing[..start]);
+            next.push_str(&section);
+            next.push_str(&existing[end..]);
+            return (next, "updated");
+        }
+    }
+
+    let mut next = existing.to_string();
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    if !next.is_empty() {
+        next.push('\n');
+    }
+    next.push_str(&section);
+    next.push('\n');
+    (next, "installed")
+}
+
+fn skill_section() -> String {
+    format!(
+        "{BEGIN_MARKER}\n{}\n{END_MARKER}",
+        r#"# Gaze MCP
+
+When Gaze MCP is available, route potentially sensitive file or text reads through `gaze_read_file` or `gaze_read_text` before using the content in an LLM response.
+
+Gaze output contains pseudonymous tokens such as `:Email_`, `:Name_`, and `:Custom:phone_`. Treat these as placeholders, not missing data. Do not invent originals. Preserve the `manifest_id` returned by Gaze so authorized restore flows can round-trip values later.
+
+This section is agent guidance, not a security boundary. The MCP chokepoint is the server-side `PiiEnvelope::dispatch` path."#
+    )
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name).map(PathBuf::from)
+}
+
+fn claude_desktop_config_path() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        return BaseDirs::new().map(|dirs| {
+            dirs.home_dir()
+                .join("Library")
+                .join("Application Support")
+                .join("Claude")
+                .join("claude_desktop_config.json")
+        });
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return directories_next::ProjectDirs::from("", "", "Claude")
+            .map(|dirs| dirs.config_dir().join("claude_desktop_config.json"));
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        directories_next::ProjectDirs::from("", "", "Claude")
+            .map(|dirs| dirs.config_dir().join("claude_desktop_config.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agents_section_is_idempotent() {
+        let (once, action) = replace_or_append_section("# Existing\n");
+        assert_eq!(action, "installed");
+        let (twice, action) = replace_or_append_section(&once);
+        assert_eq!(action, "updated");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn upsert_preserves_other_servers() {
+        let mut root = Map::new();
+        root.insert(
+            "mcpServers".to_string(),
+            serde_json::json!({ "other": { "command": "node" } }),
+        );
+        let action = upsert_gaze_server(&mut root, Path::new("/tmp/gaze")).unwrap();
+        assert_eq!(action, "installed");
+        assert!(root["mcpServers"]["other"].is_object());
+        assert_eq!(
+            root["mcpServers"]["gaze"]["args"],
+            serde_json::json!(["mcp", "serve"])
+        );
+    }
 }

--- a/crates/gaze-cli/src/commands/mcp/mod.rs
+++ b/crates/gaze-cli/src/commands/mcp/mod.rs
@@ -1,0 +1,57 @@
+mod doctor;
+mod install;
+mod serve;
+
+use std::path::PathBuf;
+
+use clap::ValueEnum;
+
+use crate::error::CliError;
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Client {
+    ClaudeCode,
+    ClaudeDesktop,
+    Cursor,
+    All,
+}
+
+#[derive(Debug)]
+pub(crate) struct InstallArgs {
+    pub client: Client,
+    pub agents_md: Option<PathBuf>,
+    pub dry_run: bool,
+    pub skip_agents_md: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct DoctorArgs {
+    pub agents_md: Option<PathBuf>,
+    pub strict: bool,
+    pub json: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct ServeArgs {
+    pub manifest_dir: Option<PathBuf>,
+    pub max_file_size: Option<u64>,
+}
+
+pub(crate) fn install(args: InstallArgs) -> Result<(), CliError> {
+    install::run(args)
+}
+
+pub(crate) fn doctor(args: DoctorArgs) -> Result<(), CliError> {
+    doctor::run(args)
+}
+
+pub(crate) fn serve(args: ServeArgs) -> Result<(), CliError> {
+    serve::run(args)
+}
+
+#[allow(dead_code)]
+fn default_agents_md() -> PathBuf {
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("AGENTS.md")
+}

--- a/crates/gaze-cli/src/commands/mcp/serve.rs
+++ b/crates/gaze-cli/src/commands/mcp/serve.rs
@@ -1,10 +1,258 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::UNIX_EPOCH;
+
+use async_trait::async_trait;
+use directories_next::ProjectDirs;
+use gaze_mcp_core::{
+    AuthError, AuthHook, BeginCallContext, CallHandle, DispatchError, DispatchHost, FailureReason,
+    Frontend, ManifestError, ManifestStore, PiiEnvelope, Principal, SessionIdPolicy, ShutdownToken,
+    SnapshotRef, ToolDescriptor, ToolRegistry, ToolResponse,
+};
+use gaze_mcp_rmcp::{FixedPrincipalResolver, RmcpFrontend};
+use serde::Serialize;
+
 use crate::error::CliError;
 
 use super::ServeArgs;
 
 pub(crate) fn run(args: ServeArgs) -> Result<(), CliError> {
-    let _ = (args.manifest_dir, args.max_file_size);
-    Err(CliError::McpDetail(
-        "`gaze mcp serve` implementation is incomplete".to_string(),
-    ))
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| CliError::McpDetail(format!("tokio runtime init failed: {err}")))?;
+    runtime.block_on(serve_stdio(args))
+}
+
+async fn serve_stdio(args: ServeArgs) -> Result<(), CliError> {
+    let manifest_dir = args
+        .manifest_dir
+        .unwrap_or_else(default_manifest_dir)
+        .join("calls");
+    let manifest = Arc::new(FileManifestStore::new(manifest_dir)?);
+    let host = Arc::new(McpHost::new(manifest, args.max_file_size)?);
+    let frontend = RmcpFrontend::stdio(Arc::new(FixedPrincipalResolver::agent("gaze-cli")));
+    frontend
+        .serve(host, ShutdownToken::new())
+        .await
+        .map_err(|err| CliError::McpDetail(format!("mcp stdio server failed: {err}")))
+}
+
+pub(crate) fn default_manifest_dir() -> PathBuf {
+    ProjectDirs::from("dev", "Gaze", "gaze")
+        .map(|dirs| dirs.data_dir().join("mcp-manifests"))
+        .unwrap_or_else(|| PathBuf::from(".gaze").join("mcp-manifests"))
+}
+
+struct McpHost {
+    registry: ToolRegistry,
+    auth: AllowAgentAuth,
+    manifest: Arc<FileManifestStore>,
+    pipeline: gaze::Pipeline,
+    session: gaze::Session,
+    session_id_policy: SessionIdPolicy,
+}
+
+impl McpHost {
+    fn new(manifest: Arc<FileManifestStore>, max_file_size: Option<u64>) -> Result<Self, CliError> {
+        let mut registry = ToolRegistry::new();
+        let mut opts = gaze_document::mcp::GazeReadOpts::default();
+        if let Some(max_file_size) = max_file_size {
+            opts.max_file_size = max_file_size;
+        }
+        gaze_document::mcp::register_tools(&mut registry, opts)
+            .map_err(|err| CliError::McpDetail(format!("mcp tool registration failed: {err}")))?;
+        let pipeline = gaze::Pipeline::builder()
+            .build()
+            .map_err(|err| CliError::McpDetail(format!("mcp redaction pipeline failed: {err}")))?;
+        let session = gaze::Session::new(gaze::Scope::Ephemeral)
+            .map_err(|err| CliError::McpDetail(format!("mcp session init failed: {err}")))?;
+        Ok(Self {
+            registry,
+            auth: AllowAgentAuth,
+            manifest,
+            pipeline,
+            session,
+            session_id_policy: SessionIdPolicy::default_strict(),
+        })
+    }
+}
+
+#[async_trait]
+impl DispatchHost for McpHost {
+    async fn dispatch(
+        &self,
+        principal: &Principal,
+        tool_name: &str,
+        raw_args: serde_json::Value,
+        external_session_id: Option<&str>,
+    ) -> Result<ToolResponse, DispatchError> {
+        let envelope = PiiEnvelope::new(
+            &self.registry,
+            &self.auth,
+            self.manifest.as_ref(),
+            &self.pipeline,
+            &self.session,
+            &[gaze::LocaleTag::Global],
+            &self.session_id_policy,
+        );
+        envelope
+            .dispatch(principal, tool_name, raw_args, external_session_id)
+            .await
+    }
+
+    fn list_tools(&self) -> Vec<ToolDescriptor> {
+        self.registry.list().into_iter().cloned().collect()
+    }
+}
+
+#[derive(Debug, Default)]
+struct AllowAgentAuth;
+
+#[async_trait]
+impl AuthHook for AllowAgentAuth {
+    async fn authorize_agent(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Ok(())
+    }
+
+    async fn authorize_operator(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Err(AuthError::Denied(
+            "gaze-cli mcp serve exposes only agent-tier document tools".to_string(),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct FileManifestStore {
+    dir: PathBuf,
+    handles: Mutex<HashSet<CallHandle>>,
+}
+
+impl FileManifestStore {
+    fn new(dir: PathBuf) -> Result<Self, CliError> {
+        std::fs::create_dir_all(&dir).map_err(|err| {
+            CliError::McpDetail(format!(
+                "cannot create manifest directory `{}`: {err}",
+                dir.display()
+            ))
+        })?;
+        Ok(Self {
+            dir,
+            handles: Mutex::new(HashSet::new()),
+        })
+    }
+
+    fn path_for(&self, handle: CallHandle) -> PathBuf {
+        self.dir.join(format!("{}.json", handle.id()))
+    }
+
+    fn write_record(&self, path: &Path, record: &ManifestRecord) -> Result<(), ManifestError> {
+        let bytes = serde_json::to_vec_pretty(record).map_err(ManifestError::backend)?;
+        std::fs::write(path, bytes).map_err(ManifestError::backend)
+    }
+}
+
+#[async_trait]
+impl ManifestStore for FileManifestStore {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        let handle = CallHandle::new(ctx.call_id);
+        {
+            let mut handles = self.handles.lock().map_err(|_| {
+                ManifestError::Validation("manifest handle mutex poisoned".to_string())
+            })?;
+            if !handles.insert(handle) {
+                return Err(ManifestError::DuplicateCallId(handle));
+            }
+        }
+        let record = ManifestRecord::Started {
+            call_id: ctx.call_id.to_string(),
+            external_session_id: ctx.external_session_id.map(ToOwned::to_owned),
+            principal_id: ctx.principal_id.to_string(),
+            tool_name: ctx.tool_name.to_string(),
+            redacted_args: ctx.redacted_args.clone(),
+            started_at_unix_ms: unix_ms(ctx.started_at),
+        };
+        self.write_record(&self.path_for(handle), &record)?;
+        Ok(handle)
+    }
+
+    async fn finish_call(
+        &self,
+        handle: CallHandle,
+        snapshot: SnapshotRef,
+    ) -> Result<(), ManifestError> {
+        self.finish_handle(handle)?;
+        self.write_record(
+            &self.path_for(handle),
+            &ManifestRecord::Finished {
+                call_id: handle.id().to_string(),
+                snapshot,
+            },
+        )
+    }
+
+    async fn fail_call(
+        &self,
+        handle: CallHandle,
+        reason: FailureReason,
+    ) -> Result<(), ManifestError> {
+        self.finish_handle(handle)?;
+        self.write_record(
+            &self.path_for(handle),
+            &ManifestRecord::Failed {
+                call_id: handle.id().to_string(),
+                reason,
+            },
+        )
+    }
+}
+
+impl FileManifestStore {
+    fn finish_handle(&self, handle: CallHandle) -> Result<(), ManifestError> {
+        let mut handles = self
+            .handles
+            .lock()
+            .map_err(|_| ManifestError::Validation("manifest handle mutex poisoned".to_string()))?;
+        if handles.remove(&handle) {
+            Ok(())
+        } else {
+            Err(ManifestError::UnknownHandle(handle))
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum ManifestRecord {
+    Started {
+        call_id: String,
+        external_session_id: Option<String>,
+        principal_id: String,
+        tool_name: String,
+        redacted_args: serde_json::Value,
+        started_at_unix_ms: u128,
+    },
+    Finished {
+        call_id: String,
+        snapshot: SnapshotRef,
+    },
+    Failed {
+        call_id: String,
+        reason: FailureReason,
+    },
+}
+
+fn unix_ms(time: std::time::SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
 }

--- a/crates/gaze-cli/src/commands/mcp/serve.rs
+++ b/crates/gaze-cli/src/commands/mcp/serve.rs
@@ -1,0 +1,10 @@
+use crate::error::CliError;
+
+use super::ServeArgs;
+
+pub(crate) fn run(args: ServeArgs) -> Result<(), CliError> {
+    let _ = (args.manifest_dir, args.max_file_size);
+    Err(CliError::McpDetail(
+        "`gaze mcp serve` implementation is incomplete".to_string(),
+    ))
+}

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -2,6 +2,8 @@ mod audit;
 mod clean;
 #[cfg(feature = "document")]
 mod document;
+#[cfg(feature = "mcp")]
+mod mcp;
 mod restore;
 
 use std::path::PathBuf;
@@ -119,6 +121,14 @@ enum Cmd {
         #[command(subcommand)]
         command: DocumentCmd,
     },
+    /// Install, diagnose, or run the Gaze MCP stdio server.
+    ///
+    /// Requires the binary to be built with `--features mcp`.
+    #[cfg(feature = "mcp")]
+    Mcp {
+        #[command(subcommand)]
+        command: McpCmd,
+    },
 }
 
 #[cfg(feature = "document")]
@@ -132,6 +142,47 @@ enum DocumentCmd {
         /// Output directory. Created if missing.
         #[arg(long)]
         out: PathBuf,
+    },
+}
+
+#[cfg(feature = "mcp")]
+#[derive(Subcommand, Debug)]
+enum McpCmd {
+    /// Install Gaze as an MCP stdio server in a supported client config.
+    Install {
+        /// Client config to update.
+        #[arg(long, value_enum)]
+        client: mcp::Client,
+        /// Agent guidance file to create/update.
+        #[arg(long)]
+        agents_md: Option<PathBuf>,
+        /// Print planned changes without writing files.
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the marker-fenced AGENTS.md skill section.
+        #[arg(long)]
+        skip_agents_md: bool,
+    },
+    /// Diagnose MCP server dependencies and client configuration.
+    Doctor {
+        /// Agent guidance file to check.
+        #[arg(long)]
+        agents_md: Option<PathBuf>,
+        /// Exit non-zero when any warning is present.
+        #[arg(long)]
+        strict: bool,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Run the Gaze MCP stdio server.
+    Serve {
+        /// Directory where MCP manifest call records are written.
+        #[arg(long)]
+        manifest_dir: Option<PathBuf>,
+        /// Maximum file size accepted by `gaze_read_file`.
+        #[arg(long)]
+        max_file_size: Option<u64>,
     },
 }
 
@@ -468,6 +519,36 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             DocumentCmd::Clean { input, out } => {
                 document::run_clean(document::CleanArgs { input, out })
             }
+        },
+        #[cfg(feature = "mcp")]
+        Cmd::Mcp { command } => match command {
+            McpCmd::Install {
+                client,
+                agents_md,
+                dry_run,
+                skip_agents_md,
+            } => mcp::install(mcp::InstallArgs {
+                client,
+                agents_md,
+                dry_run,
+                skip_agents_md,
+            }),
+            McpCmd::Doctor {
+                agents_md,
+                strict,
+                json,
+            } => mcp::doctor(mcp::DoctorArgs {
+                agents_md,
+                strict,
+                json,
+            }),
+            McpCmd::Serve {
+                manifest_dir,
+                max_file_size,
+            } => mcp::serve(mcp::ServeArgs {
+                manifest_dir,
+                max_file_size,
+            }),
         },
     }
 }

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -33,6 +33,8 @@ pub(crate) enum CliError {
     PolicyOpen,
     #[cfg(feature = "document")]
     DocumentDetail(String),
+    #[cfg(feature = "mcp")]
+    McpDetail(String),
 }
 
 impl CliError {
@@ -50,6 +52,8 @@ impl CliError {
             Self::Io | Self::PolicyOpen => 4,
             #[cfg(feature = "document")]
             Self::DocumentDetail(_) => 5,
+            #[cfg(feature = "mcp")]
+            Self::McpDetail(_) => 6,
         }
     }
 
@@ -73,6 +77,8 @@ impl CliError {
             Self::PolicyOpen => "PolicyOpen",
             #[cfg(feature = "document")]
             Self::DocumentDetail(_) => "Document",
+            #[cfg(feature = "mcp")]
+            Self::McpDetail(_) => "Mcp",
         }
     }
 
@@ -116,6 +122,17 @@ impl CliError {
             ),
             #[cfg(feature = "document")]
             Self::DocumentDetail(detail) => {
+                let detail = serde_json::to_string(detail)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"detail":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    detail
+                )
+            }
+            #[cfg(feature = "mcp")]
+            Self::McpDetail(detail) => {
                 let detail = serde_json::to_string(detail)
                     .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
                 eprintln!(

--- a/crates/gaze-cli/tests/mcp_install_doctor.rs
+++ b/crates/gaze-cli/tests/mcp_install_doctor.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "mcp")]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+#[test]
+fn mcp_install_writes_project_config_and_agents_section_idempotently() {
+    let temp = tempdir().expect("tempdir");
+    let agents = temp.path().join("AGENTS.md");
+    let config = temp.path().join(".mcp.json");
+    std::fs::write(
+        &config,
+        r#"{
+  "mcpServers": {
+    "other": {
+      "command": "node",
+      "args": ["server.js"],
+      "env": {}
+    }
+  },
+  "otherTopLevel": true
+}"#,
+    )
+    .expect("seed config");
+
+    Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .current_dir(temp.path())
+        .args([
+            "mcp",
+            "install",
+            "--client",
+            "claude-code",
+            "--agents-md",
+            agents.to_str().expect("agents path"),
+        ])
+        .assert()
+        .success();
+
+    let first_config = std::fs::read_to_string(&config).expect("config");
+    let first_agents = std::fs::read_to_string(&agents).expect("agents");
+    assert_config_has_gaze_server_and_preserves_other(&first_config);
+    assert_eq!(first_agents.matches("BEGIN GAZE MCP").count(), 1);
+
+    Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .current_dir(temp.path())
+        .args([
+            "mcp",
+            "install",
+            "--client",
+            "claude-code",
+            "--agents-md",
+            agents.to_str().expect("agents path"),
+        ])
+        .assert()
+        .success();
+
+    let second_config = std::fs::read_to_string(&config).expect("config");
+    let second_agents = std::fs::read_to_string(&agents).expect("agents");
+    assert_eq!(first_config, second_config);
+    assert_eq!(first_agents, second_agents);
+
+    Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .current_dir(temp.path())
+        .args([
+            "mcp",
+            "doctor",
+            "--agents-md",
+            agents.to_str().expect("agents path"),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn mcp_install_dry_run_does_not_write() {
+    let temp = tempdir().expect("tempdir");
+    let agents = temp.path().join("AGENTS.md");
+
+    Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .current_dir(temp.path())
+        .args([
+            "mcp",
+            "install",
+            "--client",
+            "claude-code",
+            "--agents-md",
+            agents.to_str().expect("agents path"),
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+
+    assert!(!temp.path().join(".mcp.json").exists());
+    assert!(!agents.exists());
+}
+
+fn assert_config_has_gaze_server_and_preserves_other(config: &str) {
+    let parsed: Value = serde_json::from_str(config).expect("valid json");
+    assert_eq!(parsed["otherTopLevel"], true);
+    assert_eq!(parsed["mcpServers"]["other"]["command"], "node");
+
+    let gaze = &parsed["mcpServers"]["gaze"];
+    let command = gaze["command"].as_str().expect("gaze command");
+    assert!(!command.is_empty());
+    assert!(std::path::Path::new(command).is_absolute());
+    assert_eq!(gaze["args"], serde_json::json!(["mcp", "serve"]));
+    assert_eq!(gaze["env"], serde_json::json!({}));
+}

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -73,6 +73,11 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         program: "cargo",
         args: &["test", "-p", "gaze-document", "--features", "mcp"],
     },
+    MatrixCommand {
+        label: "cargo test -p gaze-cli --features mcp",
+        program: "cargo",
+        args: &["test", "-p", "gaze-cli", "--features", "mcp"],
+    },
     // The removed hook called `xtask ci-feature-matrix`; omit it here to avoid
     // recursive self-execution while preserving the actual gate coverage.
     MatrixCommand {


### PR DESCRIPTION
## Summary
- Adds opt-in `gaze-cli` `mcp` feature with `gaze mcp serve` stdio server backed by `gaze-mcp-rmcp` and `gaze_document::mcp::register_tools`.
- Adds `gaze mcp install --client=claude-code|claude-desktop|cursor|all`, writing absolute `current_exe()` into client JSON and idempotent marker-fenced Gaze MCP guidance into `AGENTS.md`.
- Adds `gaze mcp doctor` with text/JSON diagnostics for PATH, Tesseract, pdfium, manifest dir, client configs, and AGENTS guidance.

## Locked Decisions
- Follows PR-Y brief scratchpad 1843: install/doctor verb names, `current_exe()` config path, clients at launch, and `serve` included in scope.
- Applies counselor verdicts from scratchpad 1831: guidance lives in adopter `AGENTS.md`, not a separate Claude-only skill file; client bootstrap is install-oriented and agent-agnostic.

## Examples
```sh
cargo install gaze-cli --features mcp
gaze mcp install --client=claude-code
gaze mcp install --client=all --agents-md ./AGENTS.md
gaze mcp doctor --json
gaze mcp serve --manifest-dir ~/.local/share/gaze/mcp-manifests --max-file-size 26214400
```

## North-Star Axis Check
- Axis 1 reliability: `serve` routes tool calls through `PiiEnvelope::dispatch`; `doctor` warns on missing OCR/PDF deps instead of silently claiming full coverage.
- Axis 2 reversibility: document tools return tokenized output plus `manifest_id`; install guidance tells agents to preserve it.
- Axis 3 agentic-first: installs MCP JSON for Claude Code, Claude Desktop, and Cursor; `AGENTS.md` guidance coaches agents to use `gaze_read_file` / `gaze_read_text`.
- Axis 4 trust: client config merge is deterministic and idempotent; `doctor` surfaces evidence for config state.
- Axis 5 adopter ergonomics: one `gaze mcp install` writes client config plus agent guidance; `doctor` gives a quick health check before agents depend on the server.

PR-Y completes the v0.7.x MCP follow-up wave.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p gaze-cli --features mcp`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- cargo-metadata-audit-isolation`
