### PR TITLE
[agent] refactor(audit): consolidate SqliteLogger leak-suspect method (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `@example.invalid` domain instead of reachable `@example.com` examples across
   crates and document fixtures. (Axis 4 trust.)
 
+- **`SqliteLogger` leak-suspect writes now have one canonical verb**:
+  the previous public inherent safety-net write method was removed. Call
+  `LeakSuspectLogger::log_leak_suspect` instead. This is a pre-1.0 breaking API
+  cleanup for adopter ergonomics; the SQLite schema and write behavior are
+  unchanged. (Axis 5 ergonomics.)
 - **Safety-net benchmark snapshot schema v2**: the internal benchmark artifact
   moves from the single-backend Kiji schema to a backend × locale × mode matrix
   with mode-independent `strict_span_leak_rate` entries. Adopter impact is

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -12,6 +12,8 @@ Provides `SqliteLogger` - the concrete `RedactionLogger` implementation that wri
 session-scoped redaction metadata to a local SQLite database. The audit log is
 **metadata-only**: it records class, action, source, field metadata, and timestamp,
 but never the original PII values or the pseudonymous tokens.
+Safety-net leak suspects are written through the canonical
+`LeakSuspectLogger::log_leak_suspect` trait method.
 
 ## When to use this crate
 
@@ -80,6 +82,19 @@ public items beyond `SqliteLogger`:
 | `AuditLogRow` | Shape returned by `SqliteLogger::query`. Metadata only — `class`, `action`, `field_name`, `document_kind`, `conflict_loser`, `decided_by`, `created_at`, `session_id`, snapshot metadata, and the four v0.7.x ambiguity columns. No raw PII, no token values, no restore material. |
 | `build_audit_query_sql` | Lower-level helper that constructs the `(SQL, params)` pair used by `SqliteLogger::query`. Takes column-presence booleans so callers querying older databases project `NULL AS <missing_column>` rather than failing. Exposed so external readers can run the same projection logic against a read replica without re-implementing the filter compiler. |
 | `AUDIT_RESTRICTED_COLUMNS` | Canonical allowlist of columns the audit-query path may project. `audit export` and `SqliteLogger::query` select only from this set. `redaction_log` may grow columns over time (e.g. snapshot locators, replay hashes); restricting projection here is defense in depth so future schema additions never accidentally leak raw PII, token bytes, or document content. The clean path is forbidden from touching audit storage by the `gaze_module_isolation` Dylint lint; this constant is the matching read-side guard. |
+
+Safety-net writes use the `LeakSuspectLogger` trait:
+
+```rust,no_run
+use std::path::Path;
+use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
+
+# fn log(entry: &LeakSuspectLogEntry) -> gaze_audit::Result<()> {
+let logger = SqliteLogger::new(Path::new("audit.db"))?;
+logger.log_leak_suspect(entry)?;
+# Ok(())
+# }
+```
 
 ## Ambiguity side-channel columns (v0.7.2)
 

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -506,7 +506,7 @@ impl SqliteLogger {
         Ok(entries)
     }
 
-    pub fn log_safety_net(&self, entry: &LeakSuspectLogEntry) -> Result<()> {
+    fn insert_leak_suspect(&self, entry: &LeakSuspectLogEntry) -> Result<()> {
         let conn = self
             .conn
             .lock()
@@ -568,7 +568,7 @@ impl SqliteLogger {
 
 impl LeakSuspectLogger for SqliteLogger {
     fn log_leak_suspect(&self, entry: &LeakSuspectLogEntry) -> Result<()> {
-        self.log_safety_net(entry)
+        self.insert_leak_suspect(entry)
     }
 }
 

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -141,8 +141,8 @@ fn safety_net_query_filter_maps_to_safety_net_columns() {
         Some("session-b".to_string()),
         None,
     );
-    logger.log_safety_net(&email).expect("log email suspect");
-    logger.log_safety_net(&name).expect("log name suspect");
+    logger.log_leak_suspect(&email).expect("log email suspect");
+    logger.log_leak_suspect(&name).expect("log name suspect");
 
     let rows = SqliteLogger::query_safety_net(
         temp.path(),
@@ -210,7 +210,7 @@ fn safety_net_log_does_not_persist_suspect_or_placeholder_bytes() {
         Some("replay-sha256:no-payload".to_string()),
     );
 
-    logger.log_safety_net(&entry).expect("log suspect");
+    logger.log_leak_suspect(&entry).expect("log suspect");
 
     let conn = Connection::open(temp.path()).expect("open db");
     let mut stmt = conn

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -16,7 +16,7 @@ use gaze::{
     RedactionEntry, RedactionLogError, RedactionLogger, Result as GazeResult, RuleSpec, Rulepack,
     RulepackSource, Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope, TypedContext,
 };
-use gaze_audit::{LeakSuspectLogEntry, SqliteLogger};
+use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
@@ -625,7 +625,7 @@ impl CountingLogger {
                 Some(session.audit_session_id().to_string()),
                 report.replay_hash.clone(),
             );
-            audit.log_safety_net(&entry)?;
+            audit.log_leak_suspect(&entry)?;
         }
         Ok(())
     }

--- a/crates/gaze-cli/tests/safety_net_cli.rs
+++ b/crates/gaze-cli/tests/safety_net_cli.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
 use gaze::{LeakKind, LeakSuspect, PiiClass};
-use gaze_audit::{LeakSuspectLogEntry, SqliteLogger};
+use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 use serde_json::Value;
 use tempfile::{tempdir, TempDir};
 
@@ -311,7 +311,7 @@ fn safety_net_audit_query_filters_structured_field_path() {
         Some("session-a".to_string()),
         None,
     );
-    logger.log_safety_net(&entry).unwrap();
+    logger.log_leak_suspect(&entry).unwrap();
 
     let out = Command::cargo_bin("gaze")
         .unwrap()


### PR DESCRIPTION
## Summary
- remove the public inherent SqliteLogger safety-net write method so leak suspects use the canonical LeakSuspectLogger::log_leak_suspect trait verb
- update workspace callers/tests to import and call LeakSuspectLogger
- document the pre-1.0 breaking API cleanup in gaze-audit README and CHANGELOG; SQLite schema/write behavior is unchanged

## Verification
- rg -n '\blog_safety_net\b' . returned no matches
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix
- cargo run -p xtask -- cargo-metadata-audit-isolation

Axis note: improves Axis 5 adopter ergonomics by leaving one canonical leak-suspect logging verb; no reliability, reversibility, agentic, or trust tradeoff.