### PR TITLE
refactor(gaze-document): remove legacy OcrAdapter shims, single OcrBackend trait (v0.8.x #26-cleanup)

### DIFF
--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -21,7 +21,9 @@ use std::path::PathBuf;
 use gaze::Manifest;
 use serde::{Deserialize, Serialize};
 
-use crate::ocr::{ImageFormat, ImageInput, OcrBackend, OcrError, OcrHints, OcrResult};
+use crate::ocr::{
+    detect_image_format, ImageFormat, ImageInput, OcrBackend, OcrError, OcrHints, OcrResult,
+};
 
 #[cfg(feature = "ocr-tesseract")]
 use std::collections::BTreeMap;
@@ -462,11 +464,12 @@ fn run_document_extraction(
     match kind {
         InputKind::Png | InputKind::Jpeg => {
             let bytes = fs::read(input)?;
+            let format = detect_image_format(&bytes)?;
             let (result, column_count) = recognize_image(
                 ocr_backend,
                 ImageInput {
                     bytes,
-                    format: image_format_for_kind(kind),
+                    format,
                     dpi: None,
                 },
                 options.column_detection,
@@ -598,15 +601,6 @@ fn merge_page_results(results: &[OcrResult]) -> OcrResult {
         Some((conf_sum / conf_count as f64) as f32)
     };
     OcrResult::new(text, mean_confidence, conf_count, "mixed".to_string())
-}
-
-#[cfg(feature = "ocr-tesseract")]
-fn image_format_for_kind(kind: InputKind) -> ImageFormat {
-    match kind {
-        InputKind::Png => ImageFormat::Png,
-        InputKind::Jpeg => ImageFormat::Jpeg,
-        InputKind::Pdf => ImageFormat::Png,
-    }
 }
 
 #[cfg(feature = "ocr-tesseract")]
@@ -862,7 +856,7 @@ mod tests {
         };
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
-        fs::write(&input, b"not-real-image").expect("write input");
+        fs::write(&input, b"\x89PNG\r\n\x1A\nnot-real-image").expect("write input");
 
         let bundle = Pipeline::new()
             .with_low_confidence_threshold(0.65)

--- a/crates/gaze-document/src/lib.rs
+++ b/crates/gaze-document/src/lib.rs
@@ -60,8 +60,8 @@ pub use layout::ReadingOrder;
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub use ocr::TesseractBackend;
 pub use ocr::{
-    BBox, ImageFormat, ImageInput, LanguageTag, OcrAdapter, OcrBackend, OcrError, OcrHints,
-    OcrSpan, PendingOcrAdapter,
+    detect_image_format, BBox, ImageFormat, ImageInput, LanguageTag, OcrBackend, OcrError,
+    OcrHints, OcrSpan,
 };
 pub use render::Renderer;
 

--- a/crates/gaze-document/src/ocr/mod.rs
+++ b/crates/gaze-document/src/ocr/mod.rs
@@ -19,12 +19,6 @@ pub mod tesseract;
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub use tesseract::TesseractBackend;
 
-/// Backward-compatible alias for the Tesseract subprocess OCR backend.
-#[cfg(feature = "ocr-tesseract")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
-#[deprecated(note = "use TesseractBackend")]
-pub type TesseractOcr = TesseractBackend;
-
 /// Raster image format handed to an OCR backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageFormat {
@@ -45,6 +39,28 @@ impl ImageFormat {
             Self::Tiff => "tiff",
         }
     }
+}
+
+/// Detect the encoded image format from magic bytes.
+///
+/// # Errors
+///
+/// Returns [`DocumentError::UnsupportedInput`] when the byte payload is not a
+/// supported PNG, JPEG, or TIFF image.
+pub fn detect_image_format(bytes: &[u8]) -> Result<ImageFormat, DocumentError> {
+    if bytes.starts_with(b"\x89PNG") {
+        return Ok(ImageFormat::Png);
+    }
+    if bytes.starts_with(b"\xFF\xD8\xFF") {
+        return Ok(ImageFormat::Jpeg);
+    }
+    if bytes.starts_with(b"II\x2A\x00") || bytes.starts_with(b"MM\x00\x2A") {
+        return Ok(ImageFormat::Tiff);
+    }
+    Err(DocumentError::UnsupportedInput {
+        path: std::path::PathBuf::new(),
+        reason: "image bytes are not PNG, JPEG, or TIFF",
+    })
 }
 
 /// Finalized image payload for one OCR pass.
@@ -160,49 +176,6 @@ pub trait OcrBackend: Send + Sync {
     fn recognize(&self, image: ImageInput, hints: OcrHints) -> Result<Vec<OcrSpan>, OcrError>;
 }
 
-/// Legacy text-only adapter contract kept for source compatibility.
-///
-/// New code should use [`OcrBackend`] so backend output remains traceable to
-/// bounding boxes and confidence values.
-pub trait OcrAdapter {
-    /// Extract textual content from image bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DocumentError`] when backend recognition fails.
-    fn extract_text(&self, bytes: &[u8]) -> Result<String, DocumentError>;
-}
-
-/// Reserved fail-loud legacy adapter.
-///
-/// New code should wire a concrete [`OcrBackend`]. This placeholder remains so
-/// older callers fail closed instead of receiving silent empty OCR output.
-#[non_exhaustive]
-pub struct PendingOcrAdapter {
-    _private: (),
-}
-
-impl PendingOcrAdapter {
-    /// Build the fail-loud adapter.
-    ///
-    /// # Errors
-    ///
-    /// Always returns [`DocumentError::NotImplemented`].
-    pub fn new() -> Result<Self, DocumentError> {
-        Err(DocumentError::NotImplemented(
-            "PendingOcrAdapter::new (wire a concrete OCR backend)",
-        ))
-    }
-}
-
-impl OcrAdapter for PendingOcrAdapter {
-    fn extract_text(&self, _bytes: &[u8]) -> Result<String, DocumentError> {
-        Err(DocumentError::NotImplemented(
-            "PendingOcrAdapter::extract_text (wire a concrete OCR backend)",
-        ))
-    }
-}
-
 /// Result of an OCR pass: full text + a structured confidence summary.
 ///
 /// Backend-agnostic — concrete adapters (e.g., [`tesseract::TesseractBackend`])
@@ -224,7 +197,7 @@ pub struct OcrResult {
 
 impl OcrResult {
     /// Build an OCR result from raw fields.
-    pub fn new(
+    pub(crate) fn new(
         text: String,
         mean_confidence: Option<f32>,
         word_count: usize,
@@ -349,5 +322,31 @@ mod tests {
         assert_eq!(columns, 2);
         assert_eq!(result.text, "A1\nA2\n\nB1\nB2");
         assert_eq!(result.mean_confidence_unit(), Some(0.8));
+    }
+
+    #[test]
+    fn detect_image_format_accepts_supported_magic_bytes() {
+        assert_eq!(
+            detect_image_format(b"\x89PNG\r\n\x1A\nrest").expect("png magic"),
+            ImageFormat::Png
+        );
+        assert_eq!(
+            detect_image_format(b"\xFF\xD8\xFF\xE0rest").expect("jpeg magic"),
+            ImageFormat::Jpeg
+        );
+        assert_eq!(
+            detect_image_format(b"II\x2A\x00rest").expect("little-endian tiff magic"),
+            ImageFormat::Tiff
+        );
+        assert_eq!(
+            detect_image_format(b"MM\x00\x2Arest").expect("big-endian tiff magic"),
+            ImageFormat::Tiff
+        );
+    }
+
+    #[test]
+    fn detect_image_format_rejects_unknown_bytes() {
+        let err = detect_image_format(b"not an image").expect_err("unknown format fails");
+        assert!(matches!(err, DocumentError::UnsupportedInput { .. }));
     }
 }

--- a/crates/gaze-document/src/ocr/tesseract.rs
+++ b/crates/gaze-document/src/ocr/tesseract.rs
@@ -154,13 +154,6 @@ impl OcrBackend for TesseractBackend {
     }
 }
 
-impl super::OcrAdapter for TesseractBackend {
-    fn extract_text(&self, bytes: &[u8]) -> Result<String, DocumentError> {
-        self.extract_from_bytes(bytes, "png")
-            .map(|result| result.text)
-    }
-}
-
 fn parse_tsv_result(tsv: &str, lang: &str) -> OcrResult {
     parse_tsv(tsv, lang)
 }


### PR DESCRIPTION
## Summary
- Removes the legacy `OcrAdapter` trait, `PendingOcrAdapter`, deprecated `TesseractOcr` alias, and `TesseractBackend` text-only adapter impl left behind by #218.
- Routes image ingestion through `OcrBackend::recognize` with byte-level `detect_image_format` for PNG/JPEG/TIFF.
- Makes raw `OcrResult::new` crate-only and keeps public construction on span aggregation.

## Context
Shipped #218 (`b9f3407`) left backwards-compat OCR shims that contradicted the original no-shim brief and made second-backend integration ambiguous. This PR honors scratchpads 346, 394, and cleanup brief 400 by keeping a single backend contract: `OcrBackend::recognize`.

## Five-axis note
- Reliability: unchanged; unsupported image payloads now fail closed before OCR backend dispatch.
- Reversibility: unchanged.
- Agentic fit: unchanged.
- Trust: strengthened by removing the duplicate text-only OCR contract.
- Adopter ergonomics: strengthened; second OCR backends implement one trait.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
- `cargo run -p xtask -- fixture-citation-lint`

## Notes
- `cargo test --workspace --all-targets` inside `ci-feature-matrix` emitted existing dead-code warnings for `gaze-document::bundle::run_ocr` and `gaze-cli::CliError::SafetyNetArtifactMissing`; the required clippy gate passed with `-D warnings`.
