### PR TITLE
feat(gaze-recognizers): introduce LocaleAwareModel trait + registry (v0.9 #33a)

### DIFF
--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -68,6 +68,13 @@ required-features = ["safety-net-openai"]
 name = "kiji_distilbert_subprocess"
 required-features = ["safety-net-kiji", "test-support"]
 
+[[test]]
+name = "locale_aware_registry"
+
+[[test]]
+name = "locale_aware_trait"
+required-features = ["safety-net-kiji", "test-support"]
+
 [[bench]]
 name = "dictionary"
 harness = false

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -17,6 +17,7 @@
 mod anchored_match;
 mod dictionary;
 mod error;
+mod locale_aware;
 mod ner;
 mod regex;
 #[cfg(feature = "safety-net")]
@@ -31,6 +32,10 @@ pub use error::{RecognizerError, Result};
 #[cfg(feature = "phone-parser")]
 pub use gaze_types::Region;
 pub use gaze_types::{SafetyTier, ValidatorKind};
+pub use locale_aware::{
+    LocaleAwareModel, LocaleAwareModelRegistry, ModelError, ModelHints, ModelInput, ModelSpan,
+    ModelStage,
+};
 pub use ner::{
     LabelMap, NerBackendKind, NerDetector, NerLoadError, NerOptions, NerRecognizer,
     VerifiedArtifacts,

--- a/crates/gaze-recognizers/src/locale_aware.rs
+++ b/crates/gaze-recognizers/src/locale_aware.rs
@@ -1,0 +1,141 @@
+use std::ops::Range;
+
+use gaze_types::{LocaleTag, PiiClass};
+use thiserror::Error;
+
+/// Locale-aware model backend for Pass-2 NER and Pass-3 safety-net inference.
+pub trait LocaleAwareModel: Send + Sync {
+    /// Stable backend name used in diagnostics and audit trails.
+    fn name(&self) -> &str;
+
+    /// Locales this backend natively supports.
+    fn native_locales(&self) -> &[LocaleTag];
+
+    /// Run inference for the supplied text and locale hints.
+    fn infer(&self, input: ModelInput, hints: ModelHints) -> Result<Vec<ModelSpan>, ModelError>;
+}
+
+/// Input passed to a locale-aware model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelInput {
+    pub text: String,
+    pub locale: LocaleTag,
+}
+
+/// Execution hints supplied by the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelHints {
+    pub stage: ModelStage,
+    pub max_spans: Option<u32>,
+}
+
+/// Pipeline stage requesting model inference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelStage {
+    Pass2Ner,
+    Pass3SafetyNet,
+}
+
+/// Span emitted by a locale-aware model.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelSpan {
+    pub text: String,
+    pub byte_range: Range<usize>,
+    pub class: PiiClass,
+    pub confidence: Option<f32>,
+    pub model_name: String,
+}
+
+/// Closed error set for locale-aware model routing and inference.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ModelError {
+    #[error("backend init failed: {0}")]
+    InitFailed(String),
+    #[error("inference failed: {0}")]
+    InferenceFailed(String),
+    #[error("locale not supported: {0:?}")]
+    LocaleNotSupported(LocaleTag),
+    #[error("model integrity mismatch")]
+    IntegrityMismatch,
+    #[error("no locale model coverage for {locale:?} at {stage:?}")]
+    NoLocaleModelCoverage {
+        locale: LocaleTag,
+        stage: ModelStage,
+    },
+    #[error("backend internal error: {0}")]
+    Internal(String),
+}
+
+/// Registry that resolves locale-aware model backends by locale fallback tier.
+#[derive(Default)]
+pub struct LocaleAwareModelRegistry {
+    backends: Vec<Box<dyn LocaleAwareModel>>,
+}
+
+impl LocaleAwareModelRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_backends(backends: Vec<Box<dyn LocaleAwareModel>>) -> Self {
+        Self { backends }
+    }
+
+    pub fn register(&mut self, backend: impl LocaleAwareModel + 'static) {
+        self.backends.push(Box::new(backend));
+    }
+
+    /// Resolve models by four tiers:
+    /// exact locale, parent language, multilingual `Global`, then fail-closed.
+    pub fn resolve(
+        &self,
+        locale: &LocaleTag,
+        stage: ModelStage,
+    ) -> Result<Vec<&dyn LocaleAwareModel>, ModelError> {
+        if let Some(matches) = self.matches_for(locale) {
+            return Ok(matches);
+        }
+
+        if let Some(parent) = parent_language(locale) {
+            if let Some(matches) = self.matches_for(&parent) {
+                return Ok(matches);
+            }
+        }
+
+        if let Some(matches) = self.matches_for(&LocaleTag::Global) {
+            return Ok(matches);
+        }
+
+        Err(ModelError::NoLocaleModelCoverage {
+            locale: locale.clone(),
+            stage,
+        })
+    }
+
+    fn matches_for(&self, locale: &LocaleTag) -> Option<Vec<&dyn LocaleAwareModel>> {
+        let matches: Vec<&dyn LocaleAwareModel> = self
+            .backends
+            .iter()
+            .filter(|backend| backend.native_locales().contains(locale))
+            .map(|backend| backend.as_ref())
+            .collect();
+
+        (!matches.is_empty()).then_some(matches)
+    }
+}
+
+fn parent_language(locale: &LocaleTag) -> Option<LocaleTag> {
+    match locale {
+        LocaleTag::DeDe | LocaleTag::DeAt | LocaleTag::DeCh => {
+            Some(LocaleTag::Other("de".to_string()))
+        }
+        LocaleTag::EnUs | LocaleTag::EnGb | LocaleTag::EnIe | LocaleTag::EnAu | LocaleTag::EnCa => {
+            Some(LocaleTag::Other("en".to_string()))
+        }
+        LocaleTag::Other(raw) => raw
+            .split_once('-')
+            .map(|(language, _)| LocaleTag::Other(language.to_ascii_lowercase())),
+        LocaleTag::Global => None,
+        _ => None,
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -15,6 +15,8 @@ use std::sync::{Arc, OnceLock};
 
 use gaze_types::{LeakSuspect, LocaleTag, SafetyNet, SafetyNetContext, SafetyNetError};
 
+use crate::{LocaleAwareModel, ModelError, ModelHints, ModelInput, ModelSpan};
+
 pub mod backend;
 pub mod class_map;
 
@@ -96,6 +98,64 @@ impl SafetyNet for KijiDistilbertSafetyNet {
             })
             .collect()
     }
