### PR TITLE
chore(release): v0.8.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`KijiDistilbertSafetyNet` backend** (v0.8 Tier 2.5,
-  `--safety-net-backend kiji-distilbert`): observer-only DistilBERT NER pass
-  that runs at the Pass-3 chokepoint alongside the existing OpenAI Privacy
-  Filter. Subprocess model identical to `OpenAiFilterSafetyNet`: read clean
-  text on stdin, emit a JSON span array on stdout, never mutate the manifest.
-  Pinned-artifact contract identical to the existing OpenAI filter — model
-  dir must carry `SHA256SUMS`, `labels.json`, `model.onnx`, `tokenizer.json`
-  with `0o700` directory + `0o600` file permissions on Unix; missing
-  artifacts (including a missing `SHA256SUMS`) fail closed with typed
-  `CliError::SafetyNetArtifactMissing` exit `2` *before* the subprocess
-  spawns. New CLI flags: `--safety-net-backend`, `--kiji-distilbert-command`,
-  `--kiji-distilbert-model-dir`. New fetcher: `scripts/fetch-kiji-safetynet-model.sh`
-  (HF commit SHA placeholder pending first sign-off). (Axis 1 reliability —
-  defense in depth, second NER opinion at the chokepoint.)
-
 ### Changed
-
-- Unified `core` + `core-extended` bundled rulepacks into single `core` bundle. Each recognizer now declares a `safety_tier` (`safe_default` / `locale_gated` / `opt_in`) which gates no-policy activation. `--rulepack-bundled core-extended` is deprecated (will be removed in v0.10.0); aliases to `--rulepack-bundled core` and auto-activates locale-gated tier. Adopters who relied on the v0.4.5 PR #58 no-policy surprise activation should pass `--locale=de-DE` or `--locale=en-US` explicitly.
-- [bundle-tokenization-drift] v0.8 bundle unification refreshed the `core` no-policy snapshot and removed the deprecated `core-extended` no-policy snapshot.
-- Research docs (gaze-threat-model, ner-library-evaluation, v0.4.x audits, v0.5 dylint gate, v0.7.x corpus-rework/coverage-baseline) migrated to `PIInuts/business:research/`.
 
 ### Deprecated
 
