### PR TITLE
[agent] Add gaze proxy runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +635,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -725,6 +749,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,14 +821,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -949,6 +1014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1152,7 @@ dependencies = [
  "gaze-mcp-core",
  "gaze-mcp-rmcp",
  "gaze-pii",
+ "gaze-proxy",
  "gaze-recognizers",
  "gaze-types",
  "pdfium-render",
@@ -1087,6 +1163,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1178,6 +1255,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "gaze-proxy"
+version = "0.8.0-rc.1"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bytes",
+ "chrono",
+ "daemonize",
+ "dirs",
+ "fs2",
+ "futures-util",
+ "gaze-assembly",
+ "gaze-pii",
+ "gaze-recognizers",
+ "gaze-types",
+ "http",
+ "libc",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "toml 0.8.23",
+ "tower",
+ "tracing",
+ "tracing-appender",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "gaze-recognizers"
 version = "0.8.0-rc.1"
 dependencies = [
@@ -1231,8 +1341,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1531,6 +1643,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1539,13 +1668,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1573,6 +1710,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1802,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -1627,6 +1867,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -1691,6 +1937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +2003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +2031,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
@@ -1995,6 +2259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2350,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
@@ -2299,6 +2575,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2657,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2533,6 +2879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2955,47 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "ring"
@@ -2672,6 +3070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +3118,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2963,10 +3368,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -3119,6 +3543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3564,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "target-triple"
@@ -3210,6 +3654,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,6 +3771,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3291,6 +3786,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3414,6 +3919,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,6 +3961,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,6 +3992,23 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
@@ -3573,6 +4126,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "utf16string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,6 +4152,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3642,6 +4214,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3743,6 +4324,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4078,6 +4672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xtask"
 version = "0.0.1"
 dependencies = [
@@ -4093,6 +4693,29 @@ dependencies = [
  "sha2",
  "sha3",
  "tempfile",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -4116,10 +4739,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/gaze-document",
     "crates/gaze-mcp-core",
     "crates/gaze-mcp-rmcp",
+    "crates/gaze-proxy",
     "crates/xtask",
 ]
 resolver = "2"
@@ -21,6 +22,7 @@ license = "Apache-2.0 OR MIT"
 [workspace.dependencies]
 gaze-audit = { path = "crates/gaze-audit", version = "0.8.0-rc.1" }
 gaze-types = { path = "crates/gaze-types", version = "0.8.0-rc.1" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.8.0-rc.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -298,3 +298,25 @@ restore on a newer minor, that is a bug. Open an issue tagged
 `reversibility-regression` and we will treat it as a critical defect
 against north-star axis 2. There is no migration step that asks you to
 re-tokenize stored manifests.
+# v0.8.0
+
+## gaze-proxy
+
+The new off-by-default `proxy` feature adds `gaze-proxy` and `gaze proxy`
+subcommands for multi-provider LLM SDK base-URL swaps. OpenAI, Anthropic, and
+Gemini ship as separate provider adapters from day one. The proxy uses native
+provider wire shapes and does not transcode between providers.
+
+Daemon UX is available through:
+
+```bash
+gaze proxy serve
+gaze proxy start
+gaze proxy status
+gaze proxy logs --follow
+gaze proxy stop
+gaze proxy restart
+```
+
+Pidfiles are stored in platform local-data directories and stale pidfiles are
+cleaned after process liveness checks.

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -30,6 +30,7 @@ mcp = [
     "document",
     "gaze-document/mcp",
 ]
+proxy = ["dep:gaze-proxy", "dep:tokio"]
 
 [[bin]]
 name = "gaze"
@@ -47,6 +48,7 @@ gaze-audit = { workspace = true }
 gaze-document = { path = "../gaze-document", version = "0.8.0-rc.1", optional = true }
 gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1", optional = true }
 gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0-rc.1", optional = true }
+gaze-proxy = { workspace = true, optional = true }
 gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
@@ -55,6 +57,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 tracing = "0.1"
+url = "2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -4,6 +4,8 @@ mod clean;
 mod document;
 #[cfg(feature = "mcp")]
 mod mcp;
+#[cfg(feature = "proxy")]
+mod proxy;
 mod restore;
 
 use std::path::PathBuf;
@@ -141,6 +143,14 @@ enum Cmd {
         #[command(subcommand)]
         command: McpCmd,
     },
+    /// Run or manage the Gaze LLM proxy.
+    ///
+    /// Requires the binary to be built with `--features proxy`.
+    #[cfg(feature = "proxy")]
+    Proxy {
+        #[command(subcommand)]
+        command: ProxyCmd,
+    },
 }
 
 #[cfg(feature = "document")]
@@ -196,6 +206,76 @@ enum McpCmd {
         #[arg(long)]
         max_file_size: Option<u64>,
     },
+}
+
+#[cfg(feature = "proxy")]
+#[derive(Subcommand, Debug)]
+enum ProxyCmd {
+    /// Run proxy in the foreground.
+    Serve {
+        #[arg(long, default_value = "127.0.0.1:8787")]
+        bind: std::net::SocketAddr,
+        #[arg(long, default_value = "https://api.openai.com")]
+        upstream_openai: url::Url,
+        #[arg(long, default_value = "https://api.anthropic.com")]
+        upstream_anthropic: url::Url,
+        #[arg(long, default_value = "https://generativelanguage.googleapis.com")]
+        upstream_gemini: url::Url,
+        #[arg(long)]
+        policy: Option<PathBuf>,
+        #[arg(long, default_value = "core")]
+        rulepack: String,
+        #[arg(long, default_value = "30m")]
+        session_ttl: String,
+        #[arg(long = "_foreground-daemon", hide = true)]
+        foreground_daemon: bool,
+    },
+    /// Start proxy as a detached daemon.
+    Start {
+        #[arg(long)]
+        bind: Option<std::net::SocketAddr>,
+        #[arg(long)]
+        upstream_openai: Option<url::Url>,
+        #[arg(long)]
+        upstream_anthropic: Option<url::Url>,
+        #[arg(long)]
+        upstream_gemini: Option<url::Url>,
+        #[arg(long)]
+        policy: Option<PathBuf>,
+        #[arg(long)]
+        rulepack: Option<String>,
+        #[arg(long)]
+        session_ttl: Option<String>,
+    },
+    /// Stop the detached proxy daemon.
+    Stop {
+        #[arg(long)]
+        force: bool,
+        #[arg(long, default_value = "10s")]
+        timeout: String,
+    },
+    /// Show proxy daemon status.
+    Status,
+    /// Print proxy daemon logs.
+    Logs {
+        #[arg(long)]
+        follow: bool,
+    },
+    /// Restart proxy daemon using persisted config.
+    Restart {
+        #[arg(long)]
+        force: bool,
+        #[arg(long, default_value = "10s")]
+        timeout: String,
+    },
+    /// Install macOS launchd auto-start integration.
+    InstallLaunchd,
+    /// Uninstall macOS launchd auto-start integration.
+    UninstallLaunchd,
+    /// Install Linux systemd user auto-start integration.
+    InstallSystemdUser,
+    /// Uninstall Linux systemd user auto-start integration.
+    UninstallSystemdUser,
 }
 
 #[derive(Subcommand, Debug)]
@@ -588,6 +668,55 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 manifest_dir,
                 max_file_size,
             }),
+        },
+        #[cfg(feature = "proxy")]
+        Cmd::Proxy { command } => match command {
+            ProxyCmd::Serve {
+                bind,
+                upstream_openai,
+                upstream_anthropic,
+                upstream_gemini,
+                policy,
+                rulepack,
+                session_ttl,
+                foreground_daemon,
+            } => proxy::serve(proxy::ServeArgs {
+                bind,
+                upstream_openai,
+                upstream_anthropic,
+                upstream_gemini,
+                policy,
+                rulepack,
+                session_ttl,
+                foreground_daemon,
+            }),
+            ProxyCmd::Start {
+                bind,
+                upstream_openai,
+                upstream_anthropic,
+                upstream_gemini,
+                policy,
+                rulepack,
+                session_ttl,
+            } => proxy::start(proxy::StartArgs {
+                bind,
+                upstream_openai,
+                upstream_anthropic,
+                upstream_gemini,
+                policy,
+                rulepack,
+                session_ttl,
+            }),
+            ProxyCmd::Stop { force, timeout } => proxy::stop(proxy::StopArgs { force, timeout }),
+            ProxyCmd::Status => proxy::status(),
+            ProxyCmd::Logs { follow } => proxy::logs(follow),
+            ProxyCmd::Restart { force, timeout } => {
+                proxy::restart(proxy::RestartArgs { force, timeout })
+            }
+            ProxyCmd::InstallLaunchd => proxy::install_launchd(),
+            ProxyCmd::UninstallLaunchd => proxy::uninstall_launchd(),
+            ProxyCmd::InstallSystemdUser => proxy::install_systemd_user(),
+            ProxyCmd::UninstallSystemdUser => proxy::uninstall_systemd_user(),
         },
     }
 }

