### PR TITLE
release: v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.8.1] - 2026-05-15
+
+Reversibility-first SafetyNet defaults, layout-report v2 with vector-PDF + multi-column + table-cell + deskew handling, an `OcrBackend` trait for plug-in OCR drivers, model-SHA integrity for the Kiji backend, and the default release binary now baking `--features proxy`. Schema-level: `BundleReport.bundle_version` bumps `1 → 2` (additive); `gaze-audit` rows gain a typed `fallback_triggered: Option<FallbackReason>` column and `decided_by` gains `Redact`/`Resolve`/`Fallback` variants.
+
+### Added
+
+- **SafetyNet `resolve` + `redact` + `fallback` modes** (PR #223 `167acca`): suspect spans flagged by Pass-3 SafetyNet are now promoted to custom-recognizer matches and rejoin conflict resolution before any irreversible side-effect. On promotion failure the typed fallback path emits a `:Redact_` token and records a `FallbackReason` in the audit log. Closed-enum variants: `FallbackReason::{OverlapConflict, ValidatorVeto, AnchorMissing, ResidualSuspect}`. New `decided_by` variants: `Redact`, `Resolve`, `Fallback`. CLI gains `--safety-net-mode {resolve|strict|tolerant}` and `--safety-net-fallback {redact|none}`. Tolerant remains dev-only behind `GAZE_ALLOW_TOLERANT=1`. (Axis 1 reliability, Axis 2 reversibility, Axis 4 trust.)
+- **gaze-document layout report v2** (PR #219 `6acf77e`, PR #222 `9714b41`): `BundleReport.bundle_version` bumps `1 → 2`. New per-page fields: `ocr_source`, `ocr_backend`, `confidence`, `low_confidence`, `column_count`, `page_index`. New top-level field: `low_confidence_threshold`. Vector-PDF text-extraction fallback when PDFs have selectable text; multi-column segmentation in the post-processor; per-page confidence + low-confidence flagging against the threshold; table-cell preservation in markdown output; rotation/deskew preprocessing before OCR. v1 bundles continue to parse on read; emission is always v2. (Axis 1 reliability, Axis 4 trust.)
+- **`OcrBackend` trait** (PR #218 `b9f3407`): single trait, single impl (`TesseractBackend`). `gaze-document` now exposes one OCR contract that second-party backends (ocrs, Apple Vision, PaddleOCR) can slot into cleanly. Trait is object-safe; covered by `tests/ocr_backend.rs`. (Axis 4 trust, Axis 5 ergonomics.)
+- **Kiji model-SHA integrity** (PR #221 `07cf93d`): `KijiDistilbertSafetyNet` backend now verifies the DistilBERT bundle SHA256 at init and fails closed via `SafetyNetError::ModelIntegrityMismatch { expected, actual }` on mismatch. Direct-vs-observer benchmark harness shipped under `gaze-recognizers/benches/`; published metric fields stay `null` until populated on a machine with the pinned local Kiji runtime (Axis 4 — no uncited benchmark numbers). (Axis 1 reliability, Axis 4 trust.)
+- **Safety-net architecture contract** (PR #216 `1cf6732`): `docs/architecture/safety-nets.md` now documents the resolve/redact/fallback semantics, the typed `FallbackReason` set, and how SafetyNet promotion interacts with `ConflictTier`. Companion adopter-facing doc updated in PR #217 `d55af13`.
+
+### Changed
+
+- **`--safety-net-mode resolve` is the new default** (PR #217 `d55af13`, PR #223 `167acca`), replacing `strict`. Reversibility-first; falls back to `redact` on resolve failure. Strict mode remains available for hard-fail deployments via `--safety-net-mode strict`. (Axis 1, Axis 2.)
+- **Default release binary now bakes `--features proxy`** (PR #220 `fc00c26`): the published `gaze-v0.8.1-*.tar.gz` artifacts include `gaze proxy {serve,start,stop,status,logs,restart}` out of the box. Adopters who build from source unchanged.
+- **Marketing-pass README** (PR #215 `ad22121`): adopter-focused copy refresh; no behavior change.
+- **Workspace version pin** `0.8.0 → 0.8.1` across all ten crates.
+
+### Removed
+
+- **Legacy `OcrAdapter` shims** (PR #224 `89aaa4e`): the deprecated v0.7.1 adapter surface is gone. Adopters who plug in custom OCR now implement `OcrBackend` directly. Magic-byte validation (`detect_image_format`) is now mandatory at the `clean_with_ocr_backend` boundary — bare-byte payloads fail closed with `DocumentError::UnsupportedInput`.
+
+### Fixed
+
+- **Table-cell mock-backend test missing PNG magic bytes**: `bundle::tests::clean_with_mock_backend_preserves_table_cell_context` failed on `89aaa4e` after the magic-byte gate landed in PR #224. Test fixture now prepends `\x89PNG\r\n\x1A\n` to the synthetic payload. CI was red on main HEAD; this commit makes it green.
+
+### Migration notes
+
+- If your downstream tooling reads SafeBundle JSON: handle the `bundle_version=2` field. v1 reads work; v2 emission is non-optional.
+- If you query the audit log: the new `fallback_triggered` column is nullable on existing rows; the new `decided_by` variants are closed-enum and discriminated.
+- If your pipeline expected `--safety-net-mode strict` as default: pass the flag explicitly.
+- If you embedded custom OCR via `OcrAdapter`: port to `OcrBackend` (object-safe, same shape).
+- v0.7.x → v0.8.x → v0.8.1 multi-hop adopters: read [UPGRADE.md](./UPGRADE.md) before bumping; v0.8.0 already flipped several defaults.
+
 ## [0.8.0] - 2026-05-14
 
 Bundle unification + versioned recognizer lineage + Kiji-style defense-in-depth + ten checksum-backed and locale-gated national-ID recognizers across five new locale packs, plus the new `gaze-proxy` crate that puts a PII chokepoint in front of OpenAI / Anthropic / Gemini API traffic. The workspace publish count rises from nine to ten.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aho-corasick",
  "criterion",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.8.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.8.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.8.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.8.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.8.1" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.8.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
+gaze = { path = "../gaze", version = "0.8.1", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -42,14 +42,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
+gaze = { path = "../gaze", version = "0.8.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.1" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.8.0", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.8.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.1", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.1", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -63,7 +63,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
+gaze = { path = "../gaze", version = "0.8.1", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.8.1" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -898,7 +898,7 @@ mod tests {
         };
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
-        fs::write(&input, b"not-real-image").expect("write input");
+        fs::write(&input, b"\x89PNG\r\n\x1A\nnot-real-image").expect("write input");
 
         let bundle = Pipeline::new()
             .clean_with_ocr_backend(&input, tmp.path(), &backend)

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.8.1", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.8.1" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.8.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.8.1" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.8.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.8.0" }
+gaze = { path = "../gaze", version = "0.8.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.8.1" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.8.1", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/dist/release-notes/v0.8.1.md
+++ b/dist/release-notes/v0.8.1.md
@@ -1,0 +1,56 @@
+# gaze v0.8.1 — reversibility as the new default
+
+## TL;DR
+
+v0.8.1 makes reversible pseudonymization the default safety-net behavior. When Pass-3 SafetyNet flags a suspect leak, the pipeline now attempts to promote the suspect to a manifest entry first (`--safety-net-mode resolve`), and only strips the span (`--safety-net-fallback redact`) if that promotion fails closed. Adopters who want hard-fail semantics keep opting into `--safety-net-mode strict`.
+
+This is a minor release that ships behind the v0.8.0 manifest contract — `bundle_version` for SafeBundle adopters bumps from `1` to `2`, but no breaking API changes in `gaze`, `gaze-recognizers`, `gaze-audit`, or `gaze-mcp-*`. v0.8.0 adopters can upgrade in place. **If you're upgrading from v0.7.x: read [UPGRADE.md](https://github.com/EmpireTwo/gaze/blob/main/UPGRADE.md) first** — v0.8.0 already flipped several defaults that v0.7.x users do not see in this CHANGELOG entry alone.
+
+## Defaults changed
+
+- **`--safety-net-mode resolve` is the new default** (was `strict`). Reversibility-first; falls back to `redact` on resolve failure. Strict mode is still available for hard-fail deployments via `--safety-net-mode strict`. Tolerant mode remains dev-only behind `GAZE_ALLOW_TOLERANT=1` opt-in. (Axes 1, 2.)
+- **`--safety-net-fallback redact` is the new default** for the new fallback flag. Emits a `:Redact_` token and a typed `FallbackReason` audit row when SafetyNet promotion cannot complete. (Axes 1, 2.)
+- **The published release binary now bakes `--features proxy`** so `gaze proxy {serve,start,stop,status,logs,restart}` works without rebuild. Source builds are unchanged. (Axis 5.)
+
+Example: keep the old behavior explicitly with
+
+```shell
+gaze clean --safety-net-mode strict --safety-net-fallback none input.txt
+```
+
+## Highlights
+
+1. **SafetyNet `resolve` + `redact` + fallback flag impl** (#223, axes 1+2+4). Suspect spans flagged by SafetyNet are now promoted to custom-recognizer matches and rejoin conflict resolution. On promotion failure (`ValidatorVeto`, `AnchorMissing`, `OverlapConflict`, `ResidualSuspect`), the typed fallback path kicks in — no more silent passthrough, no irreversible strip without a typed reason in the audit log.
+2. **gaze-document layout report v2** (#219 + #222, axis 1). Vector-PDF text-extraction fallback when PDFs have selectable text; multi-column segmentation in the post-processor; per-page confidence + low-confidence flagging against `low_confidence_threshold`; table-cell preservation in markdown output; rotation/deskew preprocessing before OCR. SafetyNet has more structured text to work with, less to reconstruct.
+3. **`OcrBackend` single-trait single-impl** (#218 + #224, axes 4+5). `gaze-document` now exposes one OCR contract. Second-party backends (ocrs, Apple Vision, PaddleOCR) can slot in cleanly. Legacy `OcrAdapter` shims removed; magic-byte validation at the `clean_with_ocr_backend` boundary is now mandatory and fails closed via `DocumentError::UnsupportedInput`.
+4. **Kiji model-SHA integrity** (#221, axes 1+4). The `KijiDistilbertSafetyNet` backend's DistilBERT bundle SHA256 is pinned and verified at backend init. Mismatch fails closed via `SafetyNetError::ModelIntegrityMismatch { expected, actual }`. Direct-vs-observer benchmark harness shipped; metric fields stay `null` until populated on a machine with the local Kiji runtime — gaze does not publish uncited benchmark numbers.
+
+## Schema changes
+
+- **SafeBundle `BundleReport.bundle_version` bumps `1 → 2`.** New per-page fields: `ocr_source`, `ocr_backend`, `confidence`, `low_confidence`, `column_count`, `page_index`. New top-level field: `low_confidence_threshold`. v1 bundles continue to parse on read; new emission is always v2. Adopter-tooling-reading SafeBundle JSON must handle the v2 field set.
+- **`gaze-audit` row schema delta**: new nullable column `fallback_triggered: Option<FallbackReason>`. Closed-enum `FallbackReason` variants: `OverlapConflict`, `ValidatorVeto`, `AnchorMissing`, `ResidualSuspect`. The existing `decided_by` column gains new variants: `Redact`, `Resolve`, `Fallback`. The column is nullable on pre-migration rows; existing queries continue to work.
+
+## Known limitations
+
+- Kiji `cargo bench` harness ships with `null` metric fields. Populating them requires a local Kiji runtime + pinned model directory. Axis 4: gaze does not publish uncited benchmark numbers.
+- Multi-backend SafetyNet bench (Kiji vs OpenAI Privacy Filter vs OpenMed) is a v0.9 thread, not v0.8.x.
+
+## Adopter notes
+
+- **Upgrading from v0.7.x?** Read [UPGRADE.md](https://github.com/EmpireTwo/gaze/blob/main/UPGRADE.md). Multi-hop migrations require attention to defaults that flipped at v0.8.0 and again at v0.8.1.
+- **Downstream tooling reads SafeBundle JSON?** Handle the `bundle_version=2` field. v1 reads work; v2 emission is non-optional.
+- **You query the audit log?** The new `fallback_triggered` column is nullable on existing rows; new `decided_by` variants are closed-enum.
+- **Custom OCR via `OcrAdapter`?** Port to `OcrBackend` (object-safe, same shape).
+- **Pipeline expected `--safety-net-mode strict` as default?** Pass the flag explicitly.
+
+## Download
+
+- aarch64-darwin: `gaze-v0.8.1-aarch64-apple-darwin.tar.gz`
+- x86_64-linux: `gaze-v0.8.1-x86_64-unknown-linux-gnu.tar.gz`
+- `SHA256SUMS`
+
+Both binaries are built with `--features proxy --features document`.
+
+## Changelog
+
+Full PR-by-PR detail: [CHANGELOG.md](https://github.com/EmpireTwo/gaze/blob/main/CHANGELOG.md#081---2026-05-15).


### PR DESCRIPTION
## Summary

Cut v0.8.1 from main HEAD `89aaa4e` — ten PRs accumulated since v0.8.0. Workspace + ten crate version pins bumped `0.8.0 → 0.8.1`.

Headline: **SafetyNet default flips to `--safety-net-mode=resolve`** with typed `--safety-net-fallback=redact` on promotion failure. Reversibility-first (axes 1 + 2); strict mode stays opt-in. `BundleReport.bundle_version` bumps `1 → 2` (additive). `gaze-audit` gains typed `fallback_triggered: Option<FallbackReason>` and `decided_by` variants `Redact`/`Resolve`/`Fallback`. Default release binary now bakes `--features proxy`.

Folded CI hotfix: `bundle::tests::clean_with_mock_backend_preserves_table_cell_context` was missing PNG magic bytes (added in #222, exposed by the magic-byte gate in #224). Test fixture now prepends `\x89PNG\r\n\x1A\n`.

PRs since v0.8.0: #215, #216, #217, #218, #219, #220, #221, #222, #223, #224.

## Test plan
- [ ] CI green (test workflow now passes — local `cargo test -p gaze-document --lib` reports 34/34)
- [ ] `cargo check --workspace --all-features` — local: green
- [ ] After merge, tag `v0.8.1` on the merged commit; release workflow auto-builds aarch64-darwin + x86_64-linux binaries with `--features document,proxy`
- [ ] Cargo publish all 10 crates via TP
- [ ] Edit GH release body with curated notes from `dist/release-notes/v0.8.1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)