### PR TITLE
feat(gaze-document): layout completion C-scope + bundle_version=2 (v0.8.x #28a)

### DIFF
--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -82,11 +82,11 @@ let _ = &bundle.clean_markdown;
 // Restorable manifest — pair with a `gaze::Session` to round-trip.
 let _ = &bundle.manifest;
 
-// Provenance: OCR confidence + PII counts.
+// Provenance: per-page extraction confidence + PII counts.
 println!(
-    "tokens={} confidence={:?}",
+    "tokens={} first_page_confidence={:?}",
     bundle.report.pii_token_count,
-    bundle.report.ocr_mean_confidence,
+    bundle.report.pages.first().and_then(|page| page.confidence),
 );
 # Ok::<(), gaze_document::DocumentError>(())
 ```
@@ -116,9 +116,12 @@ Stdout carries a one-line JSON summary so callers can pipe it.
   `gaze-types`). Compatible with `gaze restore` and the rest of the
   `gaze` runtime.
 * **`report.json`** — `BundleReport`. Schema versioned via
-  `bundle_version: u32 = 1`; field set is `#[non_exhaustive]` so additive
-  fields are SemVer-safe. Includes OCR confidence, per-class PII counts,
-  PDF metadata, and the source kind.
+  `bundle_version: u32 = 2`; field set is `#[non_exhaustive]` so additive
+  fields are SemVer-safe. Includes per-page extraction source
+  (`vector_pdf` or `ocr`), OCR backend, normalized confidence,
+  low-confidence flag, column count, per-class PII counts, PDF metadata,
+  and the source kind. Existing v1 reports still deserialize; new emission
+  is always v2.
 
 ## OCR brittleness + normalization
 
@@ -165,9 +168,10 @@ Two mitigations land at the test boundary so future drift fails loudly:
   substring checks (`!contains("@example.com")`, `!contains("Jane Doe")`,
   `!contains("555-0142")`) **in addition** to the positive `:Email_`,
   `:Name_`, `:Custom:phone_` token assertions.
-* `BundleReport.ocr_mean_confidence` is always surfaced to adopters
-  unmodified — no silent floor — so downstream gates can route
-  low-confidence bundles for human review.
+* `BundleReport.pages[].confidence` and `pages[].low_confidence` are always
+  surfaced to adopters. The default threshold is `0.65`, configurable with
+  `gaze_document::Pipeline::with_low_confidence_threshold()`, so downstream
+  gates can route low-confidence pages for human review.
 
 If you observe a new artifact class slipping through, file an issue
 with the OCR output and the expected normalization shape; the fix
@@ -205,7 +209,7 @@ Both tools return a JSON object:
   "file_metadata": {
     "source_kind": "text",
     "ocr_mean_confidence": null,
-    "bundle_version": 1,
+    "bundle_version": 2,
     "page_count": null
   }
 }
@@ -221,7 +225,7 @@ provides the opt-in tool implementations.
 | Feature           | Default | What it enables                                      |
 |-------------------|---------|------------------------------------------------------|
 | `ocr-tesseract`   | yes     | Tesseract subprocess OCR backend + `clean()` entry.  |
-| `pdf-input`       | yes     | `pdfium-render` PDF rasterization (single page).     |
+| `pdf-input`       | yes     | `pdfium-render` PDF text extraction + raster OCR fallback. |
 | `mcp`             | no      | `gaze_read_file` + `gaze_read_text` Tool impls.      |
 | `extract-docling` | no      | Reserved — future Docling layout adapter.            |
 | `render-image`    | no      | Reserved — future redacted-preview renderer.         |

--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -32,7 +32,8 @@ use std::path::Path;
 
 #[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze::{
-    Action, ClassRule, CleanDocument, DefaultRule, LocaleTag, Pipeline, RawDocument, Scope, Session,
+    Action, ClassRule, CleanDocument, DefaultRule, LocaleTag, Pipeline as GazePipeline,
+    RawDocument, Scope, Session,
 };
 #[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze_recognizers::{
@@ -47,7 +48,8 @@ use crate::extract::InputKind;
 use crate::DocumentError;
 
 /// Versioned `report.json` schema tag (bump on breaking shape changes).
-pub const BUNDLE_VERSION: u32 = 1;
+pub const BUNDLE_VERSION: u32 = 2;
+const DEFAULT_LOW_CONFIDENCE_THRESHOLD: f32 = 0.65;
 
 /// Bundle filename written into `--out` for tokenized Markdown.
 pub const CLEAN_MARKDOWN_FILE: &str = "clean.md";
@@ -119,6 +121,63 @@ impl ClassCount {
     }
 }
 
+/// Per-page extraction source.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OcrSource {
+    /// Selectable text extracted directly from a PDF page.
+    VectorPdf,
+    /// Raster OCR from an image page.
+    Ocr,
+}
+
+/// Per-page OCR/layout provenance.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PageReport {
+    /// Zero-based page index.
+    pub page_index: i32,
+    /// Extraction path used for this page.
+    pub ocr_source: OcrSource,
+    /// OCR backend name when [`OcrSource::Ocr`] produced the page.
+    pub ocr_backend: Option<String>,
+    /// Aggregated page confidence in `0.0..=1.0`. `None` for vector PDF text.
+    pub confidence: Option<f32>,
+    /// True when confidence is present and below the configured threshold.
+    pub low_confidence: bool,
+    /// Detected text column count. `1` means single-column.
+    pub column_count: u32,
+    /// Number of OCR words with confidence for this page.
+    pub ocr_word_count: usize,
+    /// Legacy percent-scale mean confidence for this page.
+    pub ocr_mean_confidence: Option<f32>,
+}
+
+impl PageReport {
+    fn new(
+        page_index: i32,
+        ocr_source: OcrSource,
+        ocr_backend: Option<String>,
+        ocr: &OcrResult,
+        column_count: u32,
+        low_confidence_threshold: f32,
+    ) -> Self {
+        let confidence = ocr.mean_confidence_unit();
+        Self {
+            page_index,
+            ocr_source,
+            ocr_backend,
+            confidence,
+            low_confidence: confidence
+                .map(|confidence| confidence < low_confidence_threshold)
+                .unwrap_or(false),
+            column_count,
+            ocr_word_count: ocr.word_count,
+            ocr_mean_confidence: ocr.mean_confidence,
+        }
+    }
+}
+
 /// Bundle audit + provenance report serialized to `report.json`.
 ///
 /// Schema versioned via [`BUNDLE_VERSION`]; older readers can branch on the
