### PR TITLE
feat(cli): thread policy-load error cause through PolicyConfig envelope

### DIFF
--- a/crates/gaze-cli/src/io.rs
+++ b/crates/gaze-cli/src/io.rs
@@ -43,6 +43,8 @@ pub(crate) fn require_json_format(format: &str) -> std::result::Result<(), CliEr
     if format == "json" {
         Ok(())
     } else {
-        Err(CliError::PolicyConfig)
+        Err(CliError::PolicyConfigDetail(format!(
+            "--format must be 'json', got '{format}'"
+        )))
     }
 }

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -16,14 +16,16 @@ pub(crate) fn map_policy_error(err: PolicyError) -> CliError {
         PolicyError::UnsupportedRuleKind(_) => {
             CliError::PolicyConfigDetail("column rules not supported in CLI mode".to_string())
         }
-        _ => CliError::PolicyConfig,
+        other => CliError::PolicyConfigDetail(other.to_string()),
     }
 }
 
 pub(crate) fn map_pipeline_error(err: gaze::Error) -> CliError {
     match err {
         gaze::Error::Policy(policy_err) => map_policy_error(policy_err),
-        gaze::Error::Rulepack(_) => CliError::PolicyConfig,
+        gaze::Error::Rulepack(rulepack_err) => {
+            CliError::PolicyConfigDetail(format!("rulepack error: {rulepack_err}"))
+        }
         _ => CliError::Pipeline,
     }
 }

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -88,7 +88,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         .context_json
         .map(TypedContext::load)
         .transpose()
-        .map_err(|_| CliError::PolicyConfig)?;
+        .map_err(|err| CliError::PolicyConfigDetail(format!("context json: {err}")))?;
     let context_bundle = context
         .as_ref()
         .map(dictionary_bundle_from_context)
@@ -126,11 +126,12 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
             context.as_ref().expect("checked context"),
             Arc::clone(&counter) as Arc<dyn RedactionLogger>,
         )
-        .map_err(|_| CliError::PolicyConfig)?,
+        .map_err(|err| CliError::PolicyConfigDetail(format!("context pipeline build: {err}")))?,
         None => {
             tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
-            build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>)
-                .map_err(|_| CliError::PolicyConfig)?
+            build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>).map_err(
+                |err| CliError::PolicyConfigDetail(format!("stub pipeline build: {err}")),
+            )?
         }
     };
     let pipeline = maybe_register_safety_net(pipeline, &options)?;
