### PR TITLE
Add Tier 2 checksum-backed locale validators

### DIFF
--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2707,6 +2707,44 @@ fn s2_core_extended_cli_validator_backed_iban_and_cards_emit_or_drop() {
 }
 
 #[test]
+fn s2_cli_core_validator_locale_entities_tokenize_and_round_trip() {
+    for (locale, wrong_locale, input, class) in [
+        ("fr-FR", "en-US", "NIR 190010100100058", "nir"),
+        ("nl-NL", "en-US", "BSN 111222333", "bsn"),
+        ("pt-BR", "en-US", "CPF 529.982.247-25", "cpf"),
+        ("pt-BR", "en-US", "CNPJ 04.252.011/0001-10", "cnpj"),
+        ("en-IN", "en-US", "Aadhaar 6741 8529 6303", "aadhaar"),
+        ("en-GB", "fr-FR", "NHS number 943 476 5919", "nhs_number"),
+        ("de-DE", "en-US", "Steuer-ID 48 954 371 207", "steuer_id"),
+    ] {
+        let value = clean_json_with_args(
+            &["--rulepack-bundled=core", &format!("--locale={locale}")],
+            input,
+        );
+        let clean = value["clean_text"].as_str().unwrap();
+        assert!(
+            clean.ends_with(&format!(":Custom:{class}_1>")),
+            "{locale} {input}: {clean}"
+        );
+        assert_eq!(value["stats"]["detections"], 1, "{input}");
+        assert_eq!(
+            restore_success_text(value["session_blob"].as_str().unwrap(), clean),
+            input
+        );
+
+        let wrong_locale = clean_json_with_args(
+            &[
+                "--rulepack-bundled=core",
+                &format!("--locale={wrong_locale}"),
+            ],
+            input,
+        );
+        assert_eq!(wrong_locale["clean_text"], input, "{input}");
+        assert_eq!(wrong_locale["stats"]["detections"], 0, "{input}");
+    }
+}
+
+#[test]
 fn s1_rulepack_path_override_loads_fixture_rulepack_and_round_trips() {
     let dir = tempdir().unwrap();
     let rulepack_path = dir.path().join("class-alpha.toml");
@@ -2796,6 +2834,11 @@ fn s1_three_surfaces_flags_are_exposed_and_bundled_ids_unchanged() {
     assert!(gaze_recognizers::embedded("core").is_some());
     assert!(gaze_recognizers::embedded("locale-de").is_some());
     assert!(gaze_recognizers::embedded("locale-en").is_some());
+    assert!(gaze_recognizers::embedded("locale-br").is_some());
+    assert!(gaze_recognizers::embedded("locale-fr").is_some());
+    assert!(gaze_recognizers::embedded("locale-in").is_some());
+    assert!(gaze_recognizers::embedded("locale-nl").is_some());
+    assert!(gaze_recognizers::embedded("locale-uk").is_some());
     assert!(gaze_recognizers::embedded("class_alpha").is_none());
 }
 

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -391,6 +391,153 @@ priority = 80
 
 [recognizers.token]
 
+[[recognizers]]
+id = "aadhaar.in"
+safety_tier = "safe_default"
+class = "custom:aadhaar"
+enabled = true
+locales = ["en-IN", "hi-IN"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:aadhaar|uid|unique identification|आधार)(?:\s*(?:number|no\.?|id))?\s*[:#-]?\s*(\d{4}[ -]?\d{4}[ -]?\d{4})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "aadhaar_verhoeff"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "nir.fr"
+safety_tier = "safe_default"
+class = "custom:nir"
+enabled = true
+locales = ["fr-FR"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:n[°º]?\s*ss|nir|s[ée]curit[ée]\s+sociale|num[ée]ro\s+de\s+s[ée]curit[ée]\s+sociale)\s*[:#-]?\s*([123478]\d(?:[ -]?\d){13})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "fr_nir_mod97"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "steuer_id.de"
+safety_tier = "safe_default"
+class = "custom:steuer_id"
+enabled = true
+locales = ["de-DE", "de-AT", "de-CH"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:steuer-id|steuerid|idnr\.?|steuerliche\s+identifikationsnummer|identifikationsnummer)\s*[:#-]?\s*(\d{2}[ -]?\d{3}[ -]?\d{3}[ -]?\d{3})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "de_steuer_id_mod1110"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "bsn.nl"
+safety_tier = "safe_default"
+class = "custom:bsn"
+enabled = true
+locales = ["nl-NL"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:bsn|burgerservicenummer)\s*[:#-]?\s*(\d{9})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "bsn_mod11"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "cpf.br"
+safety_tier = "safe_default"
+class = "custom:cpf"
+enabled = true
+locales = ["pt-BR"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:cpf|cadastro\s+de\s+pessoas\s+f[íi]sicas)\s*[:#-]?\s*(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "cpf_mod11"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "cnpj.br"
+safety_tier = "safe_default"
+class = "custom:cnpj"
+enabled = true
+locales = ["pt-BR"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:cnpj|cadastro\s+nacional\s+da\s+pessoa\s+jur[íi]dica)\s*[:#-]?\s*(\d{2}\.?\d{3}\.?\d{3}/?\d{4}-?\d{2})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "cnpj_mod11"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "nhs.uk"
+safety_tier = "safe_default"
+class = "custom:nhs_number"
+enabled = true
+locales = ["en-GB"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\bnhs\s*(?:number|no\.?|id)?\s*[:#-]?\s*(\d{3}[ -]?\d{3}[ -]?\d{4})\b'''
+capture_groups = [1]
+
+[recognizers.validator]
+kind = "uk_nhs_mod11"
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
 # Postal collision warning (research-855 §Collision matrix conclusion):
 # `postal.de` and `postal.us` both accept naked five-digit numeric strings.
 # This is safe only when active locale chains keep DE and US projections apart.

--- a/crates/gaze-recognizers/embedded/locale-br.toml
+++ b/crates/gaze-recognizers/embedded/locale-br.toml
@@ -1,0 +1,12 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-locale-br"
+rulepack_version = "0.5.1"
+default_locales = ["pt-BR"]
+
+[locale.cues.cpf]
+names = ["CPF", "Cadastro de Pessoas Físicas", "Cadastro de Pessoas Fisicas"]
+window_chars = 64
+
+[locale.cues.cnpj]
+names = ["CNPJ", "Cadastro Nacional da Pessoa Jurídica", "Cadastro Nacional da Pessoa Juridica"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-de.toml
+++ b/crates/gaze-recognizers/embedded/locale-de.toml
@@ -31,3 +31,7 @@ window_chars = 64
 [locale.cues.vat-id]
 names = ["USt-IdNr", "USt-ID", "Umsatzsteuer-ID", "MwSt-Nr"]
 window_chars = 64
+
+[locale.cues.steuer-id]
+names = ["Steuer-ID", "Steuerid", "IdNr.", "Steuerliche Identifikationsnummer", "Identifikationsnummer"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-fr.toml
+++ b/crates/gaze-recognizers/embedded/locale-fr.toml
@@ -1,0 +1,8 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-locale-fr"
+rulepack_version = "0.5.1"
+default_locales = ["fr-FR"]
+
+[locale.cues.nir]
+names = ["Sécurité sociale", "Securite sociale", "n° SS", "NIR", "Numéro de sécurité sociale", "Numero de securite sociale"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-in.toml
+++ b/crates/gaze-recognizers/embedded/locale-in.toml
@@ -1,0 +1,8 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-locale-in"
+rulepack_version = "0.5.1"
+default_locales = ["en-IN", "hi-IN"]
+
+[locale.cues.aadhaar]
+names = ["आधार", "Aadhaar", "UID", "Unique Identification"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-nl.toml
+++ b/crates/gaze-recognizers/embedded/locale-nl.toml
@@ -1,0 +1,8 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-locale-nl"
+rulepack_version = "0.5.1"
+default_locales = ["nl-NL"]
+
+[locale.cues.bsn]
+names = ["BSN", "Burgerservicenummer"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-uk.toml
+++ b/crates/gaze-recognizers/embedded/locale-uk.toml
@@ -1,0 +1,8 @@
+schema_version = "0.1.0"
+rulepack_id = "gaze-locale-uk"
+rulepack_version = "0.5.1"
+default_locales = ["en-GB"]
+
+[locale.cues.nhs]
+names = ["NHS number", "NHS no", "NHS id"]
+window_chars = 64

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -21,6 +21,7 @@ mod ner;
 mod regex;
 #[cfg(feature = "safety-net")]
 pub mod safety_net;
+pub mod validators;
 
 pub use anchored_match::{
     is_person_name_candidate, AnchoredBoundary, AnchoredMatchRecognizer, CuePosition, NameShape,
@@ -41,6 +42,11 @@ pub fn embedded(name: &str) -> Option<&'static str> {
         "core" | "core-extended" => Some(include_str!("../embedded/core.toml")),
         "locale-de" => Some(include_str!("../embedded/locale-de.toml")),
         "locale-en" => Some(include_str!("../embedded/locale-en.toml")),
+        "locale-br" => Some(include_str!("../embedded/locale-br.toml")),
+        "locale-fr" => Some(include_str!("../embedded/locale-fr.toml")),
+        "locale-in" => Some(include_str!("../embedded/locale-in.toml")),
+        "locale-nl" => Some(include_str!("../embedded/locale-nl.toml")),
+        "locale-uk" => Some(include_str!("../embedded/locale-uk.toml")),
         _ => None,
     }
 }
@@ -55,7 +61,7 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 16);
+        assert_eq!(rulepack.recognizers.len(), 23);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
@@ -90,7 +96,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 16);
+        assert_eq!(rulepack.recognizers.len(), 23);
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/src/validators/mod.rs
+++ b/crates/gaze-recognizers/src/validators/mod.rs
@@ -1,0 +1,5 @@
+//! Deterministic checksum validators re-exported for recognizer tests and adopters.
+
+pub mod mod11;
+pub mod mod97_nir;
+pub mod verhoeff;

--- a/crates/gaze-recognizers/src/validators/mod11.rs
+++ b/crates/gaze-recognizers/src/validators/mod11.rs
@@ -1,0 +1,26 @@
+use gaze_types::ValidatorKind;
+
+/// Validates a German Steuer-ID with ISO 7064 MOD 11,10.
+pub fn validate_de_steuer_id(digits: &str) -> bool {
+    ValidatorKind::DeSteuerIdMod1110.validates(digits)
+}
+
+/// Validates a Dutch BSN with the 11-test.
+pub fn validate_bsn(digits: &str) -> bool {
+    ValidatorKind::BsnMod11.validates(digits)
+}
+
+/// Validates a Brazilian CPF with its two MOD-11 check digits.
+pub fn validate_cpf(digits: &str) -> bool {
+    ValidatorKind::CpfMod11.validates(digits)
+}
+
+/// Validates a Brazilian CNPJ with its two MOD-11 check digits.
+pub fn validate_cnpj(digits: &str) -> bool {
+    ValidatorKind::CnpjMod11.validates(digits)
+}
+
+/// Validates a UK NHS number with the MOD-11 checksum.
+pub fn validate_uk_nhs(digits: &str) -> bool {
+    ValidatorKind::UkNhsMod11.validates(digits)
+}

--- a/crates/gaze-recognizers/src/validators/mod97_nir.rs
+++ b/crates/gaze-recognizers/src/validators/mod97_nir.rs
@@ -1,0 +1,6 @@
+use gaze_types::ValidatorKind;
+
+/// Validates a French NIR using its two-digit MOD-97 key.
+pub fn validate_fr_nir(digits: &str) -> bool {
+    ValidatorKind::FrNirMod97.validates(digits)
+}

--- a/crates/gaze-recognizers/src/validators/verhoeff.rs
+++ b/crates/gaze-recognizers/src/validators/verhoeff.rs
@@ -1,0 +1,6 @@
+use gaze_types::ValidatorKind;
+
+/// Validates an Indian Aadhaar number with the Verhoeff checksum.
+pub fn validate_aadhaar(digits: &str) -> bool {
+    ValidatorKind::AadhaarVerhoeff.validates(digits)
+}

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -368,3 +368,338 @@ fn s1_iban_mod97_failing_iban_emits_no_detection() {
 
     assert_eq!(clean, input);
 }
+
+#[test]
+fn aadhaar_verhoeff_accepts_generated_values_and_rejects_mutants() {
+    assert!(ValidatorKind::AadhaarVerhoeff.validates("2345 6789 0124"));
+
+    let values = (20..30).map(gen_aadhaar).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::AadhaarVerhoeff.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::verhoeff::validate_aadhaar(
+            value
+        ));
+        assert!(!ValidatorKind::AadhaarVerhoeff.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{4} \d{4} \d{4}\b",
+        ValidatorKind::AadhaarVerhoeff,
+        "Aadhaar 6741 8529 6303",
+        "aadhaar",
+    );
+}
+
+#[test]
+fn fr_nir_mod97_accepts_generated_values_and_rejects_mutants() {
+    for value in ["151024610204325", "1 84 12 76 451 089 46"] {
+        assert!(ValidatorKind::FrNirMod97.validates(value), "{value}");
+    }
+
+    let values = (0..10).map(gen_fr_nir).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::FrNirMod97.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod97_nir::validate_fr_nir(
+            value
+        ));
+        assert!(!ValidatorKind::FrNirMod97.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b[12]\d(?: ?\d){13}\b",
+        ValidatorKind::FrNirMod97,
+        "NIR 190010100100058",
+        "nir",
+    );
+}
+
+#[test]
+fn de_steuer_id_mod1110_accepts_generated_values_and_rejects_mutants() {
+    for value in ["48954371207", "55492670836", "65929970489"] {
+        assert!(ValidatorKind::DeSteuerIdMod1110.validates(value), "{value}");
+    }
+    assert!(!ValidatorKind::DeSteuerIdMod1110.validates("12345678903"));
+
+    let values = (0..10).map(gen_steuer_id).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::DeSteuerIdMod1110.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod11::validate_de_steuer_id(
+            value
+        ));
+        assert!(!ValidatorKind::DeSteuerIdMod1110.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{2} \d{3} \d{3} \d{3}\b",
+        ValidatorKind::DeSteuerIdMod1110,
+        "Steuer-ID 48 954 371 207",
+        "steuer_id",
+    );
+}
+
+#[test]
+fn bsn_mod11_accepts_generated_values_and_rejects_mutants() {
+    assert!(ValidatorKind::BsnMod11.validates("123456782"));
+
+    let values = (0..10).map(gen_bsn).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::BsnMod11.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod11::validate_bsn(value));
+        assert!(!ValidatorKind::BsnMod11.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{9}\b",
+        ValidatorKind::BsnMod11,
+        "BSN 111222333",
+        "bsn",
+    );
+}
+
+#[test]
+fn cpf_mod11_accepts_generated_values_and_rejects_mutants() {
+    let values = (0..10).map(gen_cpf).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::CpfMod11.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod11::validate_cpf(value));
+        assert!(!ValidatorKind::CpfMod11.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b",
+        ValidatorKind::CpfMod11,
+        "CPF 529.982.247-25",
+        "cpf",
+    );
+}
+
+#[test]
+fn cnpj_mod11_accepts_generated_values_and_rejects_mutants() {
+    let values = (0..10).map(gen_cnpj).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::CnpjMod11.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod11::validate_cnpj(value));
+        assert!(!ValidatorKind::CnpjMod11.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b",
+        ValidatorKind::CnpjMod11,
+        "CNPJ 04.252.011/0001-10",
+        "cnpj",
+    );
+}
+
+#[test]
+fn uk_nhs_mod11_accepts_generated_values_and_rejects_mutants() {
+    let values = (0..10).map(gen_nhs).collect::<Vec<_>>();
+    for value in &values {
+        assert!(ValidatorKind::UkNhsMod11.validates(value), "{value}");
+        assert!(gaze_recognizers::validators::mod11::validate_uk_nhs(value));
+        assert!(!ValidatorKind::UkNhsMod11.validates(&flip_last_digit(value)));
+    }
+
+    assert_validator_pipeline_round_trip(
+        r"\b\d{3} \d{3} \d{4}\b",
+        ValidatorKind::UkNhsMod11,
+        "NHS number 943 476 5919",
+        "nhs_number",
+    );
+}
+
+fn assert_validator_pipeline_round_trip(
+    pattern: &str,
+    validator: ValidatorKind,
+    input: &str,
+    class: &str,
+) {
+    let pipeline = custom_validator_pipeline(pattern, PiiClass::custom(class), validator, None);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input);
+
+    assert!(clean.contains(&format!(":Custom:{class}_1>")), "{clean}");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+fn flip_last_digit(value: &str) -> String {
+    let mut bytes = value.as_bytes().to_vec();
+    let index = bytes
+        .iter()
+        .rposition(u8::is_ascii_digit)
+        .expect("digit fixture");
+    bytes[index] = if bytes[index] == b'9' {
+        b'0'
+    } else {
+        bytes[index] + 1
+    };
+    String::from_utf8(bytes).expect("ascii fixture")
+}
+
+fn gen_aadhaar(seed: u64) -> String {
+    let mut digits = [0u8; 12];
+    digits[0] = 2 + (seed as u8 % 8);
+    for (index, digit) in digits[..11].iter_mut().enumerate().skip(1) {
+        *digit = ((seed + index as u64 * 7) % 10) as u8;
+    }
+    digits[11] = verhoeff_check_digit(&digits[..11]);
+    digits_to_string(&digits)
+}
+
+fn verhoeff_check_digit(digits: &[u8]) -> u8 {
+    const D: [[u8; 10]; 10] = [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [1, 2, 3, 4, 0, 6, 7, 8, 9, 5],
+        [2, 3, 4, 0, 1, 7, 8, 9, 5, 6],
+        [3, 4, 0, 1, 2, 8, 9, 5, 6, 7],
+        [4, 0, 1, 2, 3, 9, 5, 6, 7, 8],
+        [5, 9, 8, 7, 6, 0, 4, 3, 2, 1],
+        [6, 5, 9, 8, 7, 1, 0, 4, 3, 2],
+        [7, 6, 5, 9, 8, 2, 1, 0, 4, 3],
+        [8, 7, 6, 5, 9, 3, 2, 1, 0, 4],
+        [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+    ];
+    const P: [[u8; 10]; 8] = [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [1, 5, 7, 6, 2, 8, 3, 0, 9, 4],
+        [5, 8, 0, 3, 7, 9, 6, 1, 4, 2],
+        [8, 9, 1, 6, 0, 4, 3, 5, 2, 7],
+        [9, 4, 5, 3, 1, 2, 6, 8, 7, 0],
+        [4, 2, 8, 6, 5, 7, 3, 9, 0, 1],
+        [2, 7, 9, 3, 8, 0, 6, 4, 1, 5],
+        [7, 0, 4, 6, 9, 1, 3, 2, 5, 8],
+    ];
+    const INV: [u8; 10] = [0, 4, 3, 2, 1, 5, 6, 7, 8, 9];
+    let mut checksum = 0u8;
+    for (index, digit) in digits.iter().rev().enumerate() {
+        checksum = D[checksum as usize][P[(index + 1) % 8][*digit as usize] as usize];
+    }
+    INV[checksum as usize]
+}
+
+fn gen_fr_nir(seed: u64) -> String {
+    let base = format!("1{:02}0101001{:03}", 90 + seed % 10, seed % 999);
+    let number = base.parse::<u64>().expect("nir base");
+    format!("{base}{:02}", 97 - (number % 97))
+}
+
+fn gen_steuer_id(seed: u64) -> String {
+    let mut digits = [0u8; 11];
+    for (index, digit) in digits[..10].iter_mut().enumerate() {
+        *digit = ((seed + index as u64) % 10) as u8;
+    }
+    digits[0] = 1 + (digits[0] % 9);
+    digits[10] = steuer_id_check_digit(&digits[..10]);
+    digits_to_string(&digits)
+}
+
+fn steuer_id_check_digit(digits: &[u8]) -> u8 {
+    let mut product = 10u8;
+    for digit in digits {
+        let mut sum = (*digit + product) % 10;
+        if sum == 0 {
+            sum = 10;
+        }
+        product = (2 * sum) % 11;
+    }
+    (11 - product) % 10
+}
+
+fn gen_bsn(seed: u64) -> String {
+    for candidate in seed * 100.. {
+        let mut digits = first_digits::<8>(candidate);
+        digits[0] = 1 + (digits[0] % 9);
+        let sum: u32 = digits
+            .iter()
+            .enumerate()
+            .map(|(index, digit)| u32::from(*digit) * (9 - index as u32))
+            .sum();
+        let check = sum % 11;
+        if check < 10 {
+            let mut full = [0u8; 9];
+            full[..8].copy_from_slice(&digits);
+            full[8] = check as u8;
+            return digits_to_string(&full);
+        }
+    }
+    unreachable!("unbounded BSN generator finds a check digit")
+}
+
+fn gen_cpf(seed: u64) -> String {
+    let mut digits = [0u8; 11];
+    digits[..9].copy_from_slice(&first_digits::<9>(seed + 529_982_247));
+    digits[9] = cpf_check_digit(&digits[..9], 10);
+    digits[10] = cpf_check_digit(&digits[..10], 11);
+    digits_to_string(&digits)
+}
+
+fn gen_cnpj(seed: u64) -> String {
+    let mut digits = [0u8; 14];
+    digits[..12].copy_from_slice(&first_digits::<12>(seed + 42_520_110_001));
+    digits[12] = weighted_check_digit(&digits[..12], &[5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+    digits[13] = weighted_check_digit(&digits[..13], &[6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+    digits_to_string(&digits)
+}
+
+fn gen_nhs(seed: u64) -> String {
+    for candidate in seed * 100.. {
+        let digits = first_digits::<9>(candidate + 943_476_591);
+        let sum: u32 = digits
+            .iter()
+            .enumerate()
+            .map(|(index, digit)| u32::from(*digit) * (10 - index as u32))
+            .sum();
+        let check = 11 - (sum % 11);
+        let check = if check == 11 { 0 } else { check };
+        if check != 10 {
+            let mut full = [0u8; 10];
+            full[..9].copy_from_slice(&digits);
+            full[9] = check as u8;
+            return digits_to_string(&full);
+        }
+    }
+    unreachable!("unbounded NHS generator finds a check digit")
+}
+
+fn first_digits<const N: usize>(mut value: u64) -> [u8; N] {
+    let mut digits = [0u8; N];
+    for digit in digits.iter_mut().rev() {
+        *digit = (value % 10) as u8;
+        value /= 10;
+    }
+    digits
+}
+
+fn cpf_check_digit(digits: &[u8], start_weight: u8) -> u8 {
+    let sum: u32 = digits
+        .iter()
+        .zip((2..=start_weight).rev())
+        .map(|(digit, weight)| u32::from(*digit) * u32::from(weight))
+        .sum();
+    let remainder = sum % 11;
+    if remainder < 2 {
+        0
+    } else {
+        (11 - remainder) as u8
+    }
+}
+
+fn weighted_check_digit(digits: &[u8], weights: &[u8]) -> u8 {
+    let sum: u32 = digits
+        .iter()
+        .zip(weights)
+        .map(|(digit, weight)| u32::from(*digit) * u32::from(*weight))
+        .sum();
+    let remainder = sum % 11;
+    if remainder < 2 {
+        0
+    } else {
+        (11 - remainder) as u8
+    }
+}
+
+fn digits_to_string(digits: &[u8]) -> String {
+    digits
+        .iter()
+        .map(|digit| char::from(b'0' + *digit))
+        .collect()
+}

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -352,6 +352,20 @@ pub enum ValidatorFailReason {
     Ipv6ParseFailed,
     /// EIP-55 Ethereum checksum validation failed.
     EthEip55ChecksumFailed,
+    /// Aadhaar Verhoeff checksum validation failed.
+    AadhaarVerhoeffFailed,
+    /// French NIR MOD-97 key validation failed.
+    FrNirMod97Failed,
+    /// German Steuer-ID MOD 11,10 checksum validation failed.
+    DeSteuerIdMod1110Failed,
+    /// Dutch BSN MOD-11 checksum validation failed.
+    BsnMod11Failed,
+    /// Brazilian CPF MOD-11 checksum validation failed.
+    CpfMod11Failed,
+    /// Brazilian CNPJ MOD-11 checksum validation failed.
+    CnpjMod11Failed,
+    /// UK NHS number MOD-11 checksum validation failed.
+    UkNhsMod11Failed,
 }
 
 /// Typed validator outcome used by the pre-resolver validator-veto phase.
@@ -401,6 +415,20 @@ pub enum ValidatorKind {
     Ipv6Parse,
     /// EIP-55 Ethereum address checksum validator.
     EthEip55,
+    /// Indian Aadhaar Verhoeff checksum validator.
+    AadhaarVerhoeff,
+    /// French NIR MOD-97 key validator.
+    FrNirMod97,
+    /// German Steuer-ID MOD 11,10 checksum validator.
+    DeSteuerIdMod1110,
+    /// Dutch BSN MOD-11 checksum validator.
+    BsnMod11,
+    /// Brazilian CPF MOD-11 checksum validator.
+    CpfMod11,
+    /// Brazilian CNPJ MOD-11 checksum validator.
+    CnpjMod11,
+    /// UK NHS number MOD-11 checksum validator.
+    UkNhsMod11,
 }
 
 /// Regions supported by national phone validators.
@@ -430,6 +458,13 @@ impl ValidatorKind {
             "ipv4_parse" => Ok(Self::Ipv4Parse),
             "ipv6_parse" => Ok(Self::Ipv6Parse),
             "eth_eip55" => Ok(Self::EthEip55),
+            "aadhaar_verhoeff" => Ok(Self::AadhaarVerhoeff),
+            "fr_nir_mod97" => Ok(Self::FrNirMod97),
+            "de_steuer_id_mod1110" => Ok(Self::DeSteuerIdMod1110),
+            "bsn_mod11" => Ok(Self::BsnMod11),
+            "cpf_mod11" => Ok(Self::CpfMod11),
+            "cnpj_mod11" => Ok(Self::CnpjMod11),
+            "uk_nhs_mod11" => Ok(Self::UkNhsMod11),
             other => Err(ValidatorKindParseError::UnsupportedValidator {
                 kind: other.to_string(),
             }),
@@ -438,7 +473,16 @@ impl ValidatorKind {
 
     /// Returns whether the validator accepts the input.
     pub fn validates(self, input: &str) -> bool {
-        self.canonical_form(input).is_some()
+        match self {
+            Self::AadhaarVerhoeff => aadhaar_verhoeff_check(input),
+            Self::FrNirMod97 => fr_nir_mod97_check(input),
+            Self::DeSteuerIdMod1110 => de_steuer_id_mod1110_check(input),
+            Self::BsnMod11 => bsn_mod11_check(input),
+            Self::CpfMod11 => cpf_mod11_check(input),
+            Self::CnpjMod11 => cnpj_mod11_check(input),
+            Self::UkNhsMod11 => uk_nhs_mod11_check(input),
+            _ => self.canonical_form(input).is_some(),
+        }
     }
 
     /// Applies validation and returns a typed outcome for audit.
@@ -466,6 +510,25 @@ impl ValidatorKind {
             Self::Ipv4Parse => ipv4_parse_check(input).then(|| input.to_string()),
             Self::Ipv6Parse => ipv6_parse_check(input).then(|| input.to_string()),
             Self::EthEip55 => eth_eip55_check(input).then(|| input.to_string()),
+            Self::AadhaarVerhoeff => {
+                canonical_ascii_digits::<12>(input).filter(|_| aadhaar_verhoeff_check(input))
+            }
+            Self::FrNirMod97 => {
+                canonical_ascii_digits::<15>(input).filter(|_| fr_nir_mod97_check(input))
+            }
+            Self::DeSteuerIdMod1110 => {
+                canonical_ascii_digits::<11>(input).filter(|_| de_steuer_id_mod1110_check(input))
+            }
+            Self::BsnMod11 => canonical_ascii_digits::<9>(input).filter(|_| bsn_mod11_check(input)),
+            Self::CpfMod11 => {
+                canonical_ascii_digits::<11>(input).filter(|_| cpf_mod11_check(input))
+            }
+            Self::CnpjMod11 => {
+                canonical_ascii_digits::<14>(input).filter(|_| cnpj_mod11_check(input))
+            }
+            Self::UkNhsMod11 => {
+                canonical_ascii_digits::<10>(input).filter(|_| uk_nhs_mod11_check(input))
+            }
         }
     }
 
@@ -482,6 +545,13 @@ impl ValidatorKind {
             Self::Ipv4Parse => ValidatorFailReason::Ipv4ParseFailed,
             Self::Ipv6Parse => ValidatorFailReason::Ipv6ParseFailed,
             Self::EthEip55 => ValidatorFailReason::EthEip55ChecksumFailed,
+            Self::AadhaarVerhoeff => ValidatorFailReason::AadhaarVerhoeffFailed,
+            Self::FrNirMod97 => ValidatorFailReason::FrNirMod97Failed,
+            Self::DeSteuerIdMod1110 => ValidatorFailReason::DeSteuerIdMod1110Failed,
+            Self::BsnMod11 => ValidatorFailReason::BsnMod11Failed,
+            Self::CpfMod11 => ValidatorFailReason::CpfMod11Failed,
+            Self::CnpjMod11 => ValidatorFailReason::CnpjMod11Failed,
+            Self::UkNhsMod11 => ValidatorFailReason::UkNhsMod11Failed,
         }
     }
 }
@@ -649,6 +719,212 @@ fn eth_eip55_check(input: &str) -> bool {
         }
     }
     true
+}
+
+fn collect_ascii_digits<const N: usize>(input: &str) -> Option<[u8; N]> {
+    let mut digits = [0u8; N];
+    let mut count = 0usize;
+    for byte in input.bytes() {
+        if byte.is_ascii_digit() {
+            if count == N {
+                return None;
+            }
+            digits[count] = byte - b'0';
+            count += 1;
+        } else if matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | b'-' | b'.' | b'/') {
+            continue;
+        } else {
+            return None;
+        }
+    }
+    (count == N).then_some(digits)
+}
+
+fn canonical_ascii_digits<const N: usize>(input: &str) -> Option<String> {
+    let digits = collect_ascii_digits::<N>(input)?;
+    let mut canonical = String::with_capacity(N);
+    for digit in digits {
+        canonical.push(char::from(b'0' + digit));
+    }
+    Some(canonical)
+}
+
+fn not_all_same<const N: usize>(digits: &[u8; N]) -> bool {
+    digits[1..].iter().any(|digit| *digit != digits[0])
+}
+
+fn aadhaar_verhoeff_check(input: &str) -> bool {
+    const D: [[u8; 10]; 10] = [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [1, 2, 3, 4, 0, 6, 7, 8, 9, 5],
+        [2, 3, 4, 0, 1, 7, 8, 9, 5, 6],
+        [3, 4, 0, 1, 2, 8, 9, 5, 6, 7],
+        [4, 0, 1, 2, 3, 9, 5, 6, 7, 8],
+        [5, 9, 8, 7, 6, 0, 4, 3, 2, 1],
+        [6, 5, 9, 8, 7, 1, 0, 4, 3, 2],
+        [7, 6, 5, 9, 8, 2, 1, 0, 4, 3],
+        [8, 7, 6, 5, 9, 3, 2, 1, 0, 4],
+        [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+    ];
+    const P: [[u8; 10]; 8] = [
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [1, 5, 7, 6, 2, 8, 3, 0, 9, 4],
+        [5, 8, 0, 3, 7, 9, 6, 1, 4, 2],
+        [8, 9, 1, 6, 0, 4, 3, 5, 2, 7],
+        [9, 4, 5, 3, 1, 2, 6, 8, 7, 0],
+        [4, 2, 8, 6, 5, 7, 3, 9, 0, 1],
+        [2, 7, 9, 3, 8, 0, 6, 4, 1, 5],
+        [7, 0, 4, 6, 9, 1, 3, 2, 5, 8],
+    ];
+    let Some(digits) = collect_ascii_digits::<12>(input) else {
+        return false;
+    };
+    if digits[0] < 2 || !not_all_same(&digits) {
+        return false;
+    }
+    let mut checksum = 0u8;
+    for (index, digit) in digits.iter().rev().enumerate() {
+        checksum = D[checksum as usize][P[index % 8][*digit as usize] as usize];
+    }
+    checksum == 0
+}
+
+fn fr_nir_mod97_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<15>(input) else {
+        return false;
+    };
+    if !matches!(digits[0], 1 | 2 | 3 | 4 | 7 | 8) {
+        return false;
+    }
+    let month = digits[3] * 10 + digits[4];
+    if !(1..=12).contains(&month) && !(20..=42).contains(&month) && !(50..=99).contains(&month) {
+        return false;
+    }
+    let mut number = 0u32;
+    for digit in &digits[..13] {
+        number = (number * 10 + u32::from(*digit)) % 97;
+    }
+    let key = u32::from(digits[13]) * 10 + u32::from(digits[14]);
+    97 - number == key
+}
+
+fn de_steuer_id_mod1110_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<11>(input) else {
+        return false;
+    };
+    if !steuer_id_first_ten_digits_valid(&digits) {
+        return false;
+    }
+    let mut product = 10u8;
+    for digit in &digits[..10] {
+        let mut sum = (*digit + product) % 10;
+        if sum == 0 {
+            sum = 10;
+        }
+        product = (2 * sum) % 11;
+    }
+    let check = (11 - product) % 10;
+    check == digits[10]
+}
+
+fn steuer_id_first_ten_digits_valid(digits: &[u8; 11]) -> bool {
+    if digits[0] == 0 {
+        return false;
+    }
+    let mut counts = [0u8; 10];
+    for digit in &digits[..10] {
+        counts[*digit as usize] += 1;
+    }
+    let repeated_digits = counts.iter().filter(|count| **count > 1).count();
+    let missing_digits = counts.iter().filter(|count| **count == 0).count();
+    let repeated_count_valid = counts.iter().any(|count| matches!(*count, 2 | 3));
+    repeated_digits == 1 && repeated_count_valid && matches!(missing_digits, 1 | 2)
+}
+
+fn bsn_mod11_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<9>(input) else {
+        return false;
+    };
+    if !not_all_same(&digits) {
+        return false;
+    }
+    let sum: i32 = digits[..8]
+        .iter()
+        .enumerate()
+        .map(|(index, digit)| i32::from(*digit) * (9 - index as i32))
+        .sum::<i32>()
+        - i32::from(digits[8]);
+    sum.rem_euclid(11) == 0
+}
+
+fn cpf_mod11_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<11>(input) else {
+        return false;
+    };
+    if !not_all_same(&digits) {
+        return false;
+    }
+    mod11_check_digit(&digits[..9], 10) == digits[9]
+        && mod11_check_digit(&digits[..10], 11) == digits[10]
+}
+
+fn cnpj_mod11_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<14>(input) else {
+        return false;
+    };
+    if !not_all_same(&digits) {
+        return false;
+    }
+    const FIRST: [u8; 12] = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+    const SECOND: [u8; 13] = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+    weighted_mod11_check_digit(&digits[..12], &FIRST) == digits[12]
+        && weighted_mod11_check_digit(&digits[..13], &SECOND) == digits[13]
+}
+
+fn uk_nhs_mod11_check(input: &str) -> bool {
+    let Some(digits) = collect_ascii_digits::<10>(input) else {
+        return false;
+    };
+    if !not_all_same(&digits) {
+        return false;
+    }
+    let sum: u32 = digits[..9]
+        .iter()
+        .enumerate()
+        .map(|(index, digit)| u32::from(*digit) * (10 - index as u32))
+        .sum();
+    let check = 11 - (sum % 11);
+    let check = if check == 11 { 0 } else { check };
+    check != 10 && check == u32::from(digits[9])
+}
+
+fn mod11_check_digit(digits: &[u8], start_weight: u8) -> u8 {
+    let weights = (2..=start_weight).rev();
+    let sum: u32 = digits
+        .iter()
+        .zip(weights)
+        .map(|(digit, weight)| u32::from(*digit) * u32::from(weight))
+        .sum();
+    let remainder = sum % 11;
+    if remainder < 2 {
+        0
+    } else {
+        (11 - remainder) as u8
+    }
+}
+
+fn weighted_mod11_check_digit(digits: &[u8], weights: &[u8]) -> u8 {
+    let sum: u32 = digits
+        .iter()
+        .zip(weights)
+        .map(|(digit, weight)| u32::from(*digit) * u32::from(*weight))
+        .sum();
+    let remainder = sum % 11;
+    if remainder < 2 {
+        0
+    } else {
+        (11 - remainder) as u8
+    }
 }
 
 /// A detected span and its class/source metadata.

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1291,6 +1291,13 @@ window_chars = 48
                 PiiClass::custom("credit_card"),
                 PiiClass::custom("ip_address"),
                 PiiClass::custom("eth_address"),
+                PiiClass::custom("aadhaar"),
+                PiiClass::custom("nir"),
+                PiiClass::custom("steuer_id"),
+                PiiClass::custom("bsn"),
+                PiiClass::custom("cpf"),
+                PiiClass::custom("cnpj"),
+                PiiClass::custom("nhs_number"),
                 PiiClass::custom("postal_code"),
             ])
         );