@@ -147,6 +206,12 @@ pub struct BundleReport {
     pub pdf_page_count: Option<i32>,
     /// PDF page index that was rasterized. `None` for image inputs.
     pub pdf_page_index: Option<i32>,
+    /// Per-page extraction, confidence, and layout provenance.
+    #[serde(default)]
+    pub pages: Vec<PageReport>,
+    /// Confidence threshold used to set [`PageReport::low_confidence`].
+    #[serde(default = "default_low_confidence_threshold")]
+    pub low_confidence_threshold: f32,
 }
 
 impl BundleReport {
@@ -160,6 +225,8 @@ impl BundleReport {
         pii_tokens_by_class: Vec<ClassCount>,
         pdf_page_count: Option<i32>,
         pdf_page_index: Option<i32>,
+        pages: Vec<PageReport>,
+        low_confidence_threshold: f32,
     ) -> Self {
         Self {
             bundle_version: BUNDLE_VERSION,
@@ -172,7 +239,64 @@ impl BundleReport {
             pii_tokens_by_class,
             pdf_page_count,
             pdf_page_index,
+            pages,
+            low_confidence_threshold,
         }
+    }
+}
+
+fn default_low_confidence_threshold() -> f32 {
+    DEFAULT_LOW_CONFIDENCE_THRESHOLD
+}
+
+/// Configurable document-cleaning pipeline.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct Pipeline {
+    low_confidence_threshold: f32,
+    column_detection: bool,
+}
+
+impl Pipeline {
+    /// Build a pipeline with conservative defaults.
+    pub fn new() -> Self {
+        Self {
+            low_confidence_threshold: DEFAULT_LOW_CONFIDENCE_THRESHOLD,
+            column_detection: true,
+        }
+    }
+
+    /// Override the per-page low-confidence threshold.
+    pub fn with_low_confidence_threshold(mut self, threshold: f32) -> Self {
+        self.low_confidence_threshold = threshold.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Enable or disable multi-column OCR span ordering.
+    pub fn with_column_detection(mut self, enabled: bool) -> Self {
+        self.column_detection = enabled;
+        self
+    }
+
+    /// Clean one document with an adopter-supplied OCR backend.
+    ///
+    /// # Errors
+    /// Returns [`DocumentError`] for any extraction, OCR, redaction, or write failure.
+    #[cfg(feature = "ocr-tesseract")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
+    pub fn clean_with_ocr_backend(
+        &self,
+        input: &Path,
+        out_dir: &Path,
+        ocr_backend: &dyn OcrBackend,
+    ) -> Result<SafeBundle, DocumentError> {
+        clean_with_options(input, out_dir, ocr_backend, *self)
+    }
+}
+
+impl Default for Pipeline {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -214,7 +338,7 @@ impl LayoutSummary {
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> {
     let backend = crate::ocr::TesseractBackend::new();
-    clean_with_ocr_backend(input, out_dir, &backend)
+    Pipeline::new().clean_with_ocr_backend(input, out_dir, &backend)
 }
 
 /// Top-level entry point with an adopter-supplied OCR backend.
@@ -234,6 +358,16 @@ pub fn clean_with_ocr_backend(
     out_dir: &Path,
     ocr_backend: &dyn OcrBackend,
 ) -> Result<SafeBundle, DocumentError> {
+    Pipeline::new().clean_with_ocr_backend(input, out_dir, ocr_backend)
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn clean_with_options(
+    input: &Path,
+    out_dir: &Path,
+    ocr_backend: &dyn OcrBackend,
+    options: Pipeline,
+) -> Result<SafeBundle, DocumentError> {
     let kind = InputKind::detect(input)?;
     let absolute_input = absolutize(input);
     let absolute_out = absolutize(out_dir);
@@ -241,14 +375,14 @@ pub fn clean_with_ocr_backend(
     fs::create_dir_all(out_dir)
         .map_err(|err| DocumentError::OutputDir(absolute_out.clone(), err))?;
 
-    let (ocr_result, pdf_page_count, pdf_page_index) = run_ocr(input, kind, ocr_backend)?;
+    let extraction = run_document_extraction(input, kind, ocr_backend, options)?;
     // Repair known narrow OCR artifacts (e.g. spurious whitespace around
     // `@` in emails) before the redact pipeline sees the text. See
     // `crate::ocr::normalize` for the documented rule set. Axis 1
     // (never leak) requires this — the OCR pass occasionally inserts a
     // single space inside an email that would otherwise slip past strict
     // recognizers and survive into clean.md.
-    let normalized_text = crate::ocr::normalize_ocr_artifacts(&ocr_result.text);
+    let normalized_text = crate::ocr::normalize_ocr_artifacts(&extraction.ocr_result.text);
     let pipeline = build_document_pipeline()?;
     let session = Session::new(Scope::Ephemeral).map_err(|err| pipeline_err("session", err))?;
     let locale_chain = [LocaleTag::Global];
@@ -271,12 +405,14 @@ pub fn clean_with_ocr_backend(
 
     let report = BundleReport::new(
         kind_label(kind),
-        &ocr_result,
+        &extraction.ocr_result,
         clean_text.chars().count(),
         pii_token_count,
         counts,
-        pdf_page_count,
-        pdf_page_index,
+        extraction.pdf_page_count,
+        extraction.pdf_page_index,
+        extraction.pages,
+        options.low_confidence_threshold,
     );
 
     let clean_markdown = format_clean_markdown(&clean_text, kind);
@@ -285,7 +421,7 @@ pub fn clean_with_ocr_backend(
     Ok(SafeBundle::new(
         clean_markdown,
         manifest,
-        LayoutSummary::single_page(),
+        LayoutSummary::new(extraction.page_count),
         None,
         report,
         absolute_input,
@@ -294,38 +430,123 @@ pub fn clean_with_ocr_backend(
 }
 
 #[cfg(feature = "ocr-tesseract")]
+struct DocumentExtraction {
+    ocr_result: OcrResult,
+    pdf_page_count: Option<i32>,
+    pdf_page_index: Option<i32>,
+    pages: Vec<PageReport>,
+    page_count: u32,
+}
+
+#[cfg(feature = "ocr-tesseract")]
 pub(crate) fn run_ocr(
     input: &Path,
     kind: InputKind,
     ocr_backend: &dyn OcrBackend,
 ) -> Result<(OcrResult, Option<i32>, Option<i32>), DocumentError> {
+    let extraction = run_document_extraction(input, kind, ocr_backend, Pipeline::new())?;
+    Ok((
+        extraction.ocr_result,
+        extraction.pdf_page_count,
+        extraction.pdf_page_index,
+    ))
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn run_document_extraction(
+    input: &Path,
+    kind: InputKind,
+    ocr_backend: &dyn OcrBackend,
+    options: Pipeline,
+) -> Result<DocumentExtraction, DocumentError> {
     match kind {
         InputKind::Png | InputKind::Jpeg => {
             let bytes = fs::read(input)?;
-            let result = recognize_image(
+            let (result, column_count) = recognize_image(
                 ocr_backend,
                 ImageInput {
                     bytes,
                     format: image_format_for_kind(kind),
                     dpi: None,
                 },
+                options.column_detection,
             )?;
-            Ok((result, None, None))
+            let page_report = PageReport::new(
+                0,
+                OcrSource::Ocr,
+                Some(ocr_backend.name().to_string()),
+                &result,
+                column_count,
+                options.low_confidence_threshold,
+            );
+            Ok(DocumentExtraction {
+                ocr_result: result,
+                pdf_page_count: None,
+                pdf_page_index: None,
+                pages: vec![page_report],
+                page_count: 1,
+            })
         }
         InputKind::Pdf => {
             #[cfg(feature = "pdf-input")]
             {
-                use crate::extract::pdf::{rasterize_first_page, PdfRasterConfig};
-                let raster = rasterize_first_page(input, PdfRasterConfig::new())?;
-                let result = recognize_image(
-                    ocr_backend,
-                    ImageInput {
-                        bytes: raster.png_bytes,
-                        format: ImageFormat::Png,
-                        dpi: None,
-                    },
-                )?;
-                Ok((result, Some(raster.page_count), Some(raster.page_index)))
+                use crate::extract::pdf::{extract_pages, PdfPagePayload, PdfRasterConfig};
+                let payloads = extract_pages(input, PdfRasterConfig::new())?;
+                let mut page_results = Vec::with_capacity(payloads.len());
+                let mut pages = Vec::with_capacity(payloads.len());
+                let mut pdf_page_count = None;
+                let mut first_page_index = None;
+
+                for payload in payloads {
+                    pdf_page_count = Some(payload.page_count());
+                    if first_page_index.is_none() {
+                        first_page_index = Some(payload.page_index());
+                    }
+                    match payload {
+                        PdfPagePayload::VectorText {
+                            text, page_index, ..
+                        } => {
+                            let result = OcrResult::new(text, None, 0, "vector-pdf".to_string());
+                            pages.push(PageReport::new(
+                                page_index,
+                                OcrSource::VectorPdf,
+                                None,
+                                &result,
+                                1,
+                                options.low_confidence_threshold,
+                            ));
+                            page_results.push(result);
+                        }
+                        PdfPagePayload::Raster(raster) => {
+                            let (result, column_count) = recognize_image(
+                                ocr_backend,
+                                ImageInput {
+                                    bytes: raster.png_bytes,
+                                    format: ImageFormat::Png,
+                                    dpi: None,
+                                },
+                                options.column_detection,
+                            )?;
+                            pages.push(PageReport::new(
+                                raster.page_index,
+                                OcrSource::Ocr,
+                                Some(ocr_backend.name().to_string()),
+                                &result,
+                                column_count,
+                                options.low_confidence_threshold,
+                            ));
+                            page_results.push(result);
+                        }
+                    }
+                }
+
+                Ok(DocumentExtraction {
+                    ocr_result: merge_page_results(&page_results),
+                    pdf_page_count,
+                    pdf_page_index: first_page_index,
+                    page_count: pages.len() as u32,
+                    pages,
+                })
             }
             #[cfg(not(feature = "pdf-input"))]
             {
@@ -342,13 +563,41 @@ pub(crate) fn run_ocr(
 fn recognize_image(
     ocr_backend: &dyn OcrBackend,
     image: ImageInput,
-) -> Result<OcrResult, DocumentError> {
+    column_detection: bool,
+) -> Result<(OcrResult, u32), DocumentError> {
     let hints = OcrHints::default();
     let lang = hints.primary_language().to_string();
     let spans = ocr_backend
         .recognize(image, hints)
         .map_err(map_ocr_error_to_document_error)?;
-    Ok(OcrResult::from_spans(&spans, lang))
+    Ok(OcrResult::from_spans_with_column_detection(
+        &spans,
+        lang,
+        column_detection,
+    ))
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn merge_page_results(results: &[OcrResult]) -> OcrResult {
+    let text = results
+        .iter()
+        .map(|result| result.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let mut conf_sum = 0.0f64;
+    let mut conf_count = 0usize;
+    for result in results {
+        if let Some(confidence) = result.mean_confidence {
+            conf_sum += confidence as f64 * result.word_count as f64;
+            conf_count += result.word_count;
+        }
+    }
+    let mean_confidence = if conf_count == 0 {
+        None
+    } else {
+        Some((conf_sum / conf_count as f64) as f32)
+    };
+    OcrResult::new(text, mean_confidence, conf_count, "mixed".to_string())
 }
 
 #[cfg(feature = "ocr-tesseract")]
@@ -382,7 +631,7 @@ fn map_ocr_error_to_document_error(err: OcrError) -> DocumentError {
 
 #[cfg(feature = "ocr-tesseract")]
 #[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
-pub(crate) fn build_document_pipeline() -> Result<Pipeline, DocumentError> {
+pub(crate) fn build_document_pipeline() -> Result<GazePipeline, DocumentError> {
     let email = RegexDetector::emails().map_err(|err| pipeline_err("email-regex", err))?;
     // Conservative phone pattern: optional `+CC`, area, exchange, line, with
     // common separators. Synthetic fixture uses `+1-555-0142`-style numbers.
@@ -416,7 +665,7 @@ pub(crate) fn build_document_pipeline() -> Result<Pipeline, DocumentError> {
         0.88,
         110,
     );
-    Pipeline::builder()
+    GazePipeline::builder()
         .detector(email)
         .detector(phone)
         .recognizer(recipient_name)
@@ -496,6 +745,34 @@ fn pipeline_err(stage: &'static str, err: impl std::fmt::Display) -> DocumentErr
 #[cfg(all(test, feature = "ocr-tesseract"))]
 mod tests {
     use super::*;
+    use crate::ocr::{BBox, OcrSpan};
+
+    #[derive(Debug)]
+    struct MockBackend {
+        spans: Vec<OcrSpan>,
+    }
+
+    impl OcrBackend for MockBackend {
+        fn name(&self) -> &str {
+            "mock-ocr"
+        }
+
+        fn recognize(
+            &self,
+            _image: ImageInput,
+            _hints: OcrHints,
+        ) -> Result<Vec<OcrSpan>, OcrError> {
+            Ok(self.spans.clone())
+        }
+    }
+
+    fn span(text: &str, x: u32, y: u32, confidence: f32) -> OcrSpan {
+        OcrSpan {
+            text: text.to_string(),
+            bbox: BBox { x, y, w: 90, h: 16 },
+            confidence: Some(confidence),
+        }
+    }
 
     #[test]
     fn count_pii_by_class_groups_email_and_phone() {
@@ -525,11 +802,90 @@ mod tests {
             ],
             None,
             None,
+            vec![PageReport::new(
+                0,
+                OcrSource::Ocr,
+                Some("tesseract".to_string()),
+                &ocr,
+                1,
+                DEFAULT_LOW_CONFIDENCE_THRESHOLD,
+            )],
+            DEFAULT_LOW_CONFIDENCE_THRESHOLD,
         );
         let json = serde_json::to_value(&report).expect("serialize");
         assert_eq!(json["bundle_version"], BUNDLE_VERSION);
         assert_eq!(json["input_kind"], "png");
         assert_eq!(json["pii_token_count"], 3);
+        assert_eq!(json["pages"][0]["ocr_source"], "ocr");
+        assert_eq!(
+            json["low_confidence_threshold"],
+            DEFAULT_LOW_CONFIDENCE_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn v1_report_without_page_fields_still_deserializes() {
+        let json = serde_json::json!({
+            "bundle_version": 1,
+            "input_kind": "png",
+            "ocr_mean_confidence": 90.0,
+            "ocr_word_count": 2,
+            "ocr_lang": "eng",
+            "clean_char_count": 12,
+            "pii_token_count": 1,
+            "pii_tokens_by_class": [{ "class": "email", "count": 1 }],
+            "pdf_page_count": null,
+            "pdf_page_index": null
+        });
+
+        let report: BundleReport = serde_json::from_value(json).expect("v1 parses");
+
+        assert_eq!(report.bundle_version, 1);
+        assert!(report.pages.is_empty());
+        assert_eq!(
+            report.low_confidence_threshold,
+            DEFAULT_LOW_CONFIDENCE_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn clean_with_mock_backend_flags_low_confidence_and_columns() {
+        let backend = MockBackend {
+            spans: vec![
+                span("Bill", 20, 10, 0.50),
+                span("to:", 116, 10, 0.50),
+                span("Jane", 20, 36, 0.50),
+                span("Doe", 116, 36, 0.50),
+                span("Email:", 360, 10, 0.50),
+                span("alice@example.invalid", 360, 36, 0.50),
+            ],
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let input = tmp.path().join("input.png");
+        fs::write(&input, b"not-real-image").expect("write input");
+
+        let bundle = Pipeline::new()
+            .with_low_confidence_threshold(0.65)
+            .clean_with_ocr_backend(&input, tmp.path(), &backend)
+            .expect("clean succeeds");
+
+        assert_eq!(bundle.report.bundle_version, 2);
+        assert_eq!(bundle.report.pages.len(), 1);
+        let page = &bundle.report.pages[0];
+        assert_eq!(page.ocr_backend.as_deref(), Some("mock-ocr"));
+        assert_eq!(page.column_count, 2);
+        assert_eq!(page.confidence, Some(0.5));
+        assert!(page.low_confidence);
+        assert!(
+            bundle.clean_markdown.contains(":Email_"),
+            "{}",
+            bundle.clean_markdown
+        );
+        assert!(
+            !bundle.clean_markdown.contains("alice@example.invalid"),
+            "{}",
+            bundle.clean_markdown
+        );
     }
 
     #[test]

--- a/crates/gaze-document/src/extract/pdf.rs
+++ b/crates/gaze-document/src/extract/pdf.rs
@@ -1,4 +1,4 @@
-//! Single-page PDF rasterization via [`pdfium-render`](https://crates.io/crates/pdfium-render).
+//! PDF text extraction and rasterization via [`pdfium-render`](https://crates.io/crates/pdfium-render).
 //!
 //! ## Runtime dependency
 //!
@@ -11,9 +11,8 @@
 //!
 //! ## Scope (v0.0.x)
 //!
-//! * Only page index `0` is rasterized. Multi-page PDFs are accepted but the
-//!   first page wins. Multi-page support is incremental on top.
-//! * Target resolution: 150 DPI, configurable via [`PdfRasterConfig`].
+//! * Selectable text is extracted directly, per page, before OCR is attempted.
+//! * Pages with no selectable text are rasterized at 150 DPI by default.
 
 use std::io::Cursor;
 use std::path::Path;
@@ -87,6 +86,41 @@ impl RasterizedPage {
     }
 }
 
+/// Per-page PDF extraction payload.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum PdfPagePayload {
+    /// Page had selectable text and did not require OCR.
+    VectorText {
+        /// Extracted text in PDF text order.
+        text: String,
+        /// Zero-based page index.
+        page_index: i32,
+        /// Total page count in the source document.
+        page_count: i32,
+    },
+    /// Page had no selectable text and was rasterized for OCR.
+    Raster(RasterizedPage),
+}
+
+impl PdfPagePayload {
+    /// Zero-based page index.
+    pub fn page_index(&self) -> i32 {
+        match self {
+            Self::VectorText { page_index, .. } => *page_index,
+            Self::Raster(page) => page.page_index,
+        }
+    }
+
+    /// Total page count in the source document.
+    pub fn page_count(&self) -> i32 {
+        match self {
+            Self::VectorText { page_count, .. } => *page_count,
+            Self::Raster(page) => page.page_count,
+        }
+    }
+}
+
 /// Rasterize a single page of a PDF on disk to PNG bytes.
 ///
 /// # Errors
@@ -146,6 +180,97 @@ pub fn rasterize_first_page(
     })
 }
 
+/// Extract every PDF page, routing selectable-text pages directly and
+/// rasterizing image-only pages for OCR.
+///
+/// # Errors
+///
+/// Returns [`DocumentError`] when pdfium cannot open the document or a page
+/// cannot be rasterized.
+pub fn extract_pages(
+    path: &Path,
+    config: PdfRasterConfig,
+) -> Result<Vec<PdfPagePayload>, DocumentError> {
+    let bindings = Pdfium::bind_to_system_library().map_err(|err| {
+        DocumentError::PdfiumNotFound(format!("{}. {}", err, pdfium_install_hint()))
+    })?;
+    let pdfium = Pdfium::new(bindings);
+    let document = pdfium
+        .load_pdf_from_file(path, None)
+        .map_err(map_pdfium_error)?;
+    let pages = document.pages();
+    let page_count = pages.len();
+    if page_count == 0 {
+        return Err(DocumentError::PdfRasterFailed(
+            "input PDF contains zero pages".to_string(),
+        ));
+    }
+
+    let mut out = Vec::with_capacity(page_count as usize);
+    for page_index in 0..page_count {
+        let page = pages.get(page_index).map_err(map_pdfium_error)?;
+        let text = page
+            .text()
+            .ok()
+            .map(|page_text| normalize_pdf_text(&page_text.all()))
+            .unwrap_or_default();
+        if !text.trim().is_empty() {
+            out.push(PdfPagePayload::VectorText {
+                text,
+                page_index,
+                page_count,
+            });
+            continue;
+        }
+
+        out.push(PdfPagePayload::Raster(render_page(
+            &page, page_index, page_count, config,
+        )?));
+    }
+
+    Ok(out)
+}
+
+fn render_page(
+    page: &pdfium_render::prelude::PdfPage<'_>,
+    page_index: i32,
+    page_count: i32,
+    config: PdfRasterConfig,
+) -> Result<RasterizedPage, DocumentError> {
+    let mut render_config = PdfRenderConfig::new().set_target_width(config.width_px as i32);
+    if config.height_px > 0 {
+        render_config = render_config.set_maximum_height(config.height_px as i32);
+    }
+    let bitmap = page
+        .render_with_config(&render_config)
+        .map_err(map_pdfium_error)?;
+    let dynamic_image = bitmap.as_image().map_err(map_pdfium_error)?;
+    let (width, height) = (dynamic_image.width(), dynamic_image.height());
+
+    let mut buf = Cursor::new(Vec::with_capacity(64 * 1024));
+    dynamic_image
+        .write_to(&mut buf, ImageFormat::Png)
+        .map_err(|err| DocumentError::PdfRasterFailed(format!("png encode failed: {err}")))?;
+
+    Ok(RasterizedPage {
+        png_bytes: buf.into_inner(),
+        page_index,
+        page_count,
+        width_px: width,
+        height_px: height,
+    })
+}
+
+fn normalize_pdf_text(text: &str) -> String {
+    text.replace('\0', "")
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
 fn map_pdfium_error(err: PdfiumError) -> DocumentError {
     DocumentError::PdfRasterFailed(err.to_string())
 }
@@ -184,5 +309,10 @@ mod tests {
     #[test]
     fn install_hint_is_non_empty() {
         assert!(!pdfium_install_hint().is_empty());
+    }
+
+    #[test]
+    fn normalize_pdf_text_removes_nuls_and_outer_blank_space() {
+        assert_eq!(normalize_pdf_text(" hello\0 \n\n"), "hello");
     }
 }

--- a/crates/gaze-document/src/layout/mod.rs
+++ b/crates/gaze-document/src/layout/mod.rs
@@ -1,16 +1,15 @@
-//! Layout / reading-order contract surface.
+//! Layout / reading-order helpers.
 //!
-//! Concrete extraction (column detection, multi-page reading order, table
-//! flattening) lands in follow-up PRs. This module reserves the
-//! [`ReadingOrder`] handle so adopters can pin against the eventual contract.
+//! OCR backends emit flat spans. This module keeps the reading-order policy in
+//! `gaze-document` so downstream recognizers receive coherent text blocks
+//! instead of row-wise interleaving from multi-column pages.
 
+use crate::ocr::OcrSpan;
 use crate::DocumentError;
 
 /// Reading-order handle for a single document.
 ///
-/// Pre-0.1 placeholder — single-page bundles flow through [`crate::clean`]
-/// without consulting this type. Multi-page output will route through
-/// [`ReadingOrder::infer`] in a follow-up PR.
+/// Pre-0.1 placeholder for the eventual public multi-page layout contract.
 #[non_exhaustive]
 pub struct ReadingOrder {
     _private: (),
@@ -20,24 +19,201 @@ impl ReadingOrder {
     /// Build a reading-order handle.
     ///
     /// # Errors
-    /// Always returns [`DocumentError::NotImplemented`] until the
-    /// multi-page PR lands. Single-page bundles never call this; the
-    /// placeholder fails loudly so adopters cannot stumble into silent
-    /// empty-order output (Axis 1 fail-closed).
+    /// Always returns [`DocumentError::NotImplemented`] until the public
+    /// reading-order contract lands.
     pub fn new() -> Result<Self, DocumentError> {
         Err(DocumentError::NotImplemented(
-            "ReadingOrder::new (multi-page deferred to follow-up PR)",
+            "ReadingOrder::new (public reading-order contract deferred)",
         ))
     }
 
     /// Infer reading order from raw page payloads.
     ///
     /// # Errors
-    /// Returns [`DocumentError::NotImplemented`] until the multi-page PR
-    /// lands. Single-page bundles do not need this path.
+    /// Returns [`DocumentError::NotImplemented`] until the public
+    /// reading-order contract lands.
     pub fn infer(_pages: &[&[u8]]) -> Result<Self, DocumentError> {
         Err(DocumentError::NotImplemented(
-            "ReadingOrder::infer (multi-page deferred to follow-up PR)",
+            "ReadingOrder::infer (public reading-order contract deferred)",
         ))
+    }
+}
+
+/// Text and layout metadata recovered from flat OCR spans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OrderedText {
+    pub(crate) text: String,
+    pub(crate) column_count: u32,
+}
+
+/// Convert flat spans into deterministic reading order.
+pub(crate) fn order_spans(spans: &[OcrSpan], column_detection: bool) -> OrderedText {
+    if spans.is_empty() {
+        return OrderedText {
+            text: String::new(),
+            column_count: 1,
+        };
+    }
+
+    let split_x = if column_detection {
+        detect_column_split(spans)
+    } else {
+        None
+    };
+
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    for span in spans.iter().filter(|span| !span.text.is_empty()) {
+        if split_x
+            .map(|split| span.bbox.x.saturating_add(span.bbox.w / 2) > split)
+            .unwrap_or(false)
+        {
+            right.push(span.clone());
+        } else {
+            left.push(span.clone());
+        }
+    }
+
+    let mut sections = Vec::new();
+    let left_text = spans_to_lines(left);
+    if !left_text.is_empty() {
+        sections.push(left_text);
+    }
+    let right_text = spans_to_lines(right);
+    if !right_text.is_empty() {
+        sections.push(right_text);
+    }
+
+    OrderedText {
+        text: sections.join("\n\n"),
+        column_count: if split_x.is_some() && sections.len() > 1 {
+            2
+        } else {
+            1
+        },
+    }
+}
+
+fn detect_column_split(spans: &[OcrSpan]) -> Option<u32> {
+    let mut intervals = spans
+        .iter()
+        .filter(|span| !span.text.is_empty() && span.bbox.w > 0)
+        .map(|span| (span.bbox.x, span.bbox.x.saturating_add(span.bbox.w)))
+        .collect::<Vec<_>>();
+    if intervals.len() < 4 {
+        return None;
+    }
+    intervals.sort_by_key(|(left, right)| (*left, *right));
+
+    let min_x = intervals.first().map(|(left, _)| *left)?;
+    let max_x = intervals.iter().map(|(_, right)| *right).max()?;
+    let page_width = max_x.saturating_sub(min_x);
+    if page_width == 0 {
+        return None;
+    }
+
+    let mut merged: Vec<(u32, u32)> = Vec::new();
+    for (left, right) in intervals {
+        match merged.last_mut() {
+            Some((_, current_right)) if left <= current_right.saturating_add(24) => {
+                *current_right = (*current_right).max(right);
+            }
+            _ => merged.push((left, right)),
+        }
+    }
+    if merged.len() < 2 {
+        return None;
+    }
+
+    let mut best_gap = 0;
+    let mut best_split = None;
+    for pair in merged.windows(2) {
+        let left_end = pair[0].1;
+        let right_start = pair[1].0;
+        let gap = right_start.saturating_sub(left_end);
+        if gap > best_gap {
+            best_gap = gap;
+            best_split = Some(left_end.saturating_add(gap / 2));
+        }
+    }
+
+    let minimum_gap = (page_width / 6).max(48);
+    best_split.filter(|_| best_gap >= minimum_gap)
+}
+
+fn spans_to_lines(mut spans: Vec<OcrSpan>) -> String {
+    spans.sort_by_key(|span| (span.bbox.y, span.bbox.x));
+
+    let mut lines: Vec<Vec<OcrSpan>> = Vec::new();
+    for span in spans {
+        let belongs_to_current_line = lines
+            .last()
+            .and_then(|line| line.first())
+            .map(|first| span.bbox.y.abs_diff(first.bbox.y) <= span.bbox.h.max(first.bbox.h))
+            .unwrap_or(false);
+        if belongs_to_current_line {
+            if let Some(line) = lines.last_mut() {
+                line.push(span);
+            }
+        } else {
+            lines.push(vec![span]);
+        }
+    }
+
+    lines
+        .into_iter()
+        .map(|mut line| {
+            line.sort_by_key(|span| span.bbox.x);
+            line.into_iter()
+                .map(|span| span.text)
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ocr::{BBox, OcrSpan};
+
+    use super::*;
+
+    fn span(text: &str, x: u32, y: u32) -> OcrSpan {
+        OcrSpan {
+            text: text.to_string(),
+            bbox: BBox { x, y, w: 60, h: 16 },
+            confidence: Some(0.9),
+        }
+    }
+
+    #[test]
+    fn column_detection_orders_left_column_before_right_column() {
+        let spans = vec![
+            span("left-1", 20, 10),
+            span("right-1", 320, 10),
+            span("left-2", 20, 40),
+            span("right-2", 320, 40),
+        ];
+
+        let ordered = order_spans(&spans, true);
+
+        assert_eq!(ordered.column_count, 2);
+        assert_eq!(ordered.text, "left-1\nleft-2\n\nright-1\nright-2");
+    }
+
+    #[test]
+    fn column_detection_can_be_disabled() {
+        let spans = vec![
+            span("left-1", 20, 10),
+            span("right-1", 320, 10),
+            span("left-2", 20, 40),
+            span("right-2", 320, 40),
+        ];
+
+        let ordered = order_spans(&spans, false);
+
+        assert_eq!(ordered.column_count, 1);
+        assert_eq!(ordered.text, "left-1 right-1\nleft-2 right-2");
     }
 }

--- a/crates/gaze-document/src/lib.rs
+++ b/crates/gaze-document/src/lib.rs
@@ -1,6 +1,6 @@
 //! Document ingestion + safe-bundle generation for the Gaze runtime.
 //!
-//! `gaze-document` turns a single image (PNG / JPG) or single-page PDF into a
+//! `gaze-document` turns a single image (PNG / JPG) or PDF into a
 //! [`SafeBundle`]: tokenized Markdown, a restorable [`gaze::Manifest`], and a
 //! structured OCR + PII [`BundleReport`]. PII detection flows through the
 //! standard [`gaze::Pipeline`] so the manifest stays canonical and reversible
@@ -30,7 +30,7 @@
 //! | Flag             | Default | What it enables                                            |
 //! |------------------|---------|------------------------------------------------------------|
 //! | `ocr-tesseract`  | yes     | Tesseract subprocess OCR backend.                          |
-//! | `pdf-input`      | yes     | Single-page PDF rasterization via `pdfium-render`.         |
+//! | `pdf-input`      | yes     | PDF text extraction + raster OCR fallback via `pdfium-render`. |
 //! | `serde`          | yes     | `Serialize` / `Deserialize` for [`BundleReport`].          |
 //! | `extract-docling`| no      | Reserved — future Docling layout adapter (no impl yet).    |
 //! | `render-image`   | no      | Reserved — future redacted-preview renderer (no impl yet). |
@@ -51,7 +51,10 @@ pub mod render;
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub use bundle::{clean, clean_with_ocr_backend};
-pub use bundle::{BundleReport, ClassCount, LayoutSummary, SafeBundle, BUNDLE_VERSION};
+pub use bundle::{
+    BundleReport, ClassCount, LayoutSummary, OcrSource, PageReport, Pipeline, SafeBundle,
+    BUNDLE_VERSION,
+};
 pub use layout::ReadingOrder;
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]

--- a/crates/gaze-document/src/ocr/mod.rs
+++ b/crates/gaze-document/src/ocr/mod.rs
@@ -241,7 +241,17 @@ impl OcrResult {
     /// Build an OCR result from flat spans using pixel y-position to recover
     /// a conservative reading order.
     pub fn from_spans(spans: &[OcrSpan], lang: String) -> Self {
-        let text = spans_to_text(spans);
+        Self::from_spans_with_column_detection(spans, lang, false).0
+    }
+
+    /// Build an OCR result from flat spans using the crate layout
+    /// post-processor. Returns the result plus the detected column count.
+    pub(crate) fn from_spans_with_column_detection(
+        spans: &[OcrSpan],
+        lang: String,
+        column_detection: bool,
+    ) -> (Self, u32) {
+        let ordered = crate::layout::order_spans(spans, column_detection);
         let mut conf_sum = 0.0f64;
         let mut conf_count = 0usize;
         for span in spans {
@@ -255,48 +265,89 @@ impl OcrResult {
         } else {
             Some((conf_sum / conf_count as f64) as f32)
         };
-        Self {
-            text,
-            mean_confidence,
-            word_count: conf_count,
-            lang,
-        }
+        (
+            Self {
+                text: ordered.text,
+                mean_confidence,
+                word_count: conf_count,
+                lang,
+            },
+            ordered.column_count,
+        )
+    }
+
+    /// Mean confidence normalized to `0.0..=1.0`.
+    pub(crate) fn mean_confidence_unit(&self) -> Option<f32> {
+        self.mean_confidence.map(|confidence| {
+            if confidence > 1.0 {
+                (confidence / 100.0).clamp(0.0, 1.0)
+            } else {
+                confidence.clamp(0.0, 1.0)
+            }
+        })
     }
 }
 
-fn spans_to_text(spans: &[OcrSpan]) -> String {
-    let mut ordered = spans.to_vec();
-    ordered.sort_by_key(|span| (span.bbox.y, span.bbox.x));
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let mut lines: Vec<Vec<OcrSpan>> = Vec::new();
-
-    for span in ordered {
-        if span.text.is_empty() {
-            continue;
-        }
-        let belongs_to_current_line = lines
-            .last()
-            .and_then(|line| line.first())
-            .map(|first| span.bbox.y.abs_diff(first.bbox.y) <= span.bbox.h.max(first.bbox.h))
-            .unwrap_or(false);
-        if belongs_to_current_line {
-            if let Some(line) = lines.last_mut() {
-                line.push(span);
-            }
-        } else {
-            lines.push(vec![span]);
-        }
+    #[test]
+    fn mean_confidence_unit_normalizes_legacy_percent_value() {
+        let result = OcrResult::new("body".to_string(), Some(91.0), 1, "eng".to_string());
+        assert_eq!(result.mean_confidence_unit(), Some(0.91));
     }
 
-    lines
-        .into_iter()
-        .map(|mut line| {
-            line.sort_by_key(|span| span.bbox.x);
-            line.into_iter()
-                .map(|span| span.text)
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+    #[test]
+    fn from_spans_reports_detected_columns() {
+        let spans = vec![
+            OcrSpan {
+                text: "A1".to_string(),
+                bbox: BBox {
+                    x: 10,
+                    y: 10,
+                    w: 30,
+                    h: 10,
+                },
+                confidence: Some(0.8),
+            },
+            OcrSpan {
+                text: "B1".to_string(),
+                bbox: BBox {
+                    x: 280,
+                    y: 10,
+                    w: 30,
+                    h: 10,
+                },
+                confidence: Some(0.8),
+            },
+            OcrSpan {
+                text: "A2".to_string(),
+                bbox: BBox {
+                    x: 10,
+                    y: 30,
+                    w: 30,
+                    h: 10,
+                },
+                confidence: Some(0.8),
+            },
+            OcrSpan {
+                text: "B2".to_string(),
+                bbox: BBox {
+                    x: 280,
+                    y: 30,
+                    w: 30,
+                    h: 10,
+                },
+                confidence: Some(0.8),
+            },
+        ];
+
+        let (result, columns) =
+            OcrResult::from_spans_with_column_detection(&spans, "eng".to_string(), true);
+
+        assert_eq!(columns, 2);
+        assert_eq!(result.text, "A1\nA2\n\nB1\nB2");
+        assert_eq!(result.mean_confidence_unit(), Some(0.8));
+    }
 }

--- a/crates/gaze-document/tests/e2e.rs
+++ b/crates/gaze-document/tests/e2e.rs
@@ -9,7 +9,7 @@
 //! * `manifest.json` deserializes back into a `gaze::Manifest` and contains
 //!   at least one `Email` + one `Custom("phone")` span.
 //! * `report.json` deserializes into a `BundleReport` shape with
-//!   `bundle_version = 1` and non-zero PII counts.
+//!   `bundle_version = 2`, per-page provenance, and non-zero PII counts.
 //!
 //! ## Skip conditions
 //!
@@ -23,7 +23,7 @@
 use std::path::{Path, PathBuf};
 
 use gaze::Manifest;
-use gaze_document::{BundleReport, DocumentError, BUNDLE_VERSION};
+use gaze_document::{BundleReport, DocumentError, OcrSource, BUNDLE_VERSION};
 use gaze_types::PiiClass;
 
 const ORIGINAL_EMAIL: &str = "jane.doe@example.com";
@@ -132,15 +132,28 @@ fn assert_clean_bundle(input: &Path, expect_pdf_fields: bool) {
     assert_eq!(report.bundle_version, BUNDLE_VERSION);
     assert!(report.pii_token_count >= 2);
     assert!(report.clean_char_count > 0);
-    assert!(report.ocr_word_count > 0, "OCR returned zero words");
+    assert_eq!(report.low_confidence_threshold, 0.65);
+    assert_eq!(report.pages.len(), 1);
+    assert_eq!(report.pages[0].page_index, 0);
+    assert!(report.pages[0].column_count >= 1);
+    if report.pages[0].ocr_source == OcrSource::Ocr {
+        assert!(report.ocr_word_count > 0, "OCR returned zero words");
+        assert_eq!(report.pages[0].ocr_backend.as_deref(), Some("tesseract"));
+    } else {
+        assert_eq!(report.pages[0].ocr_source, OcrSource::VectorPdf);
+        assert!(report.pages[0].confidence.is_none());
+        assert!(!report.pages[0].low_confidence);
+    }
 
     if expect_pdf_fields {
         assert_eq!(report.input_kind, "pdf");
         assert_eq!(report.pdf_page_count, Some(1));
         assert_eq!(report.pdf_page_index, Some(0));
+        assert_eq!(report.pages[0].ocr_source, OcrSource::VectorPdf);
     } else {
         assert!(matches!(report.input_kind.as_str(), "png" | "jpeg"));
         assert!(report.pdf_page_count.is_none());
+        assert_eq!(report.pages[0].ocr_source, OcrSource::Ocr);
     }
 
     // Sanity: the in-memory bundle matches the written report.

--- a/crates/gaze-document/tests/mcp_stdio.rs
+++ b/crates/gaze-document/tests/mcp_stdio.rs
@@ -161,7 +161,7 @@ fn assert_clean_response(payload: &Value, expect_source_kind: &str) {
     assert!(!clean.contains("555-0142"), "{clean}");
     assert!(!payload["manifest_id"].as_str().unwrap().is_empty());
     assert_eq!(payload["file_metadata"]["source_kind"], expect_source_kind);
-    assert_eq!(payload["file_metadata"]["bundle_version"], json!(1));
+    assert_eq!(payload["file_metadata"]["bundle_version"], json!(2));
 }
 
 #[tokio::test]


### PR DESCRIPTION
North-star C-scope rationale

This ships the three highest Axis 1 + Axis 4 layout/render improvements for gaze-document on top of the narrow OcrBackend trait from #218. Correctness beats performance here: lossless selectable PDF text, deterministic column ordering, and explicit confidence signals all reduce silent PII-miss risk and make extraction provenance auditable.

Features shipped

- Vector-PDF text extraction fallback: each PDF page is routed independently. Pages with selectable text use pdfium text extraction; image-only pages still rasterize and OCR.
- Multi-column segmentation: OCR spans are grouped by detected vertical whitespace gaps and emitted column-by-column before downstream recognition.
- Per-page confidence and low-confidence flagging: report.json records page provenance, confidence, threshold, column count, and low-confidence status.

Features deferred

- Table-cell preservation: deferred to follow-up because it needs deeper layout semantics.
- Deskew/rotation preprocessing: deferred as image preprocessing work.
- DPI auto-tune: deferred as performance-oriented work per correctness-first scope.

Schema delta: bundle_version = 2

New bundles now emit bundle_version 2. report.json adds top-level low_confidence_threshold and a pages array with page_index, ocr_source, ocr_backend, confidence, low_confidence, column_count, ocr_word_count, and ocr_mean_confidence. Existing v1 bundle reports still deserialize for read compatibility, but new emission is always v2. This is the first bundle_version bump since gaze-document v0.7.1.

Migration note

Adopters parsing report.json should handle bundle_version 2 and inspect pages[] for extraction provenance and per-page confidence. Vector PDF pages report ocr_source=vector_pdf, ocr_backend=null, confidence=null, and low_confidence=false. OCR pages report the backend name and confidence values in 0.0..=1.0.

Five-axis self-check

- Axis 1 reliability: improves text recall for vector PDFs, avoids fused multi-column context, and flags weak OCR pages for escalation.
- Axis 2 reversibility: manifest/restore contract unchanged.
- Axis 3 agentic-first: threshold and column-detection builder knobs keep adopter workflow control.
- Axis 4 trust: structured deterministic provenance and confidence fields in report.json.
- Axis 5 adopter ergonomics: defaults are on and v1 read compatibility is preserved.

References

- Roadmap scratchpad 346 rev 20 item #28a.
- Prior PR handoff scratchpads 393 and 394.
- Builds on #218 / b9f3407.

Gates passed

- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix
- cargo run -p xtask -- fixture-citation-lint