### PR TITLE
[agent] Add Tier 3 locale-gated regex IDs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -169,12 +169,19 @@ spawns.
 it, your current SafetyNet configuration (OpenAI Privacy Filter or
 none) is unchanged.
 
-### Tier 3 — Regex-only locale recognizers (queued)
+### Tier 3 — Regex-only locale recognizers (additive)
 
-Queued as a follow-up PR after Tier 2 merges. Adds US SSN, UK NINO, and
-Indian PAN as `safety_tier = "locale_gated"` recognizers — they fire
-only when the resolved locale matches. No validator math; cue-anchored
-in the style of the v0.6 cue-anchored Name detection.
+PR: to be filled with the Tier 3 pull request number before merge.
+
+Adds US SSN, UK NINO, and Indian PAN as `safety_tier = "locale_gated"`
+recognizers — they fire only when the resolved locale matches. No
+validator math; regex shape plus cue context only.
+
+| Entity     | Locale | Cue examples                              | ValidatorKind |
+| ---------- | ------ | ----------------------------------------- | ------------- |
+| US SSN     | US     | `SSN`, `Social Security Number`, `SS#`    | None          |
+| UK NINO    | UK     | `NINO`, `NI Number`, `National Insurance` | None          |
+| Indian PAN | IN     | `PAN`, `Permanent Account Number`, `पैन`  | None          |
 
 **Action required:** none — pure additive coverage when the relevant
 locale is set.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -171,7 +171,7 @@ none) is unchanged.
 
 ### Tier 3 — Regex-only locale recognizers (additive)
 
-PR: to be filled with the Tier 3 pull request number before merge.
+PR [#208](https://github.com/EmpireTwo/gaze/pull/208).
 
 Adds US SSN, UK NINO, and Indian PAN as `safety_tier = "locale_gated"`
 recognizers — they fire only when the resolved locale matches. No

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2716,6 +2716,9 @@ fn s2_cli_core_validator_locale_entities_tokenize_and_round_trip() {
         ("en-IN", "en-US", "Aadhaar 6741 8529 6303", "aadhaar"),
         ("en-GB", "fr-FR", "NHS number 943 476 5919", "nhs_number"),
         ("de-DE", "en-US", "Steuer-ID 48 954 371 207", "steuer_id"),
+        ("en-US", "en-GB", "SSN 123-45-6789", "ssn"),
+        ("en-GB", "en-US", "NINO AB123456C", "nino"),
+        ("en-IN", "en-US", "PAN ABCPA1234F", "pan"),
     ] {
         let value = clean_json_with_args(
             &["--rulepack-bundled=core", &format!("--locale={locale}")],

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -538,6 +538,63 @@ priority = 86
 
 [recognizers.token]
 
+[[recognizers]]
+id = "ssn.us"
+safety_tier = "locale_gated"
+class = "custom:ssn"
+enabled = true
+locales = ["en-US"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:ssn|social\s+security(?:\s+number)?|ss#)\s*[:#-]?\s*(\d{3}-\d{2}-\d{4}|\d{9})\b'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "nino.uk"
+safety_tier = "locale_gated"
+class = "custom:nino"
+enabled = true
+locales = ["en-GB"]
+
+[recognizers.match]
+kind = "regex"
+# Prefix letters follow HMRC NINO format constraints: D/F/I/Q/U/V are
+# excluded from both positions, O is excluded from the second position, and
+# BG, GB, KN, NK, NT, TN, and ZZ are not allocated.
+pattern = '''(?i)\b(?:nino|ni\s+number|national\s+insurance(?:\s+number)?)\s*[:#-]?\s*((?:[ACEHJLMOPRSWXY][ABCEGHJKLMNPRSTWXYZ]|B[ABCEHJKLMNPRSTWXYZ]|G[ACEGHJKLMNPRSTWXYZ]|K[ABCEGHJLMPRSTWXYZ]|N[ABCEGHJLMPRSWXYZ]|T[ABCEGHJKLMPRSTWXYZ]|Z[ABCEGHJKLMNPRSTWXY])\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D])\b'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
+[[recognizers]]
+id = "pan.in"
+safety_tier = "locale_gated"
+class = "custom:pan"
+enabled = true
+locales = ["en-IN", "hi-IN"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?i)\b(?:pan|permanent\s+account\s+number|pan\s+card|pan\s+no|पैन)\s*[:#-]?\s*([A-Z]{3}[ABCFGHJLPT][A-Z]\d{4}[A-Z])\b'''
+capture_groups = [1]
+
+[recognizers.scoring]
+base = 0.88
+priority = 86
+
+[recognizers.token]
+
 # Postal collision warning (research-855 §Collision matrix conclusion):
 # `postal.de` and `postal.us` both accept naked five-digit numeric strings.
 # This is safe only when active locale chains keep DE and US projections apart.

--- a/crates/gaze-recognizers/embedded/locale-en.toml
+++ b/crates/gaze-recognizers/embedded/locale-en.toml
@@ -27,3 +27,7 @@ window_chars = 64
 [locale.cues.vat-id]
 names = ["VAT", "VAT:", "VAT no", "VAT ID", "VAT number"]
 window_chars = 64
+
+[locale.cues.ssn]
+names = ["SSN", "Social Security", "Social Security Number", "SS#"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-in.toml
+++ b/crates/gaze-recognizers/embedded/locale-in.toml
@@ -6,3 +6,7 @@ default_locales = ["en-IN", "hi-IN"]
 [locale.cues.aadhaar]
 names = ["आधार", "Aadhaar", "UID", "Unique Identification"]
 window_chars = 64
+
+[locale.cues.pan]
+names = ["PAN", "Permanent Account Number", "PAN card", "PAN no", "पैन"]
+window_chars = 64

--- a/crates/gaze-recognizers/embedded/locale-uk.toml
+++ b/crates/gaze-recognizers/embedded/locale-uk.toml
@@ -6,3 +6,7 @@ default_locales = ["en-GB"]
 [locale.cues.nhs]
 names = ["NHS number", "NHS no", "NHS id"]
 window_chars = 64
+
+[locale.cues.nino]
+names = ["NINO", "NI Number", "National Insurance", "National Insurance Number"]
+window_chars = 64

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 23);
+        assert_eq!(rulepack.recognizers.len(), 26);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
@@ -96,7 +96,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 23);
+        assert_eq!(rulepack.recognizers.len(), 26);
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -144,6 +144,18 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
             PiiClass::Custom("credit_card".to_string()),
             Action::Tokenize,
         ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("ssn".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("nino".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("pan".to_string()),
+            Action::Tokenize,
+        ))
         .rule(DefaultRule::new(Action::Preserve));
 
     for spec in &rulepack.recognizers {
@@ -478,6 +490,67 @@ fn corpus_accepts_universal_shapes_and_rejects_tenant_like_phone_inputs() {
         detect_recognizer(&rulepack, "postal.us", "ZIP 94103-1234", LocaleTag::EnUs),
         vec!["94103-1234".to_string()]
     );
+
+    for (recognizer_id, locale, input, expected) in [
+        ("ssn.us", LocaleTag::EnUs, "SSN 123-45-6789", "123-45-6789"),
+        (
+            "ssn.us",
+            LocaleTag::EnUs,
+            "Social Security Number:\n123456789",
+            "123456789",
+        ),
+        (
+            "nino.uk",
+            LocaleTag::EnGb,
+            "National Insurance Number AB123456C",
+            "AB123456C",
+        ),
+        (
+            "nino.uk",
+            LocaleTag::EnGb,
+            "NI Number: AB 12 34 56 C",
+            "AB 12 34 56 C",
+        ),
+        (
+            "pan.in",
+            LocaleTag::Other("en-IN".to_string()),
+            "PAN card ABCPA1234F",
+            "ABCPA1234F",
+        ),
+        (
+            "pan.in",
+            LocaleTag::Other("hi-IN".to_string()),
+            "पैन ABCPA1234F",
+            "ABCPA1234F",
+        ),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, recognizer_id, input, locale),
+            vec![expected.to_string()],
+            "{input}"
+        );
+    }
+
+    for (recognizer_id, locale, input) in [
+        ("ssn.us", LocaleTag::EnUs, "Reference 123-45-6789"),
+        ("nino.uk", LocaleTag::EnGb, "Reference AB123456C"),
+        ("nino.uk", LocaleTag::EnGb, "NINO GB123456C"),
+        (
+            "pan.in",
+            LocaleTag::Other("en-IN".to_string()),
+            "Reference ABCPA1234F",
+        ),
+        (
+            "pan.in",
+            LocaleTag::Other("en-IN".to_string()),
+            "PAN ABCDA1234F",
+        ),
+    ] {
+        assert!(
+            detect_recognizer(&rulepack, recognizer_id, input, locale).is_empty(),
+            "{recognizer_id} must not fire for {input}"
+        );
+    }
 
     // Source: synthetic-non-reachable; no DE equivalent of NANPA 555-01XX exists.
     // +49 1555 0112233-style literals follow the documented DE fixture shape;

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1298,6 +1298,9 @@ window_chars = 48
                 PiiClass::custom("cpf"),
                 PiiClass::custom("cnpj"),
                 PiiClass::custom("nhs_number"),
+                PiiClass::custom("ssn"),
+                PiiClass::custom("nino"),
+                PiiClass::custom("pan"),
                 PiiClass::custom("postal_code"),
             ])
         );

--- a/docs/architecture/locale-chain.md
+++ b/docs/architecture/locale-chain.md
@@ -54,6 +54,9 @@ every locale chain because `global` intersects all locale projections.
 | `core` | `cpf.br` | `custom:cpf` | `pt-BR` | `CpfMod11` |
 | `core` | `cnpj.br` | `custom:cnpj` | `pt-BR` | `CnpjMod11` |
 | `core` | `nhs.uk` | `custom:nhs_number` | `en-GB` | `UkNhsMod11` |
+| `core` | `ssn.us` | `custom:ssn` | `en-US` | None |
+| `core` | `nino.uk` | `custom:nino` | `en-GB` | None |
+| `core` | `pan.in` | `custom:pan` | `en-IN`, `hi-IN` | None |
 | `core-extended` | `postal.de` | `custom:postal_code` | `de-DE` | None |
 | `core-extended` | `postal.us` | `custom:postal_code` | `en-US` | None |
 | NER artifact | `ner` | `Name` | Policy-selected NER locale, or any locale when unset | None |


### PR DESCRIPTION
## Summary

Adds v0.8 Tier 3 regex-only, cue-prefixed national ID coverage in one PR:

| Entity | Locale | Class | Recognizer | Safety tier | Validator |
| --- | --- | --- | --- | --- | --- |
| US SSN | `en-US` | `custom:ssn` | `ssn.us` | `locale_gated` | None |
| UK NINO | `en-GB` | `custom:nino` | `nino.uk` | `locale_gated` | None |
| Indian PAN | `en-IN`, `hi-IN` | `custom:pan` | `pan.in` | `locale_gated` | None |

No validator math is introduced. Each recognizer requires cue context in the regex and is gated by locale. PAN cues extend the existing `locale-in.toml`; `CHANGELOG.md` is untouched.

## Five-axis alignment

- Axis 1, reliability: expands coverage for three common national ID leak classes while keeping high-FP shapes behind locale activation and cue context.
- Axis 2, reversibility: uses normal manifest tokenization; CLI round-trip tests cover all three entities.
- Axis 4, trust: recognizers remain deterministic regex rules with no neural or checksum side effects; emitted classes are auditable through recognizer IDs.
- Axis 5, ergonomics: adopters get coverage with the existing `--locale` / policy locale surface.

## Notes

- NINO prefix restrictions follow HMRC guidance: D/F/I/Q/U/V excluded from both prefix positions, O excluded from second position, and BG/GB/KN/NK/NT/TN/ZZ disallowed.
- PAN fourth-character entity codes are restricted to the documented Income Tax Department status codes.
- `bundle-tokenization-drift` reported no snapshot diff, so no baseline re-snap was needed.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- bundle-tokenization-drift`
- `cargo run -p xtask -- safety-net-sanity`
- `cargo run -p xtask -- recognizer-composition-validator`
- `cargo run -p xtask -- locale-cue-bundle-coherence`
- `cargo run -p xtask -- fixture-citation-lint`
- `cargo run -p xtask -- dylint-gate` (local cargo-dylint skipped outside CI per gate behavior)
