### PR TITLE
[agent] docs: add Kiji SafetyNet setup coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Claude Code, Claude Desktop, and Cursor config paths.
 
 ## Quickstart
 
-A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the v0.8.0 CLI.
+A guided path from zero PII configuration to a working clean run, with optional NER and the observer-only Privacy filter layered on top. Each step is copy-paste-able against the current `gaze` CLI.
 
 ### 1. First redact
 
@@ -188,7 +188,11 @@ Schema details, threshold range, and `~/` expansion rules: [`docs/policy.md`](do
 
 The Privacy filter is an **observer-only post-clean check**. It reads the already-tokenized text plus the manifest of emitted spans and reports any suspect bytes the deterministic passes missed. It cannot mutate the clean text, cannot mutate the manifest, and cannot affect restore — full contract in [`docs/architecture/safety-nets.md`](docs/architecture/safety-nets.md).
 
-The safety-net code path is off the default build graph. Reinstall the CLI with the feature compiled in:
+Gaze ships two SafetyNet backends. `openai-filter` wraps the upstream OpenAI Privacy Filter and is the heavier option when that infrastructure is already approved. `kiji-distilbert` is the lighter alternative: an Apache-2.0 ONNX DistilBERT model bundle, about 8.8 MB, with a 26-class upstream PII taxonomy and faster cold-start profile. Pick one based on your deployment constraints; both are observer-only and both share the same strict/tolerant exit contract.
+
+#### OpenAI Privacy Filter
+
+The safety-net code path is off the default build graph. Reinstall the CLI with the OpenAI backend compiled in:
 
 ```sh
 cargo install --path crates/gaze-cli --features safety-net-openai
@@ -231,6 +235,33 @@ A clean run produces a `leak_report` block alongside the usual JSON; `suspect_co
 
 The default safety-net mode is `strict`: if the filter raises an `Uncovered` or `PartialBleed` suspect, the CLI exits `3` with `{"error":"SafetyNet","exit":3,"variant":"SuspectedLeak"}` and stdout stays empty. Pass `--safety-net-mode tolerant` to keep running and route the warning to stderr. Full flag table, operating points, and exit-code map: [`crates/gaze-cli/README.md`](crates/gaze-cli/README.md#safety-net).
 
+#### Kiji DistilBERT
+
+The Kiji backend is also feature-gated. Fetch the pinned model bundle once, then reinstall the CLI with the Kiji feature compiled in:
+
+```sh
+bash scripts/fetch-kiji-safetynet-model.sh
+cargo install --path crates/gaze-cli --features safety-net-kiji
+```
+
+The fetcher verifies the release-pinned `SHA256SUMS.kiji` file and installs the runtime bundle into `${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert` by default. Gaze does not fetch or update the model during `gaze clean`.
+
+Activate Kiji on the same `gaze clean` invocation:
+
+```sh
+printf '%s' 'Contact alice@example.invalid for details.' \
+  | gaze clean \
+      --policy quickstart-policy.toml \
+      --safety-net kiji-distilbert \
+      --safety-net-backend kiji-distilbert \
+      --kiji-distilbert-command /opt/kiji/bin/kiji \
+      --kiji-distilbert-model-dir ~/.local/share/gaze/models/kiji-distilbert
+```
+
+The output shape is the same `leak_report` block shown above; `suspect_count = 0` remains the contract for "no leaks". The Kiji model directory must contain `SHA256SUMS`, `labels.json`, `model.onnx`, and `tokenizer.json`. Missing artifacts fail closed before subprocess spawn with `{"error":"SafetyNetArtifactMissing","exit":2,...}`.
+
+Full Kiji setup, backend switching, and failure-mode notes: [`docs/getting-started/kiji-safetynet-setup.md`](docs/getting-started/kiji-safetynet-setup.md).
+
 ## Pipeline shape
 
 ```text
@@ -262,15 +293,16 @@ Published crates. Pick the smallest surface that does the job.
 | [`gaze-assembly`](crates/gaze-assembly/) | You want bundled defaults without hand-wiring recognizers. |
 | [`gaze-recognizers`](crates/gaze-recognizers/) | You're writing a custom recognizer or rulepack. |
 | [`gaze-audit`](crates/gaze-audit/) | You want SQLite-backed metadata audit logging. Adopt directly; `gaze` core has no `rusqlite` dep in any feature graph. |
-| [`gaze-cli`](crates/gaze-cli/) | You want a process boundary for non-Rust adapters (Laravel, Python, etc.). |
 | [`gaze-types`](crates/gaze-types/) | You want the value contracts (`RedactionLogger`, `Manifest`, `LeakReport`) without ML deps. |
 | [`gaze-document`](crates/gaze-document/) | You want PNG/JPG/PDF document ingestion into SafeBundles or MCP document-read tools. |
 | [`gaze-mcp-core`](crates/gaze-mcp-core/) | You're building an MCP-protocol tool host and want every call to pass through Gaze's redaction chokepoint. |
 | [`gaze-mcp-rmcp`](crates/gaze-mcp-rmcp/) | You want the rmcp transport sink for `gaze-mcp-core` (stdio default, optional streamable HTTP). |
+| [`gaze-proxy`](crates/gaze-proxy/) | You want an HTTP proxy that sits in front of OpenAI / Anthropic / Gemini API calls and inserts a PII redact/restore boundary in the middle. Multi-provider adapter pattern, SSE + tool-call aware, daemon-mode subcommands (`gaze proxy start/stop/status/logs/restart`). |
+| [`gaze-cli`](crates/gaze-cli/) | You want a process boundary for non-Rust adapters (Laravel, Python, etc.). |
 
 Crate boundaries and the audit-isolation gate: [`docs/architecture/crates.md`](docs/architecture/crates.md).
 
-Document extension for v0.7.1+ codec adapters: [`docs/architecture/document-extension.md`](docs/architecture/document-extension.md).
+Document extension for codec adapters that use `SafeBundle`: [`docs/architecture/document-extension.md`](docs/architecture/document-extension.md).
 
 ## Detection coverage
 
@@ -297,14 +329,6 @@ gaze audit purge --audit-db audit.sqlite --before 2026-01-01T00:00:00Z
 ```
 
 The audit DB is opened read-only by `query` and `export`. The exported column set excludes raw PII payloads. There is no policy-level retention default and no background auto-purge — adopters drive retention explicitly.
-
-## Status
-
-- **Version:** v0.8.0 (2026-05).
-- **MSRV:** Rust 1.89.
-- **License:** dual `Apache-2.0 OR MIT`.
-- **crates.io:** published as `gaze-pii`. The bare `gaze` name is in transfer; until that completes, depend on `gaze-pii`. Source-compat is preserved via `[lib].name = "gaze"`.
-- **Contract surface:** `Pipeline`, `Session`, `Policy`, rulepack schema, and token shape are stable across the v0.7 line. SafetyNet contract: [`docs/architecture/safety-nets.md`](docs/architecture/safety-nets.md).
 
 ## Limits
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -166,6 +166,8 @@ permissions on Unix. Missing artifacts fail closed with typed
 `CliError::SafetyNetArtifactMissing` (exit `2`) before the subprocess
 spawns.
 
+Setup walkthrough: [`docs/getting-started/kiji-safetynet-setup.md`](docs/getting-started/kiji-safetynet-setup.md).
+
 **Action required:** none. The backend is opt-in. If you do not select
 it, your current SafetyNet configuration (OpenAI Privacy Filter or
 none) is unchanged.

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -224,6 +224,8 @@ typed `SafetyNetArtifactMissing` envelope and exit code `2` *before* the
 subprocess is spawned — Axis-1 reliability never silent-disables a
 requested backend.
 
+See also: [Kiji DistilBERT SafetyNet setup](../../docs/getting-started/kiji-safetynet-setup.md).
+
 #### Synthetic example — strict mode
 
 ```console

--- a/docs/architecture/safety-nets.md
+++ b/docs/architecture/safety-nets.md
@@ -6,6 +6,8 @@ mutate the [`Manifest`](../../crates/gaze-types/src/lib.rs), and never reach
 the restore path. They exist to surface leak suspects so the deterministic
 detectors and rulepacks can be improved.
 
+For step-by-step setup with Kiji DistilBERT, see [`docs/getting-started/kiji-safetynet-setup.md`](../getting-started/kiji-safetynet-setup.md).
+
 Validator-backed self-validation is handled earlier by the deterministic
 [`validator-veto`](validator-veto.md) stage. Safety nets do not veto candidates
 and do not participate in conflict resolution.
@@ -14,6 +16,62 @@ This document describes the safety-net contract introduced in v0.6 through
 PR #91. The first shipped backend is the OpenAI Privacy Filter
 (`opf`) subprocess adapter; the contract is generic so additional backends
 can land without changing the trait shape or audit schema.
+
+```text
+                    GAZE CLEAN INVOCATION
+                            │
+                            ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │ PASS 1 — REGEX + DICTIONARY (deterministic)                     │
+   │   "Contact alice@example.invalid"                               │
+   │     → recognizers (email.global, name.de, iban, …)              │
+   │     → Candidate { class=Email, score=1.0, span=(8,28), … }      │
+   └────────────────────────────┬────────────────────────────────────┘
+                                ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │ PASS 2 — NER (optional, opt-in feature)                         │
+   │   mBERT (Davlan) emits B-PER / I-PER / B-LOC … per token        │
+   │   → Candidate { class=Name, score=0.91, span=(0,7) }            │
+   └────────────────────────────┬────────────────────────────────────┘
+                                ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │ CONFLICT RESOLUTION + TOKENIZATION                              │
+   │   class-priority > rule-priority > score > span-len > id        │
+   │   emit tokens → "Contact <{sess}:Email_1>" + Manifest           │
+   └────────────────────────────┬────────────────────────────────────┘
+                                │ clean_text + manifest committed
+                                │ (this is what restore will reverse)
+                                ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │ PASS 3 — SAFETYNET (observer-only, opt-in)                      │
+   │   Mode selector: --safety-net-backend                           │
+   │                  ↓                  ↓                           │
+   │   ┌──────────────────────┐  ┌────────────────────────────┐     │
+   │   │  openai-filter       │  │  kiji-distilbert (v0.8+)   │     │
+   │   │  (OPF binary)        │  │  (Kiji ONNX model)         │     │
+   │   │                      │  │                            │     │
+   │   │  ─ heavier weights   │  │  ─ 8.8 MB DistilBERT       │     │
+   │   │  ─ OpenAI's PII set  │  │  ─ 26 PII classes (Kiji)   │     │
+   │   │  ─ requires `opf`    │  │  ─ ONNX subprocess         │     │
+   │   │    binary install    │  │  ─ tokenizers crate        │     │
+   │   └──────────┬───────────┘  └────────────┬───────────────┘     │
+   │              │                            │                     │
+   │              └──────────────┬─────────────┘                     │
+   │                             ▼                                   │
+   │   Subprocess contract identical for both:                       │
+   │       stdin  ← clean_text (post-tokenization!)                  │
+   │       stdout → JSON span array [{start, end, label, score}, …]  │
+   │                                                                 │
+   │   Gaze compares the SafetyNet spans against the manifest:       │
+   │     ─ Span overlaps an emitted token → covered (no leak)        │
+   │     ─ Span outside every token       → "Uncovered" suspect      │
+   │     ─ Span overlaps partial token    → "PartialBleed" suspect   │
+   │     ─ Span overlaps wrong class      → "ClassMismatch" suspect  │
+   │                                                                 │
+   │   Result: leak_report attached to JSON output. Manifest         │
+   │   UNCHANGED. Restore UNAFFECTED. (Axis 2 reversibility intact.) │
+   └─────────────────────────────────────────────────────────────────┘
+```
 
 ## North-star fit
 

--- a/docs/getting-started/kiji-safetynet-setup.md
+++ b/docs/getting-started/kiji-safetynet-setup.md
@@ -1,0 +1,307 @@
+# Kiji DistilBERT SafetyNet Setup
+
+This page is an adopter setup guide for the `kiji-distilbert` SafetyNet
+backend. For the full SafetyNet contract, see
+[`docs/architecture/safety-nets.md`](../architecture/safety-nets.md).
+
+Doc convention note: avoid version mentions unless the version is
+load-bearing, such as a dependency line, release artifact selector, or
+migration boundary. Setup docs should describe the current contract and link
+to `CHANGELOG.md` / `UPGRADE.md` for release history so front-door docs do
+not go stale.
+
+## What This Is
+
+Kiji DistilBERT is an observer-only Pass-3 SafetyNet backend. It runs after
+Gaze has already produced clean text and a manifest, then reports residual PII
+suspects that the deterministic passes may have missed. It never rewrites clean
+text, never mutates the manifest, and never participates in restore. That
+shape is intentional: SafetyNet is defense in depth for north-star Axis 1, not
+a second redaction engine.
+
+The backend wraps a local subprocess that serves pinned ONNX DistilBERT
+weights. The adapter sends already-tokenized clean text to stdin and accepts
+typed JSON spans from stdout. The runtime requires an Apache-2.0 model bundle
+with `SHA256SUMS`, `labels.json`, `model.onnx`, and `tokenizer.json` on disk
+before it will run. The upstream Kiji taxonomy has 26 PII classes; the local
+adapter validates emitted labels and maps them into Gaze's closed SafetyNet
+classes before manifest diffing.
+
+For the full pipeline view, including the canonical ASCII diagram that places
+Kiji inside Pass 3, see
+[`docs/architecture/safety-nets.md`](../architecture/safety-nets.md). Pass 3
+SafetyNet is observer-only — it never mutates `clean_text` or the manifest.
+Restore round-trip is unaffected.
+
+Source anchors:
+[`kiji_distilbert/mod.rs`][kiji-mod],
+[`backend/subprocess.rs`][kiji-subprocess], and
+[`class_map.rs`][kiji-class-map].
+
+## When To Choose Kiji Over OpenAI Filter
+
+- Choose Kiji when an OpenAI Privacy Filter install is not acceptable in your
+  deployment path. Kiji is local-subprocess only; Gaze does not call a network
+  service for SafetyNet checks.
+- Choose Kiji when you want a smaller pinned artifact and faster cold start.
+  The intended bundle is an ONNX DistilBERT model rather than the heavier OPF
+  path.
+- Choose Kiji when a second NER-oriented opinion is useful at the agent
+  chokepoint. The trade-off is a narrower closed local label map than OPF's
+  class taxonomy: Kiji emits validated person, location, organization, and
+  miscellaneous labels into Gaze's SafetyNet manifest-diff layer, while the
+  public upstream taxonomy remains the 26-class reference.
+
+## Installation
+
+1. Fetch the pinned model bundle:
+
+   ```sh
+   bash scripts/fetch-kiji-safetynet-model.sh
+   ```
+
+   The script installs to
+   `${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert` by
+   default. It fetches release checksums as `SHA256SUMS.kiji`, writes them into
+   the model directory as `SHA256SUMS`, and verifies the bundle before
+   returning. The script fails closed if the pinned upstream commit is not set,
+   if the release checksum cannot be resolved, or if any required file is
+   missing.
+
+2. Install the CLI with Kiji support:
+
+   ```sh
+   cargo install --path crates/gaze-cli --features safety-net-kiji
+   ```
+
+   If you want both SafetyNet backends in one binary:
+
+   ```sh
+   cargo install --path crates/gaze-cli --features safety-net-openai,safety-net-kiji
+   ```
+
+3. Verify the flag surface:
+
+   ```sh
+   gaze --help 2>&1 | grep kiji-distilbert
+   ```
+
+   You should see `kiji-distilbert` accepted by the SafetyNet flags. The CLI
+   flag table lives in [`crates/gaze-cli/README.md`][cli-readme], and the
+   activation path is implemented in [`crates/gaze-cli/src/pipeline/run.rs`][cli-run].
+
+Keep the fetch step in deployment automation, not inside the hot path. The
+SafetyNet backend is designed around a local pinned bundle: operators decide
+when artifacts move, verify them once, and then run `gaze clean` without
+network access. That makes SafetyNet startup boring and auditable. If your
+environment builds immutable images, bake the model directory into the image
+with owner-only permissions. If your environment provisions on first boot, run
+the fetcher before accepting traffic and fail the host health check when it
+cannot produce the required artifact set.
+
+The Kiji subprocess command is deliberately separate from the model directory.
+That lets you ship a small wrapper around the runtime you operate while keeping
+the pinned model bundle under Gaze's artifact contract. The wrapper may be a
+Python entrypoint, a compiled helper, or another local executable, but it must
+obey the stdin/stdout contract described below. Do not emit diagnostics to
+stdout; stdout is reserved for the JSON span array.
+
+## First Clean Run With Kiji
+
+Start from a policy that tokenizes emails, such as the root README Quickstart
+policy. Then run:
+
+```sh
+printf '%s' 'Contact alice@example.invalid for details.' \
+  | gaze clean \
+      --policy quickstart-policy.toml \
+      --safety-net kiji-distilbert \
+      --safety-net-backend kiji-distilbert \
+      --kiji-distilbert-command /opt/kiji/bin/kiji \
+      --kiji-distilbert-model-dir ~/.local/share/gaze/models/kiji-distilbert
+```
+
+The command path is the local Kiji subprocess you operate. The adapter invokes
+it with `--format json --output-mode typed` and appends `--model-dir <path>`
+when the model directory is configured. That subprocess must read the clean
+text from stdin and emit JSON spans shaped like:
+
+```json
+[{"label":"person","start":0,"end":11,"score":0.97}]
+```
+
+A clean run emits the normal `gaze clean` JSON plus `leak_report`:
+
+```json
+{
+  "clean_text": "Contact <{session_hex}:Email_1> for details.",
+  "session_blob": "<base64>",
+  "stats": {"detections": 1},
+  "leak_report": {
+    "stats": {
+      "suspect_count": 0,
+      "uncovered_count": 0,
+      "partial_bleed_count": 0,
+      "class_mismatch_count": 0,
+      "locale_skipped_count": 0
+    }
+  }
+}
+```
+
+`suspect_count = 0` is the contract for no SafetyNet suspects. The clean text
+and restore manifest still come only from the deterministic pipeline.
+
+Treat non-zero suspect counts as routing signals, not as automatic replacement
+instructions. A SafetyNet suspect says the backend saw a span worth reviewing
+after deterministic tokenization. The next action is to inspect the suspect
+class and leak kind, then decide whether a deterministic recognizer, dictionary
+term, rulepack locale, or policy rule should own that class. Promoting repeated
+SafetyNet findings into deterministic coverage is how the defense-in-depth
+layer improves the default pipeline without letting an ML backend mutate the
+manifest.
+
+For agent integrations, keep the same data boundary you use without SafetyNet:
+send only `clean_text` to the model, retain `session_blob` server-side, and
+restore model output only through authorized restore flows. The `leak_report`
+is operator metadata. It can be logged or audited through the metadata-only
+safety-net table, but it is not part of the prompt payload.
+
+## Switching Between Backends
+
+The backend selector is `--safety-net-backend`. The legacy activator
+`--safety-net <kind>` still turns on Pass-3 SafetyNet, and
+`--safety-net-backend` chooses which implementation runs:
+
+```sh
+gaze clean \
+  --policy quickstart-policy.toml \
+  --safety-net openai-filter \
+  --safety-net-backend kiji-distilbert \
+  --kiji-distilbert-command /opt/kiji/bin/kiji \
+  --kiji-distilbert-model-dir ~/.local/share/gaze/models/kiji-distilbert
+```
+
+This switch does not require a policy or manifest change. Both backends read
+the post-clean text, compare their typed spans against the manifest, and report
+the same `LeakReport` shape. Restore remains manifest-first and
+backend-independent.
+
+Backend switching is useful when the same product must run in different
+infrastructure tiers. A hosted environment might have the OpenAI Privacy Filter
+approved and use OPF for continuity with existing review workflows. A
+single-tenant or offline deployment might prefer Kiji because the artifact
+bundle is smaller and easier to pin. You can keep one policy file and change
+only the CLI backend flags per environment.
+
+Do not configure both backends in one `gaze clean` call. The CLI selector picks
+one active Pass-3 implementation. If you need comparative evaluation, run the
+same synthetic fixture set twice, once per backend, and compare the resulting
+`LeakReport` metadata. Keep those comparisons out of production request paths
+unless you have an explicit latency budget for duplicate subprocess calls.
+
+## Pinned-Artifact Contract
+
+Kiji is fail-closed by design. The CLI checks the configured model directory
+for every required artifact before the subprocess is spawned:
+
+- `SHA256SUMS`
+- `labels.json`
+- `model.onnx`
+- `tokenizer.json`
+
+The required file list is defined in [`REQUIRED_KIJI_ARTIFACTS`][kiji-subprocess].
+If any artifact is absent, the CLI returns `SafetyNetArtifactMissing` with exit
+`2` before the backend process starts:
+
+```json
+{
+  "error": "SafetyNetArtifactMissing",
+  "exit": 2,
+  "backend": "kiji-distilbert",
+  "path": "<missing path>"
+}
+```
+
+That exit is a configuration failure, not a leak report. It means the requested
+SafetyNet could not be trusted to run against the pinned artifact set, so Gaze
+refuses to silently continue with the backend disabled.
+
+Once the initial artifact check passes, the subprocess backend also verifies
+model directory presence during backend initialization. Missing weights at that
+layer map to `SafetyNetError::WeightsMissing`, which the CLI treats as a
+SafetyNet failure. Both checks preserve the same Axis-1 rule: requested privacy
+infrastructure must either run with the pinned inputs or fail closed.
+
+This contract is intentionally stricter than "try the backend if available."
+Silent fallback would make SafetyNet availability depend on host drift, cache
+state, or a deployment race. Instead, a configured Kiji backend has a clear
+activation predicate: command present, model directory present, required files
+present, and subprocess output parseable. If that predicate is false, the run
+must surface a typed failure before any cleaned output can be mistaken for a
+fully checked result.
+
+## Failure Modes And Exit Codes
+
+SafetyNet activation has two modes:
+
+- `--safety-net-mode strict` is the default. If Kiji reports `Uncovered` or
+  `PartialBleed`, `gaze clean` exits `3` with
+  `{"error":"SafetyNet","exit":3,"variant":"SuspectedLeak"}` and stdout stays
+  empty.
+- `--safety-net-mode tolerant` keeps stdout available and emits a warning to
+  stderr, such as
+  `{"warning":"SafetyNet","variant":"SuspectedLeak","count":1}`.
+
+`ClassMismatch` is handled differently. It means the deterministic pipeline
+tokenized the bytes, but the manifest class disagrees with the SafetyNet class.
+Strict mode warns for `ClassMismatch`; it does not block, because the suspect
+bytes are already covered by a token.
+
+Kiji suspect kinds come from `Manifest::diff_against`:
+
+- `Uncovered`: Kiji found a span with no overlapping token in the manifest.
+- `PartialBleed`: part of the Kiji span is covered by a token, but at least one
+  byte range remains uncovered.
+- `ClassMismatch`: the span is covered, but the manifest class differs from the
+  Kiji-mapped class.
+
+Other startup and runtime failures use the shared SafetyNet exit map. Missing
+backend flags or missing compile features are configuration errors. Timeouts,
+invalid JSON, non-finite scores, unsupported labels, and subprocess failures
+become SafetyNet failures. The CLI maps timeout messages to the `Timeout`
+variant; unsupported or malformed Kiji labels map to `InvalidOutput`.
+
+Use strict mode for production paths where a residual leak suspect should stop
+the response before it reaches an LLM. Use tolerant mode for measurement,
+canarying, or migration periods where you need to observe SafetyNet findings
+without blocking existing traffic. Tolerant mode is still useful only if stderr
+or the audit sink is monitored; otherwise it hides the signal you enabled the
+backend to collect.
+
+When a run fails with `SafetyNetArtifactMissing`, fix deployment state. When it
+fails with `SafetyNet` and a runtime variant, inspect the subprocess wrapper,
+timeout, stdout shape, and model permissions. When it fails with
+`SuspectedLeak`, inspect the reported leak kind and decide whether the
+deterministic pipeline needs a new recognizer or policy change. Keep raw source
+payloads out of tickets and logs; reproduce with project-approved synthetic
+fixtures whenever possible.
+
+## Cross-Links
+
+- [`docs/architecture/safety-nets.md`](../architecture/safety-nets.md) is the
+  full SafetyNet contract reference.
+- [`docs/research/v0.8-kiji-class-gap.md`](../research/v0.8-kiji-class-gap.md)
+  explains how the upstream 26-class taxonomy maps into Gaze's current
+  deterministic and observer-only coverage story.
+- [`docs/research/v0.8-kiji-benchmark.md`](../research/v0.8-kiji-benchmark.md)
+  records the benchmark methodology and measured subset status.
+- [`crates/gaze-cli/README.md`][cli-safety-net] lists the full CLI flag and
+  exit-code surface.
+
+[cli-readme]: ../../crates/gaze-cli/README.md#clean
+[cli-run]: ../../crates/gaze-cli/src/pipeline/run.rs
+[cli-safety-net]: ../../crates/gaze-cli/README.md#safety-net
+[kiji-class-map]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
+[kiji-mod]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+[kiji-subprocess]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs


### PR DESCRIPTION
## Summary

- Add Kiji DistilBERT coverage to README Quickstart alongside the existing OpenAI Privacy Filter path.
- Add `docs/getting-started/kiji-safetynet-setup.md` with install, first-run, backend switching, pinned-artifact, and failure-mode guidance.
- Add the canonical SafetyNet pipeline diagram to `docs/architecture/safety-nets.md` and cross-link the new setup page from architecture, UPGRADE, and the CLI README.
- Add `gaze-proxy` to the README crate map and remove the decorative README Status block.
- Remove gratuitous README version mentions per the new doc-convention rule; load-bearing dependency pins remain unchanged.

## Five-axis alignment

- Axis 1 reliability: closes the front-door docs gap that kept adopters from discovering the lighter Kiji defense-in-depth backend.
- Axis 4 trust: Kiji setup claims are tied to source-backed CLI flags, required artifacts, and typed exit behavior.
- Axis 5 ergonomics: Quickstart now presents a one-decision backend branch instead of implying only OPF exists.

## Validation

- `cargo run -p xtask -- fixture-citation-lint` passed.
- `npx --yes markdownlint-cli docs/getting-started/kiji-safetynet-setup.md` passed.
- `npx --yes markdownlint-cli README.md UPGRADE.md docs/getting-started/kiji-safetynet-setup.md 2>&1 | tail` still prints existing README/UPGRADE markdownlint findings outside this new setup page.

## Notes

- No `CHANGELOG.md` changes; release notes stay with the release-engineer pass.
- New file word count: 1769.
- Files changed: 5.