--- a/crates/gaze-cli/src/commands/proxy.rs
+++ b/crates/gaze-cli/src/commands/proxy.rs
@@ -1,0 +1,256 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use gaze_proxy::adapters::{AnthropicAdapter, GeminiAdapter, OpenAiAdapter};
+use gaze_proxy::daemon::{self, AdapterConfig, DaemonConfig, DaemonPaths};
+use gaze_proxy::ProxyConfig;
+use url::Url;
+
+use crate::error::CliError;
+use crate::pipeline::build::{
+    build_pipeline_from_policy, load_rulepacks, map_pipeline_error, map_policy_error,
+    merged_rulepack_default_locales, resolve_ner_threshold,
+};
+
+pub(crate) struct ServeArgs {
+    pub(crate) bind: SocketAddr,
+    pub(crate) upstream_openai: Url,
+    pub(crate) upstream_anthropic: Url,
+    pub(crate) upstream_gemini: Url,
+    pub(crate) policy: Option<PathBuf>,
+    pub(crate) rulepack: String,
+    pub(crate) session_ttl: String,
+    pub(crate) foreground_daemon: bool,
+}
+
+pub(crate) struct StartArgs {
+    pub(crate) bind: Option<SocketAddr>,
+    pub(crate) upstream_openai: Option<Url>,
+    pub(crate) upstream_anthropic: Option<Url>,
+    pub(crate) upstream_gemini: Option<Url>,
+    pub(crate) policy: Option<PathBuf>,
+    pub(crate) rulepack: Option<String>,
+    pub(crate) session_ttl: Option<String>,
+}
+
+pub(crate) struct StopArgs {
+    pub(crate) force: bool,
+    pub(crate) timeout: String,
+}
+
+pub(crate) struct RestartArgs {
+    pub(crate) force: bool,
+    pub(crate) timeout: String,
+}
+
+pub(crate) fn serve(args: ServeArgs) -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    if args.foreground_daemon {
+        daemon::init_foreground_daemon(&paths, args.bind).map_err(map_proxy)?;
+    }
+    let mut config = proxy_config(
+        args.bind,
+        args.upstream_openai,
+        args.upstream_anthropic,
+        args.upstream_gemini,
+    );
+    config.session_ttl = parse_duration(&args.session_ttl)?;
+    let pipeline = build_pipeline(args.policy, &args.rulepack)?;
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|err| CliError::ProxyDetail(format!("runtime: {err}")))?;
+    runtime
+        .block_on(gaze_proxy::serve(config, Arc::new(pipeline)))
+        .map_err(map_proxy)
+}
+
+pub(crate) fn start(args: StartArgs) -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    let mut config = daemon::read_or_default_config(&paths).map_err(map_proxy)?;
+    apply_start_overrides(&mut config, args);
+    let pid = daemon::start(daemon::StartOptions::new(paths.clone(), config.clone()))
+        .map_err(map_proxy)?;
+    println!(
+        "gaze-proxy started (pid={pid}, bind={}, log={})",
+        config.bind,
+        paths.log_file.display()
+    );
+    Ok(())
+}
+
+pub(crate) fn stop(args: StopArgs) -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    daemon::stop(daemon::StopOptions::new(
+        paths,
+        parse_duration(&args.timeout)?,
+        args.force,
+    ))
+    .map_err(map_proxy)?;
+    println!("gaze-proxy stopped");
+    Ok(())
+}
+
+pub(crate) fn status() -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    match daemon::status(&paths).map_err(map_proxy)? {
+        Some(status) if status.running => {
+            println!(
+                "gaze-proxy running (pid={}, bind={})",
+                status.pid,
+                status.bind.unwrap_or_else(|| "unknown".to_string())
+            );
+            let config = daemon::read_or_default_config(&paths).map_err(map_proxy)?;
+            println!("  adapters: openai -> {}", config.adapters.openai.upstream);
+            println!(
+                "            anthropic -> {}",
+                config.adapters.anthropic.upstream
+            );
+            println!("            gemini -> {}", config.adapters.gemini.upstream);
+        }
+        Some(status) => {
+            println!("gaze-proxy not running (stale pidfile pid={})", status.pid);
+        }
+        None => println!("gaze-proxy not running"),
+    }
+    Ok(())
+}
+
+pub(crate) fn logs(follow: bool) -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    daemon::logs(&paths, follow).map_err(map_proxy)
+}
+
+pub(crate) fn restart(args: RestartArgs) -> Result<(), CliError> {
+    let paths = DaemonPaths::resolve().map_err(map_proxy)?;
+    let config = daemon::read_or_default_config(&paths).map_err(map_proxy)?;
+    let pid = daemon::restart(
+        daemon::StartOptions::new(paths.clone(), config.clone()),
+        parse_duration(&args.timeout)?,
+        args.force,
+    )
+    .map_err(map_proxy)?;
+    println!(
+        "gaze-proxy restarted (pid={pid}, bind={}, log={})",
+        config.bind,
+        paths.log_file.display()
+    );
+    Ok(())
+}
+
+pub(crate) fn install_launchd() -> Result<(), CliError> {
+    Err(CliError::ProxyDetail(
+        "launchd integration is reserved for v0.8.x; use `gaze proxy start`".to_string(),
+    ))
+}
+
+pub(crate) fn uninstall_launchd() -> Result<(), CliError> {
+    Err(CliError::ProxyDetail(
+        "launchd integration is reserved for v0.8.x; use `gaze proxy stop`".to_string(),
+    ))
+}
+
+pub(crate) fn install_systemd_user() -> Result<(), CliError> {
+    Err(CliError::ProxyDetail(
+        "systemd user integration is reserved for v0.8.x; use `gaze proxy start`".to_string(),
+    ))
+}
+
+pub(crate) fn uninstall_systemd_user() -> Result<(), CliError> {
+    Err(CliError::ProxyDetail(
+        "systemd user integration is reserved for v0.8.x; use `gaze proxy stop`".to_string(),
+    ))
+}
+
+fn build_pipeline(policy: Option<PathBuf>, rulepack: &str) -> Result<gaze::Pipeline, CliError> {
+    if let Some(path) = policy {
+        let policy = gaze::Policy::load_for_cli(&path).map_err(map_policy_error)?;
+        let rulepacks = load_rulepacks(&policy).map_err(map_pipeline_error)?;
+        let rulepack_default_locales = merged_rulepack_default_locales(&rulepacks);
+        let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
+            None,
+            policy.locale.as_deref(),
+            Some(&rulepack_default_locales),
+        );
+        return build_pipeline_from_policy(
+            &policy,
+            &rulepacks,
+            None,
+            &locale_chain,
+            resolve_ner_threshold(None, Some(&policy)),
+        );
+    }
+    let mut config = gaze_assembly::CorePipelineConfig::new();
+    if rulepack != "core" {
+        config = config.with_bundled_rulepack(rulepack);
+    }
+    config
+        .build()
+        .map(gaze_assembly::CorePipeline::into_pipeline)
+        .map_err(|err| CliError::ProxyDetail(format!("pipeline: {err}")))
+}
+
+fn proxy_config(
+    bind: SocketAddr,
+    upstream_openai: Url,
+    upstream_anthropic: Url,
+    upstream_gemini: Url,
+) -> ProxyConfig {
+    ProxyConfig::new(
+        bind,
+        vec![
+            Arc::new(OpenAiAdapter::new(upstream_openai)),
+            Arc::new(AnthropicAdapter::new(upstream_anthropic)),
+            Arc::new(GeminiAdapter::new(upstream_gemini)),
+        ],
+    )
+}
+
+fn apply_start_overrides(config: &mut DaemonConfig, args: StartArgs) {
+    if let Some(bind) = args.bind {
+        config.bind = bind;
+    }
+    if let Some(policy) = args.policy {
+        config.policy = Some(policy);
+    }
+    if let Some(rulepack) = args.rulepack {
+        config.rulepack = Some(rulepack);
+    }
+    if let Some(session_ttl) = args.session_ttl {
+        config.session_ttl = session_ttl;
+    }
+    config.adapters = AdapterConfig::new(
+        args.upstream_openai
+            .unwrap_or_else(|| config.adapters.openai.upstream.clone()),
+        args.upstream_anthropic
+            .unwrap_or_else(|| config.adapters.anthropic.upstream.clone()),
+        args.upstream_gemini
+            .unwrap_or_else(|| config.adapters.gemini.upstream.clone()),
+    );
+}
+
+fn parse_duration(input: &str) -> Result<Duration, CliError> {
+    let trimmed = input.trim();
+    let parse_number = |suffix: &str| {
+        trimmed
+            .strip_suffix(suffix)
+            .and_then(|value| value.parse::<u64>().ok())
+    };
+    if let Some(minutes) = parse_number("m") {
+        Ok(Duration::from_secs(minutes * 60))
+    } else if let Some(seconds) = parse_number("s") {
+        Ok(Duration::from_secs(seconds))
+    } else if let Some(hours) = parse_number("h") {
+        Ok(Duration::from_secs(hours * 60 * 60))
+    } else if let Ok(seconds) = trimmed.parse::<u64>() {
+        Ok(Duration::from_secs(seconds))
+    } else {
+        Err(CliError::ProxyDetail(format!(
+            "invalid duration `{input}`; use Ns, Nm, Nh, or seconds"
+        )))
+    }
+}
+
+fn map_proxy(err: gaze_proxy::ProxyError) -> CliError {
+    CliError::ProxyDetail(err.to_string())
+}

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -46,6 +46,8 @@ pub(crate) enum CliError {
     DocumentDetail(String),
     #[cfg(feature = "mcp")]
     McpDetail(String),
+    #[cfg(feature = "proxy")]
+    ProxyDetail(String),
 }
 
 impl CliError {
@@ -69,6 +71,8 @@ impl CliError {
             Self::DocumentDetail(_) => 5,
             #[cfg(feature = "mcp")]
             Self::McpDetail(_) => 6,
+            #[cfg(feature = "proxy")]
+            Self::ProxyDetail(_) => 7,
         }
     }
 
@@ -96,6 +100,8 @@ impl CliError {
             Self::DocumentDetail(_) => "Document",
             #[cfg(feature = "mcp")]
             Self::McpDetail(_) => "Mcp",
+            #[cfg(feature = "proxy")]
+            Self::ProxyDetail(_) => "Proxy",
         }
     }
 
@@ -174,6 +180,17 @@ impl CliError {
             }
             #[cfg(feature = "mcp")]
             Self::McpDetail(detail) => {
+                let detail = serde_json::to_string(detail)
+                    .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
+                eprintln!(
+                    r#"{{"error":"{}","exit":{},"detail":{}}}"#,
+                    self.variant_name(),
+                    self.exit_code(),
+                    detail
+                )
+            }
+            #[cfg(feature = "proxy")]
+            Self::ProxyDetail(detail) => {
                 let detail = serde_json::to_string(detail)
                     .unwrap_or_else(|_| "\"<unserializable>\"".to_string());
                 eprintln!(

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "gaze-proxy"
+version = "0.8.0-rc.1"
+edition = "2021"
+rust-version = "1.89"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Feature-gated multi-provider HTTP proxy for Gaze PII pseudonymization"
+readme = "README.md"
+keywords = ["pii", "gaze", "proxy", "llm"]
+categories = ["web-programming::http-server", "text-processing"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["proxy-daemon"]
+proxy-daemon = ["dep:chrono", "dep:dirs", "dep:fs2", "dep:daemonize", "dep:tracing-appender"]
+
+[dependencies]
+async-trait = "0.1"
+axum = "0.8"
+bytes = "1"
+chrono = { version = "0.4", optional = true, default-features = false, features = ["clock", "std"] }
+daemonize = { version = "0.5", optional = true }
+dirs = { version = "6", optional = true }
+fs2 = { version = "0.4", optional = true }
+futures-util = "0.3"
+gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
+gaze-types = { workspace = true }
+http = "1"
+libc = "0.2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio-stream = "0.1"
+toml = "0.8"
+tower = "0.5"
+tracing = "0.1"
+tracing-appender = { version = "0.2", optional = true }
+url = { version = "2", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+tempfile = "3"
+tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -1,0 +1,66 @@
+# gaze-proxy
+
+`gaze-proxy` is the feature-gated HTTP proxy runtime for LLM SDK base-URL swaps.
+It preserves each provider's native wire shape and uses adapters only to locate
+PII-bearing fields before calling the supplied `gaze::Pipeline`.
+
+## Quickstart
+
+```bash
+cargo install gaze-cli --features proxy
+gaze proxy start
+```
+
+Then point SDKs at the daemon:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8787/v1
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8787
+```
+
+The default config is written to `~/.config/gaze/proxy.toml` and includes:
+
+```toml
+bind = "127.0.0.1:8787"
+session_ttl = "30m"
+rulepack = "core"
+
+[adapters.openai]
+upstream = "https://api.openai.com/"
+
+[adapters.anthropic]
+upstream = "https://api.anthropic.com/"
+
+[adapters.gemini]
+upstream = "https://generativelanguage.googleapis.com/"
+```
+
+## Providers
+
+- OpenAI: `POST /v1/chat/completions`, `/v1/completions`, `/v1/responses`
+- Anthropic: `POST /v1/messages`
+- Gemini: `POST /v1beta/models/*:{generateContent,streamGenerateContent,countTokens}`
+
+Each adapter walks text, tool-call, tool-result, and function argument surfaces
+in that provider's native JSON. The proxy does not transcode requests.
+
+## Daemon Commands
+
+```bash
+gaze proxy serve
+gaze proxy start
+gaze proxy status
+gaze proxy logs --follow
+gaze proxy stop
+gaze proxy restart
+```
+
+Pidfiles live under the platform local-data directory, never `/tmp`. Stale
+pidfiles are revalidated with process liveness checks and cleaned before start.
+
+## Security Notes
+
+Authentication headers are forwarded unchanged. The proxy does not own provider
+API keys and does not add an auth boundary around the local listener. Bind to
+loopback unless you are deliberately placing it behind a separate local access
+control layer.

--- a/crates/gaze-proxy/src/adapter.rs
+++ b/crates/gaze-proxy/src/adapter.rs
@@ -1,0 +1,108 @@
+use http::Method;
+use serde_json::Value;
+use url::Url;
+
+#[async_trait::async_trait]
+pub trait ProviderAdapter: Send + Sync + 'static {
+    fn name(&self) -> &'static str;
+    fn matches_path(&self, method: &Method, path: &str) -> bool;
+    fn upstream_base(&self) -> &Url;
+    fn request_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>>;
+    fn response_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>>;
+    fn sse_event_pii_surfaces<'a>(&self, event: &'a mut SseEvent) -> Vec<PiiSurface<'a>>;
+}
+
+pub struct PiiSurface<'a> {
+    pub field_path: String,
+    pub text: &'a mut String,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SseEvent {
+    pub event: Option<String>,
+    pub data: Value,
+}
+
+impl SseEvent {
+    pub fn new(event: Option<String>, data: Value) -> Self {
+        Self { event, data }
+    }
+}
+
+pub(crate) fn push_string<'a>(
+    surfaces: &mut Vec<PiiSurface<'a>>,
+    field_path: impl Into<String>,
+    value: &'a mut Value,
+) {
+    if let Value::String(text) = value {
+        surfaces.push(PiiSurface {
+            field_path: field_path.into(),
+            text,
+        });
+    }
+}
+
+pub(crate) fn walk_all_strings<'a>(
+    surfaces: &mut Vec<PiiSurface<'a>>,
+    prefix: String,
+    value: &'a mut Value,
+) {
+    match value {
+        Value::String(text) => surfaces.push(PiiSurface {
+            field_path: prefix,
+            text,
+        }),
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                walk_all_strings(surfaces, format!("{prefix}[{index}]"), item);
+            }
+        }
+        Value::Object(map) => {
+            for (key, child) in map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                walk_all_strings(surfaces, path, child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+pub(crate) fn push_text_blocks<'a>(
+    surfaces: &mut Vec<PiiSurface<'a>>,
+    prefix: &str,
+    value: &'a mut Value,
+) {
+    match value {
+        Value::String(text) => surfaces.push(PiiSurface {
+            field_path: prefix.to_string(),
+            text,
+        }),
+        Value::Array(items) => {
+            for (index, item) in items.iter_mut().enumerate() {
+                match item {
+                    Value::String(text) => surfaces.push(PiiSurface {
+                        field_path: format!("{prefix}[{index}]"),
+                        text,
+                    }),
+                    Value::Object(map) => {
+                        if matches!(map.get("type"), Some(Value::String(kind)) if kind == "text") {
+                            if let Some(Value::String(text)) = map.get_mut("text") {
+                                surfaces.push(PiiSurface {
+                                    field_path: format!("{prefix}[{index}].text"),
+                                    text,
+                                });
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/gaze-proxy/src/adapters/anthropic.rs
+++ b/crates/gaze-proxy/src/adapters/anthropic.rs
@@ -1,0 +1,144 @@
+use http::Method;
+use serde_json::Value;
+use url::Url;
+
+use crate::adapter::{
+    push_string, push_text_blocks, walk_all_strings, PiiSurface, ProviderAdapter, SseEvent,
+};
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct AnthropicAdapter {
+    upstream: Url,
+}
+
+impl AnthropicAdapter {
+    pub fn new(upstream: Url) -> Self {
+        Self { upstream }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for AnthropicAdapter {
+    fn name(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn matches_path(&self, method: &Method, path: &str) -> bool {
+        method == Method::POST && path == "/v1/messages"
+    }
+
+    fn upstream_base(&self) -> &Url {
+        &self.upstream
+    }
+
+    fn request_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        let mut surfaces = Vec::new();
+        if let Value::Object(root) = body {
+            for (key, value) in root {
+                match key.as_str() {
+                    "system" => push_text_blocks(&mut surfaces, "system", value),
+                    "messages" => {
+                        if let Value::Array(messages) = value {
+                            for (index, message) in messages.iter_mut().enumerate() {
+                                if let Value::Object(message) = message {
+                                    for (message_key, message_value) in message {
+                                        if message_key == "content" {
+                                            collect_content_blocks(
+                                                &mut surfaces,
+                                                &format!("messages[{index}].content"),
+                                                message_value,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        surfaces
+    }
+
+    fn response_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        let mut surfaces = Vec::new();
+        if let Value::Object(root) = body {
+            if let Some(content) = root.get_mut("content") {
+                collect_content_blocks(&mut surfaces, "content", content);
+            }
+        }
+        surfaces
+    }
+
+    fn sse_event_pii_surfaces<'a>(&self, event: &'a mut SseEvent) -> Vec<PiiSurface<'a>> {
+        let mut surfaces = Vec::new();
+        if let Value::Object(root) = &mut event.data {
+            if matches!(root.get("type"), Some(Value::String(kind)) if kind == "content_block_delta")
+            {
+                if let Some(Value::Object(delta)) = root.get_mut("delta") {
+                    for (key, value) in delta {
+                        if let Value::String(text) = value {
+                            match key.as_str() {
+                                "text" => surfaces.push(PiiSurface {
+                                    field_path: "delta.text".to_string(),
+                                    text,
+                                }),
+                                "partial_json" => surfaces.push(PiiSurface {
+                                    field_path: "delta.partial_json".to_string(),
+                                    text,
+                                }),
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        surfaces
+    }
+}
+
+fn collect_content_blocks<'a>(
+    surfaces: &mut Vec<PiiSurface<'a>>,
+    prefix: &str,
+    content: &'a mut Value,
+) {
+    match content {
+        Value::String(_) => push_string(surfaces, prefix, content),
+        Value::Array(blocks) => {
+            for (index, block) in blocks.iter_mut().enumerate() {
+                let Value::Object(block) = block else {
+                    continue;
+                };
+                match block.get("type").and_then(Value::as_str) {
+                    Some("text") => {
+                        if let Some(Value::String(text)) = block.get_mut("text") {
+                            surfaces.push(PiiSurface {
+                                field_path: format!("{prefix}[{index}].text"),
+                                text,
+                            });
+                        }
+                    }
+                    Some("tool_use") => {
+                        if let Some(input) = block.get_mut("input") {
+                            walk_all_strings(surfaces, format!("{prefix}[{index}].input"), input);
+                        }
+                    }
+                    Some("tool_result") => {
+                        if let Some(result) = block.get_mut("content") {
+                            collect_content_blocks(
+                                surfaces,
+                                &format!("{prefix}[{index}].content"),
+                                result,
+                            );
+                        }
+                    }
+                    Some("image") | None | Some(_) => {}
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/gaze-proxy/src/adapters/gemini.rs
+++ b/crates/gaze-proxy/src/adapters/gemini.rs
@@ -1,0 +1,137 @@
+use http::Method;
+use serde_json::Value;
+use url::Url;
+
+use crate::adapter::{walk_all_strings, PiiSurface, ProviderAdapter, SseEvent};
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct GeminiAdapter {
+    upstream: Url,
+}
+
+impl GeminiAdapter {
+    pub fn new(upstream: Url) -> Self {
+        Self { upstream }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for GeminiAdapter {
+    fn name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn matches_path(&self, method: &Method, path: &str) -> bool {
+        method == Method::POST
+            && path.starts_with("/v1beta/models/")
+            && (path.ends_with(":generateContent")
+                || path.ends_with(":streamGenerateContent")
+                || path.ends_with(":countTokens"))
+    }
+
+    fn upstream_base(&self) -> &Url {
+        &self.upstream
+    }
+
+    fn request_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        collect_gemini_surfaces(body, true)
+    }
+
+    fn response_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        collect_gemini_surfaces(body, false)
+    }
+
+    fn sse_event_pii_surfaces<'a>(&self, event: &'a mut SseEvent) -> Vec<PiiSurface<'a>> {
+        self.response_pii_surfaces(&mut event.data)
+    }
+}
+
+fn collect_gemini_surfaces(body: &mut Value, request: bool) -> Vec<PiiSurface<'_>> {
+    let mut surfaces = Vec::new();
+    if let Value::Object(root) = body {
+        if request {
+            for (key, value) in root {
+                match key.as_str() {
+                    "contents" => {
+                        if let Value::Array(contents) = value {
+                            for (index, content) in contents.iter_mut().enumerate() {
+                                collect_content(
+                                    &mut surfaces,
+                                    format!("contents[{index}]"),
+                                    content,
+                                );
+                            }
+                        }
+                    }
+                    "systemInstruction" => {
+                        collect_content(&mut surfaces, "systemInstruction".to_string(), value);
+                    }
+                    _ => {}
+                }
+            }
+        } else if let Some(Value::Array(candidates)) = root.get_mut("candidates") {
+            for (index, candidate) in candidates.iter_mut().enumerate() {
+                if let Value::Object(candidate) = candidate {
+                    if let Some(content) = candidate.get_mut("content") {
+                        collect_content(
+                            &mut surfaces,
+                            format!("candidates[{index}].content"),
+                            content,
+                        );
+                    }
+                }
+            }
+        }
+    }
+    surfaces
+}
+
+fn collect_content<'a>(surfaces: &mut Vec<PiiSurface<'a>>, prefix: String, value: &'a mut Value) {
+    let Value::Object(content) = value else {
+        return;
+    };
+    if let Some(Value::Array(parts)) = content.get_mut("parts") {
+        for (index, part) in parts.iter_mut().enumerate() {
+            let Value::Object(part) = part else {
+                continue;
+            };
+            for (key, value) in part {
+                match key.as_str() {
+                    "text" => {
+                        if let Value::String(text) = value {
+                            surfaces.push(PiiSurface {
+                                field_path: format!("{prefix}.parts[{index}].text"),
+                                text,
+                            });
+                        }
+                    }
+                    "functionCall" => {
+                        if let Some(args) =
+                            value.as_object_mut().and_then(|call| call.get_mut("args"))
+                        {
+                            walk_all_strings(
+                                surfaces,
+                                format!("{prefix}.parts[{index}].functionCall.args"),
+                                args,
+                            );
+                        }
+                    }
+                    "functionResponse" => {
+                        if let Some(response) = value
+                            .as_object_mut()
+                            .and_then(|call| call.get_mut("response"))
+                        {
+                            walk_all_strings(
+                                surfaces,
+                                format!("{prefix}.parts[{index}].functionResponse.response"),
+                                response,
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/crates/gaze-proxy/src/adapters/mod.rs
+++ b/crates/gaze-proxy/src/adapters/mod.rs
@@ -1,0 +1,7 @@
+pub mod anthropic;
+pub mod gemini;
+pub mod openai;
+
+pub use anthropic::AnthropicAdapter;
+pub use gemini::GeminiAdapter;
+pub use openai::OpenAiAdapter;

--- a/crates/gaze-proxy/src/adapters/openai.rs
+++ b/crates/gaze-proxy/src/adapters/openai.rs
@@ -1,0 +1,137 @@
+use http::Method;
+use serde_json::Value;
+use url::Url;
+
+use crate::adapter::{
+    push_string, push_text_blocks, walk_all_strings, PiiSurface, ProviderAdapter, SseEvent,
+};
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct OpenAiAdapter {
+    upstream: Url,
+}
+
+impl OpenAiAdapter {
+    pub fn new(upstream: Url) -> Self {
+        Self { upstream }
+    }
+}
+
+#[async_trait::async_trait]
+impl ProviderAdapter for OpenAiAdapter {
+    fn name(&self) -> &'static str {
+        "openai"
+    }
+
+    fn matches_path(&self, method: &Method, path: &str) -> bool {
+        method == Method::POST
+            && matches!(
+                path,
+                "/v1/chat/completions" | "/v1/completions" | "/v1/responses"
+            )
+    }
+
+    fn upstream_base(&self) -> &Url {
+        &self.upstream
+    }
+
+    fn request_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        let mut surfaces = Vec::new();
+        if let Value::Object(root) = body {
+            for (key, value) in root {
+                match key.as_str() {
+                    "system" => push_string(&mut surfaces, "system", value),
+                    "messages" => {
+                        if let Value::Array(messages) = value {
+                            for (index, message) in messages.iter_mut().enumerate() {
+                                collect_message_surfaces(
+                                    &mut surfaces,
+                                    format!("messages[{index}]"),
+                                    message,
+                                );
+                            }
+                        }
+                    }
+                    "input" => push_text_blocks(&mut surfaces, "input", value),
+                    _ => {}
+                }
+            }
+        }
+        surfaces
+    }
+
+    fn response_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
+        let mut surfaces = Vec::new();
+        if let Value::Object(root) = body {
+            for (key, value) in root {
+                match key.as_str() {
+                    "choices" => {
+                        if let Value::Array(choices) = value {
+                            for (index, choice) in choices.iter_mut().enumerate() {
+                                if let Value::Object(choice) = choice {
+                                    for (choice_key, choice_value) in choice {
+                                        match choice_key.as_str() {
+                                            "message" => collect_message_surfaces(
+                                                &mut surfaces,
+                                                format!("choices[{index}].message"),
+                                                choice_value,
+                                            ),
+                                            "delta" => collect_message_surfaces(
+                                                &mut surfaces,
+                                                format!("choices[{index}].delta"),
+                                                choice_value,
+                                            ),
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "output" => walk_all_strings(&mut surfaces, "output".to_string(), value),
+                    _ => {}
+                }
+            }
+        }
+        surfaces
+    }
+
+    fn sse_event_pii_surfaces<'a>(&self, event: &'a mut SseEvent) -> Vec<PiiSurface<'a>> {
+        self.response_pii_surfaces(&mut event.data)
+    }
+}
+
+fn collect_message_surfaces<'a>(
+    surfaces: &mut Vec<PiiSurface<'a>>,
+    prefix: String,
+    message: &'a mut Value,
+) {
+    let Value::Object(map) = message else {
+        return;
+    };
+    for (key, value) in map {
+        match key.as_str() {
+            "content" => push_text_blocks(surfaces, &format!("{prefix}.content"), value),
+            "tool_results" => push_text_blocks(surfaces, &format!("{prefix}.tool_results"), value),
+            "tool_calls" => {
+                if let Value::Array(tool_calls) = value {
+                    for (index, tool_call) in tool_calls.iter_mut().enumerate() {
+                        if let Value::Object(tool_call) = tool_call {
+                            if let Some(Value::Object(function)) = tool_call.get_mut("function") {
+                                if let Some(args) = function.get_mut("arguments") {
+                                    push_string(
+                                        surfaces,
+                                        format!("{prefix}.tool_calls[{index}].function.arguments"),
+                                        args,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/gaze-proxy/src/daemon.rs
+++ b/crates/gaze-proxy/src/daemon.rs
@@ -1,0 +1,539 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::ProxyError;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct DaemonPaths {
+    pub pidfile: PathBuf,
+    pub config: PathBuf,
+    pub log_file: PathBuf,
+    pub stderr_file: PathBuf,
+}
+
+impl DaemonPaths {
+    pub fn new(pidfile: PathBuf, config: PathBuf, log_file: PathBuf, stderr_file: PathBuf) -> Self {
+        Self {
+            pidfile,
+            config,
+            log_file,
+            stderr_file,
+        }
+    }
+
+    pub fn resolve() -> Result<Self, ProxyError> {
+        let data_dir = dirs::data_local_dir()
+            .ok_or_else(|| ProxyError::DaemonConfig {
+                detail: "could not resolve local data directory".to_string(),
+            })?
+            .join("gaze");
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| ProxyError::DaemonConfig {
+                detail: "could not resolve config directory".to_string(),
+            })?
+            .join("gaze");
+        let log_dir = if cfg!(target_os = "macos") {
+            dirs::home_dir()
+                .ok_or_else(|| ProxyError::DaemonConfig {
+                    detail: "could not resolve home directory".to_string(),
+                })?
+                .join("Library/Logs/gaze")
+        } else {
+            data_dir.join("Logs")
+        };
+        Ok(Self {
+            pidfile: data_dir.join("proxy.pid"),
+            config: config_dir.join("proxy.toml"),
+            log_file: log_dir.join("proxy.log"),
+            stderr_file: log_dir.join("proxy-stderr.log"),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DaemonConfig {
+    pub bind: SocketAddr,
+    pub session_ttl: String,
+    pub policy: Option<PathBuf>,
+    pub rulepack: Option<String>,
+    pub adapters: AdapterConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AdapterConfig {
+    pub openai: ProviderConfig,
+    pub anthropic: ProviderConfig,
+    pub gemini: ProviderConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProviderConfig {
+    pub upstream: Url,
+}
+
+impl ProviderConfig {
+    pub fn new(upstream: Url) -> Self {
+        Self { upstream }
+    }
+}
+
+impl AdapterConfig {
+    pub fn new(openai: Url, anthropic: Url, gemini: Url) -> Self {
+        Self {
+            openai: ProviderConfig::new(openai),
+            anthropic: ProviderConfig::new(anthropic),
+            gemini: ProviderConfig::new(gemini),
+        }
+    }
+}
+
+impl Default for AdapterConfig {
+    fn default() -> Self {
+        Self {
+            openai: ProviderConfig {
+                upstream: Url::parse("https://api.openai.com").expect("static url"),
+            },
+            anthropic: ProviderConfig {
+                upstream: Url::parse("https://api.anthropic.com").expect("static url"),
+            },
+            gemini: ProviderConfig {
+                upstream: Url::parse("https://generativelanguage.googleapis.com")
+                    .expect("static url"),
+            },
+        }
+    }
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            bind: "127.0.0.1:8787".parse().expect("static bind addr"),
+            session_ttl: "30m".to_string(),
+            policy: None,
+            rulepack: Some("core".to_string()),
+            adapters: AdapterConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct StartOptions {
+    pub paths: DaemonPaths,
+    pub config: DaemonConfig,
+    pub extra_args: Vec<String>,
+}
+
+impl StartOptions {
+    pub fn new(paths: DaemonPaths, config: DaemonConfig) -> Self {
+        Self {
+            paths,
+            config,
+            extra_args: Vec::new(),
+        }
+    }
+
+    pub fn with_extra_args(mut self, extra_args: Vec<String>) -> Self {
+        self.extra_args = extra_args;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct StopOptions {
+    pub paths: DaemonPaths,
+    pub timeout: Duration,
+    pub force: bool,
+}
+
+impl StopOptions {
+    pub fn new(paths: DaemonPaths, timeout: Duration, force: bool) -> Self {
+        Self {
+            paths,
+            timeout,
+            force,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DaemonStatus {
+    pub pid: u32,
+    pub bind: Option<String>,
+    pub started_at: Option<String>,
+    pub running: bool,
+}
+
+pub fn read_or_default_config(paths: &DaemonPaths) -> Result<DaemonConfig, ProxyError> {
+    if !paths.config.exists() {
+        return Ok(DaemonConfig::default());
+    }
+    let text = fs::read_to_string(&paths.config).map_err(|source| ProxyError::DaemonIo {
+        path: paths.config.clone(),
+        source,
+    })?;
+    toml::from_str(&text).map_err(|err| ProxyError::DaemonConfig {
+        detail: err.to_string(),
+    })
+}
+
+pub fn write_config(paths: &DaemonPaths, config: &DaemonConfig) -> Result<(), ProxyError> {
+    if let Some(parent) = paths.config.parent() {
+        fs::create_dir_all(parent).map_err(|source| ProxyError::DaemonIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let text = toml::to_string_pretty(config).map_err(|err| ProxyError::DaemonConfig {
+        detail: err.to_string(),
+    })?;
+    fs::write(&paths.config, text).map_err(|source| ProxyError::DaemonIo {
+        path: paths.config.clone(),
+        source,
+    })
+}
+
+pub fn start(options: StartOptions) -> Result<u32, ProxyError> {
+    cleanup_stale(&options.paths)?;
+    if let Some(status) = status(&options.paths)? {
+        if status.running {
+            return Err(ProxyError::DaemonAlreadyRunning {
+                pid: status.pid,
+                pidfile: options.paths.pidfile,
+            });
+        }
+    }
+    write_config(&options.paths, &options.config)?;
+    create_parent(&options.paths.pidfile)?;
+    create_parent(&options.paths.log_file)?;
+    let _lock = lock_pidfile(&options.paths)?;
+
+    let stdout = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&options.paths.log_file)
+        .map_err(|source| ProxyError::DaemonIo {
+            path: options.paths.log_file.clone(),
+            source,
+        })?;
+    let stderr = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&options.paths.stderr_file)
+        .map_err(|source| ProxyError::DaemonIo {
+            path: options.paths.stderr_file.clone(),
+            source,
+        })?;
+    let mut command =
+        Command::new(
+            std::env::current_exe().map_err(|source| ProxyError::DaemonIo {
+                path: PathBuf::from("current_exe"),
+                source,
+            })?,
+        );
+    command
+        .args(["proxy", "serve", "--_foreground-daemon"])
+        .arg("--bind")
+        .arg(options.config.bind.to_string())
+        .arg("--session-ttl")
+        .arg(&options.config.session_ttl)
+        .args(options.extra_args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    let child = command.spawn().map_err(|source| ProxyError::DaemonIo {
+        path: PathBuf::from("gaze proxy serve"),
+        source,
+    })?;
+    std::thread::sleep(Duration::from_millis(250));
+    if process_exists(child.id()) {
+        Ok(child.id())
+    } else {
+        Err(ProxyError::DaemonNotRunning)
+    }
+}
+
+pub fn init_foreground_daemon(paths: &DaemonPaths, bind: SocketAddr) -> Result<(), ProxyError> {
+    create_parent(&paths.pidfile)?;
+    create_parent(&paths.log_file)?;
+    let _lock = lock_pidfile(paths)?;
+    write_pidfile(&paths.pidfile, std::process::id(), bind, Utc::now())
+}
+
+pub fn stop(options: StopOptions) -> Result<(), ProxyError> {
+    cleanup_stale(&options.paths)?;
+    let Some(status) = status(&options.paths)? else {
+        return Err(ProxyError::DaemonNotRunning);
+    };
+    terminate(status.pid, false)?;
+    let started = Instant::now();
+    while started.elapsed() < options.timeout {
+        if !process_exists(status.pid) {
+            let _ = fs::remove_file(&options.paths.pidfile);
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    if options.force {
+        terminate(status.pid, true)?;
+        let _ = fs::remove_file(&options.paths.pidfile);
+        Ok(())
+    } else {
+        Err(ProxyError::DaemonAlreadyRunning {
+            pid: status.pid,
+            pidfile: options.paths.pidfile,
+        })
+    }
+}
+
+pub fn restart(options: StartOptions, timeout: Duration, force: bool) -> Result<u32, ProxyError> {
+    let stop_result = stop(StopOptions {
+        paths: options.paths.clone(),
+        timeout,
+        force,
+    });
+    if !matches!(stop_result, Ok(()) | Err(ProxyError::DaemonNotRunning)) {
+        cleanup_stale(&options.paths)?;
+    }
+    start(options)
+}
+
+pub fn status(paths: &DaemonPaths) -> Result<Option<DaemonStatus>, ProxyError> {
+    if !paths.pidfile.exists() {
+        return Ok(None);
+    }
+    let record = read_pidfile(&paths.pidfile)?;
+    Ok(Some(DaemonStatus {
+        running: process_exists(record.pid),
+        pid: record.pid,
+        bind: record.bind,
+        started_at: record.started_at,
+    }))
+}
+
+pub fn cleanup_stale(paths: &DaemonPaths) -> Result<(), ProxyError> {
+    if let Some(status) = status(paths)? {
+        if !status.running {
+            fs::remove_file(&paths.pidfile).map_err(|source| ProxyError::DaemonIo {
+                path: paths.pidfile.clone(),
+                source,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+pub fn logs(paths: &DaemonPaths, follow: bool) -> Result<(), ProxyError> {
+    if follow {
+        Command::new("tail")
+            .arg("-F")
+            .arg(&paths.log_file)
+            .status()
+            .map_err(|source| ProxyError::DaemonIo {
+                path: paths.log_file.clone(),
+                source,
+            })?;
+    } else if paths.log_file.exists() {
+        let text = fs::read_to_string(&paths.log_file).map_err(|source| ProxyError::DaemonIo {
+            path: paths.log_file.clone(),
+            source,
+        })?;
+        print!("{text}");
+    }
+    Ok(())
+}
+
+fn create_parent(path: &Path) -> Result<(), ProxyError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| ProxyError::DaemonIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn lock_pidfile(paths: &DaemonPaths) -> Result<File, ProxyError> {
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&paths.pidfile)
+        .map_err(|source| ProxyError::DaemonIo {
+            path: paths.pidfile.clone(),
+            source,
+        })?;
+    file.try_lock_exclusive()
+        .map_err(|source| ProxyError::DaemonIo {
+            path: paths.pidfile.clone(),
+            source,
+        })?;
+    Ok(file)
+}
+
+fn write_pidfile(
+    path: &Path,
+    pid: u32,
+    bind: SocketAddr,
+    started_at: DateTime<Utc>,
+) -> Result<(), ProxyError> {
+    let contents = format!(
+        "{pid}\nbind={bind}\nstarted_at={}\n",
+        started_at.to_rfc3339()
+    );
+    if contents.len() > 200 {
+        return Err(ProxyError::DaemonConfig {
+            detail: "pidfile content exceeds 200 bytes".to_string(),
+        });
+    }
+    fs::write(path, contents).map_err(|source| ProxyError::DaemonIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+struct PidRecord {
+    pid: u32,
+    bind: Option<String>,
+    started_at: Option<String>,
+}
+
+fn read_pidfile(path: &Path) -> Result<PidRecord, ProxyError> {
+    let mut text = String::new();
+    File::open(path)
+        .and_then(|mut file| file.read_to_string(&mut text))
+        .map_err(|source| ProxyError::DaemonIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let mut lines = text.lines();
+    let pid = lines
+        .next()
+        .ok_or_else(|| ProxyError::DaemonPidfileStale {
+            pidfile: path.to_path_buf(),
+        })?
+        .parse::<u32>()
+        .map_err(|_| ProxyError::DaemonPidfileStale {
+            pidfile: path.to_path_buf(),
+        })?;
+    let mut bind = None;
+    let mut started_at = None;
+    for line in lines {
+        if let Some(rest) = line.strip_prefix("bind=") {
+            bind = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("started_at=") {
+            started_at = Some(rest.to_string());
+        }
+    }
+    Ok(PidRecord {
+        pid,
+        bind,
+        started_at,
+    })
+}
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn process_exists(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn terminate(pid: u32, force: bool) -> Result<(), ProxyError> {
+    let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
+    let rc = unsafe { libc::kill(pid as libc::pid_t, signal) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(ProxyError::DaemonNotRunning)
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate(_pid: u32, _force: bool) -> Result<(), ProxyError> {
+    Err(ProxyError::DaemonConfig {
+        detail: "daemon stop is not implemented on this platform".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_paths(dir: &tempfile::TempDir) -> DaemonPaths {
+        DaemonPaths {
+            pidfile: dir.path().join("proxy.pid"),
+            config: dir.path().join("proxy.toml"),
+            log_file: dir.path().join("proxy.log"),
+            stderr_file: dir.path().join("proxy-stderr.log"),
+        }
+    }
+
+    #[test]
+    fn pidfile_round_trip_includes_bind_and_started_at() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = temp_paths(&dir);
+        write_pidfile(
+            &paths.pidfile,
+            123,
+            "127.0.0.1:8787".parse().unwrap(),
+            DateTime::parse_from_rfc3339("2026-05-14T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .unwrap();
+        let status = status(&paths).unwrap().unwrap();
+        assert_eq!(status.pid, 123);
+        assert_eq!(status.bind.as_deref(), Some("127.0.0.1:8787"));
+        assert!(!status.running);
+    }
+
+    #[test]
+    fn cleanup_stale_unlinks_dead_pidfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = temp_paths(&dir);
+        write_pidfile(
+            &paths.pidfile,
+            999_999,
+            "127.0.0.1:8787".parse().unwrap(),
+            Utc::now(),
+        )
+        .unwrap();
+        cleanup_stale(&paths).unwrap();
+        assert!(!paths.pidfile.exists());
+    }
+
+    #[test]
+    fn config_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = temp_paths(&dir);
+        let config = DaemonConfig::default();
+        write_config(&paths, &config).unwrap();
+        let loaded = read_or_default_config(&paths).unwrap();
+        assert_eq!(loaded.bind, config.bind);
+        assert_eq!(
+            loaded.adapters.openai.upstream,
+            config.adapters.openai.upstream
+        );
+    }
+}

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use http::Method;
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ProxyError {
+    #[error("upstream unreachable: {url}")]
+    UpstreamUnreachable {
+        url: Url,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("adapter not found for {method} {path}")]
+    AdapterNotFound { path: String, method: Method },
+    #[error("body too large: limit {limit_bytes} bytes")]
+    BodyTooLarge { limit_bytes: u64 },
+    #[error("invalid json body")]
+    InvalidJson {
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("sse partial frame: {reason}")]
+    SsePartialFrame { reason: String },
+    #[error("pipeline failed")]
+    Pipeline {
+        #[source]
+        source: gaze::Error,
+    },
+    #[error("http server failed")]
+    Server {
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("daemon already running: pid {pid} ({pidfile})", pidfile = pidfile.display())]
+    DaemonAlreadyRunning { pid: u32, pidfile: PathBuf },
+    #[error("daemon is not running")]
+    DaemonNotRunning,
+    #[error("daemon pidfile stale: {pidfile}", pidfile = pidfile.display())]
+    DaemonPidfileStale { pidfile: PathBuf },
+    #[error("daemon io failed: {path}", path = path.display())]
+    DaemonIo {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("daemon config failed: {detail}")]
+    DaemonConfig { detail: String },
+}

--- a/crates/gaze-proxy/src/lib.rs
+++ b/crates/gaze-proxy/src/lib.rs
@@ -1,0 +1,51 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+//! Multi-provider pass-through proxy for Gaze pseudonymization.
+//!
+//! The proxy does not transcode provider wire formats. Provider adapters only
+//! identify native PII-bearing JSON surfaces; the server applies the supplied
+//! [`gaze::Pipeline`] and session manifest.
+
+pub mod adapter;
+pub mod adapters;
+#[cfg(feature = "proxy-daemon")]
+pub mod daemon;
+pub mod error;
+pub mod server;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use gaze::Pipeline;
+
+pub use adapter::{PiiSurface, ProviderAdapter, SseEvent};
+pub use error::ProxyError;
+pub use server::{serve, HealthSnapshot};
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct ProxyConfig {
+    pub bind: SocketAddr,
+    pub adapters: Vec<Arc<dyn ProviderAdapter>>,
+    pub session_ttl: Duration,
+    pub body_limit_bytes: u64,
+}
+
+impl ProxyConfig {
+    pub fn new(bind: SocketAddr, adapters: Vec<Arc<dyn ProviderAdapter>>) -> Self {
+        Self {
+            bind,
+            adapters,
+            session_ttl: Duration::from_secs(30 * 60),
+            body_limit_bytes: 2 * 1024 * 1024,
+        }
+    }
+}
+
+pub async fn serve_foreground(
+    config: ProxyConfig,
+    pipeline: Arc<Pipeline>,
+) -> Result<(), ProxyError> {
+    serve(config, pipeline).await
+}

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1,0 +1,424 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use gaze::{token_shape, CleanDocument, Pipeline, RawDocument, Scope, Session};
+use reqwest::Client;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use url::Url;
+
+use crate::adapter::{ProviderAdapter, SseEvent};
+use crate::error::ProxyError;
+use crate::ProxyConfig;
+
+const SESSION_HEADER: &str = "x-gaze-session-id";
+
+#[derive(Clone)]
+struct AppState {
+    config: Arc<ProxyConfig>,
+    pipeline: Arc<Pipeline>,
+    client: Client,
+    sessions: Arc<RwLock<HashMap<String, SessionEntry>>>,
+    started_at: Instant,
+}
+
+struct SessionEntry {
+    session: Arc<Session>,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct HealthSnapshot {
+    pub uptime_secs: u64,
+    pub bind: String,
+    pub adapters: Vec<AdapterSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct AdapterSnapshot {
+    pub name: &'static str,
+    pub upstream: String,
+}
+
+pub async fn serve(config: ProxyConfig, pipeline: Arc<Pipeline>) -> Result<(), ProxyError> {
+    let bind = config.bind;
+    let state = AppState {
+        config: Arc::new(config),
+        pipeline,
+        client: Client::new(),
+        sessions: Arc::new(RwLock::new(HashMap::new())),
+        started_at: Instant::now(),
+    };
+    let app = Router::new()
+        .route("/_gaze_proxy/healthz", get(healthz))
+        .fallback(proxy)
+        .with_state(state);
+    let listener = TcpListener::bind(bind)
+        .await
+        .map_err(|source| ProxyError::Server { source })?;
+    axum::serve(listener, app)
+        .await
+        .map_err(|source| ProxyError::Server { source })
+}
+
+async fn healthz(State(state): State<AppState>) -> impl IntoResponse {
+    axum::Json(health_snapshot(&state))
+}
+
+fn health_snapshot(state: &AppState) -> HealthSnapshot {
+    HealthSnapshot {
+        uptime_secs: state.started_at.elapsed().as_secs(),
+        bind: state.config.bind.to_string(),
+        adapters: state
+            .config
+            .adapters
+            .iter()
+            .map(|adapter| AdapterSnapshot {
+                name: adapter.name(),
+                upstream: adapter.upstream_base().to_string(),
+            })
+            .collect(),
+    }
+}
+
+async fn proxy(
+    State(state): State<AppState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    match proxy_inner(state, method, uri, headers, body).await {
+        Ok(response) => response,
+        Err(err) => proxy_error_response(err),
+    }
+}
+
+async fn proxy_inner(
+    state: AppState,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ProxyError> {
+    if body.len() as u64 > state.config.body_limit_bytes {
+        return Err(ProxyError::BodyTooLarge {
+            limit_bytes: state.config.body_limit_bytes,
+        });
+    }
+    let path = uri.path();
+    let adapter = state
+        .config
+        .adapters
+        .iter()
+        .find(|adapter| adapter.matches_path(&method, path))
+        .cloned()
+        .ok_or_else(|| ProxyError::AdapterNotFound {
+            path: path.to_string(),
+            method: method.clone(),
+        })?;
+    let session = session_for(&state, &headers).await?;
+    let mut json: Value =
+        serde_json::from_slice(&body).map_err(|source| ProxyError::InvalidJson { source })?;
+    redact_surfaces(
+        &state.pipeline,
+        &session,
+        adapter.request_pii_surfaces(&mut json),
+    )?;
+
+    let upstream_url = upstream_url(adapter.upstream_base(), &uri)?;
+    let mut request = state
+        .client
+        .request(method.clone(), upstream_url.clone())
+        .json(&json);
+    request = forward_headers(request, &headers);
+    let upstream = request
+        .send()
+        .await
+        .map_err(|source| ProxyError::UpstreamUnreachable {
+            url: upstream_url.clone(),
+            source,
+        })?;
+
+    let status = upstream.status();
+    let upstream_headers = upstream.headers().clone();
+    let content_type = upstream_headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let bytes = upstream
+        .bytes()
+        .await
+        .map_err(|source| ProxyError::UpstreamUnreachable {
+            url: upstream_url,
+            source,
+        })?;
+
+    let body = if content_type.contains("text/event-stream") {
+        transform_sse(&adapter, &session, &bytes)?
+    } else {
+        let mut response_json: Value =
+            serde_json::from_slice(&bytes).map_err(|source| ProxyError::InvalidJson { source })?;
+        restore_surfaces(&session, adapter.response_pii_surfaces(&mut response_json));
+        serde_json::to_vec(&response_json).map_err(|source| ProxyError::InvalidJson { source })?
+    };
+
+    let mut response = Response::builder().status(status);
+    for (name, value) in upstream_headers {
+        if let Some(name) = name {
+            response = response.header(name, value);
+        }
+    }
+    response
+        .body(axum::body::Body::from(body))
+        .map_err(|source| ProxyError::DaemonConfig {
+            detail: source.to_string(),
+        })
+}
+
+async fn session_for(state: &AppState, headers: &HeaderMap) -> Result<Arc<Session>, ProxyError> {
+    let now = Instant::now();
+    let id = headers
+        .get(SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    {
+        let sessions = state.sessions.read().await;
+        if let Some(entry) = sessions.get(&id) {
+            if entry.expires_at > now {
+                return Ok(entry.session.clone());
+            }
+        }
+    }
+
+    let session = Arc::new(
+        Session::new(Scope::Conversation(id.clone()))
+            .map_err(|source| ProxyError::Pipeline { source })?,
+    );
+    let mut sessions = state.sessions.write().await;
+    sessions.retain(|_, entry| entry.expires_at > now);
+    sessions.insert(
+        id,
+        SessionEntry {
+            session: session.clone(),
+            expires_at: now + state.config.session_ttl,
+        },
+    );
+    Ok(session)
+}
+
+fn redact_surfaces(
+    pipeline: &Pipeline,
+    session: &Session,
+    surfaces: Vec<crate::adapter::PiiSurface<'_>>,
+) -> Result<(), ProxyError> {
+    for surface in surfaces {
+        let clean = pipeline
+            .redact(session, RawDocument::Text(surface.text.clone()))
+            .map_err(|source| ProxyError::Pipeline { source })?;
+        if let CleanDocument::Text(text) = clean {
+            *surface.text = text;
+        }
+    }
+    Ok(())
+}
+
+fn restore_surfaces(session: &Session, surfaces: Vec<crate::adapter::PiiSurface<'_>>) {
+    for surface in surfaces {
+        *surface.text = restore_text(session, surface.text);
+    }
+}
+
+fn restore_text(session: &Session, clean: &str) -> String {
+    let mut restored = String::new();
+    let mut last = 0;
+    for matched in token_shape::pattern().find_iter(clean) {
+        restored.push_str(&clean[last..matched.start()]);
+        if let Some(raw) = session.restore(matched.as_str()) {
+            restored.push_str(&raw);
+        } else {
+            restored.push_str(matched.as_str());
+        }
+        last = matched.end();
+    }
+    restored.push_str(&clean[last..]);
+    restored
+}
+
+fn transform_sse(
+    adapter: &Arc<dyn ProviderAdapter>,
+    session: &Session,
+    bytes: &[u8],
+) -> Result<Vec<u8>, ProxyError> {
+    let text = std::str::from_utf8(bytes).map_err(|err| ProxyError::SsePartialFrame {
+        reason: err.to_string(),
+    })?;
+    let mut out = String::new();
+    for frame in text.split("\n\n") {
+        if frame.trim().is_empty() {
+            continue;
+        }
+        let mut event_name = None;
+        let mut data_lines = Vec::new();
+        for line in frame.lines() {
+            if let Some(rest) = line.strip_prefix("event:") {
+                event_name = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                data_lines.push(rest.trim_start());
+            } else {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        let data = data_lines.join("\n");
+        if data == "[DONE]" {
+            if let Some(name) = event_name {
+                out.push_str("event: ");
+                out.push_str(&name);
+                out.push('\n');
+            }
+            out.push_str("data: [DONE]\n\n");
+            continue;
+        }
+        let mut event = SseEvent {
+            event: event_name.clone(),
+            data: serde_json::from_str(&data)
+                .map_err(|source| ProxyError::InvalidJson { source })?,
+        };
+        restore_surfaces(session, adapter.sse_event_pii_surfaces(&mut event));
+        if let Some(name) = event_name {
+            out.push_str("event: ");
+            out.push_str(&name);
+            out.push('\n');
+        }
+        out.push_str("data: ");
+        out.push_str(
+            &serde_json::to_string(&event.data)
+                .map_err(|source| ProxyError::InvalidJson { source })?,
+        );
+        out.push_str("\n\n");
+    }
+    Ok(out.into_bytes())
+}
+
+fn upstream_url(base: &Url, uri: &Uri) -> Result<Url, ProxyError> {
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+    base.join(path).map_err(|err| ProxyError::DaemonConfig {
+        detail: err.to_string(),
+    })
+}
+
+fn forward_headers(
+    mut request: reqwest::RequestBuilder,
+    headers: &HeaderMap,
+) -> reqwest::RequestBuilder {
+    const FORWARDED: &[&str] = &[
+        "authorization",
+        "x-api-key",
+        "anthropic-version",
+        "openai-beta",
+        "content-type",
+    ];
+    for name in FORWARDED {
+        let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        if let Some(value) = headers.get(&header_name) {
+            request = request.header(name.to_string(), value.clone());
+        }
+    }
+    request
+}
+
+fn proxy_error_response(err: ProxyError) -> Response {
+    let status = match err {
+        ProxyError::AdapterNotFound { .. } => StatusCode::NOT_FOUND,
+        ProxyError::BodyTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+        ProxyError::InvalidJson { .. } => StatusCode::BAD_REQUEST,
+        ProxyError::UpstreamUnreachable { .. } => StatusCode::BAD_GATEWAY,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    let body = serde_json::json!({
+        "error": proxy_error_name(&err),
+    });
+    (
+        status,
+        [(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        body.to_string(),
+    )
+        .into_response()
+}
+
+fn proxy_error_name(err: &ProxyError) -> &'static str {
+    match err {
+        ProxyError::UpstreamUnreachable { .. } => "UpstreamUnreachable",
+        ProxyError::AdapterNotFound { .. } => "AdapterNotFound",
+        ProxyError::BodyTooLarge { .. } => "BodyTooLarge",
+        ProxyError::InvalidJson { .. } => "InvalidJson",
+        ProxyError::SsePartialFrame { .. } => "SsePartialFrame",
+        ProxyError::Pipeline { .. } => "Pipeline",
+        ProxyError::Server { .. } => "Server",
+        ProxyError::DaemonAlreadyRunning { .. } => "DaemonAlreadyRunning",
+        ProxyError::DaemonNotRunning => "DaemonNotRunning",
+        ProxyError::DaemonPidfileStale { .. } => "DaemonPidfileStale",
+        ProxyError::DaemonIo { .. } => "DaemonIo",
+        ProxyError::DaemonConfig { .. } => "DaemonConfig",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_text_leaves_unknown_tokens() {
+        let session = Session::new(Scope::Conversation("test".to_string())).unwrap();
+        assert_eq!(restore_text(&session, "hello <Email_1>"), "hello <Email_1>");
+    }
+
+    #[test]
+    fn upstream_url_preserves_path_and_query() {
+        let base = Url::parse("https://api.openai.com").unwrap();
+        let uri: Uri = "/v1/chat/completions?x=1".parse().unwrap();
+        assert_eq!(
+            upstream_url(&base, &uri).unwrap().as_str(),
+            "https://api.openai.com/v1/chat/completions?x=1"
+        );
+    }
+
+    #[test]
+    fn health_lists_adapters() {
+        let config = ProxyConfig::new(
+            "127.0.0.1:0".parse().unwrap(),
+            vec![Arc::new(crate::adapters::OpenAiAdapter::new(
+                Url::parse("https://api.openai.com").unwrap(),
+            ))],
+        );
+        let state = AppState {
+            config: Arc::new(config),
+            pipeline: Arc::new(Pipeline::builder().build().unwrap()),
+            client: Client::new(),
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            started_at: Instant::now(),
+        };
+        assert_eq!(health_snapshot(&state).adapters[0].name, "openai");
+    }
+}

--- a/crates/gaze-proxy/tests/anthropic_surfaces.rs
+++ b/crates/gaze-proxy/tests/anthropic_surfaces.rs
@@ -1,0 +1,32 @@
+use gaze_proxy::adapters::AnthropicAdapter;
+use gaze_proxy::ProviderAdapter;
+use serde_json::json;
+use url::Url;
+
+#[test]
+fn anthropic_walks_text_tool_use_and_tool_result_but_skips_image_source() {
+    let adapter = AnthropicAdapter::new(Url::parse("https://api.anthropic.com").unwrap());
+    let mut body = json!({
+        "system": [{"type": "text", "text": "system alice@example.invalid"}],
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "email alice@example.invalid"},
+                {"type": "tool_use", "name": "lookup", "input": {"email": "alice@example.invalid"}},
+                {"type": "tool_result", "content": [{"type": "text", "text": "alice@example.invalid"}]},
+                {"type": "image", "source": {"data": "alice@example.invalid"}}
+            ]
+        }]
+    });
+    let surfaces = adapter.request_pii_surfaces(&mut body);
+    let paths: Vec<_> = surfaces
+        .iter()
+        .map(|surface| surface.field_path.as_str())
+        .collect();
+
+    assert!(paths.contains(&"system[0].text"));
+    assert!(paths.contains(&"messages[0].content[0].text"));
+    assert!(paths.contains(&"messages[0].content[1].input.email"));
+    assert!(paths.contains(&"messages[0].content[2].content[0].text"));
+    assert!(!paths.iter().any(|path| path.contains("image")));
+}

--- a/crates/gaze-proxy/tests/daemon_lifecycle.rs
+++ b/crates/gaze-proxy/tests/daemon_lifecycle.rs
@@ -1,0 +1,51 @@
+use std::time::Duration;
+
+use gaze_proxy::daemon::{self, DaemonConfig, DaemonPaths, StopOptions};
+
+fn temp_paths(dir: &tempfile::TempDir) -> DaemonPaths {
+    DaemonPaths::new(
+        dir.path().join("proxy.pid"),
+        dir.path().join("proxy.toml"),
+        dir.path().join("proxy.log"),
+        dir.path().join("proxy-stderr.log"),
+    )
+}
+
+#[test]
+fn daemon_config_and_pidfile_lifecycle_use_state_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = temp_paths(&dir);
+    let config = DaemonConfig::default();
+
+    daemon::write_config(&paths, &config).unwrap();
+    let loaded = daemon::read_or_default_config(&paths).unwrap();
+    assert_eq!(loaded.bind, config.bind);
+
+    daemon::init_foreground_daemon(&paths, config.bind).unwrap();
+    let status = daemon::status(&paths).unwrap().unwrap();
+    assert_eq!(status.pid, std::process::id());
+    assert_eq!(status.bind.as_deref(), Some("127.0.0.1:8787"));
+    assert!(status.running);
+}
+
+#[test]
+fn stale_pidfile_cleanup_unlinks_dead_process_record() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = temp_paths(&dir);
+    std::fs::write(
+        &paths.pidfile,
+        "999999\nbind=127.0.0.1:8787\nstarted_at=2026-05-14T00:00:00Z\n",
+    )
+    .unwrap();
+
+    daemon::cleanup_stale(&paths).unwrap();
+    assert!(!paths.pidfile.exists());
+}
+
+#[test]
+fn stop_reports_not_running_when_pidfile_is_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = temp_paths(&dir);
+    let err = daemon::stop(StopOptions::new(paths, Duration::from_millis(10), false)).unwrap_err();
+    assert!(matches!(err, gaze_proxy::ProxyError::DaemonNotRunning));
+}

--- a/crates/gaze-proxy/tests/gemini_surfaces.rs
+++ b/crates/gaze-proxy/tests/gemini_surfaces.rs
@@ -1,0 +1,31 @@
+use gaze_proxy::adapters::GeminiAdapter;
+use gaze_proxy::ProviderAdapter;
+use serde_json::json;
+use url::Url;
+
+#[test]
+fn gemini_walks_text_function_call_and_function_response() {
+    let adapter =
+        GeminiAdapter::new(Url::parse("https://generativelanguage.googleapis.com").unwrap());
+    let mut body = json!({
+        "systemInstruction": {"parts": [{"text": "system alice@example.invalid"}]},
+        "contents": [{
+            "role": "user",
+            "parts": [
+                {"text": "email alice@example.invalid"},
+                {"functionCall": {"name": "lookup", "args": {"email": "alice@example.invalid"}}},
+                {"functionResponse": {"name": "lookup", "response": {"email": "alice@example.invalid"}}}
+            ]
+        }]
+    });
+    let surfaces = adapter.request_pii_surfaces(&mut body);
+    let paths: Vec<_> = surfaces
+        .iter()
+        .map(|surface| surface.field_path.as_str())
+        .collect();
+
+    assert!(paths.contains(&"systemInstruction.parts[0].text"));
+    assert!(paths.contains(&"contents[0].parts[0].text"));
+    assert!(paths.contains(&"contents[0].parts[1].functionCall.args.email"));
+    assert!(paths.contains(&"contents[0].parts[2].functionResponse.response.email"));
+}

--- a/crates/gaze-proxy/tests/openai_non_stream.rs
+++ b/crates/gaze-proxy/tests/openai_non_stream.rs
@@ -1,0 +1,56 @@
+use gaze::{
+    token_shape, Action, ClassRule, CleanDocument, DefaultRule, PiiClass, Pipeline, RawDocument,
+    Scope, Session,
+};
+use gaze_proxy::adapters::OpenAiAdapter;
+use gaze_proxy::ProviderAdapter;
+use gaze_recognizers::RegexDetector;
+use serde_json::json;
+use url::Url;
+
+fn email_pipeline() -> Pipeline {
+    Pipeline::builder()
+        .detector(RegexDetector::emails().unwrap())
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn openai_request_surfaces_redact_content_and_tool_arguments() {
+    let adapter = OpenAiAdapter::new(Url::parse("https://api.openai.com").unwrap());
+    let pipeline = email_pipeline();
+    let session = Session::new(Scope::Conversation("openai".to_string())).unwrap();
+    let mut body = json!({
+        "messages": [{
+            "role": "user",
+            "content": "email alice@example.invalid",
+            "tool_calls": [{
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{\"email\":\"alice@example.invalid\"}"
+                }
+            }]
+        }]
+    });
+
+    for surface in adapter.request_pii_surfaces(&mut body) {
+        let CleanDocument::Text(clean) = pipeline
+            .redact(&session, RawDocument::Text(surface.text.clone()))
+            .unwrap()
+        else {
+            panic!("text clean document expected");
+        };
+        *surface.text = clean;
+    }
+
+    let serialized = body.to_string();
+    assert!(!serialized.contains("alice@example.invalid"));
+    assert!(serialized.contains("Email_1"));
+    let token = token_shape::find_token(&serialized).expect("token emitted");
+    assert_eq!(
+        session.restore(token).as_deref(),
+        Some("alice@example.invalid")
+    );
+}

--- a/crates/gaze-proxy/tests/openai_sse.rs
+++ b/crates/gaze-proxy/tests/openai_sse.rs
@@ -1,0 +1,55 @@
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, PiiClass, Pipeline, RawDocument, Scope, Session,
+};
+use gaze_proxy::adapter::SseEvent;
+use gaze_proxy::adapters::OpenAiAdapter;
+use gaze_proxy::ProviderAdapter;
+use gaze_recognizers::RegexDetector;
+use serde_json::json;
+use url::Url;
+
+#[test]
+fn openai_sse_surfaces_include_delta_content_and_tool_arguments() {
+    let pipeline = Pipeline::builder()
+        .detector(RegexDetector::emails().unwrap())
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap();
+    let session = Session::new(Scope::Conversation("openai-sse".to_string())).unwrap();
+    let CleanDocument::Text(token) = pipeline
+        .redact(
+            &session,
+            RawDocument::Text("alice@example.invalid".to_string()),
+        )
+        .unwrap()
+    else {
+        panic!("text clean document expected");
+    };
+    let mut event = SseEvent::new(
+        None,
+        json!({
+            "choices": [{
+                "delta": {
+                    "content": token,
+                    "tool_calls": [{
+                        "function": {
+                            "arguments": "{\"email\":\"<Email_1>\"}"
+                        }
+                    }]
+                }
+            }]
+        }),
+    );
+    let adapter = OpenAiAdapter::new(Url::parse("https://api.openai.com").unwrap());
+    let surfaces = adapter.sse_event_pii_surfaces(&mut event);
+    let paths: Vec<_> = surfaces
+        .iter()
+        .map(|surface| surface.field_path.as_str())
+        .collect();
+
+    assert!(paths.iter().any(|path| path.ends_with(".delta.content")));
+    assert!(paths
+        .iter()
+        .any(|path| path.ends_with(".delta.tool_calls[0].function.arguments")));
+}

--- a/crates/xtask/src/cargo_metadata_audit_isolation.rs
+++ b/crates/xtask/src/cargo_metadata_audit_isolation.rs
@@ -35,10 +35,16 @@ const SAFETY_NET_LEGACY_NER_EXEMPTIONS: &[LegacyNerExemption] = &[LegacyNerExemp
 // safety-net subgraph (e.g. tokio, hyper) but are not themselves part of the
 // safety-net code path. Each entry must carry an explicit reason so future
 // additions cannot silently widen the chokepoint surface.
-const SAFETY_NET_MEMBER_EXEMPTIONS: &[WorkspaceMemberExemption] = &[WorkspaceMemberExemption {
-    workspace_member: "gaze-mcp-rmcp",
-    reason: "rmcp transport sink; tokio is a runtime dep for the MCP transport, not the safety-net pipeline",
-}];
+const SAFETY_NET_MEMBER_EXEMPTIONS: &[WorkspaceMemberExemption] = &[
+    WorkspaceMemberExemption {
+        workspace_member: "gaze-mcp-rmcp",
+        reason: "rmcp transport sink; tokio is a runtime dep for the MCP transport, not the safety-net pipeline",
+    },
+    WorkspaceMemberExemption {
+        workspace_member: "gaze-proxy",
+        reason: "HTTP provider proxy; reqwest/tokio/hyper are proxy transport deps, not safety-net pipeline deps",
+    },
+];
 
 // No current workspace feature is allowed to disappear silently. Keep this
 // table explicit so future cfg-gated feature plans must carry a reason beside

--- a/docs/architecture/proxy-runtime.md
+++ b/docs/architecture/proxy-runtime.md
@@ -1,0 +1,62 @@
+# Proxy Runtime
+
+`gaze-proxy` is a pass-through-per-provider HTTP runtime. Its north-star role is
+to keep PII out of provider calls while preserving each SDK's native request and
+response shape.
+
+## Adapter Contract
+
+Adapters implement `ProviderAdapter`:
+
+- `matches_path(method, path)` claims provider-native endpoints.
+- `request_pii_surfaces(body)` returns mutable text leaves to redact before
+  forwarding upstream.
+- `response_pii_surfaces(body)` returns mutable text leaves to restore on the
+  owner-visible response.
+- `sse_event_pii_surfaces(event)` handles provider-native event payloads.
+
+Adapters do not decide what is PII. They only describe where strings live; the
+configured `gaze::Pipeline` and recognizer registry make detection decisions.
+
+## Provider Surface Matrix
+
+| Provider | Request surfaces | Response surfaces | Streaming surfaces |
+| --- | --- | --- | --- |
+| OpenAI | `messages[].content`, `system`, `tool_calls[].function.arguments`, `input` | `choices[].message.content`, `choices[].message.tool_calls[].function.arguments`, `output` | `choices[].delta.content`, `choices[].delta.tool_calls[].function.arguments` |
+| Anthropic | `system`, `messages[].content[].text`, `tool_use.input`, `tool_result.content` | `content[].text`, `tool_use.input`, `tool_result.content` | `content_block_delta.delta.text`, `delta.partial_json` |
+| Gemini | `contents[].parts[].text`, `functionCall.args`, `functionResponse.response`, `systemInstruction.parts[].text` | `candidates[].content.parts[].text`, `functionCall.args` | same parts shape per chunk |
+
+Image payloads are skipped. Tool and function objects are walked as native JSON
+objects where the provider exposes them as objects; string-encoded argument
+fields are redacted as strings without provider-shape transcoding.
+
+## Session TTL
+
+The proxy uses `X-Gaze-Session-Id` when supplied. Without that header it creates
+an ephemeral UUID-backed session. Sessions are held in memory and evicted after
+`session_ttl`; the manifest contract remains `gaze::Session`.
+
+## Daemon Lifecycle
+
+`gaze proxy start` persists config, reexecs `gaze proxy serve --_foreground-daemon`,
+and writes a pidfile:
+
+```text
+<pid>
+bind=<addr>
+started_at=<rfc3339>
+```
+
+The pidfile is UTF-8 and capped at 200 bytes. It lives in the platform local-data
+directory:
+
+- macOS: `~/Library/Application Support/gaze/proxy.pid`
+- Linux: `$XDG_DATA_HOME/gaze/proxy.pid` or `~/.local/share/gaze/proxy.pid`
+- Windows: `%LOCALAPPDATA%\gaze\proxy.pid`
+
+Status and start always validate the recorded PID with process liveness checks.
+If the PID is dead, the pidfile is stale and removed before continuing. Stop is
+signal-only: `SIGTERM`, bounded wait, optional `SIGKILL` with `--force`.
+
+The proxy exposes `/_gaze_proxy/healthz` for local health inspection. The path is
+reserved outside all adapter-matched provider routes.


### PR DESCRIPTION
## Summary
- Add feature-gated `gaze-proxy` crate with OpenAI, Anthropic, and Gemini pass-through adapters.
- Add proxy server redaction/restore flow, in-memory session TTL, SSE event restoration, and provider-aware request/response surface walkers.
- Add `gaze proxy` CLI commands for serve/start/stop/status/logs/restart plus reserved launchd/systemd user hooks, with daemon pidfile/log/config handling refined from the lean-ctx daemon learnings scratchpad.
- Document proxy runtime architecture and upgrade notes.

## Five-axis note
No intentional weakening of reliability, reversibility, agentic fit, trust, or adopter ergonomics. The proxy stays feature-gated, policy-backed via existing `gaze_assembly`, and keeps transport dependencies out of core safety-net crates via an explicit xtask exemption for `gaze-proxy`.

## Verification
- `cargo check -p gaze-proxy --all-features`
- `cargo check -p gaze-cli --features proxy`
- `cargo fmt --all -- --check`
- `cargo test -p gaze-proxy --all-features` (13 focused proxy tests)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- cargo-metadata-audit-isolation`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- safety-net-sanity`
- `cargo run -p xtask -- recognizer-composition-validator`
- `cargo run -p xtask -- bundle-tokenization-drift`
- `cargo run -p xtask -- dylint-gate`
- `cargo run -p gaze-cli --features proxy -- proxy --help` verified serve/start/stop/status/logs/restart/install-launchd/uninstall-launchd/install-systemd-user/uninstall-systemd-user