@@ -375,9 +376,12 @@ fn class_rules_for_bundled_overrides(
     };
     let mut classes = std::collections::BTreeSet::new();
     for bundle in bundled {
-        let contents = gaze_recognizers::embedded(bundle).ok_or(CliError::PolicyConfig)?;
-        let rulepack = Rulepack::load(RulepackSource::Embedded(contents))
-            .map_err(|_| CliError::PolicyConfig)?;
+        let contents = gaze_recognizers::embedded(bundle).ok_or_else(|| {
+            CliError::PolicyConfigDetail(format!("unknown bundled rulepack: {bundle}"))
+        })?;
+        let rulepack = Rulepack::load(RulepackSource::Embedded(contents)).map_err(|err| {
+            CliError::PolicyConfigDetail(format!("embedded rulepack '{bundle}': {err}"))
+        })?;
         classes.extend(rulepack.activated_classes());
         classes.extend(
             rulepack
@@ -428,7 +432,11 @@ fn parse_cli_locales(raw: &[String]) -> std::result::Result<Option<Vec<LocaleTag
         return Ok(None);
     }
     raw.iter()
-        .map(|locale| LocaleTag::parse(locale).map_err(|_| CliError::PolicyConfig))
+        .map(|locale| {
+            LocaleTag::parse(locale).map_err(|err| {
+                CliError::PolicyConfigDetail(format!("invalid --locale '{locale}': {err}"))
+            })
+        })
         .collect::<std::result::Result<Vec<_>, _>>()
         .map(Some)
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -110,6 +110,39 @@ fn parse_stderr_variant(stderr: &[u8]) -> Value {
     serde_json::from_slice(stderr).expect("stderr is one-line JSON")
 }
 
+/// Assert a `PolicyConfig`/exit=2 stderr envelope and require `detail` to be a
+/// non-empty string. The exact detail wording is intentionally not pinned here
+/// so the helper can be reused across the many sites that route through the
+/// same envelope; tests that care about specific wording should call
+/// `assert_policy_config_detail_contains` instead.
+fn assert_policy_config_envelope(stderr: &[u8]) {
+    let value = parse_stderr_variant(stderr);
+    assert_eq!(value["error"], "PolicyConfig", "stderr={value}");
+    assert_eq!(value["exit"], 2, "stderr={value}");
+    let detail = value
+        .get("detail")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        !detail.is_empty(),
+        "expected non-empty detail on PolicyConfig envelope: {value}"
+    );
+}
+
+fn assert_policy_config_detail_contains(stderr: &[u8], needle: &str) {
+    let value = parse_stderr_variant(stderr);
+    assert_eq!(value["error"], "PolicyConfig", "stderr={value}");
+    assert_eq!(value["exit"], 2, "stderr={value}");
+    let detail = value
+        .get("detail")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        detail.contains(needle),
+        "detail '{detail}' must contain '{needle}'"
+    );
+}
+
 fn assert_session_scoped_custom_token(token: &str) {
     let re = Regex::new(r"^<[0-9a-f]{8}:Custom:[a-z0-9_]+_\d+>$").unwrap();
     assert!(re.is_match(token), "unexpected custom token shape: {token}");
@@ -354,10 +387,7 @@ fn assert_symmetric_policy_config(cli_out: std::process::Output, toml_out: std::
         cli_out.stderr, toml_out.stderr,
         "CLI and TOML policy errors must be byte-identical"
     );
-    assert_eq!(
-        parse_stderr_variant(&cli_out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&cli_out.stderr);
 }
 
 fn normalize_session_hex(text: &str) -> String {
@@ -928,10 +958,7 @@ fn rulepack_recognizer_is_gated_by_policy_locale() {
     );
     assert_eq!(out.status.code(), Some(2));
     assert!(out.stdout.is_empty(), "policy config must not emit stdout");
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 
     let (_dir, path) =
         write_policy_with_rulepack(&de_email_rulepack("\"de-DE\""), Some("\"de-DE\""));
@@ -957,10 +984,7 @@ fn rulepack_recognizer_fr_fr_not_gated_by_en_us() {
 
     assert_eq!(out.status.code(), Some(2));
     assert!(out.stdout.is_empty(), "policy config must not emit stdout");
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 }
 
 #[test]
@@ -990,10 +1014,7 @@ terms = ["Sonnenlied"]
     );
     assert_eq!(out.status.code(), Some(2));
     assert!(out.stdout.is_empty(), "policy config must not emit stdout");
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 
     let (_dir, path) = write_policy_with_rulepack(rulepack, Some("\"de-DE\""));
     let v = clean_json_with_args(
@@ -2074,10 +2095,7 @@ fn t_cli_ner_threshold_out_of_range_fails_closed() {
 
     assert_eq!(out.status.code(), Some(2));
     assert!(out.stdout.is_empty());
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_detail_contains(&out.stderr, "ner.threshold");
 }
 
 #[test]
@@ -2706,10 +2724,7 @@ fn s1_ner_model_dir_and_locale_override_toml_and_detect_with_test_backend() {
 
     let out = clean_raw_with_args(&[&format!("--policy={}", policy.display())], input);
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 
     let value = clean_json_with_args(
         &[
@@ -3064,10 +3079,7 @@ action = "preserve"
     );
 
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 }
 
 #[test]
@@ -3100,10 +3112,7 @@ action = "preserve"
     );
 
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 }
 
 // -----------------------------------------------------------------------
@@ -3205,10 +3214,7 @@ fn t08_format_xml_rejected() {
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_detail_contains(&out.stderr, "--format");
 }
 
 // -----------------------------------------------------------------------
@@ -3223,9 +3229,12 @@ fn t09_bad_flag_emits_sanitized_json_not_clap_usage() {
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
+    let value = parse_stderr_variant(&out.stderr);
+    assert_eq!(value["error"], "PolicyConfig");
+    assert_eq!(value["exit"], 2);
+    assert!(
+        value.get("detail").is_none(),
+        "clap parse fallback must stay bare (no detail leak): {value}"
     );
     // No clap usage banner, no "Usage:" string.
     let stderr_str = String::from_utf8_lossy(&out.stderr);
@@ -3237,6 +3246,29 @@ fn t09_bad_flag_emits_sanitized_json_not_clap_usage() {
         !stderr_str.contains("--help"),
         "clap help leaked: {stderr_str}"
     );
+}
+
+// Adopter-pain coverage (dogfooding F#5): the operator must see *why* a
+// `PolicyConfig` was returned. These tests pin the specific detail wording
+// for the highest-traffic misconfiguration paths so a downstream agent or
+// support engineer can act without spelunking the loader.
+
+#[test]
+fn t09a_bundled_rulepack_unknown_name_surfaces_detail() {
+    let out = clean_raw_with_args(&["--rulepack-bundled=does-not-exist"], "anything");
+    assert_eq!(out.status.code(), Some(2));
+    assert_policy_config_detail_contains(&out.stderr, "unknown bundled rulepack");
+    assert_policy_config_detail_contains(&out.stderr, "does-not-exist");
+}
+
+#[test]
+fn t09b_cli_locale_invalid_surfaces_detail() {
+    // BCP47-parseable tags (e.g. "ZZ-bogus") fall through to LocaleTag::Other;
+    // use a value that fails the BCP47 grammar so LocaleTag::parse errors.
+    let out = clean_raw_with_args(&["--locale=not a locale"], "anything");
+    assert_eq!(out.status.code(), Some(2));
+    assert_policy_config_detail_contains(&out.stderr, "invalid --locale");
+    assert_policy_config_detail_contains(&out.stderr, "not a locale");
 }
 
 // -----------------------------------------------------------------------
@@ -3550,10 +3582,7 @@ action = "preserve"
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_envelope(&out.stderr);
 }
 
 #[test]
