### PR TITLE
docs: sync SECURITY + CONTRIBUTING + release-process to v0.7.2 + 9-crate reality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ locally — see the "PR-checks ritual" section below.
 
 ## Workspace shape
 
-As of v0.7.0, the workspace has eight published-shape crates plus `xtask`:
+As of v0.7.2, the workspace has **nine** published-shape crates plus `xtask`. The ninth crate is `gaze-document` (added in v0.7.1).
 
 | Crate | Role |
 |---|---|
@@ -26,6 +26,7 @@ As of v0.7.0, the workspace has eight published-shape crates plus `xtask`:
 | `crates/gaze-cli` | Standalone `gaze` binary; the only allowlisted `gaze-audit` consumer outside compatibility tests. |
 | `crates/gaze-mcp-core` | Transport-free MCP-shaped chokepoint runtime: `Tool` trait, sealed `ToolCtx`, `ToolRegistry`, `PiiEnvelope::dispatch`, `Frontend`/`DispatchHost`, `ManifestStore`, `AuthHook`, `SessionIdPolicy`. New in v0.7.0. |
 | `crates/gaze-mcp-rmcp` | rmcp transport sink: `RmcpFrontend`, stdio default transport, opt-in streamable HTTP transport, adopter-supplied `PrincipalResolver`. New in v0.7.0. |
+| `crates/gaze-document` | OSS document ingestion: PNG/JPG/PDF → Tesseract OCR → gaze redact → `SafeBundle` (`clean.md`, `manifest.json`, `report.json`). Ships a `gaze document clean` CLI verb under the `gaze-cli` `document` feature. `BundleReport` schema versioned via `bundle_version = 1`. New in v0.7.1. |
 | `crates/xtask` | Internal repository gate runner: `bundle-tokenization-drift`, `fixture-citation-lint`, `ci-feature-matrix`, `class-map-override-safety`, `symmetric-potemkin`, `no-tenant-knowledge`, `cargo-metadata-audit-isolation` (Phase C), `dylint-gate` (Phase D). |
 | `xtask/dylint/` | Dylint lint crate hosting `gaze_module_isolation`. Detached workspace pinned to `nightly-2025-09-18`. New in v0.5 Phase D. |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,11 @@ Out of scope:
 
 ## Supported versions
 
-We currently support security fixes only on the latest minor of the `0.6.x`
-series and (when released) the latest minor of `0.7.x`. Earlier versions
-do not receive backports.
+We currently support security fixes on the latest minor of the `0.7.x`
+series (`v0.7.2` at the time of writing). The last released minor of
+`0.6.x` receives one-cycle backports for high-severity findings while
+adopters complete the `0.7.x` upgrade. Earlier versions do not receive
+backports.
 
 ## Coordinated disclosure
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,15 +1,40 @@
 # Release Process
 
+`EmpireTwo/gaze` is a public repository. Two release channels are live for adopters; Homebrew remains repo-local pending a public tap.
+
+## Public release channels (live)
+
+### GitHub Releases
+
+Source: [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+- Triggered on `v*` tag pushes.
+- Builds and uploads platform binary artifacts plus a source tarball to the GitHub Releases page.
+- Release notes follow the curated-narrative voice (see [`docs/release-notes-style.md`](release-notes-style.md) when present) — past-tense PR-anchored prose with a North-Star tie, not a Keep-a-Changelog dump.
+- Browse releases at <https://github.com/EmpireTwo/gaze/releases>.
+
+### crates.io
+
+Source: [`.github/workflows/publish-crates.yml`](../.github/workflows/publish-crates.yml).
+
+- Triggered on `v*` tag pushes (with `workflow_dispatch` dry-run available).
+- Authenticates to crates.io via OIDC trusted-publisher (`rust-lang/crates-io-auth-action`); no long-lived `CARGO_REGISTRY_TOKEN` secret.
+- Publishes all nine workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
+- Skips crates already at the published version (idempotent re-runs) and retries on index-propagation lag.
+- Browse crates at <https://crates.io/crates/gaze-pii> (and sibling crate pages).
+
+Cutting a release: tag the merge commit on `main` with `vX.Y.Z` and push the tag. Both workflows fire from the same tag push; no manual crates.io step needed.
+
 ## Homebrew Tap Location
 
-Decision for v0.4.6 S6 (#184): keep Homebrew repo-local until the organization creates an explicit public tap and release publication target.
+Decision for v0.4.6 S6 (#184), reaffirmed post repo-public flip: keep Homebrew repo-local until the organization creates an explicit public tap and release publication target.
 
 Current state:
 
 - The formula source lives in this repository at `dist/homebrew/gaze.rb`.
-- No public `EmpireTwo/tap` or `EmpireTwo/homebrew-tap` repository is visible from this repo-local audit.
-- `EmpireTwo/gaze` is private, so public Homebrew installation is not a supported path yet.
-- `.github/workflows/release.yml` intentionally remains artifact-only: it builds and uploads GitHub release assets, but does not push formula updates to an external tap.
+- No public `EmpireTwo/tap` or `EmpireTwo/homebrew-tap` repository exists yet.
+- Repo-public status alone does not enable `brew install` — adopters still need a tap that serves the formula. Until that tap exists, `cargo install gaze-cli` (from crates.io) is the supported install path for the CLI.
+- `.github/workflows/release.yml` intentionally remains artifact-only for Homebrew: it builds and uploads GitHub release assets, but does not push formula updates to an external tap.
 - Modern Homebrew rejects direct install/info commands for formula files outside a tap, so local smoke means staging the formula into a scratch tap rather than installing `./dist/homebrew/gaze.rb` directly.
 
 Axis-5 rationale: documenting the repo-local formula is more ergonomic than advertising a tap that adopters cannot use. It gives collaborators a concrete smoke path while keeping public install instructions honest and reversible when a public tap is created.


### PR DESCRIPTION
## Summary

Three documentation files carried stale references that misled adopters about supported versions, workspace shape, and release channels. This PR catches them up to v0.7.2 reality.

- **`SECURITY.md`** — supported-versions matrix now names `v0.7.x` (currently `v0.7.2`) as the primary supported series, with the last released minor of `0.6.x` as a one-cycle backstop. Dropped the obsolete "(when released)" hedge on `0.7.x`.
- **`CONTRIBUTING.md`** — workspace shape header updated from "eight crates as of v0.7.0" to "nine crates as of v0.7.2"; the crate table now includes `gaze-document` (introduced v0.7.1, ships `gaze document clean` CLI verb with `BundleReport` `bundle_version = 1`).
- **`docs/release-process.md`** — removed the stale "`EmpireTwo/gaze` is private" claim. New top section documents the live public-release flow: GitHub Releases on `v*` tag push (`.github/workflows/release.yml`) and crates.io publication via OIDC trusted-publisher across all nine workspace crates in topological order (`.github/workflows/publish-crates.yml`). The Homebrew section is reframed — still repo-local until a public tap exists; `cargo install gaze-cli` is the supported CLI install path in the meantime.

## North-star alignment

- **Axis 4 (trust — auditable + deterministic):** docs now make accurate, verifiable claims about supported versions, crate count, and release channels. Versions cross-checked against `Cargo.toml` `workspace.dependencies` (`0.7.2`), crate roster against `AGENTS.md`, repo visibility against `gh repo view EmpireTwo/gaze`, and crates.io against the live `gaze-pii`/`gaze-types` registry entries (`default_version: 0.7.2`).
- **Axis 5 (adopter ergonomics):** adopters who land on these three docs now see what is actually shipping rather than a half-released state. The release-process doc gives a concrete install path (`cargo install gaze-cli`) instead of an apologetic "private repo" note.

## Test plan

- [x] `Cargo.toml` cross-check confirms workspace at `0.7.2`.
- [x] `AGENTS.md` confirms nine crates with `gaze-document` introduced in v0.7.1.
- [x] `gh repo view EmpireTwo/gaze --json visibility` returns `PUBLIC`.
- [x] crates.io API confirms `gaze-pii` and `gaze-types` default_version `0.7.2`.
- [ ] CI green on this PR (docs workflow + any other gates).

Docs-only change. No code touched, no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)