### PR TITLE
feat(audit): versioned recognizer-id retrofit + locale coverage matrix (v0.8 Tier 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,6 +1209,7 @@ version = "0.7.2"
 dependencies = [
  "phonenumber",
  "serde",
+ "serde_json",
  "sha3",
  "thiserror 1.0.69",
 ]

--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -27,6 +27,8 @@ pub struct AuditFilter {
     pub ambiguity_reason: Option<String>,
     pub collision_family: Option<String>,
     pub collision_variant: Option<String>,
+    pub recognizer_id: Option<String>,
+    pub recognizer_version_id: Option<String>,
 }
 
 /// Metadata-only redaction audit row returned by [`crate::SqliteLogger::query`].
@@ -37,6 +39,8 @@ pub struct AuditFilter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditLogRow {
     pub source: String,
+    pub recognizer_id: Option<String>,
+    pub recognizer_version_id: Option<String>,
     pub class: String,
     pub action: String,
     pub field_name: Option<String>,
@@ -84,6 +88,8 @@ pub struct LeakSuspectRow {
 /// values into the audit path.
 pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "source",
+    "recognizer_id",
+    "recognizer_version_id",
     "class",
     "action",
     "field_name",
@@ -137,6 +143,8 @@ pub fn build_audit_query_sql(
     has_ambiguity_record: bool,
     has_collision_family: bool,
     has_collision_variant: bool,
+    has_recognizer_id: bool,
+    has_recognizer_version_id: bool,
 ) -> (String, Vec<Value>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
@@ -188,8 +196,18 @@ pub fn build_audit_query_sql(
     } else {
         "NULL AS collision_variant"
     };
+    let recognizer_id_column = if has_recognizer_id {
+        "recognizer_id"
+    } else {
+        "NULL AS recognizer_id"
+    };
+    let recognizer_version_id_column = if has_recognizer_version_id {
+        "recognizer_version_id"
+    } else {
+        "NULL AS recognizer_version_id"
+    };
     let mut sql = format!(
-        "SELECT source, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column} FROM redaction_log"
+        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();
@@ -200,6 +218,22 @@ pub fn build_audit_query_sql(
     if let Some(source) = &filter.source {
         predicates.push("source = ?");
         values.push(Value::Text(source.clone()));
+    }
+    if let Some(recognizer_id) = &filter.recognizer_id {
+        if has_recognizer_id {
+            predicates.push("recognizer_id = ?");
+        } else {
+            predicates.push("NULL = ?");
+        }
+        values.push(Value::Text(recognizer_id.clone()));
+    }
+    if let Some(recognizer_version_id) = &filter.recognizer_version_id {
+        if has_recognizer_version_id {
+            predicates.push("recognizer_version_id = ?");
+        } else {
+            predicates.push("NULL = ?");
+        }
+        values.push(Value::Text(recognizer_version_id.clone()));
     }
     if let Some(action) = &filter.action {
         predicates.push("action = ?");

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -137,6 +137,8 @@ impl SqliteLogger {
             r#"
             CREATE TABLE IF NOT EXISTS redaction_log (
                 source TEXT NOT NULL,
+                recognizer_id TEXT NULL,
+                recognizer_version_id TEXT NULL,
                 class TEXT NOT NULL,
                 action TEXT NOT NULL,
                 field_name TEXT NULL,
@@ -271,6 +273,28 @@ impl SqliteLogger {
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         }
+        if !columns.iter().any(|column| column == "recognizer_id") {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN recognizer_id TEXT NULL",
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+            conn.execute(
+                "UPDATE redaction_log SET recognizer_id = 'legacy_unversioned' WHERE recognizer_id IS NULL",
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
+        if !columns
+            .iter()
+            .any(|column| column == "recognizer_version_id")
+        {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN recognizer_version_id TEXT NULL",
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -284,9 +308,11 @@ impl SqliteLogger {
             .lock()
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             params![
                 entry.source,
+                entry.recognizer_id,
+                entry.recognizer_version_id,
                 entry.class.to_canonical_str(),
                 action_to_db(entry.action),
                 entry.field_name,
@@ -312,31 +338,33 @@ impl SqliteLogger {
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record FROM redaction_log",
+                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant FROM redaction_log",
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         let rows = stmt
             .query_map([], |row| {
                 let mut entry = RedactionEntry::new(
                     row.get::<_, String>(0)?,
-                    pii_class_from_db(&row.get::<_, String>(1)?)?,
-                    action_from_db(&row.get::<_, String>(2)?)?,
-                    row.get(3)?,
-                    document_kind_from_db(&row.get::<_, String>(4)?)?,
-                    row.get::<_, i64>(5)? != 0,
-                    conflict_tier_from_db(&row.get::<_, String>(6)?)?,
-                    row.get::<_, Option<i64>>(7)?.unwrap_or(0),
-                    row.get(8)?,
-                );
+                    pii_class_from_db(&row.get::<_, String>(3)?)?,
+                    action_from_db(&row.get::<_, String>(4)?)?,
+                    row.get(5)?,
+                    document_kind_from_db(&row.get::<_, String>(6)?)?,
+                    row.get::<_, i64>(7)? != 0,
+                    conflict_tier_from_db(&row.get::<_, String>(8)?)?,
+                    row.get::<_, Option<i64>>(9)?.unwrap_or(0),
+                    row.get(10)?,
+                )
+                .with_recognizer_metadata(row.get(1)?, row.get(2)?);
                 if let Some(reason) =
-                    deserialize_json_column::<ValidatorFailReason>(row.get(9)?, 9)?
+                    deserialize_json_column::<ValidatorFailReason>(row.get(11)?, 11)?
                 {
                     entry = entry.with_validator_fail_reason(reason);
                 }
-                if let Some(record) = deserialize_json_column::<AmbiguityRecord>(row.get(10)?, 10)?
+                if let Some(record) = deserialize_json_column::<AmbiguityRecord>(row.get(12)?, 12)?
                 {
                     entry = entry.with_ambiguity_record(record);
                 }
+                entry = entry.with_collision_metadata(row.get(13)?, row.get(14)?);
                 Ok(entry)
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -365,6 +393,8 @@ impl SqliteLogger {
         let has_ambiguity_record = table_has_column(&conn, "ambiguity_record")?;
         let has_collision_family = table_has_column(&conn, "collision_family")?;
         let has_collision_variant = table_has_column(&conn, "collision_variant")?;
+        let has_recognizer_id = table_has_column(&conn, "recognizer_id")?;
+        let has_recognizer_version_id = table_has_column(&conn, "recognizer_version_id")?;
         let (sql, values) = build_audit_query_sql(
             filter,
             has_decided_by,
@@ -377,6 +407,8 @@ impl SqliteLogger {
             has_ambiguity_record,
             has_collision_family,
             has_collision_variant,
+            has_recognizer_id,
+            has_recognizer_version_id,
         );
         let mut stmt = conn
             .prepare(&sql)
@@ -385,21 +417,23 @@ impl SqliteLogger {
             .query_map(params_from_iter(values.iter()), |row| {
                 Ok(AuditLogRow {
                     source: row.get(0)?,
-                    class: row.get(1)?,
-                    action: row.get(2)?,
-                    field_name: row.get(3)?,
-                    document_kind: row.get(4)?,
-                    conflict_loser: row.get::<_, i64>(5)? != 0,
-                    decided_by: row.get(6)?,
-                    created_at: row.get(7)?,
-                    session_id: row.get(8)?,
-                    snapshot_scheme: row.get(9)?,
-                    snapshot_alg: row.get(10)?,
-                    snapshot_key_version: row.get(11)?,
-                    validator_fail_reason: row.get(12)?,
-                    ambiguity_record: row.get(13)?,
-                    collision_family: row.get(14)?,
-                    collision_variant: row.get(15)?,
+                    recognizer_id: row.get(1)?,
+                    recognizer_version_id: row.get(2)?,
+                    class: row.get(3)?,
+                    action: row.get(4)?,
+                    field_name: row.get(5)?,
+                    document_kind: row.get(6)?,
+                    conflict_loser: row.get::<_, i64>(7)? != 0,
+                    decided_by: row.get(8)?,
+                    created_at: row.get(9)?,
+                    session_id: row.get(10)?,
+                    snapshot_scheme: row.get(11)?,
+                    snapshot_alg: row.get(12)?,
+                    snapshot_key_version: row.get(13)?,
+                    validator_fail_reason: row.get(14)?,
+                    ambiguity_record: row.get(15)?,
+                    collision_family: row.get(16)?,
+                    collision_variant: row.get(17)?,
                 })
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;

--- a/crates/gaze-audit/tests/migration_spike4.rs
+++ b/crates/gaze-audit/tests/migration_spike4.rs
@@ -8,7 +8,7 @@ use gaze_types::{
 use rusqlite::Connection;
 
 #[test]
-fn spike4_migration_adds_four_columns_and_is_idempotent() {
+fn spike4_migration_adds_audit_metadata_columns_and_is_idempotent() {
     let temp = tempfile::NamedTempFile::new().expect("temp db");
     create_pre_spike4_redaction_log(temp.path());
 
@@ -17,6 +17,8 @@ fn spike4_migration_adds_four_columns_and_is_idempotent() {
 
     let rows = logger.entries().expect("legacy entries");
     assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].recognizer_id.as_deref(), Some("legacy_unversioned"));
+    assert_eq!(rows[0].recognizer_version_id, None);
     assert_eq!(rows[0].validator_fail_reason, None);
     assert_eq!(rows[0].ambiguity_record, None);
 
@@ -54,6 +56,43 @@ fn spike4_migration_adds_four_columns_and_is_idempotent() {
         Some(ValidatorFailReason::EmailRfcRejected)
     );
     assert_eq!(entries[1].ambiguity_record, Some(record));
+}
+
+#[test]
+fn recognizer_lineage_round_trips_through_redaction_log_rows() {
+    let temp = tempfile::NamedTempFile::new().expect("temp db");
+    let logger = SqliteLogger::new(temp.path()).expect("fresh schema");
+    let entry = RedactionEntry::new(
+        "ner/ort",
+        PiiClass::Name,
+        Action::Tokenize,
+        None,
+        DocumentKind::Text,
+        false,
+        ConflictTier::None,
+        300,
+        Some("session-c".to_string()),
+    )
+    .with_recognizer_metadata(
+        Some("ner".to_string()),
+        Some("ner.davlan-mbert.v1".to_string()),
+    );
+
+    logger.log(&entry).expect("log entry");
+
+    let entries = logger.entries().expect("entries");
+    assert_eq!(entries[0].recognizer_id.as_deref(), Some("ner"));
+    assert_eq!(
+        entries[0].recognizer_version_id.as_deref(),
+        Some("ner.davlan-mbert.v1")
+    );
+
+    let rows = SqliteLogger::query(temp.path(), &AuditFilter::default()).expect("query rows");
+    assert_eq!(rows[0].recognizer_id.as_deref(), Some("ner"));
+    assert_eq!(
+        rows[0].recognizer_version_id.as_deref(),
+        Some("ner.davlan-mbert.v1")
+    );
 }
 
 #[test]
@@ -139,6 +178,8 @@ fn assert_spike4_columns(path: &Path) {
         "ambiguity_record",
         "collision_family",
         "collision_variant",
+        "recognizer_id",
+        "recognizer_version_id",
     ] {
         assert!(columns.iter().any(|actual| actual == column), "{column}");
     }

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -30,7 +30,13 @@ fn opens_v05_db_creates_safety_net_log_and_preserves_redaction_rows() {
     assert_eq!(safety_net_count, 1);
 
     let after = SqliteLogger::query(temp.path(), &AuditFilter::default()).expect("migrated query");
-    assert_eq!(after, before);
+    assert!(before
+        .iter()
+        .all(|row| row.recognizer_id.is_none() && row.recognizer_version_id.is_none()));
+    assert!(after.iter().all(|row| {
+        row.recognizer_id.as_deref() == Some("legacy_unversioned")
+            && row.recognizer_version_id.is_none()
+    }));
     assert_eq!(after, legacy_rows());
 }
 
@@ -157,6 +163,8 @@ fn safety_net_query_filter_maps_to_safety_net_columns() {
             ambiguity_reason: None,
             collision_family: None,
             collision_variant: None,
+            recognizer_id: None,
+            recognizer_version_id: None,
         },
     )
     .expect("filtered query");
@@ -262,6 +270,8 @@ fn legacy_rows() -> Vec<AuditLogRow> {
     vec![
         AuditLogRow {
             source: "regex".to_string(),
+            recognizer_id: Some("legacy_unversioned".to_string()),
+            recognizer_version_id: None,
             class: "email".to_string(),
             action: "tokenize".to_string(),
             field_name: Some("contact.email".to_string()),
@@ -280,6 +290,8 @@ fn legacy_rows() -> Vec<AuditLogRow> {
         },
         AuditLogRow {
             source: "dictionary".to_string(),
+            recognizer_id: Some("legacy_unversioned".to_string()),
+            recognizer_version_id: None,
             class: "name".to_string(),
             action: "preserve".to_string(),
             field_name: None,

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -69,8 +69,10 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     }
     for row in rows {
         let base = format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
+            row.recognizer_id.as_deref().unwrap_or(""),
+            row.recognizer_version_id.as_deref().unwrap_or(""),
             row.class,
             row.action,
             row.field_name.as_deref().unwrap_or(""),
@@ -195,6 +197,8 @@ fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
             .map(normalize_kebab_variant),
         collision_family: args.collision_family.clone(),
         collision_variant: args.collision_variant.clone(),
+        recognizer_id: None,
+        recognizer_version_id: None,
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -221,6 +225,8 @@ fn read_safety_net_rows(
         ambiguity_reason: None,
         collision_family: None,
         collision_variant: None,
+        recognizer_id: None,
+        recognizer_version_id: None,
     };
     SqliteLogger::query_safety_net(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -307,6 +313,8 @@ fn ambiguity_display(value: &Option<String>) -> Result<String, CliError> {
 #[derive(Serialize)]
 struct JsonlRow {
     source: String,
+    recognizer_id: Option<String>,
+    recognizer_version_id: Option<String>,
     class: String,
     action: String,
     field_name: Option<String>,
@@ -330,6 +338,8 @@ impl TryFrom<AuditLogRow> for JsonlRow {
     fn try_from(row: AuditLogRow) -> Result<Self, Self::Error> {
         Ok(Self {
             source: row.source,
+            recognizer_id: row.recognizer_id,
+            recognizer_version_id: row.recognizer_version_id,
             class: row.class,
             action: row.action,
             field_name: row.field_name,

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -428,11 +428,11 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
     ));
-    assert!(
-        stdout.contains("dictionary:audit_terms[#0]\tcustom:term\ttokenize\t\ttext\tfalse\tnone")
-    );
+    assert!(stdout.contains("dictionary:audit_terms[#0]"));
+    assert!(stdout.contains("custom:term"));
+    assert!(stdout.contains("tokenize"));
 }
 
 #[test]
@@ -454,9 +454,11 @@ fn audit_sql_uses_restricted_column_set() {
         ambiguity_reason: None,
         collision_family: None,
         collision_variant: None,
+        recognizer_id: None,
+        recognizer_version_id: None,
     };
     let (current_sql, values) = build_audit_query_sql(
-        &filter, true, true, true, true, true, true, true, true, true, true,
+        &filter, true, true, true, true, true, true, true, true, true, true, true, true,
     );
     assert_eq!(
         values,
@@ -493,6 +495,8 @@ fn audit_sql_uses_restricted_column_set() {
     };
     let (legacy_sql, legacy_values) = build_audit_query_sql(
         &legacy_filter,
+        false,
+        false,
         false,
         false,
         false,
@@ -543,7 +547,9 @@ fn assert_restricted_sql(sql: &str) {
             "audit SQL must not read sensitive column '{sensitive}': {sql}"
         );
     }
-    assert!(lower
-        .starts_with("select source, class, action, field_name, document_kind, conflict_loser, "));
+    assert!(lower.starts_with("select source, "));
+    assert!(lower.contains("recognizer_id"));
+    assert!(lower.contains("recognizer_version_id"));
+    assert!(lower.contains(" class, action, field_name, document_kind, conflict_loser, "));
     assert!(lower.contains(" from redaction_log"));
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1204,12 +1204,12 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
     ));
     assert!(
         stdout
             .lines()
-            .any(|line| line.starts_with("regex\temail\ttokenize\t\ttext\tfalse\t")),
+            .any(|line| line.starts_with("regex\tregex\t\temail\ttokenize\t\ttext\tfalse\t")),
         "unexpected query stdout: {stdout}"
     );
 
@@ -1240,6 +1240,8 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     let row: Value = serde_json::from_str(rows.lines().next().unwrap()).unwrap();
     assert_eq!(row["class"], "email");
     assert_eq!(row["source"], "regex");
+    assert_eq!(row["recognizer_id"], "regex");
+    assert_eq!(row["recognizer_version_id"], Value::Null);
     assert_eq!(row["action"], "tokenize");
     assert_eq!(row["field_name"], Value::Null);
     assert_eq!(row["document_kind"], "text");
@@ -1317,8 +1319,8 @@ fn s4_audit_query_filters_ambiguity_and_collision_metadata() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.lines().next().unwrap().ends_with("\tambiguity"));
-    assert!(stdout.contains("hybrid\tcustom:postal_or_phone_de"));
-    assert!(!stdout.contains("regex\temail"));
+    assert!(stdout.contains("hybrid\t\t\tcustom:postal_or_phone_de"));
+    assert!(!stdout.contains("regex\t\t\temail"));
     assert!(stdout.contains(
         "class=custom:postal_or_phone_de reason=no_anchor losing=[custom:postal_de:postal-de]"
     ));
@@ -1389,11 +1391,11 @@ fn s2_audit_cli_smoke_filters_created_at_range() {
     let stdout = String::from_utf8(query.stdout).unwrap();
     let row = stdout
         .lines()
-        .find(|line| line.starts_with("regex\temail\ttokenize\t\ttext\tfalse\t"))
+        .find(|line| line.starts_with("regex\tregex\t\temail\ttokenize\t\ttext\tfalse\t"))
         .expect("expected email audit row in bounded time range");
     let created_at = row
         .split('\t')
-        .nth(7)
+        .nth(9)
         .expect("created_at column")
         .parse::<i64>()
         .expect("created_at is epoch milliseconds");
@@ -1771,6 +1773,8 @@ fn s4_audit_query_columns_are_restricted() {
         true,
         true,
         true,
+        true,
+        true,
     );
     assert!(
         values.is_empty(),
@@ -1837,6 +1841,8 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
         true,
         true,
         true,
+        true,
+        true,
     );
     let conn = Connection::open(&audit_path).unwrap();
     let mut stmt = conn.prepare(&sql).unwrap();
@@ -1844,9 +1850,9 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
         .query_map(params_from_iter(values.iter()), |row| {
             Ok((
                 row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(6)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(8)?,
             ))
         })
         .unwrap()

--- a/crates/gaze-recognizers/src/ner/backend/test_support.rs
+++ b/crates/gaze-recognizers/src/ner/backend/test_support.rs
@@ -42,6 +42,7 @@ pub(crate) fn load_test_support_recognizer(
         detector: NerDetector {
             model_dir: model_dir.to_path_buf(),
             backend_kind: NerBackendKind::Ort,
+            recognizer_version_id: "ner.test-support.v1".to_string(),
             locale: options.locale.clone(),
             threshold: options.threshold,
             backend: Arc::new(TestSupportBackend),

--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -17,6 +17,7 @@ pub struct NerDetector {
     #[allow(dead_code)]
     pub(crate) model_dir: PathBuf,
     pub(crate) backend_kind: NerBackendKind,
+    pub(crate) recognizer_version_id: String,
     pub(crate) locale: Option<String>,
     pub(crate) threshold: f32,
     pub(crate) backend: Arc<dyn NerBackend>,
@@ -27,6 +28,7 @@ impl fmt::Debug for NerDetector {
         f.debug_struct("NerDetector")
             .field("model_dir", &self.model_dir)
             .field("backend_kind", &self.backend_kind)
+            .field("recognizer_version_id", &self.recognizer_version_id)
             .field("locale", &self.locale)
             .field("threshold", &self.threshold)
             .finish_non_exhaustive()
@@ -43,6 +45,10 @@ impl NerDetector {
     pub fn load_with_options(model_dir: &Path, options: NerOptions) -> Result<Self, NerLoadError> {
         let verified = Self::verify_artifacts(model_dir)?;
         let backend_kind = verified.backend_kind;
+        let recognizer_version_id = format!(
+            "ner.{}.{}",
+            verified.recognizer_model_id, verified.recognizer_model_version
+        );
         let model_dir_path = verified.model_dir.clone();
         let label_count = verified.labels.len();
         let id2label_len = verified.id2label.len();
@@ -51,6 +57,7 @@ impl NerDetector {
 
         tracing::info!(
             backend = backend_kind.as_str(),
+            recognizer_version_id = %recognizer_version_id,
             labels = label_count,
             id2label_size = id2label_len,
             locale = options.locale.as_deref().unwrap_or(""),
@@ -62,6 +69,7 @@ impl NerDetector {
         Ok(Self {
             model_dir: model_dir_path,
             backend_kind,
+            recognizer_version_id,
             locale: options.locale,
             threshold: options.threshold,
             backend,
@@ -74,6 +82,10 @@ impl NerDetector {
 
     pub fn backend_kind(&self) -> NerBackendKind {
         self.backend_kind
+    }
+
+    pub fn recognizer_version_id(&self) -> &str {
+        &self.recognizer_version_id
     }
 
     /// Label/offset reconstruction helper. Public for testing the BIO merge.

--- a/crates/gaze-recognizers/src/ner/loader.rs
+++ b/crates/gaze-recognizers/src/ner/loader.rs
@@ -57,11 +57,23 @@ impl NerDetector {
         let labels = parse_labels(&model_dir.join(LABELS_FILE))?;
         let config = parse_config(&model_dir.join(CONFIG_FILE))?;
         let backend_kind = NerBackendKind::parse(config.backend.as_deref())?;
+        let recognizer_model_id = config
+            .recognizer_model_id()
+            .map(sanitize_recognizer_segment)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "unknown".to_string());
+        let recognizer_model_version = config
+            .recognizer_model_version()
+            .map(sanitize_version_segment)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "v0".to_string());
         let id2label = config_to_id2label(config.id2label)?;
 
         Ok(VerifiedArtifacts {
             model_dir: model_dir.to_path_buf(),
             backend_kind,
+            recognizer_model_id,
+            recognizer_model_version,
             labels,
             id2label,
         })
@@ -188,7 +200,29 @@ fn parse_labels(path: &Path) -> Result<LabelMap, NerLoadError> {
 #[derive(Deserialize)]
 struct ConfigFile {
     backend: Option<String>,
+    model_id: Option<String>,
+    model_name: Option<String>,
+    model: Option<String>,
+    version: Option<String>,
+    model_version: Option<String>,
+    recognizer_version: Option<String>,
     id2label: Option<BTreeMap<String, String>>,
+}
+
+impl ConfigFile {
+    fn recognizer_model_id(&self) -> Option<&str> {
+        self.model_id
+            .as_deref()
+            .or(self.model_name.as_deref())
+            .or(self.model.as_deref())
+    }
+
+    fn recognizer_model_version(&self) -> Option<&str> {
+        self.recognizer_version
+            .as_deref()
+            .or(self.model_version.as_deref())
+            .or(self.version.as_deref())
+    }
 }
 
 fn parse_config(path: &Path) -> Result<ConfigFile, NerLoadError> {
@@ -219,4 +253,28 @@ fn config_to_id2label(
         out[index] = label;
     }
     Ok(out)
+}
+
+fn sanitize_recognizer_segment(raw: &str) -> String {
+    raw.trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | '0'..='9' => ch,
+            _ => '-',
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn sanitize_version_segment(raw: &str) -> String {
+    let sanitized = sanitize_recognizer_segment(raw);
+    if sanitized.is_empty() || sanitized.starts_with('v') {
+        sanitized
+    } else {
+        format!("v{sanitized}")
+    }
 }

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -81,8 +81,21 @@ mod tests {
         let dir = setup_good_dir();
         let verified = NerDetector::verify_artifacts(dir.path()).expect("verify");
         assert_eq!(verified.backend_kind, NerBackendKind::Ort);
+        assert_eq!(verified.recognizer_model_id, "unknown");
+        assert_eq!(verified.recognizer_model_version, "v0");
         assert!(verified.labels.get("PER").is_some());
         assert_eq!(verified.id2label[1], "B-PER");
+    }
+
+    #[test]
+    fn verify_artifacts_reads_versioned_ner_identity_from_config() {
+        let dir = setup_dir_with_config(
+            br#"{"model_id":"Davlan/mBERT NER HRL","model_version":"1","id2label":{"0":"O","1":"B-PER","2":"I-PER"}}"#,
+        );
+        let verified = NerDetector::verify_artifacts(dir.path()).expect("verify");
+
+        assert_eq!(verified.recognizer_model_id, "davlan-mbert-ner-hrl");
+        assert_eq!(verified.recognizer_model_version, "v1");
     }
 
     #[test]
@@ -333,6 +346,7 @@ mod tests {
             detector: NerDetector {
                 model_dir: PathBuf::from("/test/fake"),
                 backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
                 locale: None,
                 threshold: 0.5,
                 backend: Arc::new(FixedBackend {
@@ -359,6 +373,10 @@ mod tests {
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].span, 6..11);
         assert_eq!(candidates[0].score, 0.50);
+        assert_eq!(
+            candidates[0].recognizer_version_id.as_deref(),
+            Some("ner.fixed.v1")
+        );
     }
 
     #[test]
@@ -389,6 +407,7 @@ mod tests {
             detector: NerDetector {
                 model_dir: PathBuf::from("/test/fake"),
                 backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
                 locale: Some("de".to_string()),
                 threshold: 0.3,
                 backend: backend.clone(),
@@ -398,6 +417,7 @@ mod tests {
             detector: NerDetector {
                 model_dir: PathBuf::from("/test/fake"),
                 backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
                 locale: Some("de".to_string()),
                 threshold: 0.5,
                 backend,

--- a/crates/gaze-recognizers/src/ner/recognizer.rs
+++ b/crates/gaze-recognizers/src/ner/recognizer.rs
@@ -52,6 +52,7 @@ impl Recognizer for NerRecognizer {
                         ConflictTier::None,
                         Vec::new(),
                     )
+                    .with_recognizer_version_id(self.detector.recognizer_version_id())
                 })
                 .collect(),
             Err(err) => {

--- a/crates/gaze-recognizers/src/ner/types.rs
+++ b/crates/gaze-recognizers/src/ner/types.rs
@@ -130,6 +130,8 @@ impl NerBackendKind {
 pub struct VerifiedArtifacts {
     pub model_dir: PathBuf,
     pub backend_kind: NerBackendKind,
+    pub recognizer_model_id: String,
+    pub recognizer_model_version: String,
     pub labels: LabelMap,
     pub id2label: Vec<String>,
 }

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -25,6 +25,9 @@ sha3 = "0.10"
 thiserror = { workspace = true }
 phonenumber = { version = "0.3.9", default-features = false, optional = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [features]
 default = []
 phone-parser = ["dep:phonenumber"]

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1465,6 +1465,10 @@ pub enum DocumentKind {
 pub struct RedactionEntry {
     /// Detector or recognizer source identifier.
     pub source: String,
+    /// Stable semantic recognizer identifier, when available.
+    pub recognizer_id: Option<String>,
+    /// Versioned recognizer artifact/rule identifier, when available.
+    pub recognizer_version_id: Option<String>,
     /// PII class affected by the decision.
     pub class: PiiClass,
     /// Policy action applied to the span.
@@ -1491,6 +1495,83 @@ pub struct RedactionEntry {
     pub collision_variant: Option<String>,
 }
 
+impl Serialize for RedactionEntry {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut len = 13;
+        if self.recognizer_id.is_some() {
+            len += 1;
+        }
+        if self.recognizer_version_id.is_some() {
+            len += 1;
+        }
+        let mut state = serializer.serialize_struct("RedactionEntry", len)?;
+        state.serialize_field("source", &self.source)?;
+        if let Some(recognizer_id) = &self.recognizer_id {
+            state.serialize_field("recognizer_id", recognizer_id)?;
+        }
+        if let Some(recognizer_version_id) = &self.recognizer_version_id {
+            state.serialize_field("recognizer_version_id", recognizer_version_id)?;
+        }
+        state.serialize_field("class", &self.class.to_canonical_str())?;
+        state.serialize_field("action", redaction_action_as_str(self.action))?;
+        state.serialize_field("field_name", &self.field_name)?;
+        state.serialize_field(
+            "document_kind",
+            redaction_document_kind_as_str(self.document_kind),
+        )?;
+        state.serialize_field("conflict_loser", &self.conflict_loser)?;
+        state.serialize_field(
+            "decided_by",
+            redaction_conflict_tier_as_str(self.decided_by),
+        )?;
+        state.serialize_field("created_at", &self.created_at)?;
+        state.serialize_field("session_id", &self.session_id)?;
+        state.serialize_field("validator_fail_reason", &self.validator_fail_reason)?;
+        state.serialize_field("ambiguity_record", &self.ambiguity_record)?;
+        state.serialize_field("collision_family", &self.collision_family)?;
+        state.serialize_field("collision_variant", &self.collision_variant)?;
+        state.end()
+    }
+}
+
+fn redaction_action_as_str(action: Action) -> &'static str {
+    match action {
+        Action::Tokenize => "tokenize",
+        Action::Redact => "redact",
+        Action::FormatPreserve => "format_preserve",
+        Action::Generalize => "generalize",
+        Action::Preserve => "preserve",
+    }
+}
+
+fn redaction_document_kind_as_str(kind: DocumentKind) -> &'static str {
+    match kind {
+        DocumentKind::Structured => "structured",
+        DocumentKind::Text => "text",
+    }
+}
+
+fn redaction_conflict_tier_as_str(tier: ConflictTier) -> &'static str {
+    match tier {
+        ConflictTier::None => "none",
+        ConflictTier::ClassPriority => "class_priority",
+        ConflictTier::RulePriority => "rule_priority",
+        ConflictTier::Score => "score",
+        ConflictTier::SpanLength => "span_length",
+        ConflictTier::Validator => "validator",
+        ConflictTier::ValidatorVeto => "validator_veto",
+        ConflictTier::CollisionPolicy => "collision_policy",
+        ConflictTier::AnchoredContext => "anchored_context",
+        ConflictTier::RecognizerId => "recognizer_id",
+        ConflictTier::Merged => "merged",
+    }
+}
+
 impl RedactionEntry {
     /// Builds a metadata-only redaction log entry.
     #[allow(clippy::too_many_arguments)]
@@ -1515,6 +1596,8 @@ impl RedactionEntry {
             decided_by,
             created_at,
             session_id,
+            recognizer_id: None,
+            recognizer_version_id: None,
             validator_fail_reason: None,
             ambiguity_record: None,
             collision_family: None,
@@ -1542,6 +1625,17 @@ impl RedactionEntry {
     ) -> Self {
         self.collision_family = family;
         self.collision_variant = variant;
+        self
+    }
+
+    /// Attaches recognizer lineage metadata to this row.
+    pub fn with_recognizer_metadata(
+        mut self,
+        recognizer_id: Option<String>,
+        recognizer_version_id: Option<String>,
+    ) -> Self {
+        self.recognizer_id = recognizer_id;
+        self.recognizer_version_id = recognizer_version_id;
         self
     }
 }
@@ -2152,6 +2246,8 @@ mod redaction_logger_tests {
         let logger = CapturingLogger;
         let entry = RedactionEntry {
             source: "unit-test".to_string(),
+            recognizer_id: None,
+            recognizer_version_id: None,
             class: PiiClass::Email,
             action: Action::Tokenize,
             field_name: None,
@@ -2168,6 +2264,80 @@ mod redaction_logger_tests {
 
         let trait_object: &dyn RedactionLogger = &logger;
         trait_object.log(&entry).expect("log entry");
+    }
+
+    #[test]
+    fn redaction_entry_json_shape_omits_absent_recognizer_lineage() {
+        let entry = RedactionEntry::new(
+            "email.global",
+            PiiClass::Email,
+            Action::Tokenize,
+            None,
+            DocumentKind::Text,
+            false,
+            ConflictTier::None,
+            0,
+            None,
+        );
+
+        let rendered = serde_json::to_string(&entry).expect("serialize redaction entry");
+
+        assert_eq!(
+            rendered,
+            r#"{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"none","created_at":0,"session_id":null,"validator_fail_reason":null,"ambiguity_record":null,"collision_family":null,"collision_variant":null}"#
+        );
+    }
+
+    #[test]
+    fn redaction_entry_json_shape_includes_recognizer_lineage_when_present() {
+        let entry = RedactionEntry::new(
+            "ner/ort",
+            PiiClass::Name,
+            Action::Tokenize,
+            None,
+            DocumentKind::Text,
+            false,
+            ConflictTier::None,
+            0,
+            None,
+        )
+        .with_recognizer_metadata(
+            Some("ner".to_string()),
+            Some("ner.davlan-mbert.v1".to_string()),
+        );
+
+        let value: serde_json::Value =
+            serde_json::to_value(&entry).expect("serialize redaction entry");
+
+        assert_eq!(value["recognizer_id"], "ner");
+        assert_eq!(value["recognizer_version_id"], "ner.davlan-mbert.v1");
+    }
+
+    #[test]
+    fn candidate_keeps_versioned_and_unversioned_recognizer_ids() {
+        let unversioned = Candidate::new(
+            0..5,
+            PiiClass::Email,
+            "email.global",
+            0.9,
+            10,
+            None,
+            "email",
+            "email.global",
+            ConflictTier::None,
+            Vec::new(),
+        );
+        assert_eq!(unversioned.recognizer_id, "email.global");
+        assert_eq!(unversioned.recognizer_version_id, None);
+
+        let versioned = unversioned
+            .clone()
+            .with_recognizer_version_id("email.global.v1");
+        assert_eq!(versioned.recognizer_id, "email.global");
+        assert_eq!(
+            versioned.recognizer_version_id.as_deref(),
+            Some("email.global.v1")
+        );
     }
 }
 
@@ -2368,6 +2538,8 @@ pub struct Candidate {
     pub class: PiiClass,
     /// Recognizer identifier.
     pub recognizer_id: String,
+    /// Optional versioned recognizer identifier for audit lineage.
+    pub recognizer_version_id: Option<String>,
     /// Recognizer confidence score.
     pub score: f32,
     /// Rule or recognizer priority.
@@ -2403,6 +2575,7 @@ impl Candidate {
             span,
             class,
             recognizer_id: recognizer_id.into(),
+            recognizer_version_id: None,
             score,
             priority,
             canonical_form,
@@ -2416,6 +2589,12 @@ impl Candidate {
     /// Returns this candidate with a translated span.
     pub fn with_span(mut self, span: Range<usize>) -> Self {
         self.span = span;
+        self
+    }
+
+    /// Returns this candidate with versioned recognizer lineage attached.
+    pub fn with_recognizer_version_id(mut self, recognizer_version_id: impl Into<String>) -> Self {
+        self.recognizer_version_id = Some(recognizer_version_id.into());
         self
     }
 }

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -480,6 +480,10 @@ impl Pipeline {
             detection.decided_by,
             crate::redaction_log::current_epoch_ms(),
             Some(session.audit_session_id().to_string()),
+        )
+        .with_recognizer_metadata(
+            detection.recognizer_id.clone(),
+            detection.recognizer_version_id.clone(),
         );
         if let Some(record) = detection.ambiguity_record.clone() {
             entry = entry.with_ambiguity_record(record);
@@ -523,6 +527,10 @@ impl Pipeline {
             crate::redaction_log::current_epoch_ms(),
             Some(session.audit_session_id().to_string()),
         )
+        .with_recognizer_metadata(
+            Some(vetoed.candidate.recognizer_id.clone()),
+            vetoed.candidate.recognizer_version_id.clone(),
+        )
         .with_validator_fail_reason(vetoed.reason);
 
         for logger in &self.redaction_loggers {
@@ -536,6 +544,8 @@ impl Pipeline {
 #[derive(Clone)]
 struct IndexedDetection {
     detection: Detection,
+    recognizer_id: Option<String>,
+    recognizer_version_id: Option<String>,
     decided_by: ConflictTier,
     family: String,
     ambiguity_record: Option<AmbiguityRecord>,
@@ -966,6 +976,8 @@ fn merged_losers(resolved: &[Candidate], registry: &RecognizerRegistry) -> Vec<I
                 let membership = registry.family_policy().membership(source);
                 IndexedDetection {
                     detection: Detection::new(winner.span.clone(), class, source.clone()),
+                    recognizer_id: Some(source.clone()),
+                    recognizer_version_id: None,
                     decided_by: if winner.decided_by == ConflictTier::Merged {
                         ConflictTier::Merged
                     } else {
@@ -1006,6 +1018,8 @@ fn indexed_detection_from_candidate(
 
     IndexedDetection {
         detection: Detection::new(candidate.span, candidate.class, candidate.source),
+        recognizer_id: Some(candidate.recognizer_id),
+        recognizer_version_id: candidate.recognizer_version_id,
         decided_by: candidate.decided_by,
         family: candidate.token_family,
         ambiguity_record,
@@ -1219,6 +1233,73 @@ mod tests {
         let entries = entries.lock().unwrap();
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().all(|e| !e.conflict_loser));
+    }
+
+    #[test]
+    fn audit_entry_threads_recognizer_lineage_from_candidate() {
+        struct VersionedRecognizer;
+
+        impl Recognizer for VersionedRecognizer {
+            fn id(&self) -> &str {
+                "name.semantic"
+            }
+
+            fn supported_class(&self) -> &PiiClass {
+                &PiiClass::Name
+            }
+
+            fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+                let Some(start) = input.find("Dr. Schmidt") else {
+                    return Vec::new();
+                };
+                let end = start + "Dr. Schmidt".len();
+                vec![Candidate::new(
+                    start..end,
+                    PiiClass::Name,
+                    self.id(),
+                    1.0,
+                    0,
+                    None,
+                    self.token_family(),
+                    "ner/ort",
+                    ConflictTier::None,
+                    Vec::new(),
+                )
+                .with_recognizer_version_id("name.semantic.v2")]
+            }
+
+            fn token_family(&self) -> &str {
+                "counter"
+            }
+        }
+
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+        let pipeline = Pipeline::builder()
+            .recognizer(VersionedRecognizer)
+            .rule(ClassRule::new(PiiClass::Name, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        pipeline
+            .redact(
+                &session,
+                RawDocument::Text("Contact Dr. Schmidt today.".to_string()),
+            )
+            .expect("redact");
+
+        let entries = entries.lock().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source, "ner/ort");
+        assert_eq!(entries[0].recognizer_id.as_deref(), Some("name.semantic"));
+        assert_eq!(
+            entries[0].recognizer_version_id.as_deref(),
+            Some("name.semantic.v2")
+        );
     }
 
     #[test]

--- a/docs/architecture/locale-chain.md
+++ b/docs/architecture/locale-chain.md
@@ -24,3 +24,34 @@ family-level token with `ConflictTier::AnchoredContext` and
 `locale-cue-bundle-coherence` xtask gate keeps mandatory-anchor declarations in
 the bundled core rulepacks aligned with the embedded `locale-de` and
 `locale-en` cue bundles.
+
+## Coverage matrix
+
+This matrix lists bundled recognizers shipped in `gaze-recognizers` and the
+locale projections that can activate them. `global` recognizers are eligible for
+every locale chain because `global` intersects all locale projections.
+
+| Bundle | Recognizer ID | Class | Supported locales | ValidatorKind |
+|---|---|---|---|---|
+| `core` | `email.global` | `Email` | `global` | `EmailRfc` |
+| `core` | `email.header.name` | `Name` | `global` | None |
+| `core` | `email.header.name.paren` | `Name` | `global` | None |
+| `core` | `name.forward_marker` | `Name` | `de-DE`, `de-AT`, `de-CH`, `en-US`, `en-GB`, `en-IE`, `en-AU`, `en-CA` | None |
+| `core` | `name.agent_recipient` | `Name` | `de-DE`, `de-AT`, `de-CH`, `en-US`, `en-GB`, `en-IE`, `en-AU`, `en-CA` | None |
+| `core` | `name.auto_footer` | `Name` | `de-DE`, `de-AT`, `de-CH`, `en-US`, `en-GB`, `en-IE`, `en-AU`, `en-CA` | None |
+| `core-extended` | `phone.structural` | `custom:phone` | `global` | `E164Phone` |
+| `core-extended` | `phone.national.de` | `custom:phone` | `de-DE`, `de-AT`, `de-CH` | `E164PhoneNational(De)` |
+| `core-extended` | `phone.national.us` | `custom:phone` | `en-US` | `E164PhoneNational(Us)` |
+| `core-extended` | `iban.structural` | `custom:iban` | `global` | `IbanMod97` |
+| `core-extended` | `card.structural` | `custom:credit_card` | `global` | `Luhn` |
+| `core-extended` | `ip.v4` | `custom:ip_address` | `global` | `Ipv4Parse` |
+| `core-extended` | `ip.v6` | `custom:ip_address` | `global` | `Ipv6Parse` |
+| `core-extended` | `eth.address` | `custom:eth_address` | `global` | `EthEip55` |
+| `core-extended` | `postal.de` | `custom:postal_code` | `de-DE` | None |
+| `core-extended` | `postal.us` | `custom:postal_code` | `en-US` | None |
+| NER artifact | `ner` | `Name` | Policy-selected NER locale, or any locale when unset | None |
+
+The NER recognizer keeps semantic `recognizer_id = "ner"` for registry
+compatibility. Audit rows additionally carry a versioned
+`recognizer_version_id` in the form `ner.<model>.<vN>` when the loaded artifact
+declares model metadata, or `ner.unknown.v0` when it does not.


### PR DESCRIPTION
## Summary
- Add versioned recognizer lineage to `Candidate` and audit-facing `RedactionEntry` while preserving the existing serialized `RedactionEntry` shape when the new fields are absent.
- Thread `recognizer_id` and `recognizer_version_id` through the pipeline audit boundary alongside the existing `source` field.
- Extend the SQLite audit schema/query path with nullable recognizer lineage columns and tag pre-migration redaction rows as `legacy_unversioned`.
- Version NER recognizer emissions as `ner.<model>.<vN>` from artifact config metadata, defaulting to `ner.unknown.v0` when absent.
- Add the locale-chain coverage matrix for bundled recognizers, supported locales, and validator coverage.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- dylint-gate`
- `cargo run -p xtask -- bundle-tokenization-drift`
- `cargo run -p xtask -- cargo-metadata-audit-isolation`

`bundle-tokenization-drift --verify-ack` reported no snapshot diff inside `ci-feature-matrix`; no rebaseline was needed.

## North-Star Alignment
- Axis 4 / trust and auditability: each audit emission can now carry semantic recognizer lineage plus an audit-facing version ID, so lineage no longer drops at the audit boundary.
- Axis 5 / adopter ergonomics: the locale coverage matrix makes bundled recognizer and validator support discoverable from the architecture docs.

## SemVer
- Additive v0.8.0 minor surface: new optional struct fields and nullable SQLite columns.

## CHANGELOG
- Deferred to the v0.8.0 release-engineer. This PR intentionally does not edit `CHANGELOG`.
