### PR TITLE
feat(kiji): pin model SHA + direct-vs-observer benchmark (v0.8.x #13)

### DIFF
--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -394,6 +394,9 @@ fn map_safety_net_error(err: gaze::SafetyNetError) -> CliError {
         gaze::SafetyNetError::ModelUnavailable { .. } => CliError::SafetyNetFailure {
             variant: "ModelUnavailable",
         },
+        gaze::SafetyNetError::ModelIntegrityMismatch { .. } => CliError::SafetyNetFailure {
+            variant: "ModelIntegrityMismatch",
+        },
         gaze::SafetyNetError::InputTooLarge { .. } => CliError::SafetyNetFailure {
             variant: "InputTooLarge",
         },

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -66,7 +66,7 @@ required-features = ["safety-net-openai"]
 
 [[test]]
 name = "kiji_distilbert_subprocess"
-required-features = ["safety-net-kiji"]
+required-features = ["safety-net-kiji", "test-support"]
 
 [[bench]]
 name = "dictionary"
@@ -75,3 +75,8 @@ harness = false
 [[bench]]
 name = "restore_pass2"
 harness = false
+
+[[bench]]
+name = "kiji_direct_vs_observer"
+harness = false
+required-features = ["safety-net-kiji"]

--- a/crates/gaze-recognizers/benches/kiji_direct_vs_observer.rs
+++ b/crates/gaze-recognizers/benches/kiji_direct_vs_observer.rs
@@ -1,0 +1,23 @@
+use gaze_recognizers::safety_net::kiji_distilbert::{
+    KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
+};
+use serde_json::Value;
+
+const SNAPSHOT: &str = include_str!("kiji_direct_vs_observer_snapshot.json");
+
+fn main() {
+    let snapshot: Value = serde_json::from_str(SNAPSHOT).expect("valid Kiji benchmark snapshot");
+    assert_eq!(
+        snapshot["pins"]["kiji_source_repo"],
+        Value::String(KIJI_DISTILBERT_HF_REPO.to_string())
+    );
+    assert_eq!(
+        snapshot["pins"]["kiji_source_commit"],
+        Value::String(KIJI_DISTILBERT_HF_COMMIT.to_string())
+    );
+    assert_eq!(
+        snapshot["pins"]["kiji_bundle_sha256"],
+        Value::String(KIJI_DISTILBERT_BUNDLE_SHA256.to_string())
+    );
+    println!("{SNAPSHOT}");
+}

--- a/crates/gaze-recognizers/benches/kiji_direct_vs_observer_snapshot.json
+++ b/crates/gaze-recognizers/benches/kiji_direct_vs_observer_snapshot.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "benchmark": "kiji-direct-vs-observer-residual",
+  "status": "not_run_requires_local_kiji_command",
+  "pins": {
+    "kiji_source_repo": "onnx-community/distilbert-NER-ONNX",
+    "kiji_source_commit": "3a19fe9404a4469d91aa3d551558a97f68872f67",
+    "kiji_bundle_sha256": "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f",
+    "kiji_model_sha256": "b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5",
+    "kiji_tokenizer_sha256": "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34",
+    "kiji_label_map_sha256": "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97",
+    "corpus_commit": "7348690",
+    "corpus_seed": "113668362958386",
+    "corpus_sha256": "c6e78cca59df550fad18e59e9877da03da82c73b80c2368e5233d76353ccfa2f"
+  },
+  "modes": {
+    "direct_detector": {
+      "precision": null,
+      "recall": null,
+      "f1": null,
+      "per_class": {}
+    },
+    "observer_residual": {
+      "precision": null,
+      "recall": null,
+      "f1": null,
+      "observer_residual_recall": null,
+      "per_class": {}
+    }
+  }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use gaze_types::SafetyNetError;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
 use crate::safety_net::kiji_distilbert::class_map::map_kiji_label;
@@ -25,6 +26,28 @@ const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 pub const REQUIRED_KIJI_ARTIFACTS: &[&str] =
     &["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"];
 
+/// Hugging Face repository for the canonical Kiji DistilBERT ONNX bundle.
+pub const KIJI_DISTILBERT_HF_REPO: &str = "onnx-community/distilbert-NER-ONNX";
+
+/// Immutable upstream revision used by `scripts/fetch-kiji-safetynet-model.sh`.
+pub const KIJI_DISTILBERT_HF_COMMIT: &str = "3a19fe9404a4469d91aa3d551558a97f68872f67";
+
+/// SHA256 of the canonical `SHA256SUMS` file for the bundle.
+///
+/// The runtime first verifies this digest, then verifies every artifact listed
+/// in the checksum file. That keeps the release-published checksum contract and
+/// local bytes tied together at load time.
+pub const KIJI_DISTILBERT_BUNDLE_SHA256: &str =
+    "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f";
+
+/// Canonical checksum file content. The model hash is the Hugging Face LFS
+/// SHA256 for `onnx/model.onnx` at `KIJI_DISTILBERT_HF_COMMIT`.
+pub const KIJI_DISTILBERT_SHA256SUMS: &str = concat!(
+    "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97  labels.json\n",
+    "b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5  model.onnx\n",
+    "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34  tokenizer.json\n",
+);
+
 /// Configuration for the local Kiji DistilBERT subprocess backend.
 #[derive(Debug, Clone)]
 pub struct SubprocessKijiConfig {
@@ -37,6 +60,8 @@ pub struct SubprocessKijiConfig {
     capture_stderr: bool,
     version: String,
     decoding_params: Vec<(&'static str, String)>,
+    #[cfg(any(test, feature = "test-support"))]
+    expected_bundle_sha256: String,
 }
 
 impl SubprocessKijiConfig {
@@ -60,6 +85,8 @@ impl SubprocessKijiConfig {
                 ("format", "json".to_string()),
                 ("output_mode", "typed".to_string()),
             ],
+            #[cfg(any(test, feature = "test-support"))]
+            expected_bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
         }
     }
 
@@ -113,12 +140,30 @@ impl SubprocessKijiConfig {
         self
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn with_expected_bundle_sha256_for_tests(mut self, sha256: impl Into<String>) -> Self {
+        self.expected_bundle_sha256 = sha256.into();
+        self
+    }
+
     pub fn command(&self) -> &Path {
         &self.command
     }
 
     pub fn model_dir(&self) -> Option<&Path> {
         self.model_dir.as_deref()
+    }
+
+    fn expected_bundle_sha256(&self) -> &str {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            &self.expected_bundle_sha256
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            KIJI_DISTILBERT_BUNDLE_SHA256
+        }
     }
 }
 
@@ -136,7 +181,7 @@ impl SubprocessKijiBackend {
             });
         }
         verify_command_path(&config.command)?;
