### PR TITLE
feat(gaze-cli): enable proxy feature in default release binary (v0.8.x #17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,15 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact: gaze-x86_64-linux-gnu
     runs-on: ${{ matrix.os }}
+    env:
+      GAZE_RELEASE_FEATURES: document,proxy
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       - name: Build
-        run: cargo build --release --bin gaze --target ${{ matrix.target }}
+        run: cargo build --release --bin gaze --target ${{ matrix.target }} --features "$GAZE_RELEASE_FEATURES"
       - name: Package
         run: |
           mkdir -p dist
@@ -55,6 +57,12 @@ jobs:
           "$bin" clean --help | grep -q -- '--ner-locale'
           "$bin" clean --help | grep -q -- '--rulepack-bundled'
           "$bin" clean --help | grep -q -- '--rulepack-path'
+          "$bin" document --help | grep -q 'clean'
+          "$bin" proxy --help | grep -q 'serve'
+          "$bin" proxy --help | grep -q 'start'
+          "$bin" proxy --help | grep -q 'stop'
+          "$bin" proxy --help | grep -q 'status'
+          "$bin" proxy --help | grep -q 'restart'
 
           clean_json="$(printf 'alice@example.invalid' | "$bin" clean)"
           clean_text="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["clean_text"])' <<< "$clean_json")"
@@ -84,6 +92,27 @@ jobs:
           extended_json="$(printf 'host 192.0.2.1' | "$bin" clean --policy="$policy")"
           extended_text="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["clean_text"])' <<< "$extended_json")"
           grep -q 'Custom:ip_address' <<< "$extended_text" || (echo "smoke failed: core-extended did not tokenize IP fixture"; exit 1)
+
+          smoke_home="$(mktemp -d)"
+          proxy_port="$(python3 - <<'PY'
+          import socket
+          s = socket.socket()
+          s.bind(("127.0.0.1", 0))
+          print(s.getsockname()[1])
+          s.close()
+          PY
+          )"
+          export HOME="$smoke_home"
+          trap '"$bin" proxy stop --force >/dev/null 2>&1 || true; rm -rf "$smoke_home"' EXIT
+          "$bin" proxy status | grep -q 'not running'
+          "$bin" proxy start --bind "127.0.0.1:$proxy_port"
+          sleep 1
+          "$bin" proxy status | grep -q 'running'
+          "$bin" proxy restart --force
+          sleep 1
+          "$bin" proxy status | grep -q 'running'
+          "$bin" proxy stop --force
+          "$bin" proxy status | grep -q 'not running'
 
   release:
     needs: build

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Pre-built binaries for Apple Silicon macOS and Linux x86_64 (glibc 2.39+) are at
 For the LLM API proxy:
 
 ```sh
-cargo install --path crates/gaze-cli --features proxy
+cargo install --path crates/gaze-cli
 gaze proxy start
 export OPENAI_BASE_URL=http://127.0.0.1:8787/v1
 export ANTHROPIC_BASE_URL=http://127.0.0.1:8787

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["proxy"]
 safety-net-openai = ["gaze-recognizers/safety-net-openai"]
 safety-net-kiji = ["gaze-recognizers/safety-net-kiji"]
 document = ["dep:gaze-document"]

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -30,6 +30,8 @@ Build from the workspace root:
 $ cargo build -p gaze-cli
 ```
 
+The default build includes `gaze proxy` for local LLM API proxy use.
+
 Build with the MCP installer/server surface:
 
 ```console
@@ -58,6 +60,7 @@ Current subcommands in [`src/commands/mod.rs`](src/commands/mod.rs):
 | `mcp install` | Installs `gaze mcp serve` into supported MCP client configs. Requires `--features mcp`. |
 | `mcp doctor` | Diagnoses MCP runtime dependencies, client config, and AGENTS.md guidance. Requires `--features mcp`. |
 | `mcp serve` | Runs the stdio MCP server exposing `gaze_read_file` and `gaze_read_text`. Requires `--features mcp`. |
+| `proxy serve/start/stop/status/restart` | Runs or manages the local LLM API proxy. Included in the default build. |
 
 Audit logging is captured on `clean` via `--audit-db <path>`; the
 `audit query` and `audit export` subcommands read the same database back.

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -7,7 +7,7 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --features proxy
+cargo install gaze-cli
 gaze proxy start
 ```
 

--- a/crates/gaze-proxy/src/daemon.rs
+++ b/crates/gaze-proxy/src/daemon.rs
@@ -221,7 +221,7 @@ pub fn start(options: StartOptions) -> Result<u32, ProxyError> {
     write_config(&options.paths, &options.config)?;
     create_parent(&options.paths.pidfile)?;
     create_parent(&options.paths.log_file)?;
-    let _lock = lock_pidfile(&options.paths)?;
+    let lock = lock_pidfile(&options.paths)?;
 
     let stdout = OpenOptions::new()
         .create(true)
@@ -256,6 +256,7 @@ pub fn start(options: StartOptions) -> Result<u32, ProxyError> {
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
+    drop(lock);
     let child = command.spawn().map_err(|source| ProxyError::DaemonIo {
         path: PathBuf::from("gaze proxy serve"),
         source,

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -74,6 +74,11 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         args: &["test", "-p", "gaze-document", "--features", "mcp"],
     },
     MatrixCommand {
+        label: "cargo test -p gaze-cli",
+        program: "cargo",
+        args: &["test", "-p", "gaze-cli"],
+    },
+    MatrixCommand {
         label: "cargo test -p gaze-cli --features mcp",
         program: "cargo",
         args: &["test", "-p", "gaze-cli", "--features", "mcp"],


### PR DESCRIPTION
## Summary
- make gaze-cli default features include proxy so cargo install/build exposes gaze proxy out of the box
- build release binaries with document,proxy and smoke-test document/proxy command availability plus proxy daemon lifecycle
- fix proxy daemon start so the child can acquire and write the pidfile after parent validation
- add an explicit default-feature gaze-cli test path to ci-feature-matrix

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test -p gaze-cli --no-fail-fast
- cargo test -p gaze-cli --features mcp --no-fail-fast
- cargo build -p gaze-cli --features document,proxy
- manual target/debug/gaze proxy serve/start/status/restart/stop smoke with isolated HOME
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix