### PR TITLE
[agent] Document v0.8 Kiji class taxonomy gap

### DIFF
--- a/docs/research/v0.8-kiji-class-gap.md
+++ b/docs/research/v0.8-kiji-class-gap.md
@@ -1,0 +1,90 @@
+# v0.8 Kiji Class-Taxonomy Gap
+
+## TL;DR
+
+- Kiji's public ONNX model card defines 26 BIO-tagged PII entity classes; this document assigns each class to one closed Gaze verdict bucket.
+- Bucket counts: 6 `beat-via-Tier-2`, 1 `beat-via-Tier-3`, 16 `observer-only-via-Tier-2.5`, 3 `parity`, 0 `deferred`.
+- Gaze beats Kiji where the deterministic recognizer is validator-backed: email, phone, credit card, IBAN, supported national-ID families, and supported tax-ID families.
+- Tier 2.5 broadens axis-1 defense in depth for Kiji-only classes, but it remains observer-only: it reports residual leak suspects and does not mutate clean text or the manifest.
+- The main taxonomy gap is not "no signal"; it is "no deterministic replacement path yet" for DOB, driver-license, passport, license-plate, credentials, account identifiers, and decomposed address fields.
+
+## Methodology
+
+Verdicts are assigned from the Gaze contract outward:
+
+1. `beat-via-Tier-2` means Gaze has a validator-backed deterministic recognizer for the class, or for a scoped locale family inside the Kiji class. This bucket cites `ValidatorKind` and the v0.8 locale-chain matrix.
+2. `beat-via-Tier-3` means Gaze has a locale-gated regex recognizer without checksum validation. In the current 26-class Kiji taxonomy, only `SSN` lands here.
+3. `observer-only-via-Tier-2.5` means no deterministic Gaze recognizer currently owns the class, but the Kiji DistilBERT safety-net backend can serve as post-clean defense in depth. This does not improve masking recall unless the finding is later promoted into a deterministic recognizer.
+4. `parity` means Gaze and Kiji both have a broadly comparable signal, with no validator-backed advantage for Gaze.
+5. `deferred` means neither deterministic Gaze nor Tier 2.5 has a useful coverage story. No Kiji class is assigned `deferred` in this pass.
+
+Primary sources:
+
+- Kiji model-card taxonomy: `DataikuNLP/kiji-pii-model-onnx` lists 26 entity types and 53 BIO labels: <https://huggingface.co/DataikuNLP/kiji-pii-model-onnx>.
+- Gaze validator contract: [`crates/gaze-types/src/lib.rs`](../../crates/gaze-types/src/lib.rs) defines `ValidatorKind` variants such as `EmailRfc`, `E164Phone`, `Luhn`, `IbanMod97`, `AadhaarVerhoeff`, `FrNirMod97`, `DeSteuerIdMod1110`, `BsnMod11`, `CpfMod11`, `CnpjMod11`, and `UkNhsMod11`.
+- Gaze recognizer registry view: [`docs/architecture/locale-chain.md`](../architecture/locale-chain.md) lists shipped recognizer IDs, classes, supported locales, safety tiers, and validators.
+- Gaze safety-net contract: [`docs/architecture/safety-nets.md`](../architecture/safety-nets.md) states that safety nets are observer-only, run after deterministic clean, and never mutate the manifest or restore path.
+- Kiji adapter implementation note: [`crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs`](../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs) currently maps the local adapter's normalized Kiji labels into Gaze's closed safety-net classes. The public 26-class source of truth remains the Hugging Face model card above.
+- Strategic inputs: Solo scratchpad 14 section B13 identifies Kiji classes missing from deterministic Gaze rulepacks; Solo scratchpad 18 defines the two-mode evaluation caveat for observer-only safety nets.
+
+## Per-Class Verdicts
+
+| Kiji class | Verdict | Rationale | Citation |
+| ---------- | ------- | --------- | -------- |
+| `AGE` | `observer-only-via-Tier-2.5` | No deterministic age recognizer is shipped; Kiji can only be used as a residual leak observer. | Kiji model card; safety-net observer contract |
+| `BUILDINGNUM` | `observer-only-via-Tier-2.5` | No standalone building-number rule exists; address decomposition is a Kiji-surface gap. | Scratchpad 18 corpus-gap notes; safety-net observer contract |
+| `CITY` | `observer-only-via-Tier-2.5` | Gaze has no deterministic city recognizer; location-like spans are safety-net suspects only. | `class_map.rs`; safety-net observer contract |
+| `COMPANYNAME` | `observer-only-via-Tier-2.5` | Gaze has no company-name rule equivalent; organization-like spans are currently safety-net suspects. | `class_map.rs`; safety-net observer contract |
+| `COUNTRY` | `observer-only-via-Tier-2.5` | Gaze has no country recognizer in the shipped deterministic registry. | `locale-chain.md`; safety-net observer contract |
+| `CREDITCARDNUMBER` | `beat-via-Tier-2` | `card.structural` uses the `Luhn` checksum validator, so Gaze rejects invalid card-like strings that an ML-only class can label. | `locale-chain.md`; `ValidatorKind::Luhn`; PR #202/#207 context |
+| `DATEOFBIRTH` | `observer-only-via-Tier-2.5` | DOB is explicitly identified as a deterministic rulepack gap; Tier 2.5 can only flag residual suspects. | Scratchpad 14 B13; scratchpad 18 corpus-gap notes |
+| `DRIVERLICENSENUM` | `observer-only-via-Tier-2.5` | No driver-license rulepack exists; locale-specific formats/checksums are future deterministic work. | Scratchpad 14 B13 |
+| `EMAIL` | `beat-via-Tier-2` | `email.global` is validator-backed by `EmailRfc`, giving deterministic shape validation before token emission. | `locale-chain.md`; `ValidatorKind::EmailRfc` |
+| `FIRSTNAME` | `parity` | Gaze covers person-name spans through cue-anchored rules and optional NER, but Kiji's first-name class is not checksum-validatable. | `locale-chain.md`; Kiji model card |
+| `IBAN` | `beat-via-Tier-2` | `iban.structural` uses `IbanMod97`, so Gaze validates the IBAN check digits before emitting a token. | `locale-chain.md`; `ValidatorKind::IbanMod97` |
+| `IDCARDNUM` | `observer-only-via-Tier-2.5` | Generic identity-card numbers are not represented by a shipped deterministic recognizer. | Scratchpad 14 B13 |
+| `LICENSEPLATENUM` | `observer-only-via-Tier-2.5` | No license-plate rule equivalent is shipped; Kiji contributes only observer coverage. | Scratchpad 14 B13 |
+| `NATIONALID` | `beat-via-Tier-2` | For supported locales, Gaze has validator-backed national-ID families including Aadhaar, NIR, Steuer-ID, BSN, and NHS; the claim is scoped to those families, not every possible national ID. | `locale-chain.md`; `ValidatorKind` national-ID variants; PR #207 |
+| `PASSPORTID` | `observer-only-via-Tier-2.5` | Passport IDs are listed as a deterministic taxonomy gap; Kiji coverage is defense-in-depth only. | Scratchpad 14 B13 |
+| `PASSWORD` | `observer-only-via-Tier-2.5` | Gaze has no deterministic password recognizer; credential-like residuals need safety-net reporting or future rulepack work. | Scratchpad 18 corpus-gap notes |
+| `PHONENUMBER` | `beat-via-Tier-2` | Structural and national phone recognizers use parser-backed E.164 and region validators. | `locale-chain.md`; `ValidatorKind::E164Phone`; `ValidatorKind::E164PhoneNational` |
+| `SECURITYTOKEN` | `observer-only-via-Tier-2.5` | Security/API tokens are a Kiji-surface gap for deterministic Gaze; Tier 2.5 can flag residual candidates only. | Scratchpad 14 B13; scratchpad 18 corpus-gap notes |
+| `SSN` | `beat-via-Tier-3` | `ssn.us` is a locale-gated regex recognizer; it improves deterministic coverage but is not checksum-backed. | `locale-chain.md`; PR #208 |
+| `STATE` | `observer-only-via-Tier-2.5` | Gaze has no deterministic state/province recognizer in the shipped registry. | `locale-chain.md`; safety-net observer contract |
+| `STREET` | `observer-only-via-Tier-2.5` | Street-name extraction is part of the address-decomposition gap, not a current deterministic recognizer. | Scratchpad 18 corpus-gap notes |
+| `SURNAME` | `parity` | Gaze covers person-name spans through cue-anchored rules and optional NER, but Kiji's surname class is not checksum-validatable. | `locale-chain.md`; Kiji model card |
+| `TAXNUM` | `beat-via-Tier-2` | For supported tax-ID families, Gaze uses checksum-backed validators such as Steuer-ID, CPF, CNPJ, NIR, and NHS; the verdict is scoped to those families. | `locale-chain.md`; `ValidatorKind` tax/health-ID variants; PR #207 |
+| `URL` | `observer-only-via-Tier-2.5` | URL is not present in the deterministic locale-chain matrix; observer coverage can report residual URL-like PII only. | `locale-chain.md`; safety-net observer contract |
+| `USERNAME` | `observer-only-via-Tier-2.5` | No deterministic username recognizer is shipped; Kiji can only provide post-clean residual reporting. | Scratchpad 18 corpus-gap notes |
+| `ZIP` | `parity` | Gaze ships DE/US postal-code recognizers, but without a validator-backed advantage over Kiji's ZIP class. | `locale-chain.md` |
+
+## Coverage Matrix Summary
+
+| Verdict | Count | Axis-1 impact |
+| ------- | ----- | ------------- |
+| `beat-via-Tier-2` | 6 | Strongest protection: deterministic token emission is gated by validators, reducing false positives and malformed-token substitutions before the manifest is written. |
+| `beat-via-Tier-3` | 1 | Deterministic coverage exists, but without checksum validation; locale gating narrows blast radius. |
+| `observer-only-via-Tier-2.5` | 16 | Defense in depth only: suspects can expose residual leaks after clean, but they do not rewrite bytes or improve restore round-trip behavior. |
+| `parity` | 3 | Comparable broad coverage without a validator-backed edge. |
+| `deferred` | 0 | No class is wholly uncovered once Tier 2.5 observer coverage is counted, but several classes still lack deterministic replacement paths. |
+
+Axis-1 interpretation:
+
+- Classes with `beat-via-Tier-2` are the only ones where this matrix should support a strong "Gaze beats Kiji" claim.
+- `observer-only-via-Tier-2.5` classes should be described as recall-oriented alerting, not as masking coverage. This follows the scratchpad 18 evaluation warning: observer residual recall is not end-to-end masking recall.
+- `parity` classes are useful adopter-facing answers to "does Gaze cover X?", but they do not establish a Gaze-over-Kiji quality claim without benchmark data.
+
+## Open Questions / Deferred Classes
+
+No class receives the literal `deferred` verdict in this pass because Tier 2.5 provides an observer story for the full Kiji taxonomy. The deterministic roadmap remains open for the following Kiji-surface classes:
+
+| Class family | Current verdict | Why it remains open |
+| ------------ | --------------- | ------------------- |
+| DOB | `observer-only-via-Tier-2.5` | Needs a locale-aware deterministic date-of-birth recognizer with context cues and age/date collision handling. |
+| Driver license | `observer-only-via-Tier-2.5` | Needs locale-specific formats and validators where available. |
+| Passport / ID card | `observer-only-via-Tier-2.5` | Needs clear split between passport, MRZ, national ID, and generic ID-card number policies. |
+| License plate | `observer-only-via-Tier-2.5` | Needs locale-specific plate formats and collision policy against order IDs and asset tags. |
+| Credentials | `observer-only-via-Tier-2.5` | Password, security-token, username, and URL coverage needs a separate credential/web/account taxonomy. |
+| Address decomposition | `observer-only-via-Tier-2.5` or `parity` for ZIP | Street, city, state, country, and building-number classes need an address-specific deterministic strategy. |
+
+These are v0.9+ candidates unless product scope pulls a subset forward. The v0.8 final-cut roadmap in Solo scratchpad 346 treats remaining Tier 2.5 items as a hoist decision rather than a release blocker.


### PR DESCRIPTION
## Summary
- add docs/research/v0.8-kiji-class-gap.md with one verdict row for each Kiji model-card class
- include bucket counts: 6 beat-via-Tier-2, 1 beat-via-Tier-3, 16 observer-only-via-Tier-2.5, 3 parity, 0 deferred
- cite the Kiji model card, Gaze validator/locale-chain docs, safety-net observer contract, and Solo research inputs

## Five-axis note
- Axis 1: clarifies where deterministic validator-backed protection exists versus observer-only defense in depth
- Axis 4: keeps claims tied to model-card labels, Gaze recognizer docs, and validator code
- Axis 5: gives adopters an answer to whether Gaze covers each Kiji class

No axis regression; doc-only.

## Verification
- counted 26 Kiji class rows
- verified closed verdict bucket counts
- checked no non-ASCII characters in the new doc
- CHANGELOG.md untouched