-        verify_model_dir(config.model_dir.as_deref())?;
+        verify_model_dir(config.model_dir.as_deref(), config.expected_bundle_sha256())?;
         Ok(Self { config })
     }
 
@@ -515,7 +560,7 @@ fn verify_command_path(command: &Path) -> Result<(), SafetyNetError> {
 
 /// Pinned-artifact contract: every entry in `REQUIRED_KIJI_ARTIFACTS` must exist
 /// under `model_dir`. Missing `SHA256SUMS` is a fail-closed condition (Axis 1).
-fn verify_model_dir(model_dir: Option<&Path>) -> Result<(), SafetyNetError> {
+fn verify_model_dir(model_dir: Option<&Path>, expected_sha256: &str) -> Result<(), SafetyNetError> {
     let Some(dir) = model_dir else {
         return Ok(());
     };
@@ -535,7 +580,85 @@ fn verify_model_dir(model_dir: Option<&Path>) -> Result<(), SafetyNetError> {
             });
         }
     }
+    verify_bundle_integrity(dir, expected_sha256)?;
     Ok(())
+}
+
+fn verify_bundle_integrity(dir: &Path, expected_sha256: &str) -> Result<(), SafetyNetError> {
+    let sha256sums_path = dir.join("SHA256SUMS");
+    let sha256sums =
+        std::fs::read(&sha256sums_path).map_err(|_| SafetyNetError::WeightsMissing {
+            path: sanitize_path(&sha256sums_path),
+        })?;
+    let actual_sha256 = hex_sha256(&sha256sums);
+    if actual_sha256 != expected_sha256 {
+        return Err(SafetyNetError::ModelIntegrityMismatch {
+            expected: expected_sha256.to_string(),
+            actual: actual_sha256,
+        });
+    }
+
+    let checksums = parse_sha256sums(&sha256sums)?;
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        if *required == "SHA256SUMS" {
+            continue;
+        }
+        let Some(expected_artifact_sha256) = checksums
+            .iter()
+            .find_map(|(sha256, name)| (name == required).then_some(sha256.as_str()))
+        else {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: format!("<checksum-entry:{required}>"),
+                actual: "<missing>".to_string(),
+            });
+        };
+        let artifact = dir.join(required);
+        let bytes = std::fs::read(&artifact).map_err(|_| SafetyNetError::WeightsMissing {
+            path: sanitize_path(&artifact),
+        })?;
+        let actual_artifact_sha256 = hex_sha256(&bytes);
+        if actual_artifact_sha256 != expected_artifact_sha256 {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: expected_artifact_sha256.to_string(),
+                actual: actual_artifact_sha256,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| SafetyNetError::ModelIntegrityMismatch {
+        expected: "valid UTF-8 SHA256SUMS".to_string(),
+        actual: "<invalid-utf8>".to_string(),
+    })?;
+    let mut entries = Vec::new();
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        let mut fields = line.split_whitespace();
+        let sha256 = fields.next().unwrap_or_default();
+        let name = fields.next().unwrap_or_default();
+        if fields.next().is_some()
+            || sha256.len() != 64
+            || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || !REQUIRED_KIJI_ARTIFACTS.contains(&name)
+            || name == "SHA256SUMS"
+            || name.contains('/')
+            || name.contains('\\')
+        {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: "canonical SHA256SUMS entries".to_string(),
+                actual: "<invalid>".to_string(),
+            });
+        }
+        entries.push((sha256.to_ascii_lowercase(), name.to_string()));
+    }
+    Ok(entries)
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex::encode(digest)
 }
 
 fn verify_sensitive_tree(path: &Path) -> Result<(), SafetyNetError> {
@@ -651,12 +774,25 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
     }
 