@@ -3702,8 +3731,5 @@ action = "preserve"
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
-    assert_eq!(
-        parse_stderr_variant(&out.stderr),
-        json!({ "error": "PolicyConfig", "exit": 2 })
-    );
+    assert_policy_config_detail_contains(&out.stderr, "parse policy.toml");
 }


### PR DESCRIPTION
## Summary

- Threads policy-loader cause through `CliError::PolicyConfigDetail` at every `map_err(|_| PolicyConfig)` site in `gaze-cli`. JSON envelope stays additive — variant name stays `PolicyConfig`, exit stays 2, `detail` field is now populated.
- Resolves dogfooding finding **F#5** from `EmpireTwo/business/dogfooding/pulseflow-demo-2026-05-13/report.md`. The Pulseflow Laravel demo spent ~30 min binary-searching a `{"error":"PolicyConfig","exit":2}` with no signal (turned out: missing `SHA256SUMS` on the NER bundle). The data carrier (`PolicyConfigDetail`) already existed; only call-site plumbing was missing.
- The clap parse fallback in `main.rs:52` is intentionally kept bare — it has no error cause to thread, and routing argv noise through `detail` would leak unsanitized input. `t09_bad_flag_emits_sanitized_json_not_clap_usage` now explicitly asserts `detail` is absent on that path.

### North-star alignment
- Axis 4 (trust / auditable): every `PolicyConfig` failure is now traceable to a typed loader error variant via the `detail` string.
- Axis 5 (adopter ergonomics): operators see *why* a policy was rejected without attaching a debugger.

### Before / after

Before:
\`\`\`json
{"error":"PolicyConfig","exit":2}
\`\`\`

After (representative):
\`\`\`json
{"error":"PolicyConfig","exit":2,"detail":"unknown bundled rulepack: garbage"}
{"error":"PolicyConfig","exit":2,"detail":"--format must be 'json', got 'xml'"}
{"error":"PolicyConfig","exit":2,"detail":"failed to parse policy.toml: TOML parse error at line 5..."}
{"error":"PolicyConfig","exit":2,"detail":"ner.threshold must be between 0.0 and 1.0 inclusive, got 1.5"}
{"error":"PolicyConfig","exit":2,"detail":"rulepack error: failed to read rulepack: No such file..."}
\`\`\`

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (94 cli_pipe + workspace, 0 failures)
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] 11 strict-equality stderr assertions migrated to `assert_policy_config_envelope` helper (asserts error + exit + non-empty detail)
- [x] 3 specific-content assertions added at high-value sites (NER threshold, `--format`, malformed TOML)
- [x] 2 new dedicated tests `t09a` (unknown bundled rulepack) and `t09b` (invalid CLI locale) for the dogfooding-surfaced paths
- [x] `t09` (clap unknown-flag) asserts `detail.is_none()` to lock in the intentional asymmetry

## Follow-ups
- F#6 (policy `schema_version` + typed `PolicySchemaUnsupported`) is the next dogfooding-driven PR; will be opened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)