### PR TITLE
refactor(gaze-document): introduce OcrBackend trait + Tesseract impl (v0.8.x #26)

### DIFF
--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use gaze::Manifest;
 use serde::{Deserialize, Serialize};
 
-use crate::ocr::OcrResult;
+use crate::ocr::{ImageFormat, ImageInput, OcrBackend, OcrError, OcrHints, OcrResult};
 
 #[cfg(feature = "ocr-tesseract")]
 use std::collections::BTreeMap;
@@ -213,6 +213,27 @@ impl LayoutSummary {
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> {
+    let backend = crate::ocr::TesseractBackend::new();
+    clean_with_ocr_backend(input, out_dir, &backend)
+}
+
+/// Top-level entry point with an adopter-supplied OCR backend.
+///
+/// The backend receives finalized single-image bytes. PDF rasterization and
+/// downstream layout/report generation remain owned by `gaze-document`.
+///
+/// # Errors
+///
+/// Returns [`DocumentError`] for any failure in the OCR → redact → write
+/// chain. OCR backend errors are mapped into the existing document error
+/// surface so current callers keep the same high-level behavior.
+#[cfg(feature = "ocr-tesseract")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
+pub fn clean_with_ocr_backend(
+    input: &Path,
+    out_dir: &Path,
+    ocr_backend: &dyn OcrBackend,
+) -> Result<SafeBundle, DocumentError> {
     let kind = InputKind::detect(input)?;
     let absolute_input = absolutize(input);
     let absolute_out = absolutize(out_dir);
@@ -220,7 +241,7 @@ pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> 
     fs::create_dir_all(out_dir)
         .map_err(|err| DocumentError::OutputDir(absolute_out.clone(), err))?;
 
-    let (ocr_result, pdf_page_count, pdf_page_index) = run_ocr(input, kind)?;
+    let (ocr_result, pdf_page_count, pdf_page_index) = run_ocr(input, kind, ocr_backend)?;
     // Repair known narrow OCR artifacts (e.g. spurious whitespace around
     // `@` in emails) before the redact pipeline sees the text. See
     // `crate::ocr::normalize` for the documented rule set. Axis 1
@@ -276,12 +297,19 @@ pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> 
 pub(crate) fn run_ocr(
     input: &Path,
     kind: InputKind,
+    ocr_backend: &dyn OcrBackend,
 ) -> Result<(OcrResult, Option<i32>, Option<i32>), DocumentError> {
-    use crate::ocr::TesseractOcr;
-    let ocr = TesseractOcr::new();
     match kind {
         InputKind::Png | InputKind::Jpeg => {
-            let result = ocr.extract_from_file(input)?;
+            let bytes = fs::read(input)?;
+            let result = recognize_image(
+                ocr_backend,
+                ImageInput {
+                    bytes,
+                    format: image_format_for_kind(kind),
+                    dpi: None,
+                },
+            )?;
             Ok((result, None, None))
         }
         InputKind::Pdf => {
@@ -289,7 +317,14 @@ pub(crate) fn run_ocr(
             {
                 use crate::extract::pdf::{rasterize_first_page, PdfRasterConfig};
                 let raster = rasterize_first_page(input, PdfRasterConfig::new())?;
-                let result = ocr.extract_from_bytes(&raster.png_bytes, "png")?;
+                let result = recognize_image(
+                    ocr_backend,
+                    ImageInput {
+                        bytes: raster.png_bytes,
+                        format: ImageFormat::Png,
+                        dpi: None,
+                    },
+                )?;
                 Ok((result, Some(raster.page_count), Some(raster.page_index)))
             }
             #[cfg(not(feature = "pdf-input"))]
@@ -300,6 +335,48 @@ pub(crate) fn run_ocr(
                 })
             }
         }
+    }
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn recognize_image(
+    ocr_backend: &dyn OcrBackend,
+    image: ImageInput,
+) -> Result<OcrResult, DocumentError> {
+    let hints = OcrHints::default();
+    let lang = hints.primary_language().to_string();
+    let spans = ocr_backend
+        .recognize(image, hints)
+        .map_err(map_ocr_error_to_document_error)?;
+    Ok(OcrResult::from_spans(&spans, lang))
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn image_format_for_kind(kind: InputKind) -> ImageFormat {
+    match kind {
+        InputKind::Png => ImageFormat::Png,
+        InputKind::Jpeg => ImageFormat::Jpeg,
+        InputKind::Pdf => ImageFormat::Png,
+    }
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn map_ocr_error_to_document_error(err: OcrError) -> DocumentError {
+    match err {
+        OcrError::InitFailed(hint) => DocumentError::TesseractNotFound(hint),
+        OcrError::RecognizeFailed(detail) => DocumentError::TesseractFailed {
+            status: -1,
+            stderr: detail,
+        },
+        OcrError::UnsupportedFormat(format) => DocumentError::UnsupportedInput {
+            path: PathBuf::new(),
+            reason: match format {
+                ImageFormat::Png => "png image format is not supported by the OCR backend",
+                ImageFormat::Jpeg => "jpeg image format is not supported by the OCR backend",
+                ImageFormat::Tiff => "tiff image format is not supported by the OCR backend",
+            },
+        },
+        OcrError::Internal(detail) => DocumentError::Pipeline(format!("ocr: {detail}")),
     }
 }
 

--- a/crates/gaze-document/src/lib.rs
+++ b/crates/gaze-document/src/lib.rs
@@ -50,10 +50,16 @@ pub mod render;
 
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
-pub use bundle::clean;
+pub use bundle::{clean, clean_with_ocr_backend};
 pub use bundle::{BundleReport, ClassCount, LayoutSummary, SafeBundle, BUNDLE_VERSION};
 pub use layout::ReadingOrder;
-pub use ocr::OcrAdapter;
+#[cfg(feature = "ocr-tesseract")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
+pub use ocr::TesseractBackend;
+pub use ocr::{
+    BBox, ImageFormat, ImageInput, LanguageTag, OcrAdapter, OcrBackend, OcrError, OcrHints,
+    OcrSpan, PendingOcrAdapter,
+};
 pub use render::Renderer;
 
 /// Crate-level error type for `gaze-document`.

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -233,8 +233,9 @@ fn map_file_metadata_error(path: &Path, err: std::io::Error) -> ToolError {
 #[cfg(feature = "ocr-tesseract")]
 fn read_file_response(path: &Path, ctx: &ToolCtx<'_>) -> Result<DocumentToolResponse, ToolError> {
     let kind = InputKind::detect(path).map_err(map_document_error)?;
+    let backend = crate::ocr::TesseractBackend::new();
     let (ocr_result, pdf_page_count, _) =
-        crate::bundle::run_ocr(path, kind).map_err(map_document_error)?;
+        crate::bundle::run_ocr(path, kind, &backend).map_err(map_document_error)?;
     let normalized = crate::ocr::normalize_ocr_artifacts(&ocr_result.text);
     let clean_text = redact_document_text(&normalized, ctx)?;
     Ok(DocumentToolResponse {

--- a/crates/gaze-document/src/ocr/mod.rs
+++ b/crates/gaze-document/src/ocr/mod.rs
@@ -1,17 +1,13 @@
-//! OCR adapter contract surface and concrete backends.
+//! OCR backend contract surface and concrete backends.
 //!
-//! The [`OcrAdapter`] trait stays open for future backends (cloud OCR, Apple
-//! Vision, etc.). The shipping backend in v0.0.x is the Tesseract subprocess
-//! adapter under [`tesseract`].
-//!
-//! The trait itself remains fail-loud-default via [`PendingOcrAdapter`] so an
-//! adopter who builds a trait object without picking a backend gets a typed
-//! `NotImplemented` error instead of silent zero-detection output (Axis 1
-//! fail-closed).
-
-use crate::DocumentError;
+//! The [`OcrBackend`] trait is intentionally narrow: finalized image bytes in,
+//! flat OCR spans out. Preprocessing, multi-page orchestration, and layout
+//! reconstruction stay above or below this module so backend plurality can
+//! arrive later without widening the trust boundary.
 
 mod normalize;
+
+use crate::DocumentError;
 
 pub(crate) use normalize::normalize_ocr_artifacts;
 
@@ -21,11 +17,195 @@ pub mod tesseract;
 
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
-pub use tesseract::TesseractOcr;
+pub use tesseract::TesseractBackend;
+
+/// Backward-compatible alias for the Tesseract subprocess OCR backend.
+#[cfg(feature = "ocr-tesseract")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
+#[deprecated(note = "use TesseractBackend")]
+pub type TesseractOcr = TesseractBackend;
+
+/// Raster image format handed to an OCR backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageFormat {
+    /// PNG image bytes.
+    Png,
+    /// JPEG image bytes.
+    Jpeg,
+    /// TIFF image bytes.
+    Tiff,
+}
+
+impl ImageFormat {
+    /// File extension used for temporary subprocess handoff.
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Jpeg => "jpg",
+            Self::Tiff => "tiff",
+        }
+    }
+}
+
+/// Finalized image payload for one OCR pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageInput {
+    /// Encoded image bytes.
+    pub bytes: Vec<u8>,
+    /// Encoded image format.
+    pub format: ImageFormat,
+    /// Optional source DPI, when known by the orchestration layer.
+    pub dpi: Option<u32>,
+}
+
+/// Backend language tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageTag(String);
+
+impl LanguageTag {
+    /// Build a language tag from a backend-specific language code.
+    pub fn new(tag: impl Into<String>) -> Self {
+        Self(tag.into())
+    }
+
+    /// Borrow the language tag as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for LanguageTag {
+    fn default() -> Self {
+        Self::new("eng")
+    }
+}
+
+/// OCR backend hints. Backends may downgrade hints they cannot support.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OcrHints {
+    /// Preferred OCR languages.
+    pub languages: Vec<LanguageTag>,
+}
+
+impl OcrHints {
+    /// Build hints with the default English Tesseract-compatible tag.
+    pub fn english() -> Self {
+        Self {
+            languages: vec![LanguageTag::default()],
+        }
+    }
+
+    /// Return the first requested language, falling back to English.
+    pub fn primary_language(&self) -> &str {
+        self.languages
+            .first()
+            .map(LanguageTag::as_str)
+            .unwrap_or("eng")
+    }
+}
+
+impl Default for OcrHints {
+    fn default() -> Self {
+        Self::english()
+    }
+}
+
+/// Bounding box in image pixel coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BBox {
+    /// Left coordinate.
+    pub x: u32,
+    /// Top coordinate.
+    pub y: u32,
+    /// Width in pixels.
+    pub w: u32,
+    /// Height in pixels.
+    pub h: u32,
+}
+
+/// One OCR text span emitted by a backend.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OcrSpan {
+    /// Recognized text for this span.
+    pub text: String,
+    /// Span bounding box in image pixel coordinates.
+    pub bbox: BBox,
+    /// Backend confidence normalized to `0.0..=1.0`.
+    pub confidence: Option<f32>,
+}
+
+/// Closed OCR backend error surface.
+#[derive(Debug, thiserror::Error)]
+pub enum OcrError {
+    /// Backend initialization failed.
+    #[error("backend init failed: {0}")]
+    InitFailed(String),
+    /// Recognition failed after backend initialization.
+    #[error("recognize failed: {0}")]
+    RecognizeFailed(String),
+    /// Image format is unsupported by this backend.
+    #[error("unsupported image format: {0:?}")]
+    UnsupportedFormat(ImageFormat),
+    /// Backend hit an internal invariant or I/O failure.
+    #[error("backend internal error: {0}")]
+    Internal(String),
+}
+
+/// Narrow OCR backend contract.
+pub trait OcrBackend: Send + Sync {
+    /// Stable backend name used in diagnostics.
+    fn name(&self) -> &str;
+
+    /// Recognize flat spans from one finalized image.
+    fn recognize(&self, image: ImageInput, hints: OcrHints) -> Result<Vec<OcrSpan>, OcrError>;
+}
+
+/// Legacy text-only adapter contract kept for source compatibility.
+///
+/// New code should use [`OcrBackend`] so backend output remains traceable to
+/// bounding boxes and confidence values.
+pub trait OcrAdapter {
+    /// Extract textual content from image bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DocumentError`] when backend recognition fails.
+    fn extract_text(&self, bytes: &[u8]) -> Result<String, DocumentError>;
+}
+
+/// Reserved fail-loud legacy adapter.
+///
+/// New code should wire a concrete [`OcrBackend`]. This placeholder remains so
+/// older callers fail closed instead of receiving silent empty OCR output.
+#[non_exhaustive]
+pub struct PendingOcrAdapter {
+    _private: (),
+}
+
+impl PendingOcrAdapter {
+    /// Build the fail-loud adapter.
+    ///
+    /// # Errors
+    ///
+    /// Always returns [`DocumentError::NotImplemented`].
+    pub fn new() -> Result<Self, DocumentError> {
+        Err(DocumentError::NotImplemented(
+            "PendingOcrAdapter::new (wire a concrete OCR backend)",
+        ))
+    }
+}
+
+impl OcrAdapter for PendingOcrAdapter {
+    fn extract_text(&self, _bytes: &[u8]) -> Result<String, DocumentError> {
+        Err(DocumentError::NotImplemented(
+            "PendingOcrAdapter::extract_text (wire a concrete OCR backend)",
+        ))
+    }
+}
 
 /// Result of an OCR pass: full text + a structured confidence summary.
 ///
-/// Backend-agnostic — concrete adapters (e.g., [`tesseract::TesseractOcr`])
+/// Backend-agnostic — concrete adapters (e.g., [`tesseract::TesseractBackend`])
 /// produce values of this shape so the rest of the pipeline does not
 /// hard-code one OCR backend's surface.
 #[non_exhaustive]
@@ -57,50 +237,66 @@ impl OcrResult {
             lang,
         }
     }
-}
 