--- a/docs/architecture/locale-chain.md
+++ b/docs/architecture/locale-chain.md
@@ -47,6 +47,13 @@ every locale chain because `global` intersects all locale projections.
 | `core-extended` | `ip.v4` | `custom:ip_address` | `global` | `Ipv4Parse` |
 | `core-extended` | `ip.v6` | `custom:ip_address` | `global` | `Ipv6Parse` |
 | `core-extended` | `eth.address` | `custom:eth_address` | `global` | `EthEip55` |
+| `core` | `aadhaar.in` | `custom:aadhaar` | `en-IN`, `hi-IN` | `AadhaarVerhoeff` |
+| `core` | `nir.fr` | `custom:nir` | `fr-FR` | `FrNirMod97` |
+| `core` | `steuer_id.de` | `custom:steuer_id` | `de-DE`, `de-AT`, `de-CH` | `DeSteuerIdMod1110` |
+| `core` | `bsn.nl` | `custom:bsn` | `nl-NL` | `BsnMod11` |
+| `core` | `cpf.br` | `custom:cpf` | `pt-BR` | `CpfMod11` |
+| `core` | `cnpj.br` | `custom:cnpj` | `pt-BR` | `CnpjMod11` |
+| `core` | `nhs.uk` | `custom:nhs_number` | `en-GB` | `UkNhsMod11` |
 | `core-extended` | `postal.de` | `custom:postal_code` | `de-DE` | None |
 | `core-extended` | `postal.us` | `custom:postal_code` | `en-US` | None |
 | NER artifact | `ner` | `Name` | Policy-selected NER locale, or any locale when unset | None |

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -580,6 +580,13 @@ kind = "luhn"
 | `ipv4_parse` | IPv4-like candidates | `std::net::Ipv4Addr` parser validation. Rejects leading-zero octets, hex forms, short forms, and out-of-range octets. |
 | `ipv6_parse` | IPv6-like candidates | `std::net::Ipv6Addr` parser validation for RFC 4291 textual forms, including IPv4-embedded addresses. Rejects bracketed URI literals and zone-id suffixes. |
 | `eth_eip55` | Ethereum address candidates | EIP-55 checksum validation using Keccak-256. Mixed-case addresses must satisfy the checksum; all-lower and all-upper legacy forms are accepted. |
