### PR TITLE
docs(research): corpus rework v2 — scenario fixtures + fake-data library evaluation

### DIFF
--- a/docs/research/v0.7.x-corpus-rework-v2.md
+++ b/docs/research/v0.7.x-corpus-rework-v2.md
@@ -1,0 +1,312 @@
+# v0.7.x Coverage Corpus Rework v2 — Scenario Fixtures + Fake-Data Library Evaluation
+
+**Status:** design-only. Implementation lands in a separate PR (see §8).
+**Predecessor:** [PR #182](https://github.com/EmpireTwo/gaze/pull/182) (`agent-coverage-corpus-realism-extension`), closed 2026-05-13 pending rework.
+**Scope:** redesign `crates/gaze-recognizers/testdata/coverage-loop/` from a *template × seed multiplicity* shape into a *curated scenario* shape, and re-snap `baseline.json` so per-(class, locale) `Uncovered` buckets remain diagnostic.
+
+## 1. TL;DR
+
+- **One seed per scenario.** Cut seed-multiplicity (N seeds × M templates) entirely; each fixture is a deliberate test case.
+- **Structural diversity is the signal axis.** Keep PR #182's *conversational / code-mixed / high-density / distractor-heavy / threaded* template families × *Snippet / Page / MultiPage* length tiers. Drop seed expansion.
+- **Target 110 fixtures (range 80–150)**, down from 123 (status quo) and 323 (PR #182).
+- **Adopt `fake` (cksac/fake-rs) as an `xtask` dev-dep** for non-validator-bound classes (Email, IPv4/IPv6, postal, Name); keep custom Rust generators for validator-tight classes (Luhn cards, MOD-97 IBANs, EIP-55 Ethereum, national phone).
+- **Property-test generators separately** under `crates/xtask/tests/coverage_corpus_generators.rs`; coverage via in-test resampling, not committed seeds. Baseline re-snap targets `Uncovered < 30` per bucket and zero whole-bucket gaps where rule-floor is achievable.
+
+## 2. Problem statement (verbatim from PR #182 close)
+
+Three converging concerns motivated the rework:
+
+1. **Signal-value vs noise (axis 1 + axis 4).** Per-template seed multiplicity (N seeds × M templates) inflates fixture count without proportionally raising detection signal. Five seed variations of "log-line with random email + IBAN at same positions" exercise the same detection paths — adding storage + baseline mass without surfacing new gaps.
+2. **Diversity is structural, not stochastic.** Real signal comes from STRUCTURAL diversity (template family, length tier, density, distractors, threading). It does NOT come from re-running the same template against more PII-generator seeds. Each fixture should be a deliberate test case.
+3. **Baseline-bucket distortion.** With ~300–500 fixtures vs prior 123, per-(class_id, locale) `Uncovered` counts likely push into the 30+ range. Trend-gate sensitivity degrades — single-entry regressions get lost in expanded buckets. The gate becomes a worse regression detector than the smaller corpus it replaced.
+
+The rework keeps PR #182's structural additions and drops its seed-multiplicity expansion.
+
+## 3. Keepers from PR #182
+
+PR #182 introduced two orthogonal axes worth preserving:
+
+### 3.1 Structural template families
+
+| Family            | Purpose / detection axis exercised                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| conversational    | Multi-turn chat-style prose; PII embedded in natural-language addressing cues (`hi {{Name}}`, `please send to {{Email}}`) |
+| code-mixed        | PII embedded inside code blocks, fenced snippets, or inline backticks; regex must not over-extend into syntax tokens     |
+| high-density      | ≥4 PII spans within a 200-byte window; conflict resolution under heavy overlap pressure                                  |
+| distractor-heavy  | High ratio of look-alike-but-not-PII strings (synthetic order IDs, version tags, timestamps) interleaved with real PII   |
+| threaded          | Quoted-reply email/forum threading (`> > > original mail`); PII context cues split across quote layers                   |
+
+### 3.2 Length tiers
+
+| Tier      | Byte size guideline | Purpose                                                                                       |
+| --------- | ------------------- | --------------------------------------------------------------------------------------------- |
+| Snippet   | < 200 B             | Status quo — log line, tool-call JSON, single sentence                                        |
+| Page      | 200–1500 B          | Mid-form prose; exercises window-scoped recognizers + multi-span conflict resolution          |
+| MultiPage | 1500–6000 B         | Multi-section document; exercises long-range context decay + threading + section-boundary cues |
+
+Length tiers are *deterministic*. The body length per fixture is fixed at generation time, not stochastically resampled.
+
+Both axes survive the rework verbatim. **What gets cut from PR #182 is the per-template seed multiplier (`fixture_variants` returning 2–5 in `crates/xtask/src/coverage_corpus/builder.rs:224`); the rework drops it to 1.**
+
+## 4. Fake-data library evaluation
+
+A standalone survey already evaluated the Rust `fake` crate ecosystem against Gaze's per-class validator constraints. Recommendation summarized here; cite the survey output rather than re-running it.
+
+### 4.1 Recommendation: hybrid
+
+Adopt `fake = "5"` (cksac/fake-rs, Apache-2.0 OR MIT, 1217★, last release 2026-03-15) as an **`xtask` dev-dependency**. Replace the following custom generators in `crates/xtask/src/coverage_corpus/generators/`:
+
+| Replace               | With                                                  | Justification                                                                |
+| --------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `email.rs`            | `fake::faker::internet::raw::FreeEmail`               | Generic `EmailRfc` validator only requires RFC shape — `fake` passes         |
+| `ip_v4.rs`, `ip_v6.rs`| `fake::faker::internet::raw::{IPv4, IPv6}`            | `std::net::IpAddr`-parseable; no validator binding beyond parse              |
+| `name_de.rs`, `name_en.rs` | `fake::faker::name::{de_de, en}::{FirstName,LastName}` | `fake` ships hundreds of curated DE/EN names vs our hand-curated 50-pool |
+| `postal_de.rs`, `postal_us.rs` | `fake::faker::address::{de_de, en}::ZipCode` | No validator binding on postal classes                                       |
+
+Total replaced: 7 files, ~215 LOC. Locale-data quality goes UP for names; LOC savings are modest.
+
+### 4.2 Keep custom (validator-tight)
+
+| Keep                        | Reason                                                                                                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `iban.rs`                   | **No Rust library generates MOD-97-valid IBANs.** Python `Faker` is the only surveyed option; not worth a Python subprocess at corpus-regen time                                |
+| `eth_eip55.rs`              | No Rust faker library ships EIP-55 mixed-case checksum. Could swap our keccak256 routine for `eip55`/`ethaddr` as a primitive, but the `Generator` impl stays custom            |
+| `card_luhn.rs`              | `fake::CreditCardNumber` is Luhn-correct but uses mangled prefixes (Amex length 13 not 15). Fine for `card.structural` today; keep custom in case per-network detection arrives |
+| `phone_national_de.rs`, `phone_national_us.rs` | `fake`'s format-only patterns may fail strict national parsers. Property-test before considering removal (see §6.3)                                          |
+| `phone_structural.rs`       | Trivial regex; not worth the dep cost                                                                                                                                           |
+
+### 4.3 Rejected options
+
+- **`faker_rand`** — abandoned 2021-01, en_us only, no validator-bound classes.
+- **`fakeit`** — no locale system; strictly narrower than `fake`.
+- **`synth`** — dormant ~20mo, DSL/CLI shape, not a `Generator` trait.
+- **Python `mimesis`** — no MOD-97 IBAN; subprocess cost not justified.
+- **Python `Faker`** — has MOD-97 IBANs across 35 country locales, but pulling Python into `cargo run -p xtask -- coverage-corpus --regenerate` is heavyweight relative to the gain. Document as a fallback if cross-locale IBAN coverage ever becomes a corpus axis.
+- **`pii-codex`** — detection lib (Presidio wrapper), not a generator. Scope mismatch.
+
+### 4.4 Dep-graph isolation invariant
+
+`fake` MUST stay in `crates/xtask/Cargo.toml` `[dev-dependencies]` only. It MUST NOT leak into `gaze`, `gaze-recognizers`, `gaze-audit`, or any other published-shape crate. The existing `cargo-metadata-audit-isolation` xtask gate guards the published surface; the rework adds a one-line assertion that `fake` does not appear in the default-feature graph of any published crate.
+
+## 5. Scenario fixture catalog
+
+Target: **~110 fixtures total** (range 80–150). One seed per scenario; one fixture per scenario; deliberate test-case shape per scenario.
+
+### 5.1 Structural split
+
+| Bucket                                                              | Fixture count | Notes                                                                                                          |
+| ------------------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------- |
+| Status-quo baseline templates (kept verbatim, 1 seed each)          | 60            | Six families × 10 templates: `log-line`, `ocr-output`, `prose-de`, `prose-en`, `support-email-de`, `tool-call-json` |
+| New: conversational × {Snippet, Page, MultiPage} × {en-US, de-DE}   | 12            | 2 scenarios per (tier, locale) cell                                                                            |
+| New: code-mixed × {Snippet, Page, MultiPage} × {global}             | 9             | Code blocks are locale-neutral; 3 scenarios per tier                                                           |
+| New: high-density × {Snippet, Page} × {de-DE, en-US, global}        | 12            | 2 per cell; MultiPage omitted (density saturates at Page tier already)                                         |
+| New: distractor-heavy × {Snippet, Page} × {de-DE, en-US, global}    | 12            | 2 per cell; MultiPage omitted (distractor signal saturates at Page tier)                                       |
+| New: threaded × {Page, MultiPage} × {de-DE, en-US}                  | 8             | 2 per cell; Snippet omitted (threading needs ≥2 quote layers, not viable < 200 B)                              |
+| **Subtotal new structural scenarios**                               | **53**        |                                                                                                                |
+| **Grand total**                                                     | **113**       | Adjustable ±20 during impl review                                                                              |
+
+### 5.2 Scenario row schema
+
+Each new scenario is a single template JSON file under `crates/xtask/src/coverage_corpus/templates/<family>/<id>.json`, following the existing schema (`id`, `context`, `locale_chain`, `body`, `expected_classes`, `notes`) with two new optional fields:
+
+```jsonc
+{
+  "id": "conversational-en-001",
+  "context": "conversational-en",
+  "locale_chain": ["en-US", "global"],
+  "length_tier": "Snippet",            // NEW: "Snippet" | "Page" | "MultiPage"
+  "structural_family": "conversational", // NEW: "conversational" | "code-mixed" | "high-density" | "distractor-heavy" | "threaded"
+  "body": "...",
+  "expected_classes": [...],
+  "notes": "...",
+  "source_citation": "..."             // OPTIONAL: provenance if adapted from a real-world template (e.g. RFC 5322 example, public dataset)
+}
+```
+
+`length_tier` and `structural_family` are absent on the 60 status-quo templates (kept for byte-stability) — the builder defaults them to `Snippet` and the existing `context` value when absent. A future PR can backfill the status-quo templates if needed; the rework does NOT churn their bytes.
+
+### 5.3 Per-scenario authoring rules
+
+- **One PII span per class per scenario unless the structural family demands more.** `high-density` is the only family that intentionally packs 4+ spans; everywhere else, aim for 1–3.
+- **Cite real-world templates where applicable.** Conversational scenarios drawn from synthetic-but-shape-realistic chat transcripts; threaded scenarios mirror Outlook/Gmail quote-reply conventions; code-mixed scenarios use shapes from public log-format docs. `source_citation` field records provenance — never link to a source that contains real PII.
+- **No real PII.** All synthetic. The existing `fixture-citation-lint` xtask gate continues to enforce `license_origin: "synthetic-rust-generator"` on every labeled span; the rework MUST keep this gate green.
+
+### 5.4 Catalog spec (impl PR will materialize these)
+
+The impl PR ships one JSON file per scenario. The exact bodies are out of scope for this design; the catalog spec below fixes id, family, tier, locale, classes, and intent for each new scenario. The impl PR is free to refine wording.
+
+| id                            | family            | tier      | locale chain     | exercised classes                                  | intent / detection axis                                                              |
+| ----------------------------- | ----------------- | --------- | ---------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| conversational-en-001         | conversational    | Snippet   | en-US, global    | Name, Email                                        | Chat-style address: "hey @{{Name}}, ping {{Email}}"                                  |
+| conversational-en-002         | conversational    | Snippet   | en-US, global    | Email, custom:phone                                | Casual handoff with US phone in narrative                                            |
+| conversational-en-003         | conversational    | Page      | en-US, global    | Name, Email, custom:credit_card                    | Multi-turn support chat; CC mentioned mid-conversation                               |
+| conversational-en-004         | conversational    | Page      | en-US, global    | Name, custom:iban, custom:ip_address               | Banking-app chat; IBAN + originating IP                                              |
+| conversational-en-005         | conversational    | MultiPage | en-US, global    | Name × 3, Email × 2, custom:phone, custom:postal_code | Long support transcript; PII drift across turns                                    |
+| conversational-en-006         | conversational    | MultiPage | en-US, global    | Email, custom:iban, custom:eth_address, Name       | Crypto-OTC chat; ETH + IBAN handoff                                                  |
+| conversational-de-001         | conversational    | Snippet   | de-DE, global    | Name, Email                                        | DE chat addressing cue (`Hallo {{Name}}, …`)                                         |
+| conversational-de-002         | conversational    | Snippet   | de-DE, global    | Email, custom:phone                                | DE phone in chat narrative                                                           |
+| conversational-de-003         | conversational    | Page      | de-DE, global    | Name, custom:iban, custom:postal_code              | DE bank-handoff chat; tests `iban` + `name.de` co-occurrence                         |
+| conversational-de-004         | conversational    | Page      | de-DE, global    | Name × 2, Email, custom:ip_address                 | DE chat with footer signature block                                                  |
+| conversational-de-005         | conversational    | MultiPage | de-DE, global    | Name × 2, custom:iban, Email × 2                   | DE multi-turn with multiple Names + IBANs                                            |
+| conversational-de-006         | conversational    | MultiPage | de-DE, global    | Name, Email, custom:credit_card, custom:phone      | DE customer-service transcript; checkout flow                                        |
+| code-mixed-001                | code-mixed        | Snippet   | global           | Email, custom:ip_address                           | Inline backtick: `` `{{Email}}` `` and IP in shell command                           |
+| code-mixed-002                | code-mixed        | Snippet   | global           | custom:iban, Email                                 | JSON config snippet inside fenced block                                              |
+| code-mixed-003                | code-mixed        | Snippet   | global           | custom:credit_card, Email                          | curl-command with `-u user:pass` and email arg                                       |
+| code-mixed-004                | code-mixed        | Page      | global           | Email × 2, custom:iban, custom:ip_address          | Python script with PII in string literals + comments                                 |
+| code-mixed-005                | code-mixed        | Page      | global           | Name, Email, custom:eth_address                    | Solidity contract comment + JS test fixture                                          |
+| code-mixed-006                | code-mixed        | Page      | global           | Email, custom:credit_card, custom:phone            | YAML config + adjacent Markdown prose                                                |
+| code-mixed-007                | code-mixed        | MultiPage | global           | Email × 2, custom:iban × 2, custom:ip_address      | Full Docker compose + README excerpt with operator emails                            |
+| code-mixed-008                | code-mixed        | MultiPage | global           | Name, Email, custom:credit_card, custom:postal_code | Migration SQL + accompanying changelog prose                                        |
+| code-mixed-009                | code-mixed        | MultiPage | global           | Email, custom:iban, custom:eth_address, Name       | Smart-contract deployment script + post-mortem prose                                 |
+| high-density-en-001           | high-density      | Snippet   | en-US, global    | Email × 2, custom:phone, custom:credit_card        | 4 spans / ~180 B; tests overlap-resolution under pressure                            |
+| high-density-en-002           | high-density      | Page      | en-US, global    | Email × 3, custom:iban × 2, custom:credit_card × 2, Name × 2 | 9 spans / ~900 B; cross-class density                                      |
+| high-density-de-001           | high-density      | Snippet   | de-DE, global    | Email × 2, custom:iban, custom:phone               | DE high-density snippet                                                              |
+| high-density-de-002           | high-density      | Page      | de-DE, global    | Name × 3, custom:iban × 2, Email × 2, custom:postal_code | DE customer roster densely packed                                              |
+| high-density-global-001       | high-density      | Snippet   | global           | custom:ip_address × 4, Email                       | Locale-neutral IP-heavy log burst                                                    |
+| high-density-global-002       | high-density      | Page      | global           | custom:ip_address × 3, custom:eth_address × 2, Email × 2 | Crypto-mixer trace; IPs + ETH + emails interleaved                              |
+| high-density-en-003           | high-density      | Snippet   | en-US, global    | Name × 2, Email × 2                                | Name + Email pair-density (4 spans / 150 B)                                          |
+| high-density-en-004           | high-density      | Page      | en-US, global    | Email × 4, custom:phone × 2, custom:postal_code × 2 | High-density US contact list                                                        |
+| high-density-de-003           | high-density      | Snippet   | de-DE, global    | custom:postal_code × 2, custom:phone, Name         | DE address fragments                                                                 |
+| high-density-de-004           | high-density      | Page      | de-DE, global    | custom:iban × 3, Name × 3, Email × 2               | DE high-density bank-statement-style                                                 |
+| high-density-global-003       | high-density      | Snippet   | global           | custom:credit_card × 2, custom:iban × 2            | CC + IBAN cross-class density                                                        |
+| high-density-global-004       | high-density      | Page      | global           | custom:eth_address × 3, custom:credit_card × 2, Email × 2 | Crypto-on-ramp density                                                          |
+| distractor-en-001             | distractor-heavy  | Snippet   | en-US, global    | Email, custom:credit_card                          | Order IDs that look like 16-digit CC; tests Luhn validator-veto                      |
+| distractor-en-002             | distractor-heavy  | Page      | en-US, global    | Name, Email, custom:phone                          | Real Name surrounded by non-PII look-alikes (product names, brands)                  |
+| distractor-de-001             | distractor-heavy  | Snippet   | de-DE, global    | custom:iban, Email                                 | Non-IBAN strings of similar shape (booking codes); tests MOD-97 veto                 |
+| distractor-de-002             | distractor-heavy  | Page      | de-DE, global    | Name, custom:postal_code                           | DE Name + ZIP surrounded by street-address noise that mimics ZIP shape               |
+| distractor-global-001         | distractor-heavy  | Snippet   | global           | custom:ip_address, Email                           | Version tags and timestamps that mimic IPv4 / IPv6 shapes                            |
+| distractor-global-002         | distractor-heavy  | Page      | global           | custom:eth_address, Email                          | Hex blobs that aren't EIP-55-checksummed (caller must reject)                        |
+| distractor-en-003             | distractor-heavy  | Snippet   | en-US, global    | custom:phone, Email                                | US phone shapes that fail NANPA validation interleaved with valid ones               |
+| distractor-en-004             | distractor-heavy  | Page      | en-US, global    | Email, Name, custom:credit_card                    | Long marketing copy with one real PII triple at the end                              |
+| distractor-de-003             | distractor-heavy  | Snippet   | de-DE, global    | Email, Name                                        | DE marketing slogan with brand names that look like surnames                         |
+| distractor-de-004             | distractor-heavy  | Page      | de-DE, global    | custom:iban, custom:phone, Email                   | DE invoice template with reference numbers that look like IBAN fragments             |
+| distractor-global-003         | distractor-heavy  | Snippet   | global           | custom:credit_card, Email                          | Test card numbers (4111…) interleaved with valid Luhn                                |
+| distractor-global-004         | distractor-heavy  | Page      | global           | custom:ip_address × 2, Email                       | Multicast/reserved IP ranges mixed with public IPs                                   |
+| threaded-en-001               | threaded          | Page      | en-US, global    | Email × 2, Name × 2                                | Single quote-layer email thread (`> > original`)                                     |
+| threaded-en-002               | threaded          | MultiPage | en-US, global    | Email × 4, Name × 3, custom:phone                  | Three quote-layers; PII context cues split across layers                             |
+| threaded-de-001               | threaded          | Page      | de-DE, global    | Email × 2, Name × 2, custom:iban                   | DE-style threaded support reply (`Am … schrieb …:`)                                  |
+| threaded-de-002               | threaded          | MultiPage | de-DE, global    | Email × 3, Name × 3, custom:iban, custom:postal_code | Three-deep DE thread with bank info repeating in quote layers                      |
+| threaded-en-003               | threaded          | Page      | en-US, global    | Email × 2, Name × 2, custom:credit_card            | Forum-style threaded reply with refund flow                                          |
+| threaded-en-004               | threaded          | MultiPage | en-US, global    | Email × 3, Name × 2, custom:eth_address            | Discord/Slack-style threaded conversation export                                     |
+| threaded-de-003               | threaded          | Page      | de-DE, global    | Email × 2, Name × 2, custom:phone                  | DE customer-service threaded handoff                                                 |
+| threaded-de-004               | threaded          | MultiPage | de-DE, global    | Email × 3, Name × 3, custom:iban × 2               | Long DE banking thread with multiple IBANs across quote layers                       |
+
+Each row is one fixture. One `<id>.txt` + one `<id>.labels.json`. No `<id>-0.txt` / `<id>-1.txt` proliferation; `fixture_variants` collapses to a constant `1`.
+
+## 6. Property-test plan
+
+Generator coverage moves OUT of committed fixtures and INTO property tests that resample each generator over many seeds per run.
+
+### 6.1 Where it lives
+
+A new test crate path: `crates/xtask/tests/coverage_corpus_generators.rs`. The file is a single `#[test]` per generator with `proptest!` (or manual loop over 1000 seeds — proptest dep is fine since this is `xtask` dev-only).
+
+### 6.2 Invariants per generator
+
+| Generator                          | Invariant                                                                                       | Why                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Email (`fake::FreeEmail`)          | Parses as valid `email_address::EmailAddress` (the crate `gaze-recognizers` uses for `EmailRfc`) | Generator must satisfy `ValidatorKind::EmailRfc`                          |
+| IBAN (`iban.rs`)                   | MOD-97 check passes via `iban_validate::Iban::parse`                                            | Generator must satisfy `ValidatorKind::IbanMod97`                         |
+| Card (`card_luhn.rs`)              | Luhn check digit valid                                                                          | Generator must satisfy `ValidatorKind::Luhn`                              |
+| Phone DE (`phone_national_de.rs`)  | `phonenumber::parse(Some(DE), s)` returns `Ok` AND `is_valid()` is true                         | Generator must satisfy national parser                                    |
+| Phone US (`phone_national_us.rs`)  | Same, region `US`. Note: NANPA 555-01xx synthetic prefix must remain in the generator surface   | Tests today's coverage gap (6 US-phone Uncovered in baseline.json)        |
+| ETH (`eth_eip55.rs`)               | EIP-55 mixed-case checksum validates against `eip55::is_address` (or `ethaddr` equivalent)      | Generator must produce checksummed addresses                              |
+| IPv4 / IPv6                        | `std::net::IpAddr::from_str` round-trips                                                        | Sanity                                                                    |
+| Postal DE / US                     | Format-matches the locale regex                                                                 | No semantic validator binding; format guard is enough                     |
+| Name DE / EN                       | Non-empty Unicode word characters; no PII real-people allow-list violations                     | `fake` curated datasets are already filtered; assert non-empty + ASCII/Unicode-letter shape |
+
+### 6.3 Pre-adoption gate for `fake` phone
+
+Before swapping any phone generator to `fake::faker::phone_number`, run the property test against `fake`'s output and assert ≥100% pass rate against the national parser. **If pass rate < 100%, keep custom.** This is the explicit deferred check from the survey (scratchpad 16 §"Risks"). Phone generators are NOT in scope for the initial swap.
+
+### 6.4 Determinism
+
+Property tests run with a fixed-seed `StdRng::seed_from_u64(0)` plus a shrinking range; failures must be reproducible from the seed alone. Property tests are NOT run inside `coverage_loop.rs` — they are independent `cargo test -p xtask`.
+
+## 7. Baseline re-snap plan
+
+After §5 lands, `crates/gaze-recognizers/testdata/coverage-loop/baseline.json` is regenerated. The shape stays identical (schema_version 1, leak_set keyed by class then locale); only the bucket counts change.
+
+### 7.1 Target shape
+
+For each (class_id, locale) bucket in the new baseline:
+
+- `Uncovered < 30` (today: `Name/de-DE = 32`, just over; rework should drive that down through targeted scenarios in §5 — the conversational + threaded × de-DE rows are intentionally Name-heavy).
+- `partial_bleed = 0` and `class_mismatch ≤ baseline` on every bucket (no regressions).
+- `covered ≥ 1` for every bucket where any new scenario emits a label of that class — i.e. no whole-bucket gaps are introduced.
+
+### 7.2 Re-snap command
+
+```bash
+cargo run -p xtask -- coverage-corpus --regenerate --seed 0
+GAZE_COVERAGE_LOOP_INFO_ONLY=1 cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture > /tmp/new-baseline.md
+# Manually translate /tmp/new-baseline.md table into baseline.json bucket counts.
+# Sanity-check by re-running with GAZE_COVERAGE_LOOP_INFO_ONLY=0 — must pass.
+```
+
+### 7.3 Verification gate
+
+After re-snap, the impl PR MUST pass `GAZE_COVERAGE_LOOP_INFO_ONLY=0 cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture` cleanly. Trend-gate logic (`enforce_trend_gate` in `crates/gaze-recognizers/tests/coverage_loop.rs`) rejects any bucket whose `Uncovered` count exceeds baseline; the re-snap must therefore be conservative — pick the higher end of the observed range, not the optimistic mean.
+
+### 7.4 Re-snap cadence
+
+The baseline is re-snapped only as part of a conscious release-train decision (today's policy, unchanged). The rework PR re-snaps once; subsequent improvements ratchet `Uncovered` down through detection fixes rather than baseline edits.
+
+## 8. Two-PR sequence
+
+### 8.1 PR-1 — this design (markdown-only)
+
+- Branch: `design/corpus-rework-v2`
+- Single commit: adds `docs/research/v0.7.x-corpus-rework-v2.md`
+- No code, no Cargo.toml, no corpus file edits. CHANGELOG untouched (release-engineer batches into v0.7.3 or v0.8.0).
+- CI: standard PR gates pass; only `fixture-citation-lint` is materially relevant (the design cites fixture paths).
+
+### 8.2 PR-2 — implementation
+
+After PR-1 review/merge:
+
+1. Add `fake = { version = "5", default-features = false, features = [...] }` to `crates/xtask/Cargo.toml` `[dev-dependencies]`.
+2. Replace 7 generator files per §4.1. Keep file paths so test imports don't churn.
+3. Drop `fixture_variants` in `crates/xtask/src/coverage_corpus/builder.rs:224` to a constant `1`. Remove the `prose-en-001` ×5 special-case.
+4. Add 53 new scenario template JSON files per §5.4, registered in `crates/xtask/src/coverage_corpus/templates/mod.rs`'s `TEMPLATE_JSON` list.
+5. Run `cargo run -p xtask -- coverage-corpus --regenerate --seed 0`. New corpus file count: ~113.
+6. Re-snap `baseline.json` per §7.
+7. Add `crates/xtask/tests/coverage_corpus_generators.rs` with property tests per §6.
+8. Update `docs/research/v0.7.x-coverage-baseline.md` with new bucket table + commentary.
+9. Run the full v0.7.x verification suite (`cargo fmt`, `clippy`, workspace tests, all xtask gates including `fixture-citation-lint` and `ci-feature-matrix`, plus the coverage-loop test in both `INFO_ONLY` modes).
+10. CHANGELOG entry deferred to release-engineer.
+
+PR-2 is large (53 new fixture pairs + generator swaps + baseline + property tests). It is reviewable because each axis (generator swap, scenarios, baseline, property tests) lives in its own commit within the PR.
+
+## 9. North-star alignment
+
+The rework strengthens axes 1 and 4 directly:
+
+- **Axis 1 (reliability — never leak).** Scenario fixtures with deliberate gaps surface detection holes faster than stochastic resampling. PR #182's seed multiplicity exercised the same code paths repeatedly; the rework spends every fixture slot on a different structural axis. Distractor-heavy and threaded families explicitly probe known weak points (validator-veto, anchored-name context).
+- **Axis 4 (trust — auditable + deterministic).** Tighter baseline buckets (target `Uncovered < 30`) keep `decided_by: ConflictTier` regressions visible in the trend gate. Property tests guarantee every committed generator passes its `ValidatorKind` over a wider seed space than committed fixtures could, without inflating the corpus.
+- **Axis 5 (adopter ergonomics).** Smaller corpus (113 vs PR #182's 323) is faster to grok during onboarding; adopters reading the corpus to understand Gaze's detection coverage get a curated catalog rather than 5× duplicates.
+- **Axes 2 (reversibility) and 3 (agentic-first).** Neutral. The rework does not touch the restore path or session contract.
+
+## 10. Open questions
+
+Decisions deferred to counselor / user review on PR-1:
+
+1. **Seed value.** Status quo seeds with `--seed 0`. The re-snap should pin a specific seed and never roll it without a release-train decision. Confirm `--seed 0` stays; alternative would be a time-stable seed like `0x6761ze` for documentation aesthetics.
+2. **`fake` feature set.** Survey suggested `default-features = false` with name + internet + address features. Confirm minimal feature set before adding to `Cargo.toml`.
+3. **`length_tier` backfill.** The status-quo 60 templates default to `Snippet` without an explicit field. Acceptable as-is, or should PR-2 backfill explicit `"length_tier": "Snippet"` (churns bytes but improves consistency)? Recommendation: don't backfill — byte-stability of the existing 60 fixtures is more valuable than schema uniformity.
+4. **Target count.** §5.1 proposes 113. Should we aim lower (~80) for tighter baseline buckets, or higher (~150) for broader structural coverage? Lower means fewer chances of single-entry regressions getting lost; higher means more detection surface. Recommendation: 110 ± 10.
+5. **MultiPage byte ceiling.** §3.2 caps MultiPage at 6000 B. Some real-world threaded emails exceed that. Recommendation: keep the cap; if longer fixtures become valuable, add a `LongForm` tier in a follow-up rather than expanding `MultiPage`.
+
+## 11. Audit citations
+
+- PR #182 close + blocking comment: <https://github.com/EmpireTwo/gaze/pull/182>
+- Current corpus root: `crates/gaze-recognizers/testdata/coverage-loop/` (123 fixtures, 60 templates × ~2 seeds)
+- Baseline: `crates/gaze-recognizers/testdata/coverage-loop/baseline.json` (schema_version 1; totals: fixture_count=123, labeled_span_total=278, uncovered_total=64, covered_total=212, class_mismatch_total=2)
+- Trend gate: `crates/gaze-recognizers/tests/coverage_loop.rs:enforce_trend_gate`
+- Builder: `crates/xtask/src/coverage_corpus/builder.rs` (`fixture_variants` at line 224)
+- Templates: `crates/xtask/src/coverage_corpus/templates/{log-line,ocr-output,prose-de,prose-en,support-email-de,tool-call-json}/`
+- Generators: `crates/xtask/src/coverage_corpus/generators/{card_luhn,email,eth_eip55,iban,ip_v4,ip_v6,name_de,name_en,phone_national_{de,us},phone_structural,postal_{de,us}}.rs`
+- Existing coverage commentary: `docs/research/v0.7.x-coverage-baseline.md`
+- Verification gates: `cargo run -p xtask -- ci-feature-matrix`, `dylint-gate`, `safety-net-sanity`, `cargo-metadata-audit-isolation`, `fixture-citation-lint`
+- North star: see `AGENTS.md` + `CLAUDE.md` §"Project north star"
+- Repo head at design time: `0e7f666` (v0.7.2 release tag)


### PR DESCRIPTION
## Summary

- Design-only artifact for the v0.7.x coverage-corpus rework after [PR #182](https://github.com/EmpireTwo/gaze/pull/182) close.
- Captures the *scenario fixture* shape (1 seed per scenario), the structural template families × length tiers (kept from #182), and the hybrid `fake` crate adoption (xtask dev-dep) for non-validator-bound classes.
- Specifies a 53-scenario catalog (113 fixtures total, down from #182's 323), generator property-test plan, and `baseline.json` re-snap targeting `Uncovered < 30` per bucket.

## Scope

- **Markdown-only.** Single new file: `docs/research/v0.7.x-corpus-rework-v2.md`. No code, no Cargo.toml, no corpus edits, no CHANGELOG.
- Implementation lands in a follow-up PR (`PR-2`) per the two-PR sequence in §8 of the design.

## North-star alignment

- Axis 1 (reliability): scenario fixtures with deliberate gaps surface detection holes faster than stochastic resampling.
- Axis 4 (trust): tighter baseline buckets keep `decided_by` regressions visible in the trend gate; property tests cover generator validator-correctness over a wider seed space than committed fixtures could.
- Axis 5 (adopter ergonomics): smaller curated corpus (~113 vs 323) is faster to grok.

## Test plan

- [x] `cargo run -p xtask -- fixture-citation-lint` — passed (the design cites fixture paths; lint stays green).
- [x] Markdown-only diff verified — `git diff --stat HEAD~1` shows only the new doc file.
- No other gates relevant. Implementation gates exercised in PR-2.

## Open questions

§10 of the design lists five items for counselor / user review (seed pinning, `fake` feature set, length_tier backfill, target fixture count, MultiPage byte ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)