### PR TITLE
docs: fix broken cli-adapter-contract.md cross-link in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,7 +175,7 @@ let pipeline = gaze_assembly::build_pipeline(
 ## Next steps
 
 - [Policy reference](policy.md) -- full TOML schema, all recognizers, locale chain
-- [CLI adapter contract](cli-adapter-contract.md) -- shell-out protocol for framework adapters
+- [CLI adapter contract](../crates/gaze-cli/README.md) -- canonical shell-out protocol (stdin/stdout/stderr) for framework adapters; see [Subcommands](../crates/gaze-cli/README.md#subcommands) for the `clean` / `restore` / `audit` surface as of v0.7.2
 - [Security review](security-review.md) -- invariants, threat boundaries, audit isolation
 - [Exit codes](../crates/gaze-cli/README.md#exit-codes) -- canonical exit code reference
 - `cargo doc --open -p gaze` -- full API reference


### PR DESCRIPTION
## Summary

- `docs/getting-started.md:178` pointed at `docs/cli-adapter-contract.md`, which never existed in git history (verified with `git log --all -- docs/cli-adapter-contract.md` returning empty).
- Repoint the "Next steps" bullet to `crates/gaze-cli/README.md` — the canonical shell-out protocol surface (stdin/stdout/stderr contract for framework adapters) at workspace v0.7.2 — with a deep-link to the `#subcommands` section so adopters land on the `clean` / `restore` / `audit` surface without scrolling.
- Single-line diff, no version bump, no CHANGELOG entry.

## North-star tie

Axis 5 (adopter ergonomics). A dead cross-link in the onboarding doc is friction for the very framework-adapter authors the doc is written for.

## Test plan

- [x] `git log --all -- docs/cli-adapter-contract.md` returns empty (file never existed)
- [x] `rg cli-adapter-contract .` returns no other references after edit
- [x] Target `crates/gaze-cli/README.md` exists and has a `## Subcommands` heading (line 47)
- [x] Workspace `Cargo.toml` reflects `0.7.2` (matches the version cited in the bullet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)