### PR TITLE
feat(policy): add schema_version field with typed PolicySchemaUnsupported error

### DIFF
--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -12,6 +12,10 @@ pub(crate) enum CliError {
     InvalidEncoding,
     PolicyConfig,
     PolicyConfigDetail(String),
+    PolicySchemaUnsupported {
+        found: String,
+        supported: &'static str,
+    },
     SafetyNetConfigDetail(String),
     SafetyNetFailure {
         variant: &'static str,
@@ -41,7 +45,10 @@ impl CliError {
     pub(crate) fn exit_code(&self) -> u8 {
         match self {
             Self::StdinParse | Self::EmptyInput | Self::InputTooLarge | Self::InvalidEncoding => 1,
-            Self::PolicyConfig | Self::PolicyConfigDetail(_) | Self::AuditPurgeIso8601 { .. } => 2,
+            Self::PolicyConfig
+            | Self::PolicyConfigDetail(_)
+            | Self::PolicySchemaUnsupported { .. }
+            | Self::AuditPurgeIso8601 { .. } => 2,
             Self::SafetyNetConfigDetail(_) | Self::SafetyNetFailure { .. } => 3,
             Self::UnknownToken { .. }
             | Self::UnsupportedSessionScope { .. }
@@ -64,6 +71,7 @@ impl CliError {
             Self::InputTooLarge => "InputTooLarge",
             Self::InvalidEncoding => "InvalidEncoding",
             Self::PolicyConfig | Self::PolicyConfigDetail(_) => "PolicyConfig",
+            Self::PolicySchemaUnsupported { .. } => "PolicySchemaUnsupported",
             Self::SafetyNetConfigDetail(_) => "SafetyNetConfig",
             Self::SafetyNetFailure { .. } => "SafetyNet",
             Self::AuditPurgeIso8601 { .. } => "AuditPurgeIso8601",
@@ -84,6 +92,19 @@ impl CliError {
 
     pub(crate) fn emit_stderr(&self) {
         match self {
+            Self::PolicySchemaUnsupported { found, supported } => {
+                let found = serde_json::to_string(found)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                let supported = serde_json::to_string(supported)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"found":{},"supported":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    found,
+                    supported
+                )
+            }
             Self::PolicyConfigDetail(detail) | Self::SafetyNetConfigDetail(detail) => {
                 let detail = serde_json::to_string(detail)
                     .unwrap_or_else(|_| "\"<unserializable>\"".to_string());

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -16,6 +16,9 @@ pub(crate) fn map_policy_error(err: PolicyError) -> CliError {
         PolicyError::UnsupportedRuleKind(_) => {
             CliError::PolicyConfigDetail("column rules not supported in CLI mode".to_string())
         }
+        PolicyError::PolicySchemaUnsupported { found, supported } => {
+            CliError::PolicySchemaUnsupported { found, supported }
+        }
         other => CliError::PolicyConfigDetail(other.to_string()),
     }
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -3733,3 +3733,91 @@ action = "preserve"
     assert_eq!(out.status.code(), Some(2));
     assert_policy_config_detail_contains(&out.stderr, "parse policy.toml");
 }
+
+// Dogfooding F#6: policy.toml schema_version mismatch must fail closed with a
+// typed envelope so adopters upgrading the gaze binary across a contract break
+// see the version mismatch directly rather than a generic PolicyConfig that
+// shadows the real cause.
+#[test]
+fn t19_policy_schema_version_unsupported_emits_typed_envelope() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+schema_version = "9.9.0"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = ".+"
+class = "email"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args(["clean", &format!("--policy={}", path.display())])
+        .write_stdin(b"anything".to_vec())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let value = parse_stderr_variant(&out.stderr);
+    assert_eq!(value["error"], "PolicySchemaUnsupported");
+    assert_eq!(value["exit"], 2);
+    assert_eq!(value["found"], "9.9.0");
+    assert_eq!(value["supported"], "0.1");
+}
+
+#[test]
+fn t19a_policy_without_schema_version_loads_via_soft_default() {
+    // Existing 0.6.x / 0.7.x policies omit `schema_version`. The loader must
+    // keep accepting them by stamping DEFAULT_POLICY_SCHEMA_VERSION so the
+    // 0.1.x deployments do not hard-break on the binary upgrade that
+    // introduces the field.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = 'a@b'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+
+    let out = clean_raw_with_args(
+        &[&format!("--policy={}", path.display())],
+        "ping a@b please",
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "soft default must accept missing schema_version: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -41,6 +41,7 @@ pub use pipeline::{Error, Pipeline, PipelineBuilder, Result};
 pub use policy::{
     validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,
     RulepackPolicy, SessionPolicy, SessionScope, DEFAULT_NER_THRESHOLD,
+    DEFAULT_POLICY_SCHEMA_VERSION, SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR,
 };
 pub use redaction_log::{ConflictTier, DocumentKind, RedactionEntry};
 pub use registry::{

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -12,6 +12,26 @@ use crate::{
 
 pub const DEFAULT_NER_THRESHOLD: f32 = 0.3;
 
+/// `major.minor` prefix of the policy schema versions this build accepts.
+///
+/// A policy.toml `schema_version` (or the [`DEFAULT_POLICY_SCHEMA_VERSION`]
+/// soft default applied when the field is omitted) must start with this string.
+/// Anything else fails closed at load with
+/// [`PolicyError::PolicySchemaUnsupported`], so operators upgrading the binary
+/// learn about a contract break instead of silently mis-loading the policy.
+///
+/// Mirrors the rulepack-side `SUPPORTED_SCHEMA_MAJOR_MINOR` in
+/// [`crate::rulepack`].
+pub const SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR: &str = "0.1";
+
+/// Schema version stamped on policy.toml documents that omit the field.
+///
+/// Existing 0.6.x / 0.7.x policies were written before `schema_version` was
+/// introduced; soft-defaulting them to `"0.1.0"` keeps the loader backward
+/// compatible. New policies should declare `schema_version = "0.1.0"`
+/// explicitly so future migrations can be detected.
+pub const DEFAULT_POLICY_SCHEMA_VERSION: &str = "0.1.0";
+
 /// Loaded redaction policy from a TOML configuration file.
 ///
 /// Defines which rulepacks activate, which recognizers are enabled, and the locale chain.
@@ -22,7 +42,7 @@ pub const DEFAULT_NER_THRESHOLD: f32 = 0.3;
 /// development smoke-testing only and has an unauditable detection posture.
 ///
 /// See `docs/policy.md` in the repository for the full TOML schema reference.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct Policy {
     pub session: SessionPolicy,
@@ -32,6 +52,29 @@ pub struct Policy {
     pub ner: Option<NerPolicy>,
     pub rulepacks: RulepackPolicy,
     pub locale: Option<Vec<LocaleTag>>,
+    /// Declared policy schema version (e.g. `"0.1.0"`).
+    ///
+    /// Populated from policy.toml's top-level `schema_version` field. Loader
+    /// requires the `major.minor` prefix to match
+    /// [`SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR`]; documents that omit the field
+    /// soft-default to [`DEFAULT_POLICY_SCHEMA_VERSION`] for backward
+    /// compatibility with policies written before v0.7.2.
+    pub schema_version: String,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self {
+            session: SessionPolicy::default(),
+            detectors: Vec::new(),
+            dictionaries: Vec::new(),
+            rules: Vec::new(),
+            ner: None,
+            rulepacks: RulepackPolicy::default(),
+            locale: None,
+            schema_version: DEFAULT_POLICY_SCHEMA_VERSION.to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,6 +246,11 @@ pub enum PolicyError {
     InvalidCollisionMetadata { name: String, reason: String },
     #[error("{0}")]
     UnsupportedRuleKind(String),
+    #[error("unsupported policy schema_version {found}; supported {supported}")]
+    PolicySchemaUnsupported {
+        found: String,
+        supported: &'static str,
+    },
 }
 
 impl Policy {
@@ -230,6 +278,8 @@ impl Policy {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawPolicy {
+    #[serde(default = "default_raw_schema_version")]
+    schema_version: String,
     session: RawSessionPolicy,
     #[serde(rename = "detector", default)]
     detectors: Vec<RawDetectorSpec>,
@@ -241,6 +291,10 @@ struct RawPolicy {
     locale: Option<RawLocalePolicy>,
     #[serde(default)]
     policy: Option<RawPolicyTables>,
+}
+
+fn default_raw_schema_version() -> String {
+    DEFAULT_POLICY_SCHEMA_VERSION.to_string()
 }
 
 #[derive(Debug, Deserialize)]
@@ -316,6 +370,16 @@ impl TryFrom<RawPolicy> for Policy {
     type Error = PolicyError;
 
     fn try_from(raw: RawPolicy) -> Result<Self, Self::Error> {
+        if !raw
+            .schema_version
+            .starts_with(SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR)
+        {
+            return Err(PolicyError::PolicySchemaUnsupported {
+                found: raw.schema_version,
+                supported: SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR,
+            });
+        }
+        let schema_version = raw.schema_version;
         let session = parse_session(raw.session)?;
 
         if !raw.detectors.is_empty() {
@@ -370,6 +434,7 @@ impl TryFrom<RawPolicy> for Policy {
             ner,
             rulepacks,
             locale,
+            schema_version,
         })
     }
 }
@@ -963,5 +1028,83 @@ action = "preserve"
             Some("songs")
         );
         assert_eq!(policy.dictionaries[0].terms, vec!["Song A"]);
+    }
+
+    fn minimal_policy_body(schema_line: &str) -> String {
+        format!(
+            r#"{schema_line}
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = 'a@b'
+class = "email"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#
+        )
+    }
+
+    fn write_policy(dir: &tempfile::TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("policy.toml");
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn schema_version_omitted_soft_defaults_to_supported() {
+        let dir = tempdir().unwrap();
+        let path = write_policy(&dir, &minimal_policy_body(""));
+        let policy = Policy::load(&path).expect("missing schema_version should soft-default");
+        assert_eq!(policy.schema_version, DEFAULT_POLICY_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn schema_version_explicit_matching_major_minor_is_accepted() {
+        let dir = tempdir().unwrap();
+        let path = write_policy(&dir, &minimal_policy_body(r#"schema_version = "0.1.7""#));
+        let policy = Policy::load(&path).expect("0.1.x must be accepted");
+        assert_eq!(policy.schema_version, "0.1.7");
+    }
+
+    #[test]
+    fn schema_version_unsupported_major_fails_closed() {
+        let dir = tempdir().unwrap();
+        let path = write_policy(&dir, &minimal_policy_body(r#"schema_version = "0.2.0""#));
+        let err = Policy::load(&path).expect_err("0.2.x must be rejected");
+        match err {
+            PolicyError::PolicySchemaUnsupported { found, supported } => {
+                assert_eq!(found, "0.2.0");
+                assert_eq!(supported, SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR);
+            }
+            other => panic!("expected PolicySchemaUnsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schema_version_unsupported_fails_before_other_validation() {
+        // Body has zero rules — would normally trip NoRules — but the schema
+        // gate must fire first so adopters see the version mismatch, not a
+        // downstream validation surprise.
+        let dir = tempdir().unwrap();
+        let path = write_policy(
+            &dir,
+            r#"
+schema_version = "9.9.9"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+"#,
+        );
+        let err = Policy::load(&path).expect_err("must reject schema first");
+        assert!(
+            matches!(err, PolicyError::PolicySchemaUnsupported { .. }),
+            "expected PolicySchemaUnsupported, got {err:?}"
+        );
     }
 }

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -74,6 +74,65 @@ recognizer definitions (`[[policy.custom_recognizers]]`), rule definitions
 define the auditable contract; changing them requires changing the policy or
 rulepack document itself.
 
+## Policy schema versioning
+
+Every `policy.toml` declares the schema it was authored against:
+
+```toml
+schema_version = "0.1.0"
+```
+
+The loader checks the `major.minor` prefix against
+[`SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR`](../crates/gaze/src/policy.rs) (currently
+`"0.1"`). A mismatch fails closed at load time with a typed envelope:
+
+```json
+{"error":"PolicySchemaUnsupported","exit":2,"found":"0.2.0","supported":"0.1"}
+```
+
+The envelope is intentionally distinct from `PolicyConfig` so adopters
+upgrading the gaze binary across a contract break see the version mismatch
+directly, rather than chasing a generic policy-load error that shadows the
+real cause. Mirrors the rulepack-side version gate in
+[`crates/gaze/src/rulepack.rs`](../crates/gaze/src/rulepack.rs).
+
+### Soft default for pre-versioned policies
+
+Policies written before the field was introduced (any 0.6.x / 0.7.x policy
+shipped before the `schema_version` field landed) omit `schema_version`. The
+loader soft-defaults the missing field to
+[`DEFAULT_POLICY_SCHEMA_VERSION`](../crates/gaze/src/policy.rs) (currently
+`"0.1.0"`) so existing deployments continue to load on the binary upgrade
+that introduces the field. New policies should declare `schema_version =
+"0.1.0"` explicitly so a future `0.2.0` migration can detect them.
+
+### Migration log
+
+Each entry below names a contract break that requires bumping
+`schema_version`. Adopters should consult the migration log when upgrading
+across the named gaze release boundary.
+
+#### `[ner]` block changes (0.6.x → 0.7.x)
+
+The 0.7.0 release tightened the `[ner]` block: `threshold` is now parsed as a
+required-typed field (0.6.x accepted any numeric coercion) and `model_dir`
+relative paths resolve against the policy file rather than the process CWD.
+A policy authored against 0.6.x that uses an unusual `threshold` literal or a
+relative `model_dir` may load against 0.7.x in unexpected ways.
+
+The recommended migration is:
+
+- Quote the threshold as a TOML float (`threshold = 0.3`, not `0.3 `).
+- Express `[ner].model_dir` as an absolute path, or move the policy file to
+  the directory the model is co-located with.
+- Stamp `schema_version = "0.1.0"` on the policy so a future contract break
+  surfaces the typed `PolicySchemaUnsupported` error instead of a generic
+  load failure.
+
+This entry exists because the Pulseflow Laravel demo
+(`EmpireTwo/business/dogfooding/pulseflow-demo-2026-05-13`) lost ~30 minutes
+of debugging time to silent `[ner]` schema drift between 0.6.6 and 0.7.1.
+
 ## Bundled rulepack version drift
 
 Bundled rulepacks in


### PR DESCRIPTION
## Summary

- Adds a top-level `schema_version` field to `policy.toml`. The loader gates the `major.minor` prefix against `SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR` (`"0.1"`) and fails closed on mismatch with a dedicated envelope `{"error":"PolicySchemaUnsupported","exit":2,"found":"...","supported":"..."}`. Distinct from `PolicyConfig` so an adopter upgrading across a contract break sees the version mismatch directly.
- Resolves dogfooding finding **F#6** from `EmpireTwo/business/dogfooding/pulseflow-demo-2026-05-13/report.md`. The Pulseflow demo lost ~30 minutes to silent `[ner]` block schema drift between 0.6.x and 0.7.x; the version gate prevents the next break from being invisible.
- Mirrors the rulepack-side `SUPPORTED_SCHEMA_MAJOR_MINOR` gate in `crates/gaze/src/rulepack.rs` for consistency.

### Backward compatibility (soft default)

Existing 0.6.x / 0.7.x policies omit `schema_version`. The loader soft-defaults the missing field to `DEFAULT_POLICY_SCHEMA_VERSION` (`"0.1.0"`) so existing deployments keep loading on the binary upgrade. New policies should declare `schema_version = "0.1.0"` explicitly so a future `0.2.0` migration can detect them. The `cli_pipe.rs::t19a_policy_without_schema_version_loads_via_soft_default` test pins this contract.

### Envelope examples

Mismatched `major.minor`:
\`\`\`json
{"error":"PolicySchemaUnsupported","exit":2,"found":"9.9.0","supported":"0.1"}
\`\`\`

Matching `major.minor` (accepted):
\`\`\`toml
schema_version = "0.1.7"
\`\`\`

### Public-surface additions

- `gaze::Policy.schema_version: String` (with manual `Default` impl stamping `DEFAULT_POLICY_SCHEMA_VERSION`).
- `gaze::PolicyError::PolicySchemaUnsupported { found: String, supported: &'static str }`.
- `gaze::SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR`, `gaze::DEFAULT_POLICY_SCHEMA_VERSION`.
- `gaze_cli::CliError::PolicySchemaUnsupported { found, supported }` with dedicated `emit_stderr` rendering.

### North-star alignment
- Axis 4 (trust / auditable): typed error keeps the closed-variant property and emits a dedicated envelope rather than overloading `PolicyConfig`.
- Axis 5 (adopter ergonomics): soft default avoids forcing a coordinated policy-rewrite across every adopter on this release.

### Docs

`docs/policy.md` gains a `Policy schema versioning` section covering the field, the gate, the soft default, and the `[ner]` 0.6→0.7 migration entry referencing the dogfooding incident.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` (gaze policy + gaze-cli cli_pipe + workspace, 0 failures)
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] gaze policy unit tests: soft default, matching `major.minor`, mismatched `major.minor`, schema check ordering (fires before downstream validation)
- [x] `cli_pipe.rs::t19_policy_schema_version_unsupported_emits_typed_envelope` pins the dedicated envelope shape
- [x] `cli_pipe.rs::t19a_policy_without_schema_version_loads_via_soft_default` pins the backward-compatibility soft default

## Relation to F#5

Independent PR from #191 (F#5: `PolicyConfig` detail field). No conflict expected: F#5 enriches `PolicyConfig` envelopes; F#6 splits a sub-class of policy errors into a dedicated `PolicySchemaUnsupported` envelope. Recommended merge order: F#5 first, then F#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)