-/// Adapter contract for OCR backends.
-///
-/// Implementations live behind feature flags (e.g., `ocr-tesseract`) and
-/// must round-trip page coordinates so the eventual `layout::ReadingOrder`
-/// pass can stitch the result without losing source spans.
-pub trait OcrAdapter {
-    /// Extract textual content from `_bytes` (raw image / page payload).
-    ///
-    /// # Errors
-    /// Implementations return [`DocumentError`] on backend failure.
-    fn extract_text(&self, bytes: &[u8]) -> Result<String, DocumentError>;
-}
-
-/// Reserved fail-loud adapter.
-///
-/// Used as an explicit "no backend wired" sentinel. Every call returns
-/// [`DocumentError::NotImplemented`] so accidental wiring is caught at the
-/// call site (Axis 1 fail-closed).
-#[non_exhaustive]
-pub struct PendingOcrAdapter {
-    _private: (),
-}
-
-impl PendingOcrAdapter {
-    /// Build the fail-loud adapter.
-    ///
-    /// # Errors
-    /// Always returns [`DocumentError::NotImplemented`]. The placeholder
-    /// exists so adopters wiring a trait object without a concrete backend
-    /// fail at construction time rather than receiving silent zero-output
-    /// (Axis 1 fail-closed).
-    pub fn new() -> Result<Self, DocumentError> {
-        Err(DocumentError::NotImplemented(
-            "PendingOcrAdapter::new (wire a concrete OCR backend)",
-        ))
+    /// Build an OCR result from flat spans using pixel y-position to recover
+    /// a conservative reading order.
+    pub fn from_spans(spans: &[OcrSpan], lang: String) -> Self {
+        let text = spans_to_text(spans);
+        let mut conf_sum = 0.0f64;
+        let mut conf_count = 0usize;
+        for span in spans {
+            if let Some(confidence) = span.confidence {
+                conf_sum += (confidence * 100.0) as f64;
+                conf_count += 1;
+            }
+        }
+        let mean_confidence = if conf_count == 0 {
+            None
+        } else {
+            Some((conf_sum / conf_count as f64) as f32)
+        };
+        Self {
+            text,
+            mean_confidence,
+            word_count: conf_count,
+            lang,
+        }
     }
 }
 
-impl OcrAdapter for PendingOcrAdapter {
-    fn extract_text(&self, _bytes: &[u8]) -> Result<String, DocumentError> {
-        Err(DocumentError::NotImplemented(
-            "PendingOcrAdapter::extract_text (wire a concrete OCR backend)",
-        ))
+fn spans_to_text(spans: &[OcrSpan]) -> String {
+    let mut ordered = spans.to_vec();
+    ordered.sort_by_key(|span| (span.bbox.y, span.bbox.x));
+
+    let mut lines: Vec<Vec<OcrSpan>> = Vec::new();
+
+    for span in ordered {
+        if span.text.is_empty() {
+            continue;
+        }
+        let belongs_to_current_line = lines
+            .last()
+            .and_then(|line| line.first())
+            .map(|first| span.bbox.y.abs_diff(first.bbox.y) <= span.bbox.h.max(first.bbox.h))
+            .unwrap_or(false);
+        if belongs_to_current_line {
+            if let Some(line) = lines.last_mut() {
+                line.push(span);
+            }
+        } else {
+            lines.push(vec![span]);
+        }
     }
+
+    lines
+        .into_iter()
+        .map(|mut line| {
+            line.sort_by_key(|span| span.bbox.x);
+            line.into_iter()
+                .map(|span| span.text)
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/crates/gaze-document/src/ocr/tesseract.rs
+++ b/crates/gaze-document/src/ocr/tesseract.rs
@@ -21,7 +21,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use super::OcrResult;
+use super::{BBox, ImageInput, OcrBackend, OcrError, OcrHints, OcrResult, OcrSpan};
 use crate::DocumentError;
 
 const STDERR_TRUNCATE_BYTES: usize = 4096;
@@ -29,14 +29,14 @@ const STDERR_TRUNCATE_BYTES: usize = 4096;
 /// Tesseract subprocess OCR backend.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
-pub struct TesseractOcr {
+pub struct TesseractBackend {
     /// Tesseract language code (default `eng`).
     pub lang: String,
     /// Optional explicit binary path. `None` → look up `tesseract` on `PATH`.
     pub binary: Option<std::path::PathBuf>,
 }
 
-impl TesseractOcr {
+impl TesseractBackend {
     /// Builds the adapter with `eng` language and `tesseract` on `PATH`.
     pub fn new() -> Self {
         Self {
@@ -58,6 +58,19 @@ impl TesseractOcr {
     /// Calls `tesseract <path> stdout -l <lang> tsv`, parses the TSV stream
     /// for text + per-word confidence in a single subprocess invocation.
     pub fn extract_from_file(&self, path: &Path) -> Result<OcrResult, DocumentError> {
+        self.extract_from_file_with_lang(path, &self.lang)
+    }
+
+    fn extract_from_file_with_lang(
+        &self,
+        path: &Path,
+        lang: &str,
+    ) -> Result<OcrResult, DocumentError> {
+        let tsv = self.run_tesseract_tsv(path, lang)?;
+        Ok(parse_tsv_result(&tsv, lang))
+    }
+
+    fn run_tesseract_tsv(&self, path: &Path, lang: &str) -> Result<String, DocumentError> {
         let binary: &std::ffi::OsStr = self
             .binary
             .as_deref()
@@ -68,7 +81,7 @@ impl TesseractOcr {
             .arg(path)
             .arg("stdout")
             .arg("-l")
-            .arg(&self.lang)
+            .arg(lang)
             .arg("tsv")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -87,8 +100,7 @@ impl TesseractOcr {
             });
         }
 
-        let tsv = String::from_utf8_lossy(&output.stdout);
-        Ok(parse_tsv(&tsv, &self.lang))
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }
 
     /// Runs OCR on an in-memory image payload.
@@ -113,18 +125,93 @@ impl TesseractOcr {
     }
 }
 
-impl Default for TesseractOcr {
+impl Default for TesseractBackend {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl super::OcrAdapter for TesseractOcr {
+impl OcrBackend for TesseractBackend {
+    fn name(&self) -> &str {
+        "tesseract"
+    }
+
+    fn recognize(&self, image: ImageInput, hints: OcrHints) -> Result<Vec<OcrSpan>, OcrError> {
+        let suffix = format!(".{}", image.format.extension());
+        let mut file = tempfile::Builder::new()
+            .prefix("gaze-document-ocr-")
+            .suffix(suffix.as_str())
+            .tempfile()
+            .map_err(|err| OcrError::Internal(err.to_string()))?;
+        file.write_all(&image.bytes)
+            .map_err(|err| OcrError::Internal(err.to_string()))?;
+        file.flush()
+            .map_err(|err| OcrError::Internal(err.to_string()))?;
+        let tsv = self
+            .run_tesseract_tsv(file.path(), hints.primary_language())
+            .map_err(document_error_to_ocr_error)?;
+        Ok(parse_tsv_spans(&tsv))
+    }
+}
+
+impl super::OcrAdapter for TesseractBackend {
     fn extract_text(&self, bytes: &[u8]) -> Result<String, DocumentError> {
-        // PNG is the default carrier we hand to Tesseract for in-memory bytes;
-        // callers with JPG should prefer `extract_from_bytes` with the right
-        // extension or `extract_from_file`.
-        self.extract_from_bytes(bytes, "png").map(|res| res.text)
+        self.extract_from_bytes(bytes, "png")
+            .map(|result| result.text)
+    }
+}
+
+fn parse_tsv_result(tsv: &str, lang: &str) -> OcrResult {
+    parse_tsv(tsv, lang)
+}
+
+fn parse_tsv_spans(tsv: &str) -> Vec<OcrSpan> {
+    let mut spans = Vec::new();
+
+    for (idx, line) in tsv.lines().enumerate() {
+        if idx == 0 || line.is_empty() {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        if cols.len() < 12 {
+            continue;
+        }
+        let level: u32 = cols[0].parse().unwrap_or(0);
+        if level != 5 {
+            continue;
+        }
+        let word = cols[11];
+        if word.is_empty() {
+            continue;
+        }
+        let confidence = cols[10]
+            .parse::<f32>()
+            .ok()
+            .filter(|conf| *conf >= 0.0)
+            .map(|conf| (conf / 100.0).clamp(0.0, 1.0));
+        spans.push(OcrSpan {
+            text: word.to_string(),
+            bbox: BBox {
+                x: cols[6].parse().unwrap_or(0),
+                y: cols[7].parse().unwrap_or(0),
+                w: cols[8].parse().unwrap_or(0),
+                h: cols[9].parse().unwrap_or(0),
+            },
+            confidence,
+        });
+    }
+
+    spans
+}
+
+fn document_error_to_ocr_error(err: DocumentError) -> OcrError {
+    match err {
+        DocumentError::TesseractNotFound(hint) => OcrError::InitFailed(hint),
+        DocumentError::TesseractFailed { status, stderr } => {
+            OcrError::RecognizeFailed(format!("status {status}: {stderr}"))
+        }
+        DocumentError::Io(err) => OcrError::Internal(err.to_string()),
+        other => OcrError::Internal(other.to_string()),
     }
 }
 

--- a/crates/gaze-document/tests/ocr_backend.rs
+++ b/crates/gaze-document/tests/ocr_backend.rs
@@ -1,0 +1,50 @@
+//! Direct OCR backend contract tests.
+
+#![cfg(feature = "ocr-tesseract")]
+
+use std::path::PathBuf;
+
+use gaze_document::{ImageFormat, ImageInput, OcrBackend, OcrError, OcrHints, TesseractBackend};
+
+fn testdata_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata")
+}
+
+#[test]
+fn ocr_backend_is_object_safe() {
+    let _backend: Box<dyn OcrBackend> = Box::new(TesseractBackend::new());
+}
+
+#[test]
+fn tesseract_backend_recognizes_synthetic_image_spans() {
+    let input = testdata_dir().join("synthetic_image.png");
+    let bytes = std::fs::read(&input).expect("fixture readable");
+    let backend = TesseractBackend::new();
+
+    let spans = match backend.recognize(
+        ImageInput {
+            bytes,
+            format: ImageFormat::Png,
+            dpi: None,
+        },
+        OcrHints::default(),
+    ) {
+        Ok(spans) => spans,
+        Err(OcrError::InitFailed(reason)) => {
+            eprintln!("SKIP: tesseract not installed: {reason}");
+            return;
+        }
+        Err(err) => panic!("tesseract recognize failed: {err}"),
+    };
+
+    assert!(!spans.is_empty(), "expected at least one OCR span");
+    let recognized = spans
+        .iter()
+        .map(|span| span.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        recognized.contains("Bill"),
+        "expected OCR spans to include fixture text, got: {recognized}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements roadmap scratchpad 346 rev 16 item #26 by introducing a narrow internal OCR backend seam in `gaze-document`.

- Adds `OcrBackend` as an object-safe trait: image bytes + hints -> `OcrSpan` list.
- Adds closed-enum `OcrError` and typed OCR input/span primitives.
- Renames the concrete implementation to `TesseractBackend` while preserving legacy adapter compatibility.
- Threads the backend through bundle/MCP OCR call sites with `clean_with_ocr_backend` for internal injection.
- Keeps preprocessing, PDF rasterization, multipage handling, and bundle assembly outside the trait.

## Scope Notes

This deliberately mirrors the SafetyNet precedent: the abstraction lands now with one production backend, and backend plurality remains pull-driven. There is no second OCR backend, no new crate, no preprocessing abstraction, no multipage OCR trait, and no `bundle_version` bump.

`BundleReport`, manifest shape, `clean.md`, and `report.json` output contracts are unchanged. Tesseract behavior is preserved; backend errors are mapped fail-closed into existing `DocumentError` variants.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`

Added `crates/gaze-document/tests/ocr_backend.rs` with:
- object-safety coverage for `dyn OcrBackend`
- fixture-backed `TesseractBackend::recognize` span coverage

## Five-Axis Self-Check

No axis is weakened. Reliability/trust improve through a closed backend error surface and explicit OCR boundary. Reversibility is unchanged because manifest/restore contracts are untouched. Agentic fit and adopter ergonomics are preserved by keeping bundle output stable and limiting the abstraction to the minimum needed seam.