+| `aadhaar_verhoeff` | Aadhaar candidates | Verhoeff checksum validation for cue-anchored Indian Aadhaar recognizers. |
+| `fr_nir_mod97` | French NIR candidates | French NIR two-digit MOD-97 key validation. |
+| `de_steuer_id_mod1110` | German Steuer-ID candidates | ISO 7064 MOD 11,10 checksum validation. |
+| `bsn_mod11` | Dutch BSN candidates | Dutch 11-test checksum validation. |
+| `cpf_mod11` | Brazilian CPF candidates | Two-stage MOD-11 checksum validation with repeated-digit rejection. |
+| `cnpj_mod11` | Brazilian CNPJ candidates | Two-stage weighted MOD-11 checksum validation with repeated-digit rejection. |
+| `uk_nhs_mod11` | UK NHS number candidates | NHS MOD-11 checksum validation; check digit 10 is rejected. |
 
 Validator-backed regex candidates fail closed: a regex match whose validator
 returns false emits no detection. This is intentionally stricter than emitting


### PR DESCRIPTION
## Summary
- Adds one safe_default core recognizer each for Aadhaar, French NIR, German Steuer-ID, Dutch BSN, Brazilian CPF, Brazilian CNPJ, and UK NHS numbers.
- Adds typed ValidatorKind support plus recognizer wrapper modules for Verhoeff, MOD-97 NIR, MOD 11,10 Steuer-ID, and MOD-11 family checks.
- Adds locale cue bundles, CLI round-trip coverage, validator generated fixture tests, and policy/locale-chain docs.