+}
+
+impl LocaleAwareModel for KijiDistilbertSafetyNet {
+    fn name(&self) -> &str {
+        "kiji-distilbert"
+    }
+
+    fn native_locales(&self) -> &[LocaleTag] {
+        &[LocaleTag::Global]
+    }
+
+    fn infer(&self, input: ModelInput, hints: ModelHints) -> Result<Vec<ModelSpan>, ModelError> {
+        let backend = self
+            .backend()
+            .map_err(|error| ModelError::InitFailed(error.to_string()))?;
+        let mut spans = backend
+            .infer(&input.text)
+            .map_err(|error| ModelError::InferenceFailed(error.to_string()))?
+            .into_iter()
+            .map(|raw| raw_span_to_model_span(raw, self.name(), &input.text))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if let Some(max_spans) = hints.max_spans {
+            spans.truncate(max_spans as usize);
+        }
+
+        Ok(spans)
+    }
+}
+
+fn raw_span_to_model_span(
+    raw: RawSpan,
+    model_name: &str,
+    input: &str,
+) -> Result<ModelSpan, ModelError> {
+    if raw.start >= raw.end
+        || raw.end > input.len()
+        || !input.is_char_boundary(raw.start)
+        || !input.is_char_boundary(raw.end)
+    {
+        return Err(ModelError::InferenceFailed(
+            "kiji returned out-of-bounds span".to_string(),
+        ));
+    }
+
+    let label = map_kiji_label(&raw.label)
+        .map_err(|error| ModelError::InferenceFailed(error.to_string()))?;
+    let class = kiji_label_to_pii_class(label);
+    let byte_range = raw.start..raw.end;
+    let text = input[byte_range.clone()].to_string();
+
+    Ok(ModelSpan {
+        text,
+        byte_range,
+        class,
+        confidence: raw.score,
+        model_name: model_name.to_string(),
+    })
 }
 
 fn raw_span_to_suspect(

--- a/crates/gaze-recognizers/tests/locale_aware_registry.rs
+++ b/crates/gaze-recognizers/tests/locale_aware_registry.rs
@@ -1,0 +1,101 @@
+use gaze_recognizers::{
+    LocaleAwareModel, LocaleAwareModelRegistry, ModelError, ModelHints, ModelInput, ModelSpan,
+    ModelStage,
+};
+use gaze_types::LocaleTag;
+
+#[derive(Debug)]
+struct TestModel {
+    name: &'static str,
+    locales: Vec<LocaleTag>,
+}
+
+impl TestModel {
+    fn new(name: &'static str, locales: Vec<LocaleTag>) -> Self {
+        Self { name, locales }
+    }
+}
+
+impl LocaleAwareModel for TestModel {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn native_locales(&self) -> &[LocaleTag] {
+        &self.locales
+    }
+
+    fn infer(&self, _input: ModelInput, _hints: ModelHints) -> Result<Vec<ModelSpan>, ModelError> {
+        Ok(Vec::new())
+    }
+}
+
+#[test]
+fn resolves_exact_locale_before_parent_and_global() {
+    let registry = LocaleAwareModelRegistry::from_backends(vec![
+        Box::new(TestModel::new("global", vec![LocaleTag::Global])),
+        Box::new(TestModel::new(
+            "de-parent",
+            vec![LocaleTag::Other("de".to_string())],
+        )),
+        Box::new(TestModel::new("de-de", vec![LocaleTag::DeDe])),
+    ]);
+
+    let models = registry
+        .resolve(&LocaleTag::DeDe, ModelStage::Pass3SafetyNet)
+        .unwrap();
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].name(), "de-de");
+}
+
+#[test]
+fn resolves_parent_language_when_exact_is_absent() {
+    let registry = LocaleAwareModelRegistry::from_backends(vec![
+        Box::new(TestModel::new("global", vec![LocaleTag::Global])),
+        Box::new(TestModel::new(
+            "de-parent",
+            vec![LocaleTag::Other("de".to_string())],
+        )),
+    ]);
+
+    let models = registry
+        .resolve(&LocaleTag::DeAt, ModelStage::Pass2Ner)
+        .unwrap();
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].name(), "de-parent");
+}
+
+#[test]
+fn resolves_multilingual_global_when_locale_specific_models_are_absent() {
+    let registry = LocaleAwareModelRegistry::from_backends(vec![Box::new(TestModel::new(
+        "global",
+        vec![LocaleTag::Global],
+    ))]);
+
+    let models = registry
+        .resolve(&LocaleTag::EnGb, ModelStage::Pass3SafetyNet)
+        .unwrap();
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].name(), "global");
+}
+
+#[test]
+fn fails_closed_when_no_locale_model_covers_request() {
+    let registry = LocaleAwareModelRegistry::new();
+
+    let error = match registry.resolve(&LocaleTag::EnUs, ModelStage::Pass2Ner) {
+        Ok(models) => panic!("expected fail-closed error, got {} models", models.len()),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        ModelError::NoLocaleModelCoverage {
+            locale: LocaleTag::EnUs,
+            stage: ModelStage::Pass2Ner,
+        }
+    );
+}

