### PR TITLE
chore(release): v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.7.2] - 2026-05-13
+
+Dogfooding-driven point release. Both findings surfaced during a Pulseflow
+adopter demo (`EmpireTwo/business:dogfooding/pulseflow-demo-2026-05-13`) and
+strengthen the trust + adopter-ergonomics axes of the north star.
+
+### Added
+
+- **Policy schema versioning** (F#6, PR #192 `e698e35`): new top-level
+  `schema_version` field in `policy.toml`. The loader gates the `major.minor`
+  prefix against the supported version and fails closed with a dedicated
+  `{"error":"PolicySchemaUnsupported","exit":2,"found":"...","supported":"0.1"}`
+  CLI envelope. Existing 0.6.x/0.7.x policies continue to load via a soft
+  default. Public-surface additions: `gaze::SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR`,
+  `gaze::DEFAULT_POLICY_SCHEMA_VERSION`, `gaze::PolicyError::PolicySchemaUnsupported`,
+  `gaze_cli::CliError::PolicySchemaUnsupported`. (Axis 4 trust, Axis 5 ergonomics.)
+
+### Changed
+
+- **PolicyConfig error envelope now carries detail** (F#5, PR #191 `6ec7afd`):
+  every `gaze-cli` `map_err(|_| PolicyConfig)` site now threads the underlying
+  loader cause through `CliError::PolicyConfigDetail`. JSON shape stays additive
+  — `{"error":"PolicyConfig","exit":2}` unchanged, optional `detail` field now
+  populated at every site EXCEPT the bare clap parse fallback (intentional —
+  argv noise must not leak through `detail`). (Axis 4 trust, Axis 5 ergonomics.)
+
 ## [0.7.1] - 2026-05-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.7.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.7.1" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.7.2" }
+gaze-types = { path = "crates/gaze-types", version = "0.7.2" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The audit DB is opened read-only by `query` and `export`. The exported column se
 
 ## Status
 
-- **Version:** v0.7.1 (2026-05).
+- **Version:** v0.7.2 (2026-05).
 - **MSRV:** Rust 1.89.
 - **License:** dual `Apache-2.0 OR MIT`.
 - **crates.io:** published as `gaze-pii`. The bare `gaze` name is in transfer; until that completes, depend on `gaze-pii`. Source-compat is preserved via `[lib].name = "gaze"`.

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.1", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1" }
+gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -40,13 +40,13 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.7.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.7.1" }
+gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.7.2" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.7.1", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.1", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.1", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1" }
+gaze-document = { path = "../gaze-document", version = "0.7.2", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.2", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -59,7 +59,7 @@ tracing = "0.1"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.1", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.1", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1" }
+gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.1" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.2" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,7 +20,7 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.7.1"
+gaze-document = "0.7.2"
 ```
 
 ### CLI

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.1", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.7.1" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.7.2" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.1" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.7.1" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.7.2" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"


### PR DESCRIPTION
Dogfooding-driven point release. Both findings surfaced during a Pulseflow adopter demo on 2026-05-13 and strengthen the trust + adopter-ergonomics axes of the north star.

## Highlights

- **Added — Policy schema versioning** (F#6, PR #192 `e698e35`): new top-level `schema_version` field in `policy.toml`. Loader gates the `major.minor` prefix against the supported version and fails closed with a dedicated `{"error":"PolicySchemaUnsupported","exit":2,"found":"...","supported":"0.1"}` CLI envelope. Existing 0.6.x/0.7.x policies continue to load via a soft default. Public-surface additions: `gaze::SUPPORTED_POLICY_SCHEMA_MAJOR_MINOR`, `gaze::DEFAULT_POLICY_SCHEMA_VERSION`, `gaze::PolicyError::PolicySchemaUnsupported`, `gaze_cli::CliError::PolicySchemaUnsupported`.
- **Changed — PolicyConfig error envelope now carries detail** (F#5, PR #191 `6ec7afd`): every `gaze-cli` `map_err(|_| PolicyConfig)` site now threads the underlying loader cause through `CliError::PolicyConfigDetail`. JSON shape stays additive — `{"error":"PolicyConfig","exit":2}` unchanged, optional `detail` field now populated at every site except the bare clap parse fallback (intentional — argv noise must not leak through `detail`).

## Mechanics

- Workspace + all 9 publish-shape crates bumped 0.7.1 → 0.7.2.
- Exact-pin install snippets bumped in `crates/gaze-document/README.md` and top-level `README.md`.
- Local gates green: fmt, clippy `--workspace --all-features --all-targets -D warnings`, test `--workspace --all-features`, xtask `ci-feature-matrix` / `dylint-gate` / `safety-net-sanity` / `cargo-metadata-audit-isolation` / `fixture-citation-lint`, `cargo publish --dry-run -p gaze-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)