## Five-axis review
- Reliability: checksum-backed recognizers reject last-digit mutants; Steuer-ID also enforces first-ten digit structure. All seven recognizers ship safety_tier = "safe_default" and remain locale/cue anchored.
- Reversibility: CLI and validator pipeline tests prove tokenization restores to the original input for all seven entities.
- Agentic-first: entities are bundled in core for locale-aware agent workflows and gated by explicit locale chains.
- Trust: typed validator kinds and fail reasons make each acceptance/rejection auditable and deterministic.
- Adopter ergonomics: BR/FR/IN/NL/UK locale bundles are available through bundled core with docs in policy and locale-chain tables.

No axis regression is intentional.

## Parity notes
- Fixtures include cloakrs-style examples for Aadhaar, NIR digit forms, Steuer-ID, BSN, CPF, CNPJ, and NHS.
- French NIR support in this PR is digit-only MOD-97. Corsica 2A/2B alphanumeric NIR shapes remain out of this batch because the current ValidatorKind contract canonicalizes ASCII digits.

## Local gates
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix
- cargo run -p xtask -- bundle-tokenization-drift
- cargo run -p xtask -- safety-net-sanity
- cargo run -p xtask -- recognizer-composition-validator
- cargo run -p xtask -- locale-cue-bundle-coherence
- cargo run -p xtask -- dylint-gate

Files changed: 18
Baseline.json diff lines: 0
CHANGELOG.md: untouched