@@ -37,6 +18,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.8.0-rc.1] - 2026-05-14
+
+First v0.8 pre-release. Bundle unification + versioned recognizer lineage + Kiji-style defense-in-depth. Tier 2 checksum-backed locale parity (Aadhaar / NIR / Steuer-ID / BSN / CPF / CNPJ / NHS) and Tier 3 regex locales (SSN / NINO / PAN) follow in rc.2 / rc.3.
+
+### Added
+
+- **Versioned recognizer lineage** (v0.8 Tier 1, PR #203 `3c95304`): `Candidate.recognizer_version_id` + `RedactionEntry.recognizer_id` + `recognizer_version_id` (all `Option<String>`, additive). Audit boundary in `pipeline.rs` now propagates lineage instead of dropping at `source`. SQLite schema gains nullable `recognizer_id` / `recognizer_version_id` columns; pre-migration rows tagged `legacy_unversioned`. NER recognizer emissions versioned as `ner.<model>.<vN>` from artifact config metadata (`ner.unknown.v0` fallback). `docs/architecture/locale-chain.md` gains a coverage matrix listing every bundled recognizer × supported locales × ValidatorKind. (Axis 4 trust/auditable, Axis 5 ergonomics.)
+- **`SafetyTier` enum on rulepack recognizers** (v0.8 Tier 1.5, PR #201 `8ab9daf`): `SafeDefault`, `LocaleGated`, `OptIn` with `#[non_exhaustive]`. Closed-enum activation gate replaces the dual-bundle activation model. (Axis 1 reliability, Axis 4 trust.)
+- **`KijiDistilbertSafetyNet` backend** (v0.8 Tier 2.5, PR #202 `0cd9ccc`): new `--safety-net-backend kiji-distilbert` flag (default remains `openai-filter` for compat). Pass-3 SafetyNet device with pinned-artifact contract identical to existing OpenAI filter (SHA256SUMS hard-fail on missing). New `CliError::SafetyNetArtifactMissing { backend, path }` typed variant. `scripts/fetch-kiji-safetynet-model.sh` mirror of existing NER fetcher. (Axis 1 defense-in-depth.)
+
+### Changed
+
+- **Unified `core` + `core-extended` bundled rulepacks** into single `core` bundle (v0.8 Tier 1.5, PR #201). Each recognizer now declares a `safety_tier` field; no-policy activation gates on `SafeDefault` only. Adopter behavior preserved through alias path described under Deprecated.
+
+### Deprecated
+
+- **`--rulepack-bundled core-extended`** is deprecated (v0.8 Tier 1.5, PR #201). Aliases to `--rulepack-bundled core` with auto-activation of `LocaleGated` recognizers + a `tracing::warn!` deprecation notice. Scheduled removal in v0.10.0. Adopters who relied on the v0.4.5 PR #58 no-policy surprise activation for `phone.national.*` / `postal.*` should pass `--locale=de-DE` or `--locale=en-US` explicitly.
+
+### Migration notes
+
+- Existing `RedactionEntry` JSON consumers see no shape change — new fields use `#[serde(skip_serializing_if = "Option::is_none")]` and emit nothing when None.
+- Existing SQLite audit DBs are migrated forward: pre-migration redaction rows get `recognizer_id = "legacy_unversioned"`, `recognizer_version_id = NULL`. Migration is idempotent.
+- Existing `policy.toml` files unchanged. No new required fields.
 
 ## [0.7.2] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.7.2" }
-gaze-types = { path = "crates/gaze-types", version = "0.7.2" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.8.0-rc.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.8.0-rc.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Claude Code, Claude Desktop, and Cursor config paths.
 
 ## Quickstart
 
-A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the v0.7.2 CLI.
+A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the v0.8.0-rc.1 CLI.
 
 ### 1. First redact
 
@@ -300,7 +300,7 @@ The audit DB is opened read-only by `query` and `export`. The exported column se
 
 ## Status
 
-- **Version:** v0.7.2 (2026-05).
+- **Version:** v0.8.0-rc.1 (2026-05, pre-release).
 - **MSRV:** Rust 1.89.
 - **License:** dual `Apache-2.0 OR MIT`.
 - **crates.io:** published as `gaze-pii`. The bare `gaze` name is in transfer; until that completes, depend on `gaze-pii`. Source-compat is preserved via `[lib].name = "gaze"`.
@@ -319,11 +319,11 @@ The CLI is a process boundary around the Rust runtime; you can link the runtime 
 
 ```toml
 [dependencies]
-gaze-pii = "0.7"
-gaze-assembly = "0.7"
+gaze-pii = "0.8.0-rc.1"
+gaze-assembly = "0.8.0-rc.1"
 ```
 
-The crate is published as `gaze-pii` because the bare `gaze` name is in transfer; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved.
+The crate is published as `gaze-pii` because the bare `gaze` name is in transfer; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved. During the v0.8 pre-release window, pin the exact `0.8.0-rc.N` version — Cargo's caret operator excludes pre-releases.
 
 - Minimal example and the API surface table: [`crates/gaze/README.md`](crates/gaze/README.md) (also rendered on [`crates.io/crates/gaze-pii`](https://crates.io/crates/gaze-pii)).
 - Full walk-through with structured documents, tenant-specific recognizers, and policy TOML: [`docs/getting-started.md`](docs/getting-started.md).

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
+gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -41,13 +41,13 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.7.2" }
+gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.7.2", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.2", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
+gaze-document = { path = "../gaze-document", version = "0.8.0-rc.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0-rc.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -60,7 +60,7 @@ tracing = "0.1"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
+gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.7.2" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0-rc.1" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.7.2", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.7.2" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.7.2" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.7.2" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.8.0-rc.1" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.7.2"
+version = "0.8.0-rc.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.7.2", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,9 +12,11 @@ restore key, send only safe text to an LLM, and restore original values from the
 
 ```toml
 [dependencies]
-gaze-pii = "0.7"
-gaze-assembly = "0.7"
+gaze-pii = "0.8.0-rc.1"
+gaze-assembly = "0.8.0-rc.1"
 ```
+
+> v0.8 pre-release window: pin the exact `0.8.0-rc.N` version. Cargo's caret operator excludes pre-releases, so `"0.8"` will not resolve to `0.8.0-rc.1`.
 
 The crate is published as `gaze-pii`. Import path remains `use gaze::...`.
 


### PR DESCRIPTION
## Summary

First v0.8 pre-release. Bundle unification + versioned recognizer lineage + Kiji-style defense-in-depth shipping. Tier 2 checksum-backed locale parity (Aadhaar / NIR / Steuer-ID / BSN / CPF / CNPJ / NHS) and Tier 3 regex locales (SSN / NINO / PAN) follow in rc.2 / rc.3.

## CHANGELOG entries

### Added

- **Versioned recognizer lineage** (v0.8 Tier 1, PR #203 `3c95304`): `Candidate.recognizer_version_id` + `RedactionEntry.recognizer_id` + `recognizer_version_id` (all `Option<String>`, additive). Audit boundary in `pipeline.rs` now propagates lineage instead of dropping at `source`. SQLite schema gains nullable `recognizer_id` / `recognizer_version_id` columns; pre-migration rows tagged `legacy_unversioned`. NER recognizer emissions versioned as `ner.<model>.<vN>` from artifact config metadata (`ner.unknown.v0` fallback). `docs/architecture/locale-chain.md` gains a coverage matrix listing every bundled recognizer × supported locales × ValidatorKind.
- **`SafetyTier` enum on rulepack recognizers** (v0.8 Tier 1.5, PR #201 `8ab9daf`): `SafeDefault`, `LocaleGated`, `OptIn` with `#[non_exhaustive]`. Closed-enum activation gate replaces the dual-bundle activation model.
- **`KijiDistilbertSafetyNet` backend** (v0.8 Tier 2.5, PR #202 `0cd9ccc`): new `--safety-net-backend kiji-distilbert` flag (default remains `openai-filter` for compat). Pass-3 SafetyNet device with pinned-artifact contract identical to existing OpenAI filter (SHA256SUMS hard-fail on missing). New `CliError::SafetyNetArtifactMissing { backend, path }` typed variant. `scripts/fetch-kiji-safetynet-model.sh` mirror of existing NER fetcher.

### Changed

- **Unified `core` + `core-extended` bundled rulepacks** into single `core` bundle (v0.8 Tier 1.5, PR #201). Each recognizer now declares a `safety_tier` field; no-policy activation gates on `SafeDefault` only. Adopter behavior preserved through alias path.

### Deprecated

- **`--rulepack-bundled core-extended`** is deprecated (v0.8 Tier 1.5, PR #201). Aliases to `--rulepack-bundled core` with auto-activation of `LocaleGated` recognizers + a `tracing::warn!` deprecation notice. Scheduled removal in v0.10.0. Adopters who relied on the v0.4.5 PR #58 no-policy surprise activation for `phone.national.*` / `postal.*` should pass `--locale=de-DE` or `--locale=en-US` explicitly.

### Migration notes

- Existing `RedactionEntry` JSON consumers see no shape change — new fields use `#[serde(skip_serializing_if = "Option::is_none")]` and emit nothing when None.
- Existing SQLite audit DBs are migrated forward: pre-migration redaction rows get `recognizer_id = "legacy_unversioned"`, `recognizer_version_id = NULL`. Migration is idempotent.
- Existing `policy.toml` files unchanged. No new required fields.

## North-star axis alignment

- **Tier 1 (versioned lineage)** — Axis 4 (trust/auditable: every redaction entry now carries an opaque, additive recognizer-version handle, so adopters can trace every token to a recognizer commit) + Axis 5 (ergonomics: locale coverage matrix gives adopters a single grep target for "what does the bundled `core` rulepack actually cover").
- **Tier 1.5 (SafetyTier + bundle unification)** — Axis 1 (reliability: closed-enum tier replaces the dual-bundle scheme, eliminating the "did core-extended activate by accident?" footgun) + Axis 4 (trust: tier metadata is part of the rulepack source of truth) + Axis 5 (ergonomics: one bundle, one mental model; `core-extended` alias preserves prior behavior with a deprecation warn).
- **Tier 2.5 (Kiji-DistilBERT SafetyNet)** — Axis 1 (defense-in-depth: second NER opinion at the Pass-3 chokepoint, observer-only, never mutates manifest, fail-closed pinned-artifact contract identical to existing OpenAI filter).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] `cargo run -p xtask -- dylint-gate` (UI fixtures verified; full lint runs in PR CI via `GAZE_RUN_DYLINT=1`)
- [x] `cargo run -p xtask -- bundle-tokenization-drift`
- [x] `cargo run -p xtask -- safety-net-sanity`
- [x] `cargo package -p <each>` succeeds for all 9 crates (downstream `cargo publish --dry-run` resolution requires the publish chain itself; that runs at tag time)
- [ ] PR CI `.github/workflows/docs.yml` green
- [ ] Tag `v0.8.0-rc.1`, publish 9 crates in dep order (`gaze-types` → `gaze-recognizers` → `gaze-audit` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-cli`), draft GH pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)