### PR TITLE
[agent] feat(cli): emit `entries` in plaintext JSON gaze clean response (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CLI plaintext JSON `entries` field**: `gaze clean --format=json` now emits
+  top-level `entries` mirroring the session snapshot entries (`class`, `raw`,
+  `token`, `family`) while preserving the existing signed `session_blob`.
+  Empty detections emit `entries: []`. (Axis 5 ergonomics; unblocks
+  gaze-laravel `GazeSession::$entries`.)
+
 ### Changed
 
 - **Safety-net benchmark snapshot schema v2**: the internal benchmark artifact

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use gaze::{
     dictionary_bundle_from_context, Action, DictionaryBundle, DictionarySource, DocumentKind,
@@ -232,11 +233,14 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     };
 
     let snapshot: SensitiveSnapshot = session.export().map_err(|_| CliError::Pipeline)?;
-    let session_blob = BASE64.encode(snapshot.into_bytes());
+    let snapshot_bytes = snapshot.into_bytes();
+    let entries = entries_from_snapshot(&snapshot_bytes)?;
+    let session_blob = BASE64.encode(&snapshot_bytes);
 
     let response = CleanResponse {
         clean_text,
         session_blob,
+        entries,
         stats: Stats {
             detections: counter.detections.load(Ordering::Relaxed),
             locale_chain: locale_chain.to_strings(),
@@ -251,6 +255,21 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
     println!("{json}");
     Ok(())
+}
+
+fn entries_from_snapshot(snapshot: &[u8]) -> std::result::Result<Vec<EntryJson>, CliError> {
+    const SIGNED_SNAPSHOT_PAYLOAD_OFFSET: usize = 97;
+
+    let payload = snapshot
+        .get(SIGNED_SNAPSHOT_PAYLOAD_OFFSET..)
+        .ok_or(CliError::Pipeline)?;
+    let payload: SnapshotPayloadJson =
+        serde_json::from_slice(payload).map_err(|_| CliError::Pipeline)?;
+    payload
+        .entries
+        .into_iter()
+        .map(EntryJson::try_from)
+        .collect()
 }
 
 fn maybe_register_safety_net(
@@ -633,8 +652,55 @@ impl RedactionLogger for CountingLogger {
 struct CleanResponse {
     clean_text: String,
     session_blob: String,
+    entries: Vec<EntryJson>,
     stats: Stats,
     leak_report: LeakReportResponse,
+}
+
+#[derive(Deserialize)]
+struct SnapshotPayloadJson {
+    entries: Vec<SnapshotEntryJson>,
+}
+
+#[derive(Deserialize)]
+struct SnapshotEntryJson {
+    class: Value,
+    raw: String,
+    token: String,
+    family: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EntryJson {
+    class: String,
+    raw: String,
+    token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    family: Option<String>,
+}
+
+impl TryFrom<SnapshotEntryJson> for EntryJson {
+    type Error = CliError;
+
+    fn try_from(entry: SnapshotEntryJson) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            class: snapshot_class_to_string(entry.class)?,
+            raw: entry.raw,
+            token: entry.token,
+            family: entry.family,
+        })
+    }
+}
+
+fn snapshot_class_to_string(class: Value) -> std::result::Result<String, CliError> {
+    match class {
+        Value::String(class) => Ok(class),
+        Value::Object(mut class) => match class.remove("Custom") {
+            Some(Value::String(name)) if !name.is_empty() => Ok(format!("Custom:{name}")),
+            _ => Err(CliError::Pipeline),
+        },
+        _ => Err(CliError::Pipeline),
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -718,6 +718,33 @@ fn t01_roundtrip_email_tokenized_then_restored() {
     );
 }
 
+#[test]
+fn clean_json_emits_top_level_entries_for_detections() {
+    let v = clean_json_with_args(&[], "Contact Alice at alice@example.invalid for details.");
+    let entries = v["entries"].as_array().expect("entries array");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["class"], "Email");
+    assert_eq!(entries[0]["raw"], "alice@example.invalid");
+    assert_eq!(entries[0]["family"], "counter");
+    assert!(entries[0]["token"].as_str().unwrap().contains(":Email_1>"));
+    assert!(
+        v["clean_text"]
+            .as_str()
+            .unwrap()
+            .contains(entries[0]["token"].as_str().unwrap()),
+        "clean_text must contain the emitted entry token"
+    );
+}
+
+#[test]
+fn clean_json_emits_empty_top_level_entries_without_detections() {
+    let v = clean_json_with_args(&[], "Nothing detectable in this text.");
+
+    assert_eq!(v["stats"]["detections"], 0);
+    assert!(v["entries"].as_array().expect("entries array").is_empty());
+}
+
 // -----------------------------------------------------------------------
 // 2. Canary
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Emit top-level `entries` in `gaze clean --format=json`, derived from the same signed session snapshot entries (`class`, `raw`, `token`, `family`).
- Preserve existing `session_blob` behavior and emit `entries: []` when no detections fire.
- Add CLI integration coverage and CHANGELOG entry.

## Origin / Unblock
- Dogfooding F#1 origin: adopter session cleanup UI needs plaintext entry metadata without decoding owner-only snapshot blobs.
- Unblocks gaze-laravel PR #75 `GazeSession::$entries` adopter surface.

## Gates
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`