-    fn populate_secure_model_dir(dir: &Path) {
+    fn populate_secure_model_dir(dir: &Path) -> String {
         #[cfg(unix)]
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).unwrap();
         for required in REQUIRED_KIJI_ARTIFACTS {
+            if *required == "SHA256SUMS" {
+                continue;
+            }
             write_secure_artifact(dir, required, b"fixture");
         }
+        let sums = fixture_sha256sums();
+        write_secure_artifact(dir, "SHA256SUMS", sums.as_bytes());
+        hex_sha256(sums.as_bytes())
+    }
+
+    fn fixture_sha256sums() -> String {
+        let artifact_sha = hex_sha256(b"fixture");
+        format!(
+            "{artifact_sha}  labels.json\n{artifact_sha}  model.onnx\n{artifact_sha}  tokenizer.json\n"
+        )
     }
 
     #[test]
@@ -725,9 +861,49 @@ mod tests {
     #[test]
     fn complete_artifact_set_constructs_backend() {
         let dir = tempfile::tempdir().unwrap();
-        populate_secure_model_dir(dir.path());
-        let config = SubprocessKijiConfig::new("kiji").with_model_dir(dir.path());
+        let expected_sha = populate_secure_model_dir(dir.path());
+        let config = SubprocessKijiConfig::new("kiji")
+            .with_model_dir(dir.path())
+            .with_expected_bundle_sha256_for_tests(expected_sha);
         SubprocessKijiBackend::new(config).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn checksum_mismatch_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected_sha = populate_secure_model_dir(dir.path());
+        write_secure_artifact(dir.path(), "model.onnx", b"tampered");
+        let config = SubprocessKijiConfig::new("kiji")
+            .with_model_dir(dir.path())
+            .with_expected_bundle_sha256_for_tests(expected_sha);
+        let error = SubprocessKijiBackend::new(config).unwrap_err();
+        assert!(matches!(
+            error,
+            SafetyNetError::ModelIntegrityMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn documented_bundle_sha_matches_canonical_checksum_file() {
+        assert_eq!(
+            hex_sha256(KIJI_DISTILBERT_SHA256SUMS.as_bytes()),
+            KIJI_DISTILBERT_BUNDLE_SHA256
+        );
+
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace = manifest_dir.parent().unwrap().parent().unwrap();
+        let setup_doc =
+            std::fs::read_to_string(workspace.join("docs/getting-started/kiji-safetynet-setup.md"))
+                .unwrap();
+        let fetcher =
+            std::fs::read_to_string(workspace.join("scripts/fetch-kiji-safetynet-model.sh"))
+                .unwrap();
+
+        for content in [setup_doc, fetcher] {
+            assert!(content.contains(KIJI_DISTILBERT_HF_COMMIT));
+            assert!(content.contains(KIJI_DISTILBERT_BUNDLE_SHA256));
+        }
     }
 
     #[cfg(unix)]

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -19,7 +19,9 @@ pub mod backend;
 pub mod class_map;
 
 pub use backend::subprocess::{
-    SubprocessKijiBackend, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+    SubprocessKijiBackend, SubprocessKijiConfig, KIJI_DISTILBERT_BUNDLE_SHA256,
+    KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO, KIJI_DISTILBERT_SHA256SUMS,
+    REQUIRED_KIJI_ARTIFACTS,
 };
 pub use backend::{KijiDistilbertBackend, RawSpan};
 pub use class_map::{

--- a/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
+++ b/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
@@ -15,6 +15,7 @@ use gaze_recognizers::safety_net::kiji_distilbert::{
     KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
 };
 use gaze_types::{DocumentKind, LocaleTag, Manifest, SafetyNet, SafetyNetContext, SafetyNetError};
+use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
 
 fn write_mock_kiji(body: &str) -> (TempDir, PathBuf) {
@@ -35,15 +36,30 @@ printf '%s\n' '{}'
     (dir, path)
 }
 
-fn populate_model_dir() -> TempDir {
+fn populate_model_dir() -> (TempDir, String) {
     let dir = tempdir().unwrap();
     fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
     for required in REQUIRED_KIJI_ARTIFACTS {
+        if *required == "SHA256SUMS" {
+            continue;
+        }
         let path = dir.path().join(required);
         fs::write(&path, b"fixture").unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
     }
-    dir
+    let artifact_sha = hex_sha256(b"fixture");
+    let sha256sums = format!(
+        "{artifact_sha}  labels.json\n{artifact_sha}  model.onnx\n{artifact_sha}  tokenizer.json\n"
+    );
+    let path = dir.path().join("SHA256SUMS");
+    fs::write(&path, sha256sums.as_bytes()).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    let expected_sha = hex_sha256(sha256sums.as_bytes());
+    (dir, expected_sha)
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
 }
 
 #[test]
@@ -84,9 +100,11 @@ fn subprocess_span_round_trips_through_manifest_diff() {
     // empty manifest classifies that as Uncovered.
     let (_kiji_dir, kiji) =
         write_mock_kiji(r#"[{"label":"person","start":0,"end":11,"score":0.97}]"#);
-    let model = populate_model_dir();
+    let (model, expected_sha) = populate_model_dir();
 
-    let config = SubprocessKijiConfig::new(&kiji).with_model_dir(model.path());
+    let config = SubprocessKijiConfig::new(&kiji)
+        .with_model_dir(model.path())
+        .with_expected_bundle_sha256_for_tests(expected_sha);
     let net = KijiDistilbertSafetyNet::new(config);
     let manifest = Manifest::default();
     let ctx = SafetyNetContext::new(

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1639,6 +1639,14 @@ pub enum SafetyNetError {
         /// Sanitized reason.
         reason: String,
     },
+    /// Backend model artifacts failed integrity verification.
+    #[error("safety net model integrity mismatch: expected={expected}, actual={actual}")]
+    ModelIntegrityMismatch {
+        /// Expected SHA256 digest.
+        expected: String,
+        /// Actual SHA256 digest.
+        actual: String,
+    },
     /// Input exceeded configured backend limit.
     #[error("safety net input too large: limit={limit}, actual={actual}")]
     InputTooLarge {
@@ -2761,6 +2769,11 @@ mod safety_net_manifest_tests {
             .to_string(),
             SafetyNetError::ModelUnavailable {
                 reason: "load failed".to_string(),
+            }
+            .to_string(),
+            SafetyNetError::ModelIntegrityMismatch {
+                expected: "e3b0c44298fc1c149afbf4c8996fb924".to_string(),
+                actual: "4e07408562bedb8b60ce05c1decfe3ad".to_string(),
             }
             .to_string(),
             SafetyNetError::InputTooLarge {

--- a/docs/architecture/kiji-benchmark.md
+++ b/docs/architecture/kiji-benchmark.md
@@ -1,0 +1,27 @@
+# Kiji Benchmark
+
+The tracked benchmark snapshot lives at
+`crates/gaze-recognizers/benches/kiji_direct_vs_observer_snapshot.json`.
+`cargo bench -p gaze-recognizers --features safety-net-kiji --bench kiji_direct_vs_observer`
+validates that the snapshot pins match the runtime Kiji constants and prints
+the JSON for CI logs.
+
+Current status: `not_run_requires_local_kiji_command`.
+
+| Pin | Value |
+|---|---|
+| Source repo | `onnx-community/distilbert-NER-ONNX` |
+| Source commit | `3a19fe9404a4469d91aa3d551558a97f68872f67` |
+| Bundle SHA256 | `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f` |
+| Model SHA256 | `b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5` |
+| Tokenizer SHA256 | `cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34` |
+| Label-map SHA256 | `d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97` |
+
+The result fields for direct-detector precision, recall, F1, per-class
+breakdown, and observer-residual recall are present in the snapshot but remain
+`null` until a pinned local Kiji command and model directory are available.
+Publishing numeric Kiji claims without those pins would violate the Axis 4
+trust contract.
+
+The methodology and rule-floor baseline are documented in
+[`docs/research/v0.8-kiji-benchmark.md`](../research/v0.8-kiji-benchmark.md).

--- a/docs/getting-started/kiji-safetynet-setup.md
+++ b/docs/getting-started/kiji-safetynet-setup.md
@@ -23,9 +23,13 @@ The backend wraps a local subprocess that serves pinned ONNX DistilBERT
 weights. The adapter sends already-tokenized clean text to stdin and accepts
 typed JSON spans from stdout. The runtime requires an Apache-2.0 model bundle
 with `SHA256SUMS`, `labels.json`, `model.onnx`, and `tokenizer.json` on disk
-before it will run. The upstream Kiji taxonomy has 26 PII classes; the local
-adapter validates emitted labels and maps them into Gaze's closed SafetyNet
-classes before manifest diffing.
+before it will run. The canonical upstream source is
+`onnx-community/distilbert-NER-ONNX` at commit
+`3a19fe9404a4469d91aa3d551558a97f68872f67`; the runtime pins the canonical
+bundle checksum file to SHA256
+`c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f`.
+The local adapter validates emitted labels and maps them into Gaze's closed
+SafetyNet classes before manifest diffing.
 
 For the full pipeline view, including the canonical ASCII diagram that places
 Kiji inside Pass 3, see
@@ -211,8 +215,9 @@ for every required artifact before the subprocess is spawned:
 - `tokenizer.json`
 
 The required file list is defined in [`REQUIRED_KIJI_ARTIFACTS`][kiji-subprocess].
-If any artifact is absent, the CLI returns `SafetyNetArtifactMissing` with exit
-`2` before the backend process starts:
+The checksum pin is defined beside that list as
+`KIJI_DISTILBERT_BUNDLE_SHA256`. If any artifact is absent, the CLI returns
+`SafetyNetArtifactMissing` with exit `2` before the backend process starts:
 
 ```json
 {
@@ -228,9 +233,11 @@ SafetyNet could not be trusted to run against the pinned artifact set, so Gaze
 refuses to silently continue with the backend disabled.
 
 Once the initial artifact check passes, the subprocess backend also verifies
-model directory presence during backend initialization. Missing weights at that
-layer map to `SafetyNetError::WeightsMissing`, which the CLI treats as a
-SafetyNet failure. Both checks preserve the same Axis-1 rule: requested privacy
+model directory presence and bundle integrity during backend initialization.
+Missing weights at that layer map to `SafetyNetError::WeightsMissing`; a
+checksum-file or artifact hash mismatch maps to
+`SafetyNetError::ModelIntegrityMismatch`. The CLI treats both as SafetyNet
+failures. Both checks preserve the same Axis-1 rule: requested privacy
 infrastructure must either run with the pinned inputs or fail closed.
 
 This contract is intentionally stricter than "try the backend if available."

--- a/docs/research/v0.8-kiji-benchmark.md
+++ b/docs/research/v0.8-kiji-benchmark.md
@@ -6,7 +6,7 @@
 - Headline metric is strict span leak rate: `1 - strict_recall`, where strict means byte-boundary exact match and canonical class exact match. F1 is intentionally not the ranker for this benchmark.
 - Gaze rule-floor snapshot on commit `7348690` over 150 fixtures: `Email`, `credit_card`, German `phone`, global `phone`, and German/US `postal_code` have `0.000` strict leak rate; US `phone`, global `postal_code`, and `Name` proxy spans have `1.000` strict leak rate.
 - `IBAN` is a scorer-label-map caveat in this snapshot: Gaze emits an equivalent bank-account/IBAN detection, but the current coverage oracle labels it `custom:iban`, so strict canonical class scoring records class mismatches and reports `1.000` strict leak rate until the benchmark label map is made explicit.
-- Kiji direct-detector and observer-residual numbers are not populated in this document because this worktree does not contain a pinned Kiji model artifact or frozen benchmark snapshot. The reproducibility contract below requires the model SHA256 before any Kiji numeric claim is citable.
+- Kiji direct-detector and observer-residual numbers remain `not_run` until CI has a local Kiji command and pinned model directory. The model identity is now citable: `onnx-community/distilbert-NER-ONNX` at `3a19fe9404a4469d91aa3d551558a97f68872f67`, with canonical bundle checksum-file SHA256 `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f`.
 
 ## Methodology
 
@@ -39,8 +39,12 @@ cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture
 | Fixture count | `150` |
 | Gaze tag | `v0.8.0-rc.1-4-g7348690` |
 | Rulepack versions | `core=0.5.1`, `core-extended=0.5.1` |
-| Kiji model SHA256 | Required before publishing Kiji numbers; not present in this worktree |
-| Kiji tokenizer/config SHA256 | Required before publishing Kiji numbers; not present in this worktree |
+| Kiji source repo | `onnx-community/distilbert-NER-ONNX` |
+| Kiji source commit | `3a19fe9404a4469d91aa3d551558a97f68872f67` |
+| Kiji bundle SHA256 | `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f` (`SHA256SUMS`) |
+| Kiji model SHA256 | `b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5` (`model.onnx`) |
+| Kiji tokenizer SHA256 | `cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34` (`tokenizer.json`) |
+| Kiji label-map SHA256 | `d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97` (`labels.json`) |
 | Live network fetches | Forbidden in CI; use a local pinned artifact only |
 
 The benchmark result JSON should include these pins plus the scorer version, label-map version, locale set, operating-point parameters, OS/arch/thread metadata, and deterministic output hash. Comparisons against a prior baseline must refuse to compare when the provenance hash changes unless the baseline is explicitly refreshed.

--- a/scripts/fetch-kiji-safetynet-model.sh
+++ b/scripts/fetch-kiji-safetynet-model.sh
@@ -20,11 +20,9 @@ set -euo pipefail
 
 # ---- Pinned artifact contract -----------------------------------------------
 
-# TODO(v0.8-signoff): replace with the real pinned commit SHA from the upstream
-# DistilBERT NER repository after the first reproducible fetch run. Until then,
-# this script will refuse to run with the placeholder.
 HF_REPO="onnx-community/distilbert-NER-ONNX"
-HF_COMMIT_SHA="0000000000000000000000000000000000000000"
+HF_COMMIT_SHA="3a19fe9404a4469d91aa3d551558a97f68872f67"
+KIJI_BUNDLE_SHA256="c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f"
 GITHUB_REPO="${GAZE_GITHUB_REPO:-EmpireTwo/gaze}"
 
 # Files that must end up in the destination directory.
@@ -111,13 +109,6 @@ fi
 
 DEST="${DEST:-$DEFAULT_DEST}"
 
-# Fail closed on placeholder SHA — Axis-1 reliability: no silent-disable.
-if [ "$HF_COMMIT_SHA" = "0000000000000000000000000000000000000000" ]; then
-  log "HF_COMMIT_SHA is still a placeholder. Edit scripts/fetch-kiji-safetynet-model.sh"
-  log "and replace HF_COMMIT_SHA with the pinned upstream commit before fetching."
-  exit 2
-fi
-
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     log "missing required command: $1"
@@ -169,6 +160,20 @@ fetch_sha256sums() {
 }
 
 verify_sha256sums() {
+  local actual
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 SHA256SUMS | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum SHA256SUMS | awk '{print $1}')"
+  else
+    log "missing required command: shasum or sha256sum"
+    exit 2
+  fi
+  if [ "$actual" != "$KIJI_BUNDLE_SHA256" ]; then
+    log "SHA256SUMS integrity mismatch: expected $KIJI_BUNDLE_SHA256 got $actual"
+    exit 4
+  fi
+
   if command -v shasum >/dev/null 2>&1; then
     shasum -a 256 -c SHA256SUMS
   elif command -v sha256sum >/dev/null 2>&1; then
@@ -197,8 +202,20 @@ fetch_raw() {
 
 fetch_raw "onnx/model.onnx" "model.onnx"
 fetch_raw "tokenizer.json" "tokenizer.json"
-# Kiji ships its label set in labels.json at the repo root.
-fetch_raw "labels.json" "labels.json"
+cat > labels.json <<EOF
+{
+  "schema_version": 1,
+  "source": "${HF_REPO}",
+  "source_commit": "${HF_COMMIT_SHA}",
+  "labels": [
+    {"id": "person", "upstream": ["B-PER", "I-PER"]},
+    {"id": "location", "upstream": ["B-LOC", "I-LOC"]},
+    {"id": "organization", "upstream": ["B-ORG", "I-ORG"]},
+    {"id": "miscellaneous", "upstream": ["B-MISC", "I-MISC"]}
+  ]
+}
+EOF
+chmod 0600 labels.json 2>/dev/null || true
 
 # ---- Fetch release checksum contract ----------------------------------------
 


### PR DESCRIPTION
## Summary

- Pins Kiji DistilBERT to `onnx-community/distilbert-NER-ONNX` commit `3a19fe9404a4469d91aa3d551558a97f68872f67` and canonical bundle SHA256 `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f`.
- Verifies `SHA256SUMS` plus every required local artifact hash during Kiji backend initialization; mismatches fail closed via `SafetyNetError::ModelIntegrityMismatch`.
- Updates the fetcher/docs and adds a cargo bench snapshot for direct-detector vs observer-residual Kiji metrics.

## Benchmark

The tracked benchmark snapshot is currently `not_run_requires_local_kiji_command`: this worktree does not have an executable Kiji runtime and pinned local model dir, so direct-detector recall and observer-residual recall remain `null` rather than publishing uncited numbers. The bench target validates that snapshot pins match runtime constants:

```sh
cargo bench -p gaze-recognizers --features safety-net-kiji --bench kiji_direct_vs_observer -- --nocapture
```

## Five-axis check

- Axis 1: strengthens fail-closed supply-chain handling for requested Kiji SafetyNet runs.
- Axis 4: makes model identity auditable and drift-checked across runtime constants, fetcher, docs, and benchmark snapshot.
- Axis 5: documents the exact adopter bundle pin and failure mode.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo bench -p gaze-recognizers --features safety-net-kiji --bench kiji_direct_vs_observer -- --nocapture`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- safety-net-sanity`
