### PR TITLE
release: v0.8.0 (final)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -40,7 +40,7 @@ jobs:
 
           # Topological order, dependency crates first. The core package is
           # published as gaze-pii while its library target remains `gaze`.
-          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-document gaze-cli; do
+          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-document gaze-proxy gaze-cli; do
             echo "=== publishing $crate ==="
             attempt=1
             while true; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.8.0-rc.1] - 2026-05-14
+## [0.8.0] - 2026-05-14
 
-First v0.8 pre-release. Bundle unification + versioned recognizer lineage + Kiji-style defense-in-depth. Tier 2 checksum-backed locale parity (Aadhaar / NIR / Steuer-ID / BSN / CPF / CNPJ / NHS) and Tier 3 regex locales (SSN / NINO / PAN) follow in rc.2 / rc.3.
+Bundle unification + versioned recognizer lineage + Kiji-style defense-in-depth + ten checksum-backed and locale-gated national-ID recognizers across five new locale packs, plus the new `gaze-proxy` crate that puts a PII chokepoint in front of OpenAI / Anthropic / Gemini API traffic. The workspace publish count rises from nine to ten.
 
 ### Added
 
 - **Versioned recognizer lineage** (v0.8 Tier 1, PR #203 `3c95304`): `Candidate.recognizer_version_id` + `RedactionEntry.recognizer_id` + `recognizer_version_id` (all `Option<String>`, additive). Audit boundary in `pipeline.rs` now propagates lineage instead of dropping at `source`. SQLite schema gains nullable `recognizer_id` / `recognizer_version_id` columns; pre-migration rows tagged `legacy_unversioned`. NER recognizer emissions versioned as `ner.<model>.<vN>` from artifact config metadata (`ner.unknown.v0` fallback). `docs/architecture/locale-chain.md` gains a coverage matrix listing every bundled recognizer × supported locales × ValidatorKind. (Axis 4 trust/auditable, Axis 5 ergonomics.)
 - **`SafetyTier` enum on rulepack recognizers** (v0.8 Tier 1.5, PR #201 `8ab9daf`): `SafeDefault`, `LocaleGated`, `OptIn` with `#[non_exhaustive]`. Closed-enum activation gate replaces the dual-bundle activation model. (Axis 1 reliability, Axis 4 trust.)
 - **`KijiDistilbertSafetyNet` backend** (v0.8 Tier 2.5, PR #202 `0cd9ccc`): new `--safety-net-backend kiji-distilbert` flag (default remains `openai-filter` for compat). Pass-3 SafetyNet device with pinned-artifact contract identical to existing OpenAI filter (SHA256SUMS hard-fail on missing). New `CliError::SafetyNetArtifactMissing { backend, path }` typed variant. `scripts/fetch-kiji-safetynet-model.sh` mirror of existing NER fetcher. (Axis 1 defense-in-depth.)
+- **Seven checksum-backed locale validators** (v0.8 Tier 2, PR #207 `16c1fd5`): Aadhaar Verhoeff (IN), French NIR MOD-97 variant (FR), German Steuer-ID MOD 11,10 (DE), Dutch BSN MOD-11 (NL), Brazilian CPF + CNPJ MOD-11 (BR), and UK NHS number MOD-11 (UK). New `ValidatorKind` variants are closed-enum and fail-closed on parse. Five new locale packs ship alongside: `locale-fr`, `locale-nl`, `locale-br`, `locale-in`, `locale-uk`. Every entity ships at `safety_tier = "safe_default"`, so adopters in BR/FR/NL/IN/UK get coverage out of the box once their locale is set. (Axis 1 reliability, Axis 3 agentic-first.)
+- **Three locale-gated regex recognizers** (v0.8 Tier 3, PR #208 `7348690`): US SSN, UK NINO, and Indian PAN. All ship at `safety_tier = "locale_gated"` — no bare 9-digit / 10-character shapes activate without explicit locale + cue context. PAN extends the existing `locale-in` pack from Tier 2 in place. (Axis 1 reliability, Axis 4 trust.)
+- **Corpus rework v2 implementation** (PR #205 `aa9c5fc`): the 61 stochastic status-quo templates + the `fixture_variants` mechanism are replaced with 150 deliberate scenarios. Each scenario declares its expected emissions including `recognizer_version_id` from day one. `fake` crate added as an xtask-only dev dependency; seed pinned in a documented `COVERAGE_CORPUS_SEED` constant. `baseline.json` fully re-snapped. (Axis 4 trust.)
+- **`UPGRADE.md`** (PR #206 `492573d`): per-minor migration guide complementing `CHANGELOG.md`, with v0.7.x → v0.8.0 TL;DR + backfill summaries for v0.4 → v0.7.
+- **`docs/research/v0.8-kiji-class-gap.md`** (PR #210 `eba350a`): coverage map of all 26 Kiji PII classes against gaze's recognizers — 6 beat-via-Tier-2, 1 beat-via-Tier-3, 16 observer-only-via-Tier-2.5, 3 parity, 0 deferred.
+- **`docs/research/v0.8-kiji-benchmark.md`** (PR #209 `b875381`): two-mode (direct-detector + observer-residual) benchmark methodology headlining strict span leak rate, with a rule-floor snapshot pinned to corpus + Gaze tag. Kiji direct-detector + observer-residual cells deferred (no pinned model SHA yet — tracked as v0.8.x follow-up).
+- **`ARCHITECTURE.md`** (PR #211 `fd130ac`): 14.8 KiB repo-root architecture overview of how the ten workspace crates fit together, with eight numbered Key Design Decisions and a one-diagram view of the redact/restore path.
+- **`gaze-proxy` crate at v0.8.0** (PR #212 `503d0f9`): new published workspace crate. Multi-provider HTTP proxy with an adapter/driver pattern that serves OpenAI's `/v1/chat/completions`, Anthropic's `/v1/messages`, and Gemini's `/v1beta/models/*:{generateContent,streamGenerateContent}` without translation. SSE streaming and tool-call argument reconstruction wired through `gaze::Pipeline` (chunk-split PII spans inside `tool_calls.function.arguments` are accumulated and redacted before leaving the proxy). Daemon-mode subcommands `gaze proxy {serve,start,stop,status,logs,restart}` plus opt-in `install-launchd` / `install-systemd-user` installers. Feature-gated on `gaze-cli` as `--features proxy`, off by default. (Axis 3 agentic-first, Axis 5 ergonomics.)
 
 ### Changed
 
 - **Unified `core` + `core-extended` bundled rulepacks** into single `core` bundle (v0.8 Tier 1.5, PR #201). Each recognizer now declares a `safety_tier` field; no-policy activation gates on `SafeDefault` only. Adopter behavior preserved through alias path described under Deprecated.
+- **Workspace version pin** `0.8.0-rc.1` → `0.8.0` across ten crates (was nine; `gaze-proxy` joins this release).
+- **[bundle-tokenization-drift] `baseline.json`** fully re-snapped against the corpus rework v2 scenarios.
 
 ### Deprecated
 
@@ -42,6 +52,8 @@ First v0.8 pre-release. Bundle unification + versioned recognizer lineage + Kiji
 - Existing `RedactionEntry` JSON consumers see no shape change — new fields use `#[serde(skip_serializing_if = "Option::is_none")]` and emit nothing when None.
 - Existing SQLite audit DBs are migrated forward: pre-migration redaction rows get `recognizer_id = "legacy_unversioned"`, `recognizer_version_id = NULL`. Migration is idempotent.
 - Existing `policy.toml` files unchanged. No new required fields.
+- **`gaze-proxy` is opt-in** behind `--features proxy` on `gaze-cli`; existing adopters are unaffected unless they invoke `gaze proxy serve` or `gaze proxy start`.
+- All Tier 2 + Tier 3 entity adds are additive. Adopters in BR / FR / NL / IN / UK / US-only / UK-only see no behavior change unless they enable their locale via `--locale=<bcp47>`.
 
 ## [0.7.2] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.8.0-rc.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.8.0-rc.1" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.8.0-rc.1" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.8.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.8.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.8.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Claude Code, Claude Desktop, and Cursor config paths.
 
 ## Quickstart
 
-A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the v0.8.0-rc.1 CLI.
+A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the v0.8.0 CLI.
 
 ### 1. First redact
 
@@ -300,7 +300,7 @@ The audit DB is opened read-only by `query` and `export`. The exported column se
 
 ## Status
 
-- **Version:** v0.8.0-rc.1 (2026-05, pre-release).
+- **Version:** v0.8.0 (2026-05).
 - **MSRV:** Rust 1.89.
 - **License:** dual `Apache-2.0 OR MIT`.
 - **crates.io:** published as `gaze-pii`. The bare `gaze` name is in transfer; until that completes, depend on `gaze-pii`. Source-compat is preserved via `[lib].name = "gaze"`.
@@ -319,11 +319,11 @@ The CLI is a process boundary around the Rust runtime; you can link the runtime 
 
 ```toml
 [dependencies]
-gaze-pii = "0.8.0-rc.1"
-gaze-assembly = "0.8.0-rc.1"
+gaze-pii = "0.8.0"
+gaze-assembly = "0.8.0"
 ```
 
-The crate is published as `gaze-pii` because the bare `gaze` name is in transfer; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved. During the v0.8 pre-release window, pin the exact `0.8.0-rc.N` version — Cargo's caret operator excludes pre-releases.
+The crate is published as `gaze-pii` because the bare `gaze` name is in transfer; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved.
 
 - Minimal example and the API surface table: [`crates/gaze/README.md`](crates/gaze/README.md) (also rendered on [`crates.io/crates/gaze-pii`](https://crates.io/crates/gaze-pii)).
 - Full walk-through with structured documents, tenant-specific recognizers, and policy TOML: [`docs/getting-started.md`](docs/getting-started.md).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -35,10 +35,11 @@ exists today.)
 
 ## v0.7.x → v0.8.0
 
-Status: **in flight.** v0.8.0-rc.1 has been tagged at commit `448c292`.
-Crates.io publish of the nine workspace crates is pending; until then,
-adopters can build from the tag (see "Building from a tag during the rc
-cycle" below).
+Status: **shipped.** v0.8.0 is published to crates.io; the workspace
+now includes ten published crates (the new `gaze-proxy` joins
+`gaze-types`, `gaze-recognizers`, `gaze-audit`, `gaze-pii`,
+`gaze-assembly`, `gaze-mcp-core`, `gaze-mcp-rmcp`, `gaze-document`,
+and `gaze-cli`).
 
 ### TL;DR
 
@@ -186,21 +187,17 @@ validator math; regex shape plus cue context only.
 **Action required:** none — pure additive coverage when the relevant
 locale is set.
 
-### Building from a tag during the rc cycle
+### Depending on v0.8.0
 
-While `v0.8.0-rc.1` is on Git but not yet on crates.io, depend on the
-tag directly:
+The workspace is published to crates.io. Pin by version:
 
 ```toml
 [dependencies]
-gaze-pii = { git = "https://github.com/EmpireTwo/gaze", tag = "v0.8.0-rc.1" }
+gaze-pii = "0.8.0"
 ```
 
 The exact crate name is `gaze-pii` (cargo package); the library imports
-as `gaze` (e.g. `use gaze::Pipeline;`). Replace the dependency with a
-plain version pin (`gaze-pii = "0.8.0-rc.1"`) once the workspace is
-published to crates.io. CHANGELOG.md notes the publish date when it
-happens.
+as `gaze` (e.g. `use gaze::Pipeline;`).
 
 ### Schema-version field on `policy.toml`
 

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -42,14 +42,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
+gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.8.0-rc.1", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0-rc.1", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.8.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -63,7 +63,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0-rc.1" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0-rc.1" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.8.0-rc.1" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.8.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.8.0-rc.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0-rc.1" }
+gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0-rc.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,11 +12,9 @@ restore key, send only safe text to an LLM, and restore original values from the
 
 ```toml
 [dependencies]
-gaze-pii = "0.8.0-rc.1"
-gaze-assembly = "0.8.0-rc.1"
+gaze-pii = "0.8.0"
+gaze-assembly = "0.8.0"
 ```
-
-> v0.8 pre-release window: pin the exact `0.8.0-rc.N` version. Cargo's caret operator excludes pre-releases, so `"0.8"` will not resolve to `0.8.0-rc.1`.
 
 The crate is published as `gaze-pii`. Import path remains `use gaze::...`.
 


### PR DESCRIPTION
## Summary

- Bumps workspace + ten crate `version` pins from `0.8.0-rc.1` → `0.8.0`.
- Rewrites the `## [0.8.0-rc.1]` CHANGELOG section as `## [0.8.0]` and absorbs the post-rc.1 PRs (#205, #206, #207, #208, #209, #210, #211, #212) — checksum-backed locale validators, locale-gated regex recognizers, corpus rework v2, `UPGRADE.md`, two Kiji research docs, `ARCHITECTURE.md`, and the new `gaze-proxy` crate.
- Refreshes README, `docs/getting-started.md`, and `UPGRADE.md` adopter snippets to drop the pre-release pin guidance and use plain `"0.8.0"` version pins.
- Extends `.github/workflows/publish-crates.yml` to include `gaze-proxy` in the publish loop (10 crates now, was 9). The workflow uses Trusted Publishing (OIDC); the `v0.8.0` tag push will fire the publish.

Publish order (matches actual dep graph from `cargo metadata`):

```
gaze-types → gaze-audit → gaze-recognizers → gaze-pii → gaze-assembly →
gaze-mcp-core → gaze-mcp-rmcp → gaze-document → gaze-proxy → gaze-cli
```

## Test plan

- [x] `cargo update --workspace --offline` regenerates `Cargo.lock` cleanly (10 workspace bumps, 4 unchanged deps).
- [ ] PR-triggered `docs.yml` check passes (doc-tests + rustdoc warnings).
- [ ] After squash-merge, `git tag -a v0.8.0` push fires `publish-crates.yml` and uploads all 10 crates with OIDC.
- [ ] `cargo info <crate>@0.8.0` resolves for each of the 10 crates.
- [ ] `gh release create v0.8.0 --target main` publishes the GH release with the curated v0.8.0 body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)