### PR TITLE
docs(crates): refresh gaze-recognizers + gaze-audit + gaze-mcp-core READMEs with v0.7.x features

### DIFF
--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -62,6 +62,49 @@ for row in &rows {
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+## Audit-query API surface
+
+Adopters building dashboards, exports, or compliance views interact with four
+public items beyond `SqliteLogger`:
+
+| Item | Role |
+|------|------|
+| `AuditFilter` | Plain-struct filter builder. All fields are `Option<_>` and default to `None`, so `AuditFilter::default()` returns every row. Narrow by `class`, `source`, `action`, `document_kind`, `field_path`, `session_id`, `from_epoch_ms` / `to_epoch_ms`, snapshot scheme / alg / key version, plus the v0.7.x ambiguity columns described below. |
+| `AuditLogRow` | Shape returned by `SqliteLogger::query`. Metadata only — `class`, `action`, `field_name`, `document_kind`, `conflict_loser`, `decided_by`, `created_at`, `session_id`, snapshot metadata, and the four v0.7.x ambiguity columns. No raw PII, no token values, no restore material. |
+| `build_audit_query_sql` | Lower-level helper that constructs the `(SQL, params)` pair used by `SqliteLogger::query`. Takes column-presence booleans so callers querying older databases project `NULL AS <missing_column>` rather than failing. Exposed so external readers can run the same projection logic against a read replica without re-implementing the filter compiler. |
+| `AUDIT_RESTRICTED_COLUMNS` | Canonical allowlist of columns the audit-query path may project. `audit export` and `SqliteLogger::query` select only from this set. `redaction_log` may grow columns over time (e.g. snapshot locators, replay hashes); restricting projection here is defense in depth so future schema additions never accidentally leak raw PII, token bytes, or document content. The clean path is forbidden from touching audit storage by the `gaze_module_isolation` Dylint lint; this constant is the matching read-side guard. |
+
+## Ambiguity side-channel columns (v0.7.2)
+
+`SqliteLogger`'s `redaction_log` migration adds four nullable columns and
+`AuditLogRow` mirrors them as `Option<String>`:
+
+- `validator_fail_reason` — JSON-encoded closed enum (`LuhnFailed`,
+  `IbanMod97Failed`, `EmailRfcFailed`, `E164PhoneFailed`) for validator-veto
+  losers. Populated only on rows where `decided_by = ValidatorVeto`.
+- `ambiguity_record` — JSON-encoded `AmbiguityRecord` (family-level class,
+  losing candidate list, closed `AmbiguityReason`). Populated when the
+  resolver fell back to a family-level token instead of a precise variant.
+- `collision_family` — plain string identifier for the
+  `[recognizers.collision]` family this row belongs to. `NULL` for rows
+  outside collision-family policy.
+- `collision_variant` — plain string variant identifier within the family.
+  `NULL` when the family-level fallback fired (no specific variant was
+  emitted).
+
+Migration is lazy and idempotent: `SqliteLogger::new(path)` runs
+`CREATE TABLE IF NOT EXISTS` followed by `PRAGMA table_info` and
+`ALTER TABLE ADD COLUMN` for any missing column. There is no schema-version
+table; reopening an up-to-date database is a no-op.
+
+`AuditFilter` exposes four matching filter fields (`has_ambiguity`,
+`ambiguity_reason`, `collision_family`, `collision_variant`) and the CLI
+surfaces them as `--has-ambiguity`, `--ambiguity-reason <variant>` (kebab
+case, e.g. `no-anchor`), `--collision-family <id>`, and
+`--collision-variant <id>` on `gaze audit query` and `gaze audit export`.
+Full contract:
+[`docs/architecture/ambiguity-side-channel.md`](../../docs/architecture/ambiguity-side-channel.md).
+
 ## Isolation gate
 
 `gaze` core has **no compile-time dependency** on `gaze-audit`. The `gaze_module_isolation`

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,6 +4,15 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
+> **Adding `gaze-mcp-core` (v0.7.2) to your crate enables:** the transport-free
+> MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
+> `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
+> points, and the optional `core-tools` agent-tier tool set.
+> **Does NOT bring in:** an MCP transport. No stdio, no streamable HTTP, no
+> JSON-RPC framing — this crate is transport-free by design.
+> **For the rmcp transport sink, also add `gaze-mcp-rmcp`** (or implement
+> `Frontend` yourself; see below).
+
 ### Scope
 
 `gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -146,6 +146,74 @@ Loading failures are policy configuration failures in the CLI path.
 The loader returns `None` for unknown names. Policy/CLI callers should treat
 unknown bundled names as configuration errors.
 
+## Recognizer-level metadata (v0.7.2)
+
+Rulepacks loaded into this crate can carry two cross-cutting metadata blocks
+that change conflict-resolution behavior without changing the underlying
+backend implementation. Both are designed to fail closed: when adopters
+under-specify them, Gaze emits a coarser family-level token rather than a
+guess.
+
+### Collision-family policy
+
+Cross-class recognizer rivalries (PAN vs IBAN, postal vs phone, …) declare
+collision metadata beside the recognizer definition:
+
+```toml
+[[recognizers]]
+id = "iban.structural"
+class = "custom:iban"
+
+[recognizers.collision]
+family = "payment-card-or-iban"
+variant = "iban"
+precedence = 10
+```
+
+Adopter policy uses the same shape under `[[policy.custom_recognizers]]` with
+a `[policy.custom_recognizers.collision]` table. The runtime compiles these
+into a `FamilyPolicyTable` queried by stable recognizer id. Validator-veto
+runs first; family policy then arbitrates same-family different-variant
+overlaps with `ConflictTier::CollisionPolicy`. Equal precedence between
+variants emits a family-level `PiiClass::Custom("family:<name>")` token plus
+`AmbiguityRecord::PrecedenceTie`. Reserved bundled family names cannot be
+claimed by adopter policy. Full contract:
+[`docs/architecture/collision-family.md`](../../docs/architecture/collision-family.md).
+
+### Mandatory-anchor resolution
+
+A collision-family recognizer can require a deterministic cue before emitting
+its narrower variant:
+
+```toml
+[recognizers.collision]
+family = "payment-card-or-iban"
+variant = "iban"
+precedence = 10
+mandatory_anchor = "iban"
+```
+
+Locale rulepacks (e.g. `locale-en`, `locale-de`) supply the matching cue
+bundle:
+
+```toml
+[locale.cues.iban]
+names = ["IBAN", "IBAN:", "Account No."]
+window_chars = 64
+```
+
+When the anchor cue is found in a bounded window around the candidate span,
+the variant class flows normally. When the anchor is missing — or the locale
+bundle does not provide that cue key — Gaze emits one family-level
+`PiiClass::Custom("family:<name>")` token, sets the decision to
+`ConflictTier::AnchoredContext`, and attaches an `AmbiguityRecord` with
+`AmbiguityReason::NoAnchor`. The cleaned text receives one token and the
+manifest stores one restore mapping. The bundled
+`cargo run -p xtask -- locale-cue-bundle-coherence` gate fails if a bundled
+recognizer declares `mandatory_anchor` without a matching bundled cue block.
+Full contract:
+[`docs/architecture/anchor-resolution.md`](../../docs/architecture/anchor-resolution.md).
+
 ## Adding recognizers here
 
 Add a recognizer to this crate when it is a built-in backend Gaze should ship


### PR DESCRIPTION
## Summary

Three per-crate README refreshes covering v0.7.x features that landed without
adopter-facing docs. All three were already specified in `docs/architecture/`;
this PR surfaces them where adopters land first (crates.io / docs.rs).

### `crates/gaze-recognizers/README.md`

- New "Recognizer-level metadata (v0.7.2)" section.
- **Collision-family policy:** documents `[recognizers.collision]` /
  `[policy.custom_recognizers.collision]` metadata, the compiled
  `FamilyPolicyTable`, validator-veto-first ordering,
  `ConflictTier::CollisionPolicy`, precedence-tie fallback to
  `PiiClass::Custom("family:<name>")` + `AmbiguityRecord::PrecedenceTie`, and
  the reserved-bundled-family guard. Cites
  `docs/architecture/collision-family.md`.
- **Mandatory-anchor resolution:** documents the `mandatory_anchor`
  recognizer field, the `[locale.cues.<key>]` cue-bundle shape, the
  bounded-window scan, and the closed-loop failure mode (one family-level
  `PiiClass::Custom("family:<name>")` token, `ConflictTier::AnchoredContext`,
  `AmbiguityReason::NoAnchor`). Cites
  `docs/architecture/anchor-resolution.md` and the
  `locale-cue-bundle-coherence` xtask gate.

### `crates/gaze-audit/README.md`

- New "Audit-query API surface" section enumerating `AuditFilter`,
  `AuditLogRow`, `build_audit_query_sql`, and `AUDIT_RESTRICTED_COLUMNS` —
  including why the restricted-column allowlist exists (defense in depth
  against future schema additions that might carry restore material or
  document content).
- New "Ambiguity side-channel columns (v0.7.2)" section documenting the four
  v0.7.x audit columns (`validator_fail_reason`, `ambiguity_record`,
  `collision_family`, `collision_variant`), the lazy idempotent migration,
  and the matching CLI flags on `gaze audit query` / `gaze audit export`.
  Cites `docs/architecture/ambiguity-side-channel.md`.

### `crates/gaze-mcp-core/README.md`

- New top-of-README dep-graph callout: what `gaze-mcp-core` v0.7.2 enables in
  your dep graph (transport-free MCP chokepoint runtime, optional
  `core-tools`), what it does NOT bring in (no MCP transport), and the
  pointer to `gaze-mcp-rmcp` for the rmcp sink (or implementing `Frontend`
  directly).
- v0.7.x stable wording already in place from `617c1c4` doc-sync — verified,
  no churn.

## North-star alignment

**Axis 5 — adopter ergonomics.** The behavior was already specified in
`docs/architecture/*`. Adopters landing on a crate's docs.rs page can now
discover collision-family policy, anchor resolution, the audit-query API
shape, and the `gaze-mcp-core` dep-graph boundary without spelunking the
architecture directory.

Axes 1-4 are unaffected — this is documentation only; no behavior changes,
no code, no CHANGELOG.

## Test plan

- [ ] CI green (PR-triggered `docs.yml` exercises rustdoc / doc-test
      warnings on the workspace).
- [ ] Visual check: each new section renders cleanly on GitHub README view.
- [ ] Cited architecture-doc relative links resolve from each crate's
      README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)