--- a/crates/gaze-recognizers/tests/locale_aware_trait.rs
+++ b/crates/gaze-recognizers/tests/locale_aware_trait.rs
@@ -1,0 +1,101 @@
+//! Kiji LocaleAwareModel contract tests.
+
+#![cfg(all(unix, feature = "safety-net-kiji"))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use gaze_recognizers::safety_net::kiji_distilbert::{
+    KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+};
+use gaze_recognizers::{LocaleAwareModel, ModelHints, ModelInput, ModelStage};
+use gaze_types::{LocaleTag, PiiClass};
+use sha2::{Digest, Sha256};
+use tempfile::{tempdir, TempDir};
+
+fn write_mock_kiji(body: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mock-kiji");
+    fs::write(
+        &path,
+        format!(
+            r#"#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{}'
+"#,
+            body
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    (dir, path)
+}
+
+fn populate_model_dir() -> (TempDir, String) {
+    let dir = tempdir().unwrap();
+    fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        if *required == "SHA256SUMS" {
+            continue;
+        }
+        let path = dir.path().join(required);
+        fs::write(&path, b"fixture").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    let artifact_sha = hex_sha256(b"fixture");
+    let sha256sums = format!(
+        "{artifact_sha}  labels.json\n{artifact_sha}  model.onnx\n{artifact_sha}  tokenizer.json\n"
+    );
+    let path = dir.path().join("SHA256SUMS");
+    fs::write(&path, sha256sums.as_bytes()).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    let expected_sha = hex_sha256(sha256sums.as_bytes());
+    (dir, expected_sha)
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+#[test]
+fn kiji_is_object_safe_locale_aware_model_with_global_native_locale() {
+    let net = KijiDistilbertSafetyNet::new(SubprocessKijiConfig::new("kiji"));
+    let model: &dyn LocaleAwareModel = &net;
+
+    assert_eq!(model.name(), "kiji-distilbert");
+    assert_eq!(model.native_locales(), &[LocaleTag::Global]);
+}
+
+#[test]
+fn kiji_infer_round_trips_spans_through_locale_aware_trait() {
+    let (_kiji_dir, kiji) =
+        write_mock_kiji(r#"[{"label":"person","start":0,"end":11,"score":0.97}]"#);
+    let (model_dir, expected_sha) = populate_model_dir();
+    let net = KijiDistilbertSafetyNet::new(
+        SubprocessKijiConfig::new(&kiji)
+            .with_model_dir(model_dir.path())
+            .with_expected_bundle_sha256_for_tests(expected_sha),
+    );
+    let model: &dyn LocaleAwareModel = &net;
+
+    let spans = model
+        .infer(
+            ModelInput {
+                text: "Dr. Schmidt greets you".to_string(),
+                locale: LocaleTag::Global,
+            },
+            ModelHints {
+                stage: ModelStage::Pass3SafetyNet,
+                max_spans: Some(1),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].text, "Dr. Schmidt");
+    assert_eq!(spans[0].byte_range, 0..11);
+    assert_eq!(spans[0].class, PiiClass::Name);
+    assert_eq!(spans[0].confidence, Some(0.97));
+    assert_eq!(spans[0].model_name, "kiji-distilbert");
+}


### PR DESCRIPTION
## Summary
- Introduce `LocaleAwareModel`, `LocaleAwareModelRegistry`, `ModelInput`, `ModelHints`, `ModelStage`, `ModelSpan`, and closed `ModelError` in `gaze-recognizers`.
- Implement 4-tier registry resolution: exact locale, parent language, `LocaleTag::Global`, then fail-closed `NoLocaleModelCoverage`.
- Wire `KijiDistilbertSafetyNet` as the only concrete backend with `native_locales() == [Global]` and no routing/default behavior change.

## Design Scope
- Follows scratchpad 19 research synthesis / v0.9 sub-task 33a.
- No OpenAI Privacy Filter model backend.
- No OpenMed/second backend.
- No EN routing flip.
- No pipeline default behavior change for Kiji.

## Five-Axis Check
- Reliability: fail-closed registry miss via typed `ModelError::NoLocaleModelCoverage`; Kiji inference reuses existing validated Kiji subprocess span path.
- Reversibility: no manifest or restore contract changes.
- Agentic-first: additive model-routing surface for Pass-2/Pass-3 workflows.
- Trust: closed `ModelStage`/`ModelError`; backend name emitted in `ModelSpan::model_name`.
- Ergonomics: existing `SafetyNet` API remains unchanged; Kiji is additionally available through the trait.

## Verification
- `cargo fmt --all -- --check` passed.
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` passed.
- `cargo test -p gaze-recognizers --test locale_aware_registry --test locale_aware_trait --features safety-net-kiji,test-support` passed.
- `cargo test -p gaze-recognizers --all-features` passed.
- `cargo run -p xtask -- safety-net-sanity` passed.

## Known Base Gate Failure
- `cargo test --workspace --all-features` fails in unchanged `gaze-document` test `bundle::tests::clean_with_mock_backend_preserves_table_cell_context` with `UnsupportedInput { path: "", reason: "image bytes are not PNG, JPEG, or TIFF" }`.
- `cargo run -p xtask -- ci-feature-matrix` fails at the same unchanged `gaze-document` leg: `cargo test -p gaze-document --features mcp`.
