### PR TITLE
fix(ci): release smoke captures proxy status via $() (avoid SIGPIPE)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,15 +104,20 @@ jobs:
           )"
           export HOME="$smoke_home"
           trap '"$bin" proxy stop --force >/dev/null 2>&1 || true; rm -rf "$smoke_home"' EXIT
-          "$bin" proxy status | grep -q 'not running'
+          # Capture `proxy status` stdout via $() instead of piping into `grep -q`.
+          # grep -q closes stdin on first match → upstream gaze hits EPIPE on
+          # the next println and the CLI panic hook emits {"error":"Pipeline","exit":3}.
+          # The $() form lets gaze finish writing before grep inspects the result.
+          # Underlying SIGPIPE tolerance is tracked as a v0.8.2 follow-up.
+          status_out="$("$bin" proxy status)"; grep -q 'not running' <<< "$status_out"
           "$bin" proxy start --bind "127.0.0.1:$proxy_port"
           sleep 1
-          "$bin" proxy status | grep -q 'running'
+          status_out="$("$bin" proxy status)"; grep -q 'running' <<< "$status_out"
           "$bin" proxy restart --force
           sleep 1
-          "$bin" proxy status | grep -q 'running'
+          status_out="$("$bin" proxy status)"; grep -q 'running' <<< "$status_out"
           "$bin" proxy stop --force
-          "$bin" proxy status | grep -q 'not running'
+          status_out="$("$bin" proxy status)"; grep -q 'not running' <<< "$status_out"
 
   release:
     needs: build


### PR DESCRIPTION
## Summary

v0.8.1 release smoke fails on macOS at `proxy status | grep -q PATTERN`: grep -q closes stdin on first match, gaze hits EPIPE on next println, the CLI panic hook emits `{"error":"Pipeline","exit":3}`. v0.8.0 didn't test proxy in smoke (proxy went default in #220), so the regression only surfaced on the v0.8.1 tag push.

Switch each proxy-status assertion to `status_out=\$(...); grep -q PAT <<< "\$status_out"` so gaze finishes writing before grep inspects the captured copy.

Underlying gaze-cli SIGPIPE tolerance filed as a v0.8.2 follow-up — the published binary is correct for any consumer that reads its stdout to EOF, so this CI patch is enough to ship v0.8.1.

## Test plan
- [x] Smoke patched locally; runs end-to-end without Pipeline envelope
- [ ] After merge, re-tag v0.8.1 on the fix commit → release workflow re-runs + creates GH release

🤖 Generated with [Claude Code](https://claude.com/claude-code)