### PR TITLE
feat(safety-net): implement redact + resolve modes + fallback flag + tolerant-warn (v0.8.x #23/#24/#30/#25)

### DIFF
--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -56,6 +56,7 @@ pub struct AuditLogRow {
     pub ambiguity_record: Option<String>,
     pub collision_family: Option<String>,
     pub collision_variant: Option<String>,
+    pub fallback_triggered: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -105,6 +106,7 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "ambiguity_record",
     "collision_family",
     "collision_variant",
+    "fallback_triggered",
 ];
 
 pub const SAFETY_NET_RESTRICTED_COLUMNS: &[&str] = &[
@@ -143,6 +145,7 @@ pub fn build_audit_query_sql(
     has_ambiguity_record: bool,
     has_collision_family: bool,
     has_collision_variant: bool,
+    has_fallback_triggered: bool,
     has_recognizer_id: bool,
     has_recognizer_version_id: bool,
 ) -> (String, Vec<Value>) {
@@ -196,6 +199,11 @@ pub fn build_audit_query_sql(
     } else {
         "NULL AS collision_variant"
     };
+    let fallback_triggered_column = if has_fallback_triggered {
+        "fallback_triggered"
+    } else {
+        "NULL AS fallback_triggered"
+    };
     let recognizer_id_column = if has_recognizer_id {
         "recognizer_id"
     } else {
@@ -207,7 +215,7 @@ pub fn build_audit_query_sql(
         "NULL AS recognizer_version_id"
     };
     let mut sql = format!(
-        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column} FROM redaction_log"
+        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column}, {fallback_triggered_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use gaze_types::{
-    Action, AmbiguityRecord, ConflictTier, DocumentKind, LeakKind, LeakSuspect, PiiClass,
-    RedactionEntry, ValidatorFailReason,
+    Action, AmbiguityRecord, ConflictTier, DocumentKind, FallbackReason, LeakKind, LeakSuspect,
+    PiiClass, RedactionEntry, ValidatorFailReason,
 };
 use rusqlite::{params, params_from_iter, Connection, OpenFlags};
 use serde::de::DeserializeOwned;
@@ -153,7 +153,8 @@ impl SqliteLogger {
                 validator_fail_reason TEXT NULL,
                 ambiguity_record TEXT NULL,
                 collision_family TEXT NULL,
-                collision_variant TEXT NULL
+                collision_variant TEXT NULL,
+                fallback_triggered TEXT NULL
             );
 
             CREATE TABLE IF NOT EXISTS safety_net_log (
@@ -273,6 +274,13 @@ impl SqliteLogger {
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         }
+        if !columns.iter().any(|column| column == "fallback_triggered") {
+            conn.execute(
+                "ALTER TABLE redaction_log ADD COLUMN fallback_triggered TEXT NULL",
+                [],
+            )
+            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        }
         if !columns.iter().any(|column| column == "recognizer_id") {
             conn.execute(
                 "ALTER TABLE redaction_log ADD COLUMN recognizer_id TEXT NULL",
@@ -303,12 +311,13 @@ impl SqliteLogger {
     pub fn log(&self, entry: &RedactionEntry) -> Result<()> {
         let validator_fail_reason = serialize_json_column(entry.validator_fail_reason.as_ref())?;
         let ambiguity_record = serialize_json_column(entry.ambiguity_record.as_ref())?;
+        let fallback_triggered = entry.fallback_triggered.map(fallback_reason_to_db);
         let conn = self
             .conn
             .lock()
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 entry.source,
                 entry.recognizer_id,
@@ -325,6 +334,7 @@ impl SqliteLogger {
                 ambiguity_record,
                 entry.collision_family,
                 entry.collision_variant,
+                fallback_triggered,
             ],
         )
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -338,7 +348,7 @@ impl SqliteLogger {
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant FROM redaction_log",
+                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered FROM redaction_log",
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         let rows = stmt
@@ -365,6 +375,13 @@ impl SqliteLogger {
                     entry = entry.with_ambiguity_record(record);
                 }
                 entry = entry.with_collision_metadata(row.get(13)?, row.get(14)?);
+                if let Some(reason) = row
+                    .get::<_, Option<String>>(15)?
+                    .map(|value| fallback_reason_from_db(&value))
+                    .transpose()?
+                {
+                    entry = entry.with_fallback_triggered(reason);
+                }
                 Ok(entry)
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -393,6 +410,7 @@ impl SqliteLogger {
         let has_ambiguity_record = table_has_column(&conn, "ambiguity_record")?;
         let has_collision_family = table_has_column(&conn, "collision_family")?;
         let has_collision_variant = table_has_column(&conn, "collision_variant")?;
+        let has_fallback_triggered = table_has_column(&conn, "fallback_triggered")?;
         let has_recognizer_id = table_has_column(&conn, "recognizer_id")?;
         let has_recognizer_version_id = table_has_column(&conn, "recognizer_version_id")?;
         let (sql, values) = build_audit_query_sql(
@@ -407,6 +425,7 @@ impl SqliteLogger {
             has_ambiguity_record,
             has_collision_family,
             has_collision_variant,
+            has_fallback_triggered,
             has_recognizer_id,
             has_recognizer_version_id,
         );
@@ -434,6 +453,7 @@ impl SqliteLogger {
                     ambiguity_record: row.get(15)?,
                     collision_family: row.get(16)?,
                     collision_variant: row.get(17)?,
+                    fallback_triggered: row.get(18)?,
                 })
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -575,8 +595,40 @@ fn conflict_tier_to_db(tier: ConflictTier) -> &'static str {
         ConflictTier::AnchoredContext => "anchored_context",
         ConflictTier::RecognizerId => "recognizer_id",
         ConflictTier::Merged => "merged",
+        ConflictTier::Redact => "redact",
+        ConflictTier::Resolve => "resolve",
+        ConflictTier::Fallback => "fallback",
         _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {tier:?}"),
     }
+}
+
+fn fallback_reason_to_db(reason: FallbackReason) -> &'static str {
+    match reason {
+        FallbackReason::OverlapConflict => "overlap_conflict",
+        FallbackReason::ValidatorVeto => "validator_veto",
+        FallbackReason::AnchorMissing => "anchor_missing",
+        FallbackReason::ResidualSuspect => "residual_suspect",
+        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {reason:?}"),
+    }
+}
+
+fn fallback_reason_from_db(value: &str) -> std::result::Result<FallbackReason, rusqlite::Error> {
+    Ok(match value {
+        "overlap_conflict" => FallbackReason::OverlapConflict,
+        "validator_veto" => FallbackReason::ValidatorVeto,
+        "anchor_missing" => FallbackReason::AnchorMissing,
+        "residual_suspect" => FallbackReason::ResidualSuspect,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                18,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unknown fallback reason {other}"),
+                )),
+            ))
+        }
+    })
 }
 
 fn leak_kind_to_db(kind: &LeakKind) -> &'static str {
@@ -632,6 +684,9 @@ fn conflict_tier_from_db(value: &str) -> std::result::Result<ConflictTier, rusql
         "anchored_context" => ConflictTier::AnchoredContext,
         "recognizer_id" => ConflictTier::RecognizerId,
         "merged" => ConflictTier::Merged,
+        "redact" => ConflictTier::Redact,
+        "resolve" => ConflictTier::Resolve,
+        "fallback" => ConflictTier::Fallback,
         other => {
             return Err(rusqlite::Error::FromSqlConversionFailure(
                 6,

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -287,6 +287,7 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             ambiguity_record: None,
             collision_family: None,
             collision_variant: None,
+            fallback_triggered: None,
         },
         AuditLogRow {
             source: "dictionary".to_string(),
@@ -307,6 +308,7 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             ambiguity_record: None,
             collision_family: None,
             collision_variant: None,
+            fallback_triggered: None,
         },
     ]
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -69,7 +69,7 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     }
     for row in rows {
         let base = format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.recognizer_id.as_deref().unwrap_or(""),
             row.recognizer_version_id.as_deref().unwrap_or(""),
@@ -91,7 +91,8 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
             row.validator_fail_reason.as_deref().unwrap_or(""),
             row.ambiguity_record.as_deref().unwrap_or(""),
             row.collision_family.as_deref().unwrap_or(""),
-            row.collision_variant.as_deref().unwrap_or("")
+            row.collision_variant.as_deref().unwrap_or(""),
+            row.fallback_triggered.as_deref().unwrap_or("")
         );
         if include_ambiguity {
             writeln!(
@@ -330,6 +331,7 @@ struct JsonlRow {
     ambiguity_record: Option<AmbiguityRecord>,
     collision_family: Option<String>,
     collision_variant: Option<String>,
+    fallback_triggered: Option<String>,
 }
 
 impl TryFrom<AuditLogRow> for JsonlRow {
@@ -355,6 +357,7 @@ impl TryFrom<AuditLogRow> for JsonlRow {
             ambiguity_record: parse_json_opt(row.ambiguity_record)?,
             collision_family: row.collision_family,
             collision_variant: row.collision_variant,
+            fallback_triggered: row.fallback_triggered,
         })
     }
 }

--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::{
-    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetKind, SafetyNetMode,
+    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetFallback,
+    SafetyNetKind, SafetyNetMode,
 };
 use crate::error::CliError;
 use crate::pipeline::{run_clean, CleanOptions};
@@ -31,6 +32,7 @@ pub(crate) struct Args {
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
+    pub(crate) safety_net_fallback: SafetyNetFallback,
 }
 
 pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
@@ -59,5 +61,6 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         safety_net_timeout_ms: args.safety_net_timeout_ms,
         safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
         safety_net_mode: args.safety_net_mode,
+        safety_net_fallback: args.safety_net_fallback,
     })
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -105,8 +105,11 @@ enum Cmd {
         #[arg(long, default_value_t = DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES)]
         safety_net_input_limit_bytes: usize,
         /// Safety-net handling mode for suspected leaks.
-        #[arg(long, value_enum, default_value_t = SafetyNetMode::Strict)]
+        #[arg(long, value_enum, default_value_t = SafetyNetMode::Resolve)]
         safety_net_mode: SafetyNetMode,
+        /// Fallback when safety-net resolve or redact cannot complete.
+        #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
+        safety_net_fallback: SafetyNetFallback,
     },
     /// Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout.
     Restore {
@@ -399,6 +402,15 @@ impl OpenAiFilterDevice {
 pub(crate) enum SafetyNetMode {
     Strict,
     Tolerant,
+    Redact,
+    Resolve,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SafetyNetFallback {
+    Strict,
+    Tolerant,
+    Redact,
 }
 
 pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
@@ -428,6 +440,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,
+            safety_net_fallback,
         } => clean::run(clean::Args {
             policy,
             format,
@@ -453,6 +466,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             safety_net_timeout_ms,
             safety_net_input_limit_bytes,
             safety_net_mode,
+            safety_net_fallback,
         }),
         Cmd::Restore {
             format,

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -19,8 +19,9 @@ use gaze_audit::{LeakSuspectLogEntry, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
-    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetKind, SafetyNetMode,
-    DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES, DEFAULT_SAFETY_NET_TIMEOUT_MS,
+    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetFallback,
+    SafetyNetKind, SafetyNetMode, DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES,
+    DEFAULT_SAFETY_NET_TIMEOUT_MS,
 };
 use crate::error::CliError;
 use crate::io::{read_stdin_text, require_json_format};
@@ -57,6 +58,7 @@ pub(crate) struct CleanOptions<'a> {
     pub(crate) safety_net_timeout_ms: u64,
     pub(crate) safety_net_input_limit_bytes: usize,
     pub(crate) safety_net_mode: SafetyNetMode,
+    pub(crate) safety_net_fallback: SafetyNetFallback,
 }
 
 /// Resolves the active Pass-3 SafetyNet backend.
@@ -168,6 +170,14 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         }
     };
     let pipeline = maybe_register_safety_net(pipeline, &options)?;
+    validate_safety_net_tolerant_gate(options.safety_net_mode, options.safety_net_fallback)?;
+    if matches!(
+        options.safety_net_mode,
+        SafetyNetMode::Strict | SafetyNetMode::Tolerant
+    ) && options.safety_net_fallback != SafetyNetFallback::Redact
+    {
+        eprintln!("warning: --safety-net-fallback is ignored when --safety-net-mode is terminal");
+    }
 
     let session = match effective_policy {
         Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
@@ -180,11 +190,12 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
 
     let (clean_doc, leak_report) = if options.safety_net.is_some() {
         let (doc, _manifest, _report) = pipeline
-            .clean_with_safety_net_detect_context(
+            .clean_with_safety_net_policy_detect_context(
                 &session,
                 RawDocument::Text(raw),
                 locale_chain.as_slice(),
                 &dictionaries,
+                safety_net_policy(options.safety_net_mode, options.safety_net_fallback),
             )
             .map_err(map_safety_net_pipeline_error)?;
         (doc, _report)
@@ -202,7 +213,11 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     counter
         .log_safety_net_report(&leak_report, &session, DocumentKind::Text)
         .map_err(|_| CliError::Pipeline)?;
-    enforce_safety_net_mode(&leak_report, options.safety_net_mode)?;
+    enforce_safety_net_mode(
+        &leak_report,
+        options.safety_net_mode,
+        options.safety_net_fallback,
+    )?;
 
     let clean_text = match clean_doc {
         gaze::CleanDocument::Text(text) => text,
@@ -774,6 +789,7 @@ fn document_kind_label(kind: DocumentKind) -> &'static str {
 fn enforce_safety_net_mode(
     report: &LeakReport,
     mode: SafetyNetMode,
+    fallback: SafetyNetFallback,
 ) -> std::result::Result<(), CliError> {
     let suspected_leaks = report.stats.uncovered_count + report.stats.partial_bleed_count;
     if suspected_leaks > 0 {
@@ -783,13 +799,54 @@ fn enforce_safety_net_mode(
                     variant: "SuspectedLeak",
                 });
             }
-            SafetyNetMode::Tolerant => emit_safety_net_warning("SuspectedLeak", suspected_leaks),
+            SafetyNetMode::Tolerant => emit_tolerant_deprecation_warning(),
+            SafetyNetMode::Redact | SafetyNetMode::Resolve => {
+                if fallback == SafetyNetFallback::Tolerant {
+                    emit_tolerant_deprecation_warning();
+                }
+            }
         }
     }
     if report.stats.class_mismatch_count > 0 {
         emit_safety_net_warning("ClassMismatch", report.stats.class_mismatch_count);
     }
     Ok(())
+}
+
+fn validate_safety_net_tolerant_gate(
+    mode: SafetyNetMode,
+    fallback: SafetyNetFallback,
+) -> std::result::Result<(), CliError> {
+    if (mode == SafetyNetMode::Tolerant || fallback == SafetyNetFallback::Tolerant)
+        && std::env::var_os("GAZE_ALLOW_TOLERANT").is_none()
+    {
+        return Err(CliError::SafetyNetFailure {
+            variant: "TolerantModeDisabled",
+        });
+    }
+    Ok(())
+}
+
+fn safety_net_policy(mode: SafetyNetMode, fallback: SafetyNetFallback) -> gaze::SafetyNetPolicy {
+    gaze::SafetyNetPolicy::new(
+        match mode {
+            SafetyNetMode::Strict => gaze::SafetyNetMode::Strict,
+            SafetyNetMode::Tolerant => gaze::SafetyNetMode::Tolerant,
+            SafetyNetMode::Redact => gaze::SafetyNetMode::Redact,
+            SafetyNetMode::Resolve => gaze::SafetyNetMode::Resolve,
+        },
+        match fallback {
+            SafetyNetFallback::Strict => gaze::SafetyNetFallback::Strict,
+            SafetyNetFallback::Tolerant => gaze::SafetyNetFallback::Tolerant,
+            SafetyNetFallback::Redact => gaze::SafetyNetFallback::Redact,
+        },
+    )
+}
+
+fn emit_tolerant_deprecation_warning() {
+    eprintln!(
+        "warning: tolerant mode downgrades suspect leaks; deprecated v0.9, removal candidate v0.10."
+    );
 }
 
 fn emit_safety_net_warning(variant: &'static str, count: usize) {

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -428,7 +428,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\n"
     ));
     assert!(stdout.contains("dictionary:audit_terms[#0]"));
     assert!(stdout.contains("custom:term"));
@@ -458,7 +458,7 @@ fn audit_sql_uses_restricted_column_set() {
         recognizer_version_id: None,
     };
     let (current_sql, values) = build_audit_query_sql(
-        &filter, true, true, true, true, true, true, true, true, true, true, true, true,
+        &filter, true, true, true, true, true, true, true, true, true, true, true, true, true,
     );
     assert_eq!(
         values,
@@ -495,6 +495,7 @@ fn audit_sql_uses_restricted_column_set() {
     };
     let (legacy_sql, legacy_values) = build_audit_query_sql(
         &legacy_filter,
+        false,
         false,
         false,
         false,

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1204,7 +1204,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\n"
     ));
     assert!(
         stdout
@@ -1775,6 +1775,7 @@ fn s4_audit_query_columns_are_restricted() {
         true,
         true,
         true,
+        true,
     );
     assert!(
         values.is_empty(),
@@ -1831,6 +1832,7 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
     assert!(AUDIT_RESTRICTED_COLUMNS.contains(&"source"));
     let (sql, values) = build_audit_query_sql(
         &AuditFilter::default(),
+        true,
         true,
         true,
         true,

--- a/crates/gaze-cli/tests/safety_net_cli.rs
+++ b/crates/gaze-cli/tests/safety_net_cli.rs
@@ -75,6 +75,17 @@ fn clean(args: &[String], input: &str) -> std::process::Output {
         .unwrap()
 }
 
+fn clean_with_tolerant_env(args: &[String], input: &str) -> std::process::Output {
+    Command::cargo_bin("gaze")
+        .unwrap()
+        .arg("clean")
+        .args(args)
+        .env("GAZE_ALLOW_TOLERANT", "1")
+        .write_stdin(input.as_bytes().to_vec())
+        .output()
+        .unwrap()
+}
+
 fn safety_args(command: &Path, checkpoint: &Path) -> Vec<String> {
     vec![
         "--safety-net".to_string(),
@@ -149,13 +160,62 @@ fn missing_checkpoint_fails_closed_with_sanitized_error() {
 fn uncovered_suspect_exits_three_in_strict_mode_without_stdout() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_person","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
-    let out = clean(&safety_args(&opf, checkpoint.path()), "Plain text");
+    let mut args = safety_args(&opf, checkpoint.path());
+    args.extend(["--safety-net-mode".to_string(), "strict".to_string()]);
+    let out = clean(&args, "Plain text");
 
     assert_eq!(out.status.code(), Some(3));
     assert!(out.stdout.is_empty());
     let stderr: Value = serde_json::from_slice(&out.stderr).unwrap();
     assert_eq!(stderr["variant"], "SuspectedLeak");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("Plain text"));
+}
+
+#[test]
+fn default_safety_net_mode_resolves_with_redact_fallback() {
+    let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
+    let checkpoint = checkpoint_dir();
+    let out = clean(&safety_args(&opf, checkpoint.path()), "Plain text");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let clean_text = body["clean_text"].as_str().expect("clean_text");
+    assert!(!clean_text.starts_with("Plain"));
+    assert!(clean_text.ends_with(" text"));
+    assert_eq!(body["leak_report"]["stats"]["uncovered_count"], 1);
+}
+
+#[test]
+fn tolerant_mode_requires_env_opt_in() {
+    let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
+    let checkpoint = checkpoint_dir();
+    let mut args = safety_args(&opf, checkpoint.path());
+    args.extend(["--safety-net-mode".to_string(), "tolerant".to_string()]);
+    let out = clean(&args, "Plain text");
+
+    assert_eq!(out.status.code(), Some(3));
+    assert!(out.stdout.is_empty());
+    let stderr: Value = serde_json::from_slice(&out.stderr).unwrap();
+    assert_eq!(stderr["variant"], "TolerantModeDisabled");
+}
+
+#[test]
+fn tolerant_fallback_requires_env_opt_in() {
+    let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
+    let checkpoint = checkpoint_dir();
+    let mut args = safety_args(&opf, checkpoint.path());
+    args.extend(["--safety-net-fallback".to_string(), "tolerant".to_string()]);
+    let out = clean(&args, "Plain text");
+
+    assert_eq!(out.status.code(), Some(3));
+    assert!(out.stdout.is_empty());
+    let stderr: Value = serde_json::from_slice(&out.stderr).unwrap();
+    assert_eq!(stderr["variant"], "TolerantModeDisabled");
 }
 
 #[test]
@@ -204,10 +264,10 @@ fn tolerant_uncovered_outputs_report_and_logs_audit_row() {
         "--audit-db".to_string(),
         audit.display().to_string(),
     ]);
-    let out = clean(&args, "Plain text");
+    let out = clean_with_tolerant_env(&args, "Plain text");
 
     assert_eq!(out.status.code(), Some(0));
-    assert!(String::from_utf8_lossy(&out.stderr).contains(r#""variant":"SuspectedLeak""#));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("warning: tolerant mode downgrades"));
     let body: Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(body["leak_report"]["stats"]["uncovered_count"], 1);
 

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1439,6 +1439,26 @@ pub enum ConflictTier {
     RecognizerId,
     /// Candidate was merged with another candidate.
     Merged,
+    /// Safety-net redact mode stripped a suspect span.
+    Redact,
+    /// Safety-net resolve mode promoted a suspect span into a reversible token.
+    Resolve,
+    /// Safety-net fallback policy decided the outcome.
+    Fallback,
+}
+
+/// Safety-net fallback reason recorded in metadata-only audit rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum FallbackReason {
+    /// The suspect overlapped an existing emitted token in a way that could not be promoted.
+    OverlapConflict,
+    /// A validator rejected the promoted candidate.
+    ValidatorVeto,
+    /// A mandatory anchor was missing for the promoted candidate.
+    AnchorMissing,
+    /// A follow-up safety-net pass still observed a suspect.
+    ResidualSuspect,
 }
 
 /// Source document kind for metadata-only audit logging.
@@ -1493,6 +1513,8 @@ pub struct RedactionEntry {
     pub collision_family: Option<String>,
     /// Collision variant that influenced this decision.
     pub collision_variant: Option<String>,
+    /// Safety-net fallback reason, when fallback policy handled the row.
+    pub fallback_triggered: Option<FallbackReason>,
 }
 
 impl Serialize for RedactionEntry {
@@ -1502,7 +1524,7 @@ impl Serialize for RedactionEntry {
     {
         use serde::ser::SerializeStruct;
 
-        let mut len = 13;
+        let mut len = 14;
         if self.recognizer_id.is_some() {
             len += 1;
         }
@@ -1535,6 +1557,7 @@ impl Serialize for RedactionEntry {
         state.serialize_field("ambiguity_record", &self.ambiguity_record)?;
         state.serialize_field("collision_family", &self.collision_family)?;
         state.serialize_field("collision_variant", &self.collision_variant)?;
+        state.serialize_field("fallback_triggered", &self.fallback_triggered)?;
         state.end()
     }
 }
@@ -1569,6 +1592,9 @@ fn redaction_conflict_tier_as_str(tier: ConflictTier) -> &'static str {
         ConflictTier::AnchoredContext => "anchored_context",
         ConflictTier::RecognizerId => "recognizer_id",
         ConflictTier::Merged => "merged",
+        ConflictTier::Redact => "redact",
+        ConflictTier::Resolve => "resolve",
+        ConflictTier::Fallback => "fallback",
     }
 }
 
@@ -1602,6 +1628,7 @@ impl RedactionEntry {
             ambiguity_record: None,
             collision_family: None,
             collision_variant: None,
+            fallback_triggered: None,
         }
     }
 
@@ -1625,6 +1652,12 @@ impl RedactionEntry {
     ) -> Self {
         self.collision_family = family;
         self.collision_variant = variant;
+        self
+    }
+
+    /// Attaches safety-net fallback metadata to this row.
+    pub fn with_fallback_triggered(mut self, reason: FallbackReason) -> Self {
+        self.fallback_triggered = Some(reason);
         self
     }
 
@@ -2260,6 +2293,7 @@ mod redaction_logger_tests {
             ambiguity_record: None,
             collision_family: None,
             collision_variant: None,
+            fallback_triggered: None,
         };
 
         let trait_object: &dyn RedactionLogger = &logger;
@@ -2284,7 +2318,7 @@ mod redaction_logger_tests {
 
         assert_eq!(
             rendered,
-            r#"{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"none","created_at":0,"session_id":null,"validator_fail_reason":null,"ambiguity_record":null,"collision_family":null,"collision_variant":null}"#
+            r#"{"source":"email.global","class":"email","action":"tokenize","field_name":null,"document_kind":"text","conflict_loser":false,"decided_by":"none","created_at":0,"session_id":null,"validator_fail_reason":null,"ambiguity_record":null,"collision_family":null,"collision_variant":null,"fallback_triggered":null}"#
         );
     }
 

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -32,12 +32,14 @@ pub use dictionaries::{
 pub use gaze_types::{
     CodecAuditRow, CodecCapabilitySet, CollisionMembership, DocumentExtension,
     DocumentExtensionBuilder, DocumentExtensionError, EmittedTokenSpan, ExtractionDensityPolicy,
-    LeakKind, LeakReport, LeakReportStats, LeakReportTelemetry, LeakSuspect, Manifest,
-    OpenAiPrivateLabel, RedactionLogError, RedactionLogger, SafetyNet, SafetyNetContext,
+    FallbackReason, LeakKind, LeakReport, LeakReportStats, LeakReportTelemetry, LeakSuspect,
+    Manifest, OpenAiPrivateLabel, RedactionLogError, RedactionLogger, SafetyNet, SafetyNetContext,
     SafetyNetError, SafetyNetPiiClass, SafetyTier, TextOrigin, RESERVED_BUNDLED_FAMILIES,
 };
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
-pub use pipeline::{Error, Pipeline, PipelineBuilder, Result};
+pub use pipeline::{
+    Error, Pipeline, PipelineBuilder, Result, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
+};
 pub use policy::{
     validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,
     RulepackPolicy, SessionPolicy, SessionScope, DEFAULT_NER_THRESHOLD,

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
+use std::ops::Range;
 use std::sync::Arc;
 
 use gaze_types::{
-    AmbiguityReason, AmbiguityRecord, CollisionMembership, EmittedTokenSpan, LeakReport,
-    LeakReportTelemetry, LeakSuspect, Manifest, RedactionLogError, RedactionLogger, SafetyNet,
-    SafetyNetContext, SafetyNetError,
+    AmbiguityReason, AmbiguityRecord, CollisionMembership, EmittedTokenSpan, FallbackReason,
+    LeakKind, LeakReport, LeakReportTelemetry, LeakSuspect, Manifest, RedactionLogError,
+    RedactionLogger, SafetyNet, SafetyNetContext, SafetyNetError,
 };
 use thiserror::Error;
 
@@ -52,12 +53,53 @@ pub enum Error {
     SafetyNet(#[from] SafetyNetError),
     #[error("redaction log error: {0}")]
     RedactionLog(#[from] RedactionLogError),
+    #[error("safety net fallback failed closed: {0:?}")]
+    SafetyNetFallback(FallbackReason),
     #[error("unsupported raw document variant")]
     UnsupportedRawDocumentVariant,
     #[error("unsupported structured value variant")]
     UnsupportedValueVariant,
     #[error("unsupported policy action variant")]
     UnsupportedActionVariant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SafetyNetMode {
+    Strict,
+    Tolerant,
+    Redact,
+    Resolve,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SafetyNetFallback {
+    Strict,
+    Tolerant,
+    Redact,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SafetyNetPolicy {
+    pub mode: SafetyNetMode,
+    pub fallback: SafetyNetFallback,
+}
+
+impl Default for SafetyNetPolicy {
+    fn default() -> Self {
+        Self {
+            mode: SafetyNetMode::Resolve,
+            fallback: SafetyNetFallback::Redact,
+        }
+    }
+}
+
+impl SafetyNetPolicy {
+    pub fn new(mode: SafetyNetMode, fallback: SafetyNetFallback) -> Self {
+        Self { mode, fallback }
+    }
 }
 
 /// The stateless PII pseudonymization engine.
@@ -200,6 +242,23 @@ impl Pipeline {
         locale_chain: &[crate::LocaleTag],
         dictionaries: &DictionaryBundle,
     ) -> Result<(CleanDocument, Vec<EmittedTokenSpan>, LeakReport)> {
+        self.clean_with_safety_net_policy_detect_context(
+            session,
+            raw,
+            locale_chain,
+            dictionaries,
+            SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
+        )
+    }
+
+    pub fn clean_with_safety_net_policy_detect_context(
+        &self,
+        session: &Session,
+        raw: RawDocument,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+        policy: SafetyNetPolicy,
+    ) -> Result<(CleanDocument, Vec<EmittedTokenSpan>, LeakReport)> {
         match raw {
             RawDocument::Structured(structured_fields) => {
                 let mut report = LeakReport::default();
@@ -214,7 +273,7 @@ impl Pipeline {
                 Ok((CleanDocument::Structured(clean), Vec::new(), report))
             }
             RawDocument::Text(text) => {
-                let clean = self.redact_text_with_manifest(
+                let mut clean = self.redact_text_with_manifest(
                     session,
                     &text,
                     None,
@@ -229,6 +288,15 @@ impl Pipeline {
                     DocumentKind::Text,
                     locale_chain,
                     None,
+                )?;
+                self.apply_safety_net_policy(
+                    session,
+                    &mut clean,
+                    &report,
+                    DocumentKind::Text,
+                    locale_chain,
+                    None,
+                    policy,
                 )?;
                 Ok((CleanDocument::Text(clean.text), clean.manifest, report))
             }
@@ -454,6 +522,223 @@ impl Pipeline {
         Ok(LeakReport::from_parts(suspects, telemetry))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn apply_safety_net_policy(
+        &self,
+        session: &Session,
+        clean: &mut CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        locale_chain: &[crate::LocaleTag],
+        field_path: Option<&str>,
+        policy: SafetyNetPolicy,
+    ) -> Result<()> {
+        match policy.mode {
+            SafetyNetMode::Strict | SafetyNetMode::Tolerant => Ok(()),
+            SafetyNetMode::Redact => self.redact_safety_net_suspects(
+                session,
+                clean,
+                report,
+                document_kind,
+                field_path,
+                None,
+                true,
+            ),
+            SafetyNetMode::Resolve => {
+                let reason = match self.resolve_safety_net_suspects(
+                    session,
+                    clean,
+                    report,
+                    document_kind,
+                    field_path,
+                )? {
+                    Some(reason) => Some(reason),
+                    None => {
+                        let follow_up = self.run_safety_nets(
+                            session,
+                            &clean.text,
+                            &Manifest::from_spans(clean.manifest.clone()),
+                            document_kind,
+                            locale_chain,
+                            field_path,
+                        )?;
+                        (follow_up.stats.uncovered_count + follow_up.stats.partial_bleed_count > 0)
+                            .then_some(FallbackReason::ResidualSuspect)
+                    }
+                };
+                if let Some(reason) = reason {
+                    self.apply_safety_net_fallback(
+                        session,
+                        clean,
+                        report,
+                        document_kind,
+                        field_path,
+                        policy.fallback,
+                        reason,
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn resolve_safety_net_suspects(
+        &self,
+        session: &Session,
+        clean: &mut CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+    ) -> Result<Option<FallbackReason>> {
+        if report
+            .suspects
+            .iter()
+            .any(|suspect| matches!(suspect.kind, LeakKind::ClassMismatch { .. }))
+        {
+            return Ok(Some(FallbackReason::OverlapConflict));
+        }
+        for suspect in actionable_suspects(report).into_iter().rev() {
+            let span = suspect_action_span(suspect);
+            if !is_char_boundary_range(&clean.text, &span) {
+                return Ok(Some(FallbackReason::ResidualSuspect));
+            }
+            let raw = clean.text[span.clone()].to_string();
+            let replacement = session.tokenize_with_family("safety_net", &suspect.class, &raw)?;
+            self.log_safety_net_entry(
+                session,
+                suspect,
+                document_kind,
+                field_path,
+                Action::Tokenize,
+                false,
+                ConflictTier::Resolve,
+                None,
+            )?;
+            replace_clean_span(
+                clean,
+                span.clone(),
+                &replacement,
+                Some(EmittedTokenSpan::new(
+                    span.start..span.start + replacement.len(),
+                    span,
+                    suspect.class.clone(),
+                )),
+            );
+        }
+        Ok(None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apply_safety_net_fallback(
+        &self,
+        session: &Session,
+        clean: &mut CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+        fallback: SafetyNetFallback,
+        reason: FallbackReason,
+    ) -> Result<()> {
+        for suspect in redaction_suspects(report) {
+            self.log_safety_net_entry(
+                session,
+                suspect,
+                document_kind,
+                field_path,
+                fallback_action(fallback),
+                true,
+                ConflictTier::Fallback,
+                Some(reason),
+            )?;
+        }
+        match fallback {
+            SafetyNetFallback::Strict => Err(Error::SafetyNetFallback(reason)),
+            SafetyNetFallback::Tolerant => Ok(()),
+            SafetyNetFallback::Redact => self.redact_safety_net_suspects(
+                session,
+                clean,
+                report,
+                document_kind,
+                field_path,
+                Some(reason),
+                false,
+            ),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn redact_safety_net_suspects(
+        &self,
+        session: &Session,
+        clean: &mut CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+        fallback_reason: Option<FallbackReason>,
+        log_entries: bool,
+    ) -> Result<()> {
+        for suspect in redaction_suspects(report).into_iter().rev() {
+            let span = suspect_action_span(suspect);
+            if !is_char_boundary_range(&clean.text, &span) {
+                continue;
+            }
+            if log_entries {
+                self.log_safety_net_entry(
+                    session,
+                    suspect,
+                    document_kind,
+                    field_path,
+                    Action::Redact,
+                    fallback_reason.is_some(),
+                    if fallback_reason.is_some() {
+                        ConflictTier::Fallback
+                    } else {
+                        ConflictTier::Redact
+                    },
+                    fallback_reason,
+                )?;
+            }
+            replace_clean_span(clean, span, "", None);
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn log_safety_net_entry(
+        &self,
+        session: &Session,
+        suspect: &LeakSuspect,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+        action: Action,
+        conflict_loser: bool,
+        decided_by: ConflictTier,
+        fallback_reason: Option<FallbackReason>,
+    ) -> Result<()> {
+        let source = format!("safety_net.{}", suspect.safety_net_id);
+        let mut entry = RedactionEntry::new(
+            source.clone(),
+            suspect.class.clone(),
+            action,
+            field_path
+                .map(str::to_string)
+                .or_else(|| suspect.field_path.clone()),
+            document_kind,
+            conflict_loser,
+            decided_by,
+            crate::redaction_log::current_epoch_ms(),
+            Some(session.audit_session_id().to_string()),
+        )
+        .with_recognizer_metadata(Some(source), None);
+        if let Some(reason) = fallback_reason {
+            entry = entry.with_fallback_triggered(reason);
+        }
+        for logger in &self.redaction_loggers {
+            logger.log(&entry)?;
+        }
+        Ok(())
+    }
+
     fn action_for(&self, detection: &Detection, context: &RuleContext) -> Action {
         self.rules
             .iter()
@@ -556,6 +841,90 @@ struct IndexedDetection {
 struct CleanText {
     text: String,
     manifest: Vec<EmittedTokenSpan>,
+}
+
+fn actionable_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
+    let mut suspects = report
+        .suspects
+        .iter()
+        .filter(|suspect| {
+            matches!(
+                suspect.kind,
+                LeakKind::Uncovered | LeakKind::PartialBleed { .. }
+            )
+        })
+        .collect::<Vec<_>>();
+    suspects.sort_by_key(|suspect| suspect_action_span(suspect).start);
+    suspects
+}
+
+fn redaction_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
+    let mut suspects = report.suspects.iter().collect::<Vec<_>>();
+    suspects.sort_by_key(|suspect| suspect_action_span(suspect).start);
+    suspects
+}
+
+fn suspect_action_span(suspect: &LeakSuspect) -> Range<usize> {
+    match &suspect.kind {
+        LeakKind::PartialBleed { uncovered } => uncovered.clone(),
+        _ => suspect.span.clone(),
+    }
+}
+
+fn fallback_action(fallback: SafetyNetFallback) -> Action {
+    match fallback {
+        SafetyNetFallback::Strict | SafetyNetFallback::Tolerant => Action::Preserve,
+        SafetyNetFallback::Redact => Action::Redact,
+    }
+}
+
+fn is_char_boundary_range(text: &str, span: &Range<usize>) -> bool {
+    span.start <= span.end
+        && span.end <= text.len()
+        && text.is_char_boundary(span.start)
+        && text.is_char_boundary(span.end)
+}
+
+fn replace_clean_span(
+    clean: &mut CleanText,
+    span: Range<usize>,
+    replacement: &str,
+    emitted: Option<EmittedTokenSpan>,
+) {
+    let removed_len = span.end - span.start;
+    let replacement_len = replacement.len();
+    clean.text.replace_range(span.clone(), replacement);
+    clean.manifest = clean
+        .manifest
+        .iter()
+        .filter_map(|existing| adjust_emitted_span(existing, &span, replacement_len, removed_len))
+        .chain(emitted)
+        .collect();
+    clean.manifest.sort_by_key(|span| span.clean_span.start);
+}
+
+fn adjust_emitted_span(
+    existing: &EmittedTokenSpan,
+    edited: &Range<usize>,
+    replacement_len: usize,
+    removed_len: usize,
+) -> Option<EmittedTokenSpan> {
+    if existing.clean_span.start < edited.end && edited.start < existing.clean_span.end {
+        return None;
+    }
+    let mut span = existing.clone();
+    if span.clean_span.start >= edited.end {
+        if replacement_len >= removed_len {
+            let delta = replacement_len - removed_len;
+            span.clean_span.start += delta;
+            span.clean_span.end += delta;
+        } else {
+            let delta = removed_len - replacement_len;
+            span.clean_span.start -= delta;
+            span.clean_span.end -= delta;
+        }
+    }
+    Some(span)
 }
 
 /// Builder for [`Pipeline`].

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -3,9 +3,10 @@ use std::ops::Range;
 use std::sync::{Arc, Mutex};
 
 use gaze::{
-    Action, ClassRule, CleanDocument, DefaultRule, Detection, Detector, DocumentKind,
-    EmittedTokenSpan, LeakKind, LeakReportTelemetry, LeakSuspect, PiiClass, Pipeline, RawDocument,
-    SafetyNet, SafetyNetContext, SafetyNetError, Scope, Session, Value,
+    Action, ClassRule, CleanDocument, ConflictTier, DefaultRule, Detection, Detector, DocumentKind,
+    EmittedTokenSpan, FallbackReason, LeakKind, LeakReportTelemetry, LeakSuspect, PiiClass,
+    Pipeline, RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, SafetyNet,
+    SafetyNetContext, SafetyNetError, Scope, Session, Value,
 };
 
 #[derive(Clone)]
@@ -42,6 +43,30 @@ struct SeenCheck {
     field_path: Option<String>,
     document_kind: DocumentKind,
     manifest: Vec<EmittedTokenSpan>,
+}
+
+#[derive(Clone)]
+struct MemoryLogger {
+    entries: Arc<Mutex<Vec<RedactionEntry>>>,
+}
+
+impl MemoryLogger {
+    fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn entries(&self) -> Vec<RedactionEntry> {
+        self.entries.lock().expect("entries").clone()
+    }
+}
+
+impl RedactionLogger for MemoryLogger {
+    fn log(&self, entry: &RedactionEntry) -> Result<(), RedactionLogError> {
+        self.entries.lock().expect("entries").push(entry.clone());
+        Ok(())
+    }
 }
 
 impl MockNet {
@@ -176,6 +201,114 @@ fn tokenizing_pipeline_with_net(net: MockNet) -> Pipeline {
         .register_safety_net(net)
         .build()
         .expect("pipeline")
+}
+
+#[test]
+fn safety_net_resolve_mode_promotes_suspect_to_manifest_token() {
+    let suspect = "alice@example.invalid";
+    let raw = format!("Reach {suspect}");
+    let start = raw.find(suspect).expect("suspect");
+    let net = MockNet::new(Some(start..start + suspect.len()), PiiClass::Email);
+    let logger = MemoryLogger::new();
+    let pipeline = Pipeline::builder()
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(net)
+        .redaction_logger(logger.clone())
+        .build()
+        .expect("pipeline");
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::default(),
+        )
+        .expect("resolve");
+    let clean_text = text(clean);
+
+    assert!(!clean_text.contains(suspect));
+    assert_eq!(manifest.len(), 1);
+    assert_eq!(report.stats.uncovered_count, 1);
+    assert_eq!(
+        session.restore(&clean_text[start..]),
+        Some(suspect.to_string())
+    );
+    assert!(logger
+        .entries()
+        .iter()
+        .any(|entry| entry.decided_by == ConflictTier::Resolve && !entry.conflict_loser));
+}
+
+#[test]
+fn safety_net_redact_mode_strips_suspect_without_manifest_entry() {
+    let suspect = "alice@example.invalid";
+    let raw = format!("Reach {suspect}");
+    let start = raw.find(suspect).expect("suspect");
+    let net = MockNet::new(Some(start..start + suspect.len()), PiiClass::Email);
+    let pipeline = pipeline_with_net(Some(net));
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("redact");
+
+    assert_eq!(text(clean), "Reach ");
+    assert!(manifest.is_empty());
+    assert_eq!(report.stats.uncovered_count, 1);
+}
+
+#[test]
+fn safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit() {
+    let session = session();
+    let raw = RawDocument::Text("alice@example.invalid ok".to_string());
+    let baseline = text(
+        tokenizing_pipeline()
+            .redact(&session, raw.clone())
+            .expect("baseline"),
+    );
+    let token_len = baseline.find(" ok").expect("token suffix");
+    let logger = MemoryLogger::new();
+    let net = MockNet::new(Some(0..token_len), PiiClass::Name);
+    let pipeline = Pipeline::builder()
+        .detector(FixedDetector {
+            span: 0.."alice@example.invalid".len(),
+            class: PiiClass::Email,
+        })
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(net)
+        .redaction_logger(logger.clone())
+        .build()
+        .expect("pipeline");
+
+    let (clean, _, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            raw,
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::default(),
+        )
+        .expect("fallback redact");
+
+    assert_eq!(report.stats.class_mismatch_count, 1);
+    assert_eq!(text(clean), " ok");
+    assert!(logger.entries().iter().any(|entry| {
+        entry.decided_by == ConflictTier::Fallback
+            && entry.fallback_triggered == Some(FallbackReason::OverlapConflict)
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Implements safety-net `resolve` and `redact` modes, with CLI defaults locked to `--safety-net-mode resolve` and `--safety-net-fallback redact`.
- Adds closed `SafetyNetMode`, `SafetyNetFallback`, and `FallbackReason` contracts plus audit `decided_by` coverage for `redact`, `resolve`, and `fallback` outcomes.
- Adds `fallback_triggered: Option<FallbackReason>` to restricted audit rows and plumbs it through SQLite/query/CLI audit output.
- Gates tolerant mode and tolerant fallback behind `GAZE_ALLOW_TOLERANT=1` and emits the deprecation warning when tolerant is explicitly enabled.

## North Star
This moves the documented default from observer-only behavior to fail-closed remediation: uncovered safety-net suspects are resolved into manifest-backed tokens when possible, and unresolved/conflicting outcomes fall back to deterministic redaction. The design keeps raw suspect bytes out of audit rows and preserves traceable, closed metadata for every fallback reason.

## Tests
- `cargo check -p gaze-pii -p gaze-audit -p gaze-cli --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- safety-net-sanity`
- `cargo run -p xtask -- dylint-gate`
- `cargo run -p xtask -- cargo-metadata-audit-isolation`

Refs roadmap scratchpad 346 and design docs. Closes #23. Closes #24. Closes #30. Closes #25.
