### PR TITLE
feat(safety-net): add KijiDistilbertSafetyNet backend (v0.8 Tier 2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`KijiDistilbertSafetyNet` backend** (v0.8 Tier 2.5,
+  `--safety-net-backend kiji-distilbert`): observer-only DistilBERT NER pass
+  that runs at the Pass-3 chokepoint alongside the existing OpenAI Privacy
+  Filter. Subprocess model identical to `OpenAiFilterSafetyNet`: read clean
+  text on stdin, emit a JSON span array on stdout, never mutate the manifest.
+  Pinned-artifact contract identical to the existing OpenAI filter — model
+  dir must carry `SHA256SUMS`, `labels.json`, `model.onnx`, `tokenizer.json`
+  with `0o700` directory + `0o600` file permissions on Unix; missing
+  artifacts (including a missing `SHA256SUMS`) fail closed with typed
+  `CliError::SafetyNetArtifactMissing` exit `2` *before* the subprocess
+  spawns. New CLI flags: `--safety-net-backend`, `--kiji-distilbert-command`,
+  `--kiji-distilbert-model-dir`. New fetcher: `scripts/fetch-kiji-safetynet-model.sh`
+  (HF commit SHA placeholder pending first sign-off). (Axis 1 reliability —
+  defense in depth, second NER opinion at the chokepoint.)
+
 ### Changed
 
 ### Deprecated

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 safety-net-openai = ["gaze-recognizers/safety-net-openai"]
+safety-net-kiji = ["gaze-recognizers/safety-net-kiji"]
 document = ["dep:gaze-document"]
 mcp = [
     "dep:async-trait",

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -141,10 +141,13 @@ Flags:
 | `--max-bytes <bytes>` | Stdin byte cap. Defaults to `10485760`. |
 | `--context-json <path>` | Typed context envelope with dictionaries, class map, and fields. |
 | `--audit-db <path>` | Optional SQLite redaction-log database path for metadata-only audit entries. |
-| `--safety-net <kind>` | Optional observer-only safety net. Currently `openai-filter`. Activates the post-clean leak audit. |
-| `--openai-filter-command <path>` | Path to the local OpenAI Privacy Filter `opf` command. Required with `--safety-net=openai-filter`. |
-| `--openai-filter-checkpoint <path>` | Path to the OPF checkpoint or model directory. Required with `--safety-net=openai-filter`. |
+| `--safety-net <kind>` | Optional observer-only safety net. Accepts `openai-filter` (v0.6+) or `kiji-distilbert` (v0.8+). Activates the post-clean leak audit. |
+| `--safety-net-backend <backend>` | v0.8 backend selector: `openai-filter` (default) or `kiji-distilbert`. When set alongside `--safety-net=<kind>`, this flag wins and lets adopters swap the Pass-3 implementation without re-typing the legacy `--safety-net` value. |
+| `--openai-filter-command <path>` | Path to the local OpenAI Privacy Filter `opf` command. Required with the `openai-filter` backend. |
+| `--openai-filter-checkpoint <path>` | Path to the OPF checkpoint or model directory. Required with the `openai-filter` backend. |
 | `--openai-filter-operating-point <point>` | Operating point: `high-recall`, `balanced`, `high-precision`. |
+| `--kiji-distilbert-command <path>` | Path to the local Kiji DistilBERT subprocess command. Required with the `kiji-distilbert` backend. |
+| `--kiji-distilbert-model-dir <path>` | Path to the pinned Kiji DistilBERT model directory (must contain `SHA256SUMS`, `labels.json`, `model.onnx`, `tokenizer.json`). Required with the `kiji-distilbert` backend. |
 | `--safety-net-timeout-ms <ms>` | Subprocess deadline. Defaults to `5000`. |
 | `--safety-net-input-limit-bytes <bytes>` | Clean-text input cap forwarded to the safety net. Defaults to `1048576`. |
 | `--safety-net-mode <strict\|tolerant>` | `strict` exits `3` on `Uncovered`/`PartialBleed` suspects; `tolerant` emits warnings on stderr and continues. Defaults to `strict`. |
@@ -154,19 +157,44 @@ surface can be exercised. Production use should pass `--policy`.
 
 ### Safety net
 
-The optional `--safety-net=openai-filter` flag activates the observer-only
-safety net documented in
+The optional `--safety-net=<kind>` flag activates the observer-only safety
+net documented in
 [docs/architecture/safety-nets.md](../../docs/architecture/safety-nets.md).
 The safety net runs after the deterministic clean and reports suspected
 leaks against the manifest of emitted tokens. It cannot mutate the clean
 text and cannot affect restore.
 
+#### Safety-net backends
+
+Two observer-only backends are available; pick one via
+`--safety-net-backend <backend>` (v0.8) or the legacy `--safety-net=<kind>`.
+Both share the strict/tolerant exit-code contract, the `LeakReport` shape,
+and the `safety_net_log` audit table.
+
+**`openai-filter`** (v0.6+) wraps the official `openai/privacy-filter`
+subprocess. Strengths: eight typed labels covering Person, Email, Phone,
+URL, Address, Date, Account number, Secret; documented operating points;
+mature upstream. Trade-offs: heavier model and slower per-clean latency;
+no first-party fetch path; runtime depends on a third-party Python install
+the operator pins.
+
+**`kiji-distilbert`** (v0.8+) wraps a pinned DistilBERT NER model as a
+subprocess. Strengths: lightweight ONNX-served weights, faster startup,
+straightforward fetch script, second NER opinion at the chokepoint that
+complements OPF's class set. Trade-offs: narrower closed label set
+(`person`, `location`, `organization`, `miscellaneous`) so financial-secret
+or account-number suspects are not surfaced; pinned-artifact contract
+requires `SHA256SUMS` present on disk (Axis-1 fail-closed — no silent
+disable).
+
 #### Setup
 
-The safety-net feature is gated off by default. Build with:
+The safety-net features are gated off by default. Build with one or both:
 
 ```console
 $ cargo build -p gaze-cli --features safety-net-openai
+$ cargo build -p gaze-cli --features safety-net-kiji
+$ cargo build -p gaze-cli --features safety-net-openai,safety-net-kiji
 ```
 
 The `opf` command must be installed from a pinned upstream Git revision or
@@ -187,6 +215,14 @@ If the checkpoint is missing, the CLI fails closed with exit `3` and
 variant `WeightsMissing` before any subprocess spawn. Initialization
 failures are cached for the lifetime of the process so missing-checkpoint
 errors do not retry on every clean.
+
+The Kiji DistilBERT backend follows the same bring-your-own pattern. The
+model directory must contain `SHA256SUMS`, `labels.json`, `model.onnx`,
+and `tokenizer.json`; populate it via `scripts/fetch-kiji-safetynet-model.sh`.
+A missing artifact (including a missing `SHA256SUMS`) fails closed with the
+typed `SafetyNetArtifactMissing` envelope and exit code `2` *before* the
+subprocess is spawned — Axis-1 reliability never silent-disables a
+requested backend.
 
 #### Synthetic example — strict mode
 
@@ -245,6 +281,24 @@ Strict mode (the default) would exit `3` with the JSON error
 `{"error":"SafetyNet","exit":3,"variant":"SuspectedLeak"}` and stdout would
 be empty. `ClassMismatch` suspects always warn but never fail strict mode,
 because the manifest still tokenized the bytes — only the class disagrees.
+
+#### Synthetic example — Kiji DistilBERT backend
+
+```console
+$ printf '%s' 'Alice Example mailed the package to Berlin' \
+  | gaze clean \
+      --policy=policy.toml \
+      --safety-net=kiji-distilbert \
+      --safety-net-backend=kiji-distilbert \
+      --kiji-distilbert-command=/opt/kiji/bin/kiji \
+      --kiji-distilbert-model-dir=~/.local/share/gaze/models/kiji-distilbert
+```
+
+The `--safety-net-backend` flag overrides any legacy `--safety-net=<kind>`
+value, so a deployment can keep its existing `--safety-net=openai-filter`
+invocation and flip to Kiji by adding one flag. Suspects emit the same
+`LeakReport` shape; the `safety_net_id` field switches to
+`kiji-distilbert`.
 
 #### Approved synthetic PII
 
@@ -379,7 +433,7 @@ Exit codes are defined by `CliError` in [`src/error.rs`](src/error.rs).
 |------|----------|
 | `0` | Success, help, version output, or tolerant-mode safety-net runs that produced only stderr warnings. |
 | `1` | `StdinParse`, `EmptyInput`, `InputTooLarge`, `InvalidEncoding`. |
-| `2` | `PolicyConfig`, including unsupported format, invalid policy, invalid locale, invalid NER threshold, unknown rulepack, unsupported CLI column rules, or `SafetyNetConfig` (missing `--openai-filter-command` / `--openai-filter-checkpoint`, or safety-net flags supplied without the `safety-net-openai` feature). |
+| `2` | `PolicyConfig`, including unsupported format, invalid policy, invalid locale, invalid NER threshold, unknown rulepack, unsupported CLI column rules, `SafetyNetConfig` (missing backend command/checkpoint or safety-net flags supplied without the matching feature), or `SafetyNetArtifactMissing` (Axis-1 fail-closed when a backend's pinned artifact is absent, including a missing `SHA256SUMS` for the Kiji DistilBERT backend). |
 | `3` | `UnknownToken`, `InvalidSignature`, `InvalidBlobVersion`, `BlobExpired`, `Pipeline`, sanitized panic path, and `SafetyNetFailure` variants: `Unavailable`, `WeightsMissing`, `ModelUnavailable`, `InputTooLarge`, `Timeout`, `Runtime`, `InvalidOutput`, `SuspectedLeak` (strict mode only). |
 | `4` | `Io`, `PolicyOpen`. |
 

--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use super::{OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode};
+use super::{
+    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetKind, SafetyNetMode,
+};
 use crate::error::CliError;
 use crate::pipeline::{run_clean, CleanOptions};
 
@@ -19,10 +21,13 @@ pub(crate) struct Args {
     pub(crate) context_json: Option<PathBuf>,
     pub(crate) audit_db: Option<PathBuf>,
     pub(crate) safety_net: Option<SafetyNetKind>,
+    pub(crate) safety_net_backend: SafetyNetBackend,
     pub(crate) openai_filter_command: Option<PathBuf>,
     pub(crate) openai_filter_checkpoint: Option<PathBuf>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    pub(crate) kiji_distilbert_command: Option<PathBuf>,
+    pub(crate) kiji_distilbert_model_dir: Option<PathBuf>,
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
@@ -44,10 +49,13 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         context_json: args.context_json.as_deref(),
         audit_db: args.audit_db.as_deref(),
         safety_net: args.safety_net,
+        safety_net_backend: args.safety_net_backend,
         openai_filter_command: args.openai_filter_command.as_deref(),
         openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
         openai_filter_operating_point: args.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
+        kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
+        kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
         safety_net_timeout_ms: args.safety_net_timeout_ms,
         safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
         safety_net_mode: args.safety_net_mode,

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -74,6 +74,11 @@ enum Cmd {
         /// Optional observer-only privacy safety net.
         #[arg(long, value_enum)]
         safety_net: Option<SafetyNetKind>,
+        /// v0.8 backend selector. Defaults to `openai-filter`. When set with
+        /// `--safety-net=<kind>`, this flag wins. Lets adopters swap the
+        /// Pass-3 backend without re-typing the legacy `--safety-net` value.
+        #[arg(long, value_enum, default_value_t = SafetyNetBackend::OpenaiFilter)]
+        safety_net_backend: SafetyNetBackend,
         /// Path to the local OpenAI Privacy Filter `opf` command.
         #[arg(long)]
         openai_filter_command: Option<PathBuf>,
@@ -86,6 +91,13 @@ enum Cmd {
         /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
         #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
         openai_filter_device: OpenAiFilterDevice,
+        /// Path to the local Kiji DistilBERT subprocess command.
+        #[arg(long)]
+        kiji_distilbert_command: Option<PathBuf>,
+        /// Path to the pinned Kiji DistilBERT model directory (must contain
+        /// SHA256SUMS, labels.json, model.onnx, tokenizer.json).
+        #[arg(long)]
+        kiji_distilbert_model_dir: Option<PathBuf>,
         /// Safety-net subprocess timeout in milliseconds.
         #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
         safety_net_timeout_ms: u64,
@@ -322,6 +334,27 @@ enum SafetyNetAuditCmd {
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SafetyNetKind {
     OpenaiFilter,
+    KijiDistilbert,
+}
+
+/// v0.8 forward-compatible backend selector.
+///
+/// `--safety-net-backend` lets adopters pick which observer-only backend runs
+/// at Pass-3 when more than one is wired in. Defaults to `openai-filter`,
+/// which preserves the v0.6/v0.7 single-backend behavior.
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SafetyNetBackend {
+    OpenaiFilter,
+    KijiDistilbert,
+}
+
+impl From<SafetyNetKind> for SafetyNetBackend {
+    fn from(kind: SafetyNetKind) -> Self {
+        match kind {
+            SafetyNetKind::OpenaiFilter => Self::OpenaiFilter,
+            SafetyNetKind::KijiDistilbert => Self::KijiDistilbert,
+        }
+    }
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
@@ -385,10 +418,13 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             context_json,
             audit_db,
             safety_net,
+            safety_net_backend,
             openai_filter_command,
             openai_filter_checkpoint,
             openai_filter_operating_point,
             openai_filter_device,
+            kiji_distilbert_command,
+            kiji_distilbert_model_dir,
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,
@@ -407,10 +443,13 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             context_json,
             audit_db,
             safety_net,
+            safety_net_backend,
             openai_filter_command,
             openai_filter_checkpoint,
             openai_filter_operating_point,
             openai_filter_device,
+            kiji_distilbert_command,
+            kiji_distilbert_model_dir,
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -20,6 +20,13 @@ pub(crate) enum CliError {
     SafetyNetFailure {
         variant: &'static str,
     },
+    /// Pinned-artifact contract violation: a safety-net backend was requested
+    /// but its required artifact (e.g. `SHA256SUMS`) is missing on disk. Exit
+    /// code 2 (config-level error). Axis-1 fail-closed: never silent-disable.
+    SafetyNetArtifactMissing {
+        backend: &'static str,
+        path: String,
+    },
     AuditPurgeIso8601 {
         input: String,
     },
@@ -48,7 +55,8 @@ impl CliError {
             Self::PolicyConfig
             | Self::PolicyConfigDetail(_)
             | Self::PolicySchemaUnsupported { .. }
-            | Self::AuditPurgeIso8601 { .. } => 2,
+            | Self::AuditPurgeIso8601 { .. }
+            | Self::SafetyNetArtifactMissing { .. } => 2,
             Self::SafetyNetConfigDetail(_) | Self::SafetyNetFailure { .. } => 3,
             Self::UnknownToken { .. }
             | Self::UnsupportedSessionScope { .. }
@@ -74,6 +82,7 @@ impl CliError {
             Self::PolicySchemaUnsupported { .. } => "PolicySchemaUnsupported",
             Self::SafetyNetConfigDetail(_) => "SafetyNetConfig",
             Self::SafetyNetFailure { .. } => "SafetyNet",
+            Self::SafetyNetArtifactMissing { .. } => "SafetyNetArtifactMissing",
             Self::AuditPurgeIso8601 { .. } => "AuditPurgeIso8601",
             Self::UnknownToken { .. } => "UnknownToken",
             Self::UnsupportedSessionScope { .. } => "UnsupportedSessionScope",
@@ -141,6 +150,17 @@ impl CliError {
                 self.exit_code(),
                 variant
             ),
+            Self::SafetyNetArtifactMissing { backend, path } => {
+                let path = serde_json::to_string(path)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"backend":"{}","path":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    backend,
+                    path
+                )
+            }
             #[cfg(feature = "document")]
             Self::DocumentDetail(detail) => {
                 let detail = serde_json::to_string(detail)

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -19,7 +19,7 @@ use gaze_audit::{LeakSuspectLogEntry, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
-    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetKind, SafetyNetMode,
+    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetKind, SafetyNetMode,
     DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES, DEFAULT_SAFETY_NET_TIMEOUT_MS,
 };
 use crate::error::CliError;
@@ -45,13 +45,29 @@ pub(crate) struct CleanOptions<'a> {
     pub(crate) context_json: Option<&'a Path>,
     pub(crate) audit_db: Option<&'a Path>,
     pub(crate) safety_net: Option<SafetyNetKind>,
+    pub(crate) safety_net_backend: SafetyNetBackend,
     pub(crate) openai_filter_command: Option<&'a Path>,
     pub(crate) openai_filter_checkpoint: Option<&'a Path>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    pub(crate) kiji_distilbert_command: Option<&'a Path>,
+    pub(crate) kiji_distilbert_model_dir: Option<&'a Path>,
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
+}
+
+/// Resolves the active Pass-3 SafetyNet backend.
+///
+/// `--safety-net-backend` takes precedence when explicitly different from the
+/// default (`openai-filter`). Otherwise we fall back to the value of
+/// `--safety-net=<kind>`. Returns `None` when no safety net is active.
+pub(crate) fn effective_safety_net_backend(options: &CleanOptions<'_>) -> Option<SafetyNetBackend> {
+    let activator = options.safety_net?;
+    if options.safety_net_backend != SafetyNetBackend::OpenaiFilter {
+        return Some(options.safety_net_backend);
+    }
+    Some(SafetyNetBackend::from(activator))
 }
 
 pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), CliError> {
@@ -205,8 +221,22 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     Ok(())
 }
 
-#[cfg(feature = "safety-net-openai")]
 fn maybe_register_safety_net(
+    pipeline: gaze::Pipeline,
+    options: &CleanOptions<'_>,
+) -> std::result::Result<gaze::Pipeline, CliError> {
+    let Some(backend) = effective_safety_net_backend(options) else {
+        validate_no_backend_options(options)?;
+        return Ok(pipeline);
+    };
+    match backend {
+        SafetyNetBackend::OpenaiFilter => register_openai_filter(pipeline, options),
+        SafetyNetBackend::KijiDistilbert => register_kiji_distilbert(pipeline, options),
+    }
+}
+
+#[cfg(feature = "safety-net-openai")]
+fn register_openai_filter(
     pipeline: gaze::Pipeline,
     options: &CleanOptions<'_>,
 ) -> std::result::Result<gaze::Pipeline, CliError> {
@@ -214,71 +244,116 @@ fn maybe_register_safety_net(
         OpenAiFilterSafetyNet, SubprocessOpenAiFilterConfig,
     };
 
-    let Some(kind) = options.safety_net else {
-        validate_no_openai_filter_options(options)?;
-        return Ok(pipeline);
-    };
-    match kind {
-        SafetyNetKind::OpenaiFilter => {
-            let command = options.openai_filter_command.ok_or_else(|| {
-                CliError::SafetyNetConfigDetail(
-                    "--openai-filter-command is required for --safety-net=openai-filter"
-                        .to_string(),
-                )
-            })?;
-            let checkpoint = options.openai_filter_checkpoint.ok_or_else(|| {
-                CliError::SafetyNetConfigDetail(
-                    "--openai-filter-checkpoint is required for --safety-net=openai-filter"
-                        .to_string(),
-                )
-            })?;
-            let mut config = SubprocessOpenAiFilterConfig::new(command)
-                .with_checkpoint_path(checkpoint)
-                .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
-                .with_max_input_bytes(options.safety_net_input_limit_bytes);
-            let mut opf_args = vec!["--format", "json", "--output-mode", "typed"];
-            if let Some(operating_point) = options.openai_filter_operating_point {
-                let value = operating_point.as_opf_value();
-                opf_args.extend(["--operating-point", value]);
-                config = config.with_decoding_param("operating_point", value);
-            }
-            if let Some(device) = options.openai_filter_device.as_opf_value() {
-                opf_args.extend(["--device", device]);
-                config = config.with_decoding_param("device", device);
-            }
-            config = config.with_args(opf_args);
-            Ok(pipeline.with_safety_net(OpenAiFilterSafetyNet::new(config)))
-        }
+    let command = options.openai_filter_command.ok_or_else(|| {
+        CliError::SafetyNetConfigDetail(
+            "--openai-filter-command is required for --safety-net-backend=openai-filter"
+                .to_string(),
+        )
+    })?;
+    let checkpoint = options.openai_filter_checkpoint.ok_or_else(|| {
+        CliError::SafetyNetConfigDetail(
+            "--openai-filter-checkpoint is required for --safety-net-backend=openai-filter"
+                .to_string(),
+        )
+    })?;
+    let mut config = SubprocessOpenAiFilterConfig::new(command)
+        .with_checkpoint_path(checkpoint)
+        .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
+        .with_max_input_bytes(options.safety_net_input_limit_bytes);
+    let mut opf_args = vec!["--format", "json", "--output-mode", "typed"];
+    if let Some(operating_point) = options.openai_filter_operating_point {
+        let value = operating_point.as_opf_value();
+        opf_args.extend(["--operating-point", value]);
+        config = config.with_decoding_param("operating_point", value);
     }
+    if let Some(device) = options.openai_filter_device.as_opf_value() {
+        opf_args.extend(["--device", device]);
+        config = config.with_decoding_param("device", device);
+    }
+    config = config.with_args(opf_args);
+    Ok(pipeline.with_safety_net(OpenAiFilterSafetyNet::new(config)))
 }
 
 #[cfg(not(feature = "safety-net-openai"))]
-fn maybe_register_safety_net(
+fn register_openai_filter(
+    _pipeline: gaze::Pipeline,
+    _options: &CleanOptions<'_>,
+) -> std::result::Result<gaze::Pipeline, CliError> {
+    Err(CliError::SafetyNetConfigDetail(
+        "safety net requested but gaze-cli was not compiled with feature safety-net-openai"
+            .to_string(),
+    ))
+}
+
+#[cfg(feature = "safety-net-kiji")]
+fn register_kiji_distilbert(
     pipeline: gaze::Pipeline,
     options: &CleanOptions<'_>,
 ) -> std::result::Result<gaze::Pipeline, CliError> {
-    if options.safety_net.is_some() {
-        return Err(CliError::SafetyNetConfigDetail(
-            "safety net requested but gaze-cli was not compiled with feature safety-net-openai"
+    use gaze_recognizers::safety_net::kiji_distilbert::{
+        KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+    };
+
+    let command = options.kiji_distilbert_command.ok_or_else(|| {
+        CliError::SafetyNetConfigDetail(
+            "--kiji-distilbert-command is required for --safety-net-backend=kiji-distilbert"
                 .to_string(),
-        ));
+        )
+    })?;
+    let model_dir = options.kiji_distilbert_model_dir.ok_or_else(|| {
+        CliError::SafetyNetConfigDetail(
+            "--kiji-distilbert-model-dir is required for --safety-net-backend=kiji-distilbert"
+                .to_string(),
+        )
+    })?;
+
+    // Pinned-artifact contract (Axis 1): the runtime never silently disables
+    // the backend. Surface the artifact-missing predicate as a config-level
+    // error (exit 2) with the install hint, so the activation predicate
+    // documented in docs/architecture/safety-nets.md is preserved.
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        let artifact = model_dir.join(required);
+        if !artifact.exists() {
+            return Err(CliError::SafetyNetArtifactMissing {
+                backend: "kiji-distilbert",
+                path: format!(
+                    "{} (install via scripts/fetch-kiji-safetynet-model.sh)",
+                    artifact.display()
+                ),
+            });
+        }
     }
-    validate_no_openai_filter_options(options)?;
-    Ok(pipeline)
+
+    let config = SubprocessKijiConfig::new(command)
+        .with_model_dir(model_dir)
+        .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
+        .with_max_input_bytes(options.safety_net_input_limit_bytes);
+    Ok(pipeline.with_safety_net(KijiDistilbertSafetyNet::new(config)))
 }
 
-fn validate_no_openai_filter_options(
-    options: &CleanOptions<'_>,
-) -> std::result::Result<(), CliError> {
+#[cfg(not(feature = "safety-net-kiji"))]
+fn register_kiji_distilbert(
+    _pipeline: gaze::Pipeline,
+    _options: &CleanOptions<'_>,
+) -> std::result::Result<gaze::Pipeline, CliError> {
+    Err(CliError::SafetyNetConfigDetail(
+        "kiji-distilbert backend requested but gaze-cli was not compiled with feature safety-net-kiji"
+            .to_string(),
+    ))
+}
+
+fn validate_no_backend_options(options: &CleanOptions<'_>) -> std::result::Result<(), CliError> {
     if options.openai_filter_command.is_some()
         || options.openai_filter_checkpoint.is_some()
         || options.openai_filter_operating_point.is_some()
         || options.openai_filter_device != OpenAiFilterDevice::Auto
+        || options.kiji_distilbert_command.is_some()
+        || options.kiji_distilbert_model_dir.is_some()
         || options.safety_net_timeout_ms != DEFAULT_SAFETY_NET_TIMEOUT_MS
         || options.safety_net_input_limit_bytes != DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES
     {
         return Err(CliError::SafetyNetConfigDetail(
-            "openai-filter options require --safety-net=openai-filter".to_string(),
+            "safety-net backend options require --safety-net=<kind> activation".to_string(),
         ));
     }
     Ok(())

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -3821,3 +3821,65 @@ action = "preserve"
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+// ------------------------------------------------------------------
+// Kiji DistilBERT safety-net backend activation predicate (v0.8 T2.5)
+// ------------------------------------------------------------------
+
+/// Activating `--safety-net-backend=kiji-distilbert` with a missing model
+/// artifact must fail closed with the typed `SafetyNetArtifactMissing` envelope
+/// and CLI exit code 2 (config-level, Axis-1 reliability — never silent-
+/// disable).
+#[cfg(feature = "safety-net-kiji")]
+#[test]
+fn t_kiji_distilbert_backend_without_artifact_emits_typed_envelope() {
+    let dir = tempdir().unwrap();
+    let kiji = dir.path().join("kiji");
+    fs::write(&kiji, b"#!/bin/sh\ncat >/dev/null\nprintf '[]\\n'\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&kiji, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    let model_dir = dir.path().join("kiji-distilbert");
+    fs::create_dir(&model_dir).unwrap();
+    // No SHA256SUMS, no model.onnx, no tokenizer.json, no labels.json.
+
+    let out = clean_raw_with_args(
+        &[
+            "--safety-net=kiji-distilbert",
+            "--safety-net-backend=kiji-distilbert",
+            &format!("--kiji-distilbert-command={}", kiji.display()),
+            &format!("--kiji-distilbert-model-dir={}", model_dir.display()),
+        ],
+        "hello",
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr_line = String::from_utf8_lossy(&out.stderr)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    let value: Value =
+        serde_json::from_str(&stderr_line).expect("stderr is line-delimited JSON envelope");
+    assert_eq!(value["error"], "SafetyNetArtifactMissing");
+    assert_eq!(value["exit"], 2);
+    assert_eq!(value["backend"], "kiji-distilbert");
+    let path = value["path"].as_str().expect("path field");
+    // First missing artifact surfaced is SHA256SUMS — the pinned-artifact
+    // contract enforces this order: SHA256SUMS, labels.json, model.onnx,
+    // tokenizer.json.
+    assert!(
+        path.contains("SHA256SUMS"),
+        "expected SHA256SUMS in artifact path, got {path}"
+    );
+    assert!(
+        path.contains("fetch-kiji-safetynet-model.sh"),
+        "expected install hint, got {path}"
+    );
+}

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -22,6 +22,7 @@ default = ["phone-parser"]
 phone-parser = ["dep:phonenumber", "gaze-types/phone-parser"]
 safety-net = []
 safety-net-openai = ["safety-net"]
+safety-net-kiji = ["safety-net"]
 test-support = ["safety-net"]
 
 [dependencies]
@@ -62,6 +63,10 @@ required-features = ["test-support"]
 [[test]]
 name = "openai_filter_subprocess"
 required-features = ["safety-net-openai"]
+
+[[test]]
+name = "kiji_distilbert_subprocess"
+required-features = ["safety-net-kiji"]
 
 [[bench]]
 name = "dictionary"

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
@@ -1,0 +1,138 @@
+use std::cmp::Ordering;
+
+use gaze_types::SafetyNetError;
+
+pub mod subprocess;
+
+/// Internal Kiji span after PII-bearing upstream fields have been dropped.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawSpan {
+    /// Byte start in the clean text checked by the safety net.
+    pub start: usize,
+    /// Byte end in the clean text checked by the safety net.
+    pub end: usize,
+    /// Shape-validated raw Kiji label.
+    pub label: String,
+    /// Optional backend confidence score.
+    pub score: Option<f32>,
+}
+
+impl RawSpan {
+    pub fn new(start: usize, end: usize, label: impl Into<String>, score: Option<f32>) -> Self {
+        Self {
+            start,
+            end,
+            label: label.into(),
+            score,
+        }
+    }
+}
+
+/// Backend abstraction for local Kiji DistilBERT NER inference.
+pub trait KijiDistilbertBackend: Send + Sync {
+    fn id(&self) -> &str;
+    fn version(&self) -> &str;
+    fn decoding_params(&self) -> &[(&str, String)];
+    fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError>;
+}
+
+pub(crate) fn normalize_raw_spans(
+    mut spans: Vec<RawSpan>,
+    clean: &str,
+) -> Result<Vec<RawSpan>, SafetyNetError> {
+    for span in &spans {
+        if span.start >= span.end
+            || span.end > clean.len()
+            || !clean.is_char_boundary(span.start)
+            || !clean.is_char_boundary(span.end)
+        {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "kiji returned out-of-bounds span".to_string(),
+            });
+        }
+    }
+
+    spans.sort_by(|left, right| {
+        (
+            left.start,
+            left.end,
+            left.label.as_str(),
+            ScoreSort(left.score),
+        )
+            .cmp(&(
+                right.start,
+                right.end,
+                right.label.as_str(),
+                ScoreSort(right.score),
+            ))
+    });
+
+    for pair in spans.windows(2) {
+        if pair[0].end > pair[1].start {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "kiji returned overlapping spans".to_string(),
+            });
+        }
+    }
+
+    Ok(spans)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScoreSort(Option<f32>);
+
+impl PartialEq for ScoreSort {
+    fn eq(&self, other: &Self) -> bool {
+        score_bits(self.0) == score_bits(other.0)
+    }
+}
+
+impl Eq for ScoreSort {}
+
+impl PartialOrd for ScoreSort {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ScoreSort {
+    fn cmp(&self, other: &Self) -> Ordering {
+        score_bits(self.0).cmp(&score_bits(other.0))
+    }
+}
+
+fn score_bits(score: Option<f32>) -> u32 {
+    score.map(f32::to_bits).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_spans_deterministically() {
+        let spans = vec![
+            RawSpan::new(4, 7, "person", Some(0.4)),
+            RawSpan::new(2, 4, "location", Some(0.9)),
+            RawSpan::new(0, 2, "person", Some(0.1)),
+        ];
+
+        let normalized = normalize_raw_spans(spans, "abcdefg").unwrap();
+        assert_eq!(normalized[0].score, Some(0.1));
+        assert_eq!(normalized[1].score, Some(0.9));
+        assert_eq!(normalized[2].label, "person");
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_and_overlaps() {
+        assert!(normalize_raw_spans(vec![RawSpan::new(0, 9, "person", None)], "short").is_err());
+        assert!(normalize_raw_spans(
+            vec![
+                RawSpan::new(0, 3, "person", None),
+                RawSpan::new(2, 4, "location", None)
+            ],
+            "abcdef"
+        )
+        .is_err());
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
@@ -1,0 +1,751 @@
+use std::ffi::OsString;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use gaze_types::SafetyNetError;
+use serde::Deserialize;
+
+use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
+use crate::safety_net::kiji_distilbert::class_map::map_kiji_label;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
+const DEFAULT_MAX_STDOUT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_VERBOSE_STDERR_BYTES: usize = 256;
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Files Kiji must ship under `model_dir` for the pinned-artifact contract.
+///
+/// Missing `SHA256SUMS` is an Axis-1 reliability defect: the runtime must
+/// fail closed rather than silently degrade. Mirrors the NER load contract
+/// in `crates/gaze/testdata/ner/`.
+pub const REQUIRED_KIJI_ARTIFACTS: &[&str] =
+    &["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"];
+
+/// Configuration for the local Kiji DistilBERT subprocess backend.
+#[derive(Debug, Clone)]
+pub struct SubprocessKijiConfig {
+    command: PathBuf,
+    args: Vec<OsString>,
+    model_dir: Option<PathBuf>,
+    timeout: Duration,
+    max_input_bytes: usize,
+    max_stdout_bytes: usize,
+    capture_stderr: bool,
+    version: String,
+    decoding_params: Vec<(&'static str, String)>,
+}
+
+impl SubprocessKijiConfig {
+    /// Creates a config for an explicit `kiji` command path.
+    pub fn new(command: impl Into<PathBuf>) -> Self {
+        Self {
+            command: command.into(),
+            args: vec![
+                OsString::from("--format"),
+                OsString::from("json"),
+                OsString::from("--output-mode"),
+                OsString::from("typed"),
+            ],
+            model_dir: None,
+            timeout: DEFAULT_TIMEOUT,
+            max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+            max_stdout_bytes: DEFAULT_MAX_STDOUT_BYTES,
+            capture_stderr: false,
+            version: "kiji/distilbert:external".to_string(),
+            decoding_params: vec![
+                ("format", "json".to_string()),
+                ("output_mode", "typed".to_string()),
+            ],
+        }
+    }
+
+    /// Creates a config from `GAZE_KIJI_DISTILBERT_COMMAND`.
+    pub fn from_env() -> Result<Self, SafetyNetError> {
+        let command = std::env::var_os("GAZE_KIJI_DISTILBERT_COMMAND").ok_or_else(|| {
+            SafetyNetError::Unavailable {
+                reason: "GAZE_KIJI_DISTILBERT_COMMAND is not set".to_string(),
+            }
+        })?;
+        Ok(Self::new(command))
+    }
+
+    pub fn with_args(mut self, args: impl IntoIterator<Item = impl Into<OsString>>) -> Self {
+        self.args = args.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_model_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.model_dir = Some(path.into());
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
+        self.max_input_bytes = max_input_bytes;
+        self
+    }
+
+    pub fn with_max_stdout_bytes(mut self, max_stdout_bytes: usize) -> Self {
+        self.max_stdout_bytes = max_stdout_bytes;
+        self
+    }
+
+    pub fn with_stderr_diagnostics(mut self, enabled: bool) -> Self {
+        self.capture_stderr = enabled;
+        self
+    }
+
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = version.into();
+        self
+    }
+
+    pub fn with_decoding_param(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.decoding_params.push((key, value.into()));
+        self
+    }
+
+    pub fn command(&self) -> &Path {
+        &self.command
+    }
+
+    pub fn model_dir(&self) -> Option<&Path> {
+        self.model_dir.as_deref()
+    }
+}
+
+/// Kiji DistilBERT subprocess backend.
+#[derive(Debug, Clone)]
+pub struct SubprocessKijiBackend {
+    config: SubprocessKijiConfig,
+}
+
+impl SubprocessKijiBackend {
+    pub fn new(config: SubprocessKijiConfig) -> Result<Self, SafetyNetError> {
+        if config.command.as_os_str().is_empty() {
+            return Err(SafetyNetError::Unavailable {
+                reason: "kiji command path is empty".to_string(),
+            });
+        }
+        verify_command_path(&config.command)?;
+        verify_model_dir(config.model_dir.as_deref())?;
+        Ok(Self { config })
+    }
+
+    pub fn config(&self) -> &SubprocessKijiConfig {
+        &self.config
+    }
+
+    fn run(&self, clean: &str) -> Result<Vec<u8>, SafetyNetError> {
+        let actual = clean.len();
+        if actual > self.config.max_input_bytes {
+            return Err(SafetyNetError::InputTooLarge {
+                limit: self.config.max_input_bytes,
+                actual,
+            });
+        }
+
+        let mut command = Command::new(&self.config.command);
+        command.args(&self.config.args);
+        if let Some(model_dir) = &self.config.model_dir {
+            command.arg("--model-dir").arg(model_dir);
+        }
+        command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(
+            if self.config.capture_stderr {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            },
+        );
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to spawn kiji subprocess: {}",
+                    sanitize_error(&error.to_string())
+                ),
+            })?;
+
+        let mut stdin = child.stdin.take().ok_or_else(|| SafetyNetError::Runtime {
+            message: "failed to open kiji stdin".to_string(),
+        })?;
+        let input = clean.as_bytes().to_vec();
+        let stdin_thread = thread::spawn(move || {
+            stdin.write_all(&input)?;
+            stdin.flush()
+        });
+
+        let stdout = child.stdout.take().ok_or_else(|| SafetyNetError::Runtime {
+            message: "failed to open kiji stdout".to_string(),
+        })?;
+        let max_stdout_bytes = self.config.max_stdout_bytes;
+        let stdout_thread = thread::spawn(move || read_bounded(stdout, max_stdout_bytes));
+
+        let stderr_thread = child
+            .stderr
+            .take()
+            .map(|stderr| thread::spawn(move || read_bounded(stderr, MAX_VERBOSE_STDERR_BYTES)));
+
+        let deadline = Instant::now() + self.config.timeout;
+        let mut stdin_thread = Some(stdin_thread);
+        let mut stdout_thread = Some(stdout_thread);
+        let mut stderr_thread = stderr_thread;
+        let mut status = None;
+        let mut stdout = None;
+        let mut stderr = if stderr_thread.is_some() {
+            None
+        } else {
+            Some(String::new())
+        };
+
+        loop {
+            if stdin_thread
+                .as_ref()
+                .is_some_and(thread::JoinHandle::is_finished)
+            {
+                let thread = stdin_thread.take().expect("checked stdin thread");
+                if let Err(error) = join_stdin(thread) {
+                    kill_reap(&mut child);
+                    join_remaining(stdin_thread, stdout_thread, stderr_thread);
+                    return Err(error);
+                }
+            }
+
+            if stdout_thread
+                .as_ref()
+                .is_some_and(thread::JoinHandle::is_finished)
+            {
+                let thread = stdout_thread.take().expect("checked stdout thread");
+                match join_reader(thread, "stdout") {
+                    Ok(output) => stdout = Some(output),
+                    Err(error) => {
+                        kill_reap(&mut child);
+                        join_remaining(stdin_thread, stdout_thread, stderr_thread);
+                        return Err(error);
+                    }
+                }
+            }
+
+            if stderr_thread
+                .as_ref()
+                .is_some_and(thread::JoinHandle::is_finished)
+            {
+                let thread = stderr_thread.take().expect("checked stderr thread");
+                match join_reader(thread, "stderr") {
+                    Ok(output) => stderr = Some(sanitize_stderr(&output)),
+                    Err(error) => {
+                        kill_reap(&mut child);
+                        join_remaining(stdin_thread, stdout_thread, stderr_thread);
+                        return Err(error);
+                    }
+                }
+            }
+
+            if status.is_none() {
+                match child.try_wait() {
+                    Ok(Some(child_status)) => status = Some(child_status),
+                    Ok(None) => {}
+                    Err(error) => {
+                        kill_reap(&mut child);
+                        join_remaining(stdin_thread, stdout_thread, stderr_thread);
+                        return Err(SafetyNetError::Runtime {
+                            message: format!(
+                                "failed waiting for kiji subprocess: {}",
+                                sanitize_error(&error.to_string())
+                            ),
+                        });
+                    }
+                }
+            }
+
+            if status.is_some() && stdin_thread.is_none() && stdout.is_some() && stderr.is_some() {
+                break;
+            }
+
+            if Instant::now() >= deadline {
+                kill_reap(&mut child);
+                join_remaining(stdin_thread, stdout_thread, stderr_thread);
+                return Err(SafetyNetError::Runtime {
+                    message: "kiji subprocess timed out and was killed".to_string(),
+                });
+            }
+
+            thread::sleep(WAIT_POLL_INTERVAL);
+        }
+
+        let status = status.expect("status checked before loop exit");
+        let stdout = stdout.expect("stdout checked before loop exit");
+        let stderr = stderr.expect("stderr checked before loop exit");
+
+        if !status.success() {
+            let detail = if stderr.is_empty() {
+                format!("kiji subprocess exited with status {status}")
+            } else {
+                format!("kiji subprocess exited with status {status}: {stderr}")
+            };
+            return Err(SafetyNetError::Runtime { message: detail });
+        }
+
+        Ok(stdout)
+    }
+}
+
+impl KijiDistilbertBackend for SubprocessKijiBackend {
+    fn id(&self) -> &str {
+        "kiji-distilbert-subprocess"
+    }
+
+    fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    fn decoding_params(&self) -> &[(&str, String)] {
+        &self.config.decoding_params
+    }
+
+    fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError> {
+        let stdout = self.run(clean)?;
+        let spans = parse_kiji_output(&stdout)?
+            .into_iter()
+            .map(PrivateKijiSpan::into_raw_span)
+            .collect::<Result<Vec<_>, _>>()?;
+        normalize_raw_spans(spans, clean)
+    }
+}
+
+#[derive(Deserialize)]
+struct PrivateKijiSpan {
+    label: String,
+    start: usize,
+    end: usize,
+    #[serde(default)]
+    score: Option<f32>,
+    /// Drop-on-deser: PII-bearing literal source text from Kiji output. Treated
+    /// as a private deserialization detail; never crosses the adapter boundary.
+    #[serde(default)]
+    _text: Option<PrivatePiiString>,
+}
+
+impl std::fmt::Debug for PrivateKijiSpan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PrivateKijiSpan")
+            .field("label", &self.label)
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("score", &self.score)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PrivateKijiSpan {
+    fn into_raw_span(self) -> Result<RawSpan, SafetyNetError> {
+        map_kiji_label(&self.label)?;
+        if let Some(score) = self.score {
+            if !score.is_finite() {
+                return Err(SafetyNetError::InvalidOutput {
+                    message: "kiji returned non-finite score".to_string(),
+                });
+            }
+        }
+        Ok(RawSpan::new(self.start, self.end, self.label, self.score))
+    }
+}
+
+#[derive(Deserialize)]
+struct PrivatePiiString(String);
+
+impl std::fmt::Debug for PrivatePiiString {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("<private-kiji-field>")
+    }
+}
+
+impl Drop for PrivatePiiString {
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
+
+fn parse_kiji_output(stdout: &[u8]) -> Result<Vec<PrivateKijiSpan>, SafetyNetError> {
+    let text = std::str::from_utf8(stdout).map_err(|_| SafetyNetError::InvalidOutput {
+        message: "kiji stdout was not valid UTF-8".to_string(),
+    })?;
+    serde_json::from_str(text).map_err(|_| SafetyNetError::InvalidOutput {
+        message: "kiji stdout was not valid JSON".to_string(),
+    })
+}
+
+fn read_bounded(mut reader: impl Read, max_bytes: usize) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            return Ok(out);
+        }
+        if out.len().saturating_add(read) > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "stream exceeded configured byte cap",
+            ));
+        }
+        out.extend_from_slice(&chunk[..read]);
+    }
+}
+
+fn join_reader(
+    thread: thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    stream: &'static str,
+) -> Result<Vec<u8>, SafetyNetError> {
+    thread
+        .join()
+        .map_err(|_| SafetyNetError::Runtime {
+            message: format!("kiji {stream} reader panicked"),
+        })?
+        .map_err(|error| SafetyNetError::Runtime {
+            message: format!(
+                "kiji {stream} capture failed: {}",
+                sanitize_error(&error.to_string())
+            ),
+        })
+}
+
+fn join_stdin(thread: thread::JoinHandle<std::io::Result<()>>) -> Result<(), SafetyNetError> {
+    thread
+        .join()
+        .map_err(|_| SafetyNetError::Runtime {
+            message: "kiji stdin writer panicked".to_string(),
+        })?
+        .map_err(|error| SafetyNetError::Runtime {
+            message: format!(
+                "kiji stdin write failed: {}",
+                sanitize_error(&error.to_string())
+            ),
+        })
+}
+
+fn kill_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn join_remaining(
+    stdin_thread: Option<thread::JoinHandle<std::io::Result<()>>>,
+    stdout_thread: Option<thread::JoinHandle<std::io::Result<Vec<u8>>>>,
+    stderr_thread: Option<thread::JoinHandle<std::io::Result<Vec<u8>>>>,
+) {
+    if let Some(thread) = stdin_thread {
+        let _ = join_stdin(thread);
+    }
+    if let Some(thread) = stdout_thread {
+        let _ = join_reader(thread, "stdout");
+    }
+    if let Some(thread) = stderr_thread {
+        let _ = join_reader(thread, "stderr");
+    }
+}
+
+fn sanitize_stderr(bytes: &[u8]) -> String {
+    let ascii = bytes
+        .iter()
+        .map(|byte| {
+            if byte.is_ascii_graphic() || *byte == b' ' {
+                char::from(*byte)
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>();
+
+    sanitize_error(&ascii)
+        .chars()
+        .take(MAX_VERBOSE_STDERR_BYTES)
+        .collect()
+}
+
+fn sanitize_error(message: &str) -> String {
+    message
+        .split_ascii_whitespace()
+        .map(sanitize_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_token(token: &str) -> String {
+    if token.contains('@') {
+        return "<redacted>".to_string();
+    }
+
+    let digit_count = token.bytes().filter(u8::is_ascii_digit).count();
+    if digit_count >= 7 {
+        return "<redacted>".to_string();
+    }
+
+    token.to_string()
+}
+
+fn verify_command_path(command: &Path) -> Result<(), SafetyNetError> {
+    if command.components().count() <= 1 {
+        return Ok(());
+    }
+
+    let metadata =
+        std::fs::symlink_metadata(command).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "kiji command path is not accessible".to_string(),
+        })?;
+
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji command path is not a regular file".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Pinned-artifact contract: every entry in `REQUIRED_KIJI_ARTIFACTS` must exist
+/// under `model_dir`. Missing `SHA256SUMS` is a fail-closed condition (Axis 1).
+fn verify_model_dir(model_dir: Option<&Path>) -> Result<(), SafetyNetError> {
+    let Some(dir) = model_dir else {
+        return Ok(());
+    };
+
+    if !dir.exists() {
+        return Err(SafetyNetError::WeightsMissing {
+            path: sanitize_path(dir),
+        });
+    }
+    verify_sensitive_tree(dir)?;
+
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        let artifact = dir.join(required);
+        if !artifact.exists() {
+            return Err(SafetyNetError::WeightsMissing {
+                path: sanitize_path(&artifact),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn verify_sensitive_tree(path: &Path) -> Result<(), SafetyNetError> {
+    let metadata = verify_one_sensitive_path(path)?;
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to read kiji sensitive directory".to_string(),
+        })? {
+            let entry = entry.map_err(|_| SafetyNetError::ModelUnavailable {
+                reason: "failed to read kiji sensitive directory entry".to_string(),
+            })?;
+            verify_sensitive_tree(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to inspect kiji sensitive path".to_string(),
+        })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must not be a symlink".to_string(),
+        });
+    }
+
+    let uid = current_uid();
+    if metadata.uid() != uid {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path owner mismatch".to_string(),
+        });
+    }
+
+    let mode = metadata.permissions().mode() & 0o777;
+    if file_type.is_dir() {
+        if mode != 0o700 {
+            return Err(SafetyNetError::ModelUnavailable {
+                reason: "kiji sensitive directory must be mode 0700".to_string(),
+            });
+        }
+    } else if file_type.is_file() {
+        if mode & 0o022 != 0 {
+            return Err(SafetyNetError::ModelUnavailable {
+                reason: "kiji sensitive file must not be group/world writable".to_string(),
+            });
+        }
+    } else {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must be a regular file or directory".to_string(),
+        });
+    }
+
+    Ok(metadata)
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    std::fs::metadata(".")
+        .map(|metadata| {
+            use std::os::unix::fs::MetadataExt;
+            metadata.uid()
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(windows)]
+fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to inspect kiji sensitive path".to_string(),
+        })?;
+    if metadata.file_type().is_symlink() {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must not be a symlink".to_string(),
+        });
+    }
+    if !(metadata.file_type().is_file() || metadata.file_type().is_dir()) {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must be a regular file or directory".to_string(),
+        });
+    }
+    if metadata.permissions().readonly() {
+        return Ok(metadata);
+    }
+    Err(SafetyNetError::ModelUnavailable {
+        reason: "kiji sensitive Windows ACL could not be verified".to_string(),
+    })
+}
+
+fn sanitize_path(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("<missing:{name}>"))
+        .unwrap_or_else(|| "<missing:model>".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn write_secure_artifact(dir: &Path, name: &str, body: &[u8]) {
+        let path = dir.join(name);
+        std::fs::write(&path, body).unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    fn populate_secure_model_dir(dir: &Path) {
+        #[cfg(unix)]
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        for required in REQUIRED_KIJI_ARTIFACTS {
+            write_secure_artifact(dir, required, b"fixture");
+        }
+    }
+
+    #[test]
+    fn private_fields_do_not_debug() {
+        let span: PrivateKijiSpan =
+            serde_json::from_str(r#"{"label":"person","start":0,"end":5,"text":"Alice Smith"}"#)
+                .unwrap();
+        let debug = format!("{span:?}");
+        assert!(!debug.contains("Alice Smith"));
+        assert!(debug.contains("person"));
+    }
+
+    #[test]
+    fn parses_typed_span_array() {
+        let spans = parse_kiji_output(
+            br#"[{"label":"person","start":0,"end":11,"text":"Alice Smith","score":0.97}]"#,
+        )
+        .unwrap();
+        assert_eq!(spans.len(), 1);
+        let raw = spans.into_iter().next().unwrap().into_raw_span().unwrap();
+        assert_eq!(raw, RawSpan::new(0, 11, "person", Some(0.97)));
+    }
+
+    #[test]
+    fn sanitizes_stderr_pii() {
+        let stderr = sanitize_stderr(b"failed for alice@example.invalid at +1-555-0101");
+        assert!(!stderr.contains("alice@example.invalid"));
+        assert!(!stderr.contains("+1-555-0101"));
+        assert!(stderr.contains("<redacted>"));
+    }
+
+    #[test]
+    fn missing_model_dir_fails_closed() {
+        let missing = tempfile::tempdir().unwrap().path().join("kiji-distilbert");
+        let config = SubprocessKijiConfig::new("kiji").with_model_dir(missing);
+        let error = SubprocessKijiBackend::new(config).unwrap_err();
+        assert!(matches!(error, SafetyNetError::WeightsMissing { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_sha256sums_fails_closed_with_weights_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        // Provide every required artifact except SHA256SUMS — Axis-1 fail-closed.
+        for required in REQUIRED_KIJI_ARTIFACTS {
+            if *required == "SHA256SUMS" {
+                continue;
+            }
+            write_secure_artifact(dir.path(), required, b"fixture");
+        }
+        let config = SubprocessKijiConfig::new("kiji").with_model_dir(dir.path());
+        let error = SubprocessKijiBackend::new(config).unwrap_err();
+        match error {
+            SafetyNetError::WeightsMissing { path } => {
+                assert!(
+                    path.contains("SHA256SUMS"),
+                    "missing-artifact path should name SHA256SUMS, got: {path}"
+                );
+            }
+            other => panic!("expected WeightsMissing, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn complete_artifact_set_constructs_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        populate_secure_model_dir(dir.path());
+        let config = SubprocessKijiConfig::new("kiji").with_model_dir(dir.path());
+        SubprocessKijiBackend::new(config).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_writable_artifact_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        for required in REQUIRED_KIJI_ARTIFACTS {
+            write_secure_artifact(dir.path(), required, b"fixture");
+        }
+        // Loosen mode on SHA256SUMS to trigger the verify_one_sensitive_path branch.
+        std::fs::set_permissions(
+            dir.path().join("SHA256SUMS"),
+            std::fs::Permissions::from_mode(0o660),
+        )
+        .unwrap();
+        let config = SubprocessKijiConfig::new("kiji").with_model_dir(dir.path());
+        let error = SubprocessKijiBackend::new(config).unwrap_err();
+        assert!(matches!(error, SafetyNetError::ModelUnavailable { .. }));
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
@@ -1,0 +1,116 @@
+//! DistilBERT NER label vocabulary for the Kiji safety-net backend.
+//!
+//! Kiji wraps a DistilBERT NER head whose label set is the standard CoNLL-style
+//! `PER` / `LOC` / `ORG` / `MISC` tags. The Kiji subprocess collapses BIO
+//! prefixes (`B-PER`, `I-PER`) into bare entity labels before emitting the
+//! span shape Gaze consumes; this map only deals with the validated bare
+//! labels.
+
+use gaze_types::{PiiClass, SafetyNetError, SafetyNetPiiClass};
+
+const MAX_KIJI_LABEL_LEN: usize = 16;
+
+/// Closed Kiji label set, mirroring the closed `OpenAiPrivateLabel` shape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KijiLabel {
+    Person,
+    Location,
+    Organization,
+    Miscellaneous,
+}
+
+impl KijiLabel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Person => "person",
+            Self::Location => "location",
+            Self::Organization => "organization",
+            Self::Miscellaneous => "miscellaneous",
+        }
+    }
+}
+
+/// Validates Kiji label shape before any class mapping.
+pub fn validate_kiji_label(label: &str) -> Result<(), SafetyNetError> {
+    if label.is_empty() || label.len() > MAX_KIJI_LABEL_LEN {
+        return Err(invalid_label());
+    }
+
+    if label
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+    {
+        Ok(())
+    } else {
+        Err(invalid_label())
+    }
+}
+
+/// Maps the four CoNLL-style Kiji labels into the closed Gaze NER vocabulary.
+pub fn map_kiji_label(label: &str) -> Result<KijiLabel, SafetyNetError> {
+    validate_kiji_label(label)?;
+    match label {
+        "person" => Ok(KijiLabel::Person),
+        "location" => Ok(KijiLabel::Location),
+        "organization" => Ok(KijiLabel::Organization),
+        "miscellaneous" => Ok(KijiLabel::Miscellaneous),
+        _ => Err(SafetyNetError::InvalidOutput {
+            message: "kiji returned unsupported label".to_string(),
+        }),
+    }
+}
+
+/// Maps a validated Kiji label into the closed safety-net PII vocabulary.
+///
+/// `Organization` and `Miscellaneous` map to `SafetyNetPiiClass::Name` so the
+/// downstream manifest-diff stage classifies them as candidate Name leaks; the
+/// safety-net contract does not (yet) distinguish org/misc spans from person
+/// spans at the manifest layer.
+pub fn kiji_label_to_safety_net_class(label: KijiLabel) -> SafetyNetPiiClass {
+    match label {
+        KijiLabel::Person => SafetyNetPiiClass::Name,
+        KijiLabel::Location => SafetyNetPiiClass::Location,
+        KijiLabel::Organization | KijiLabel::Miscellaneous => SafetyNetPiiClass::Name,
+    }
+}
+
+/// Convenience: validated label -> Gaze `PiiClass`.
+pub fn kiji_label_to_pii_class(label: KijiLabel) -> PiiClass {
+    kiji_label_to_safety_net_class(label).to_pii_class()
+}
+
+fn invalid_label() -> SafetyNetError {
+    SafetyNetError::InvalidOutput {
+        message: "kiji returned invalid label".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_labels_map_to_closed_classes() {
+        let cases = [
+            ("person", PiiClass::Name),
+            ("location", PiiClass::Location),
+            ("organization", PiiClass::Name),
+            ("miscellaneous", PiiClass::Name),
+        ];
+
+        for (label, expected) in cases {
+            let kiji_label = map_kiji_label(label).expect("official label");
+            assert_eq!(kiji_label.as_str(), label);
+            assert_eq!(kiji_label_to_pii_class(kiji_label), expected);
+        }
+    }
+
+    #[test]
+    fn unknown_and_invalid_labels_fail_closed() {
+        assert!(map_kiji_label("PERSON").is_err());
+        assert!(map_kiji_label("per-son").is_err());
+        assert!(map_kiji_label("date").is_err());
+        assert!(map_kiji_label("").is_err());
+        assert!(map_kiji_label("organization_12345").is_err());
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -1,0 +1,145 @@
+//! Kiji DistilBERT safety-net adapter (v0.8 Tier 2.5).
+//!
+//! Pass-3 SafetyNet backend that runs a pinned DistilBERT NER model as a
+//! subprocess. The contract is observer-only: every label arrives as a
+//! validated `KijiLabel`, every span passes through `normalize_raw_spans`,
+//! and no PII-bearing upstream field crosses the adapter boundary. This is
+//! the second NER opinion at the chokepoint (Axis 1 — defense in depth).
+//!
+//! The subprocess reads tokenized clean text on stdin and emits a JSON span
+//! array on stdout (`[{label, start, end, score?}, ...]`). The `_text` and
+//! `_placeholder` fields, if present, are dropped at deserialization with a
+//! buffer-scrub on `Drop`.
+
+use std::sync::{Arc, OnceLock};
+
+use gaze_types::{LeakSuspect, LocaleTag, SafetyNet, SafetyNetContext, SafetyNetError};
+
+pub mod backend;
+pub mod class_map;
+
+pub use backend::subprocess::{
+    SubprocessKijiBackend, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+};
+pub use backend::{KijiDistilbertBackend, RawSpan};
+pub use class_map::{
+    kiji_label_to_pii_class, kiji_label_to_safety_net_class, map_kiji_label, validate_kiji_label,
+    KijiLabel,
+};
+
+/// Safety-net implementation backed by a lazily initialized Kiji subprocess.
+///
+/// Same caching strategy as `OpenAiFilterSafetyNet`: deterministic init
+/// failures (missing SHA256SUMS, missing artifacts, bad perms) cache in a
+/// `OnceLock` so we never retry-storm on every check.
+#[derive(Debug)]
+pub struct KijiDistilbertSafetyNet {
+    locales: Vec<LocaleTag>,
+    config: SubprocessKijiConfig,
+    backend: OnceLock<Result<Arc<SubprocessKijiBackend>, Arc<SafetyNetError>>>,
+}
+
+impl KijiDistilbertSafetyNet {
+    pub fn new(config: SubprocessKijiConfig) -> Self {
+        Self {
+            locales: vec![LocaleTag::Global],
+            config,
+            backend: OnceLock::new(),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, SafetyNetError> {
+        Ok(Self::new(SubprocessKijiConfig::from_env()?))
+    }
+
+    pub fn with_locales(mut self, locales: Vec<LocaleTag>) -> Self {
+        self.locales = locales;
+        self
+    }
+
+    fn backend(&self) -> Result<Arc<SubprocessKijiBackend>, SafetyNetError> {
+        match self.backend.get_or_init(|| {
+            SubprocessKijiBackend::new(self.config.clone())
+                .map(Arc::new)
+                .map_err(Arc::new)
+        }) {
+            Ok(backend) => Ok(Arc::clone(backend)),
+            Err(error) => Err((**error).clone()),
+        }
+    }
+}
+
+impl SafetyNet for KijiDistilbertSafetyNet {
+    fn id(&self) -> &str {
+        "kiji-distilbert"
+    }
+
+    fn supported_locales(&self) -> &[LocaleTag] {
+        &self.locales
+    }
+
+    fn check(
+        &self,
+        clean_text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        let backend = self.backend()?;
+        let raw_spans = backend.infer(clean_text)?;
+        raw_spans
+            .into_iter()
+            .filter_map(|raw| match raw_span_to_suspect(raw, &*backend, context) {
+                Ok(Some(suspect)) => Some(Ok(suspect)),
+                Ok(None) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect()
+    }
+}
+
+fn raw_span_to_suspect(
+    raw: RawSpan,
+    backend: &dyn KijiDistilbertBackend,
+    context: SafetyNetContext<'_>,
+) -> Result<Option<LeakSuspect>, SafetyNetError> {
+    let label = map_kiji_label(&raw.label)?;
+    let class = kiji_label_to_pii_class(label);
+    let span = raw.start..raw.end;
+    let Some(kind) = context.manifest.diff_against(&span, &class) else {
+        return Ok(None);
+    };
+
+    Ok(Some(LeakSuspect::new(
+        span,
+        class,
+        backend.id(),
+        raw.score,
+        kind,
+        raw.label,
+        context.field_path.map(str::to_string),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use gaze_types::{DocumentKind, Manifest};
+
+    use super::*;
+
+    #[test]
+    fn empty_command_failure_is_cached() {
+        let net = KijiDistilbertSafetyNet::new(SubprocessKijiConfig::new(""));
+        let manifest = Manifest::default();
+        let context = SafetyNetContext::new(
+            &manifest,
+            &[LocaleTag::Global],
+            DocumentKind::Text,
+            None,
+            None,
+        );
+
+        let first = net.check("clean", context).unwrap_err();
+        let second = net.check("clean", context).unwrap_err();
+        assert_eq!(first, second);
+        assert!(net.backend.get().is_some());
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "safety-net-openai")]
 pub mod openai_filter;
 
+#[cfg(feature = "safety-net-kiji")]
+pub mod kiji_distilbert;
+
 #[cfg(feature = "test-support")]
 pub mod test_support;

--- a/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
+++ b/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
@@ -1,0 +1,107 @@
+//! Kiji DistilBERT subprocess adapter integration tests.
+//!
+//! Mirrors the `openai_filter_subprocess` suite at the boundary level: drive
+//! the adapter against a fake `kiji` CLI written in shell, assert the
+//! `SafetyNet::check` contract returns shape-valid `LeakSuspect`s and the
+//! manifest-diff classification is wired through.
+
+#![cfg(all(unix, feature = "safety-net-kiji"))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use gaze_recognizers::safety_net::kiji_distilbert::{
+    KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+};
+use gaze_types::{DocumentKind, LocaleTag, Manifest, SafetyNet, SafetyNetContext, SafetyNetError};
+use tempfile::{tempdir, TempDir};
+
+fn write_mock_kiji(body: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mock-kiji");
+    fs::write(
+        &path,
+        format!(
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{}'
+"#,
+            body
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    (dir, path)
+}
+
+fn populate_model_dir() -> TempDir {
+    let dir = tempdir().unwrap();
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        let path = dir.path().join(required);
+        fs::write(&path, b"fixture").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn missing_sha256sums_is_weights_missing() {
+    let dir = tempdir().unwrap();
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        if *required == "SHA256SUMS" {
+            continue;
+        }
+        let path = dir.path().join(required);
+        fs::write(&path, b"fixture").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let config = SubprocessKijiConfig::new("kiji").with_model_dir(dir.path());
+    let net = KijiDistilbertSafetyNet::new(config);
+    let manifest = Manifest::default();
+    let ctx = SafetyNetContext::new(
+        &manifest,
+        &[LocaleTag::Global],
+        DocumentKind::Text,
+        None,
+        None,
+    );
+    let error = net.check("hello", ctx).unwrap_err();
+    match error {
+        SafetyNetError::WeightsMissing { path } => {
+            assert!(path.contains("SHA256SUMS"), "got {path}");
+        }
+        other => panic!("expected WeightsMissing, got {other:?}"),
+    }
+}
+
+#[test]
+fn subprocess_span_round_trips_through_manifest_diff() {
+    // Mock-kiji emits one person span at [0,11] over "Alice Smith". The default
+    // empty manifest classifies that as Uncovered.
+    let (_kiji_dir, kiji) =
+        write_mock_kiji(r#"[{"label":"person","start":0,"end":11,"score":0.97}]"#);
+    let model = populate_model_dir();
+
+    let config = SubprocessKijiConfig::new(&kiji).with_model_dir(model.path());
+    let net = KijiDistilbertSafetyNet::new(config);
+    let manifest = Manifest::default();
+    let ctx = SafetyNetContext::new(
+        &manifest,
+        &[LocaleTag::Global],
+        DocumentKind::Text,
+        None,
+        None,
+    );
+
+    let suspects = net.check("Alice Smith greets you", ctx).unwrap();
+    assert_eq!(suspects.len(), 1);
+    let suspect = &suspects[0];
+    assert_eq!(suspect.safety_net_id, "kiji-distilbert-subprocess");
+    assert_eq!(suspect.raw_label, "person");
+    assert_eq!(suspect.span, 0..11);
+    assert_eq!(suspect.score, Some(0.97));
+}

--- a/scripts/fetch-kiji-safetynet-model.sh
+++ b/scripts/fetch-kiji-safetynet-model.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Fetch and verify the pinned Kiji DistilBERT safety-net artifact.
+#
+# Mirrors `scripts/fetch-ner-model.sh` exactly in shape: pulls a DistilBERT
+# NER model at a pinned Hugging Face commit SHA, drops it under the same
+# XDG-style cache path, and verifies via shasum against the release-pinned
+# SHA256SUMS.kiji checksum file. No runtime network and no local ONNX export
+# happens in the gaze binary; the binary only consumes the pinned local
+# artifacts produced by this script.
+#
+# Checksums are published as SHA256SUMS.kiji in each Gaze GitHub release once
+# the first sign-off run lands real hashes.
+#
+# Usage:
+#   scripts/fetch-kiji-safetynet-model.sh [--gaze-version <tag>] [dest_dir]
+#
+# Default dest_dir = ${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert
+
+set -euo pipefail
+
+# ---- Pinned artifact contract -----------------------------------------------
+
+# TODO(v0.8-signoff): replace with the real pinned commit SHA from the upstream
+# DistilBERT NER repository after the first reproducible fetch run. Until then,
+# this script will refuse to run with the placeholder.
+HF_REPO="onnx-community/distilbert-NER-ONNX"
+HF_COMMIT_SHA="0000000000000000000000000000000000000000"
+GITHUB_REPO="${GAZE_GITHUB_REPO:-EmpireTwo/gaze}"
+
+# Files that must end up in the destination directory.
+REQUIRED_FILES=(
+  "model.onnx"
+  "tokenizer.json"
+  "labels.json"
+  "SHA256SUMS"
+)
+
+# ---- Destination ------------------------------------------------------------
+
+DEFAULT_DEST="${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert"
+DEST=""
+GAZE_VERSION=""
+
+log() { printf '[fetch-kiji-safetynet-model] %s\n' "$*"; }
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/fetch-kiji-safetynet-model.sh [--gaze-version <tag>] [dest_dir]
+
+Options:
+  --gaze-version <tag>  Gaze GitHub release tag that provides SHA256SUMS.kiji.
+  -h, --help            Show this help.
+
+Default dest_dir = ${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --gaze-version)
+      if [ "$#" -lt 2 ]; then
+        log "missing value for --gaze-version"
+        exit 2
+      fi
+      GAZE_VERSION="$2"
+      shift 2
+      ;;
+    --gaze-version=*)
+      GAZE_VERSION="${1#--gaze-version=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      log "unknown option: $1"
+      usage
+      exit 2
+      ;;
+    *)
+      if [ -n "$DEST" ]; then
+        log "unexpected extra argument: $1"
+        usage
+        exit 2
+      fi
+      DEST="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ "$#" -gt 0 ]; then
+  if [ "$#" -gt 1 ]; then
+    log "unexpected extra argument: $2"
+    usage
+    exit 2
+  fi
+  if [ -n "$DEST" ]; then
+    log "unexpected extra argument: $1"
+    usage
+    exit 2
+  fi
+  DEST="$1"
+fi
+
+DEST="${DEST:-$DEFAULT_DEST}"
+
+# Fail closed on placeholder SHA — Axis-1 reliability: no silent-disable.
+if [ "$HF_COMMIT_SHA" = "0000000000000000000000000000000000000000" ]; then
+  log "HF_COMMIT_SHA is still a placeholder. Edit scripts/fetch-kiji-safetynet-model.sh"
+  log "and replace HF_COMMIT_SHA with the pinned upstream commit before fetching."
+  exit 2
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "missing required command: $1"
+    exit 2
+  fi
+}
+
+require_cmd curl
+
+detect_gaze_version_from_git() {
+  if command -v git >/dev/null 2>&1; then
+    git -C "$(dirname "${BASH_SOURCE[0]}")/.." describe --tags --abbrev=0 --exclude '*-*' 2>/dev/null || true
+  fi
+}
+
+detect_latest_gaze_release() {
+  local api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+  curl -fsSL "$api_url" 2>/dev/null \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -n 1 \
+    || true
+}
+
+resolve_gaze_version() {
+  local version="$GAZE_VERSION"
+
+  if [ -z "$version" ]; then
+    version="$(detect_gaze_version_from_git)"
+  fi
+
+  if [ -z "$version" ]; then
+    version="$(detect_latest_gaze_release)"
+  fi
+
+  if [ -z "$version" ]; then
+    log "could not determine Gaze release version for SHA256SUMS.kiji"
+    log "specify one explicitly: scripts/fetch-kiji-safetynet-model.sh --gaze-version <tag> [dest_dir]"
+    exit 2
+  fi
+
+  printf '%s\n' "$version"
+}
+
+fetch_sha256sums() {
+  local version="$1"
+  local url="https://github.com/${GITHUB_REPO}/releases/download/${version}/SHA256SUMS.kiji"
+  log "fetching release checksums ${version} -> SHA256SUMS"
+  curl -fL --retry 3 -o SHA256SUMS "$url"
+}
+
+verify_sha256sums() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c SHA256SUMS
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c SHA256SUMS
+  else
+    log "missing required command: shasum or sha256sum"
+    exit 2
+  fi
+}
+
+mkdir -p "$DEST"
+chmod 0700 "$DEST" 2>/dev/null || true
+cd "$DEST"
+GAZE_VERSION="$(resolve_gaze_version)"
+
+# ---- Download pinned HF artifacts ------------------------------------------
+
+fetch_raw() {
+  local source_file="$1"
+  local dest_file="$2"
+  local url="https://huggingface.co/${HF_REPO}/resolve/${HF_COMMIT_SHA}/${source_file}"
+  log "fetching ${source_file} -> ${dest_file}"
+  curl -fL --retry 3 -o "${dest_file}" "${url}"
+  chmod 0600 "${dest_file}" 2>/dev/null || true
+}
+
+fetch_raw "onnx/model.onnx" "model.onnx"
+fetch_raw "tokenizer.json" "tokenizer.json"
+# Kiji ships its label set in labels.json at the repo root.
+fetch_raw "labels.json" "labels.json"
+
+# ---- Fetch release checksum contract ----------------------------------------
+
+fetch_sha256sums "$GAZE_VERSION"
+
+# ---- Verify checksums -------------------------------------------------------
+
+for f in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$f" ]; then
+    log "required artifact missing: $f"
+    exit 4
+  fi
+done
+
+log "verifying checksums"
+verify_sha256sums
+
+log "done. model dir: $DEST"
+log "next: pass --safety-net-backend=kiji-distilbert --kiji-distilbert-model-dir=\"$DEST\" to gaze clean"


### PR DESCRIPTION
## Summary

- Adds `KijiDistilbertSafetyNet` — second observer-only Pass-3 backend alongside `OpenAiFilterSafetyNet`. Subprocess model identical: clean text on stdin, typed JSON span array on stdout, manifest never mutated.
- New CLI surface: `--safety-net-backend {openai-filter|kiji-distilbert}` (v0.8 forward-compat selector, default `openai-filter` preserves v0.6/v0.7 behavior), `--kiji-distilbert-command`, `--kiji-distilbert-model-dir`. `SafetyNetKind::KijiDistilbert` variant lets `--safety-net=kiji-distilbert` work too. New `CliError::SafetyNetArtifactMissing { backend, path }` exit-2 envelope.
- Pinned-artifact contract: model dir must carry `SHA256SUMS`, `labels.json`, `model.onnx`, `tokenizer.json` with `0o700` directory + `0o600` file permissions on Unix. Missing artifacts (incl. missing `SHA256SUMS`) fail closed **before** the subprocess spawns. New fetcher `scripts/fetch-kiji-safetynet-model.sh` mirrors `fetch-ner-model.sh`; HF commit SHA is a TODO placeholder pending first sign-off run (script fail-closes on placeholder).

## Axis alignment

- **Axis 1 (never leak) — defense in depth.** A second NER opinion at the chokepoint shrinks the `Uncovered`/`PartialBleed` leak surface. Pinned-artifact contract is non-negotiable: no SHA256SUMS = fail closed, surfaced as a typed CLI envelope so adopters can branch on it without parsing free-form text.
- **Axis 2 (reversibility).** Backend is observer-only by trait shape. No manifest mutation, no token emission, no restore-path coupling — same invariant as the OPF adapter.
- **Axis 3 (agentic-first).** Manifest-diff classification, structured-field path traversal, and `LeakReport` shape are unchanged; new backend slots into the existing chokepoint without per-field rework.
- **Axis 4 (trust).** Closed `KijiLabel` set (`person`, `location`, `organization`, `miscellaneous`); unknown labels return `SafetyNetError::InvalidOutput`; PII-bearing upstream `_text` field treated as a private deser detail with a `Drop`-scrub. `safety_net_log` audit row shape is unchanged.
- **Axis 5 (ergonomics).** Adopters keep using `--safety-net=openai-filter` invocations unchanged; flipping to Kiji is a one-flag change (`--safety-net-backend=kiji-distilbert`). The README "Safety-net backends" section enumerates pros/cons for both backends.

## CHANGELOG (`## [Unreleased]` `### Added`)

```
- **KijiDistilbertSafetyNet backend** (v0.8 Tier 2.5, --safety-net-backend kiji-distilbert):
  observer-only DistilBERT NER pass that runs at the Pass-3 chokepoint alongside the
  existing OpenAI Privacy Filter. Subprocess model identical to OpenAiFilterSafetyNet:
  read clean text on stdin, emit a JSON span array on stdout, never mutate the manifest.
  Pinned-artifact contract identical to the existing OpenAI filter — model dir must carry
  SHA256SUMS, labels.json, model.onnx, tokenizer.json with 0o700 directory + 0o600 file
  permissions on Unix; missing artifacts (including a missing SHA256SUMS) fail closed
  with typed CliError::SafetyNetArtifactMissing exit 2 before the subprocess spawns.
  New CLI flags: --safety-net-backend, --kiji-distilbert-command,
  --kiji-distilbert-model-dir. New fetcher: scripts/fetch-kiji-safetynet-model.sh
  (HF commit SHA placeholder pending first sign-off). (Axis 1 reliability — defense in
  depth, second NER opinion at the chokepoint.)
```

## Test plan

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-features --all-targets -- -D warnings
- [x] cargo test --workspace --all-features
- [x] cargo run -p xtask -- safety-net-sanity
- [x] cargo run -p xtask -- ci-feature-matrix
- [x] new `kiji_distilbert_subprocess.rs` integration test (2 cases: missing-SHA256SUMS fail-closed, end-to-end mock subprocess → manifest diff → typed `LeakSuspect`)
- [x] new `t_kiji_distilbert_backend_without_artifact_emits_typed_envelope` in `cli_pipe.rs` (locks the typed `SafetyNetArtifactMissing` envelope shape + install-hint string)
- [ ] First sign-off run: replace `HF_COMMIT_SHA="0000…"` placeholder in `scripts/fetch-kiji-safetynet-model.sh` and publish `SHA256SUMS.kiji` in the v0.8 release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)