### PR TITLE
feat(safety-net): ship Python kiji-runner reference wrapper (#33d partial)

### DIFF
--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
@@ -1,10 +1,9 @@
 //! DistilBERT NER label vocabulary for the Kiji safety-net backend.
 //!
 //! Kiji wraps a DistilBERT NER head whose label set is the standard CoNLL-style
-//! `PER` / `LOC` / `ORG` / `MISC` tags. The Kiji subprocess collapses BIO
-//! prefixes (`B-PER`, `I-PER`) into bare entity labels before emitting the
-//! span shape Gaze consumes; this map only deals with the validated bare
-//! labels.
+//! `PER` / `LOC` / `ORG` / `MISC` tags. The reference subprocess emits bare
+//! upstream entity labels after BIO decoding; older wrappers may emit the
+//! lower-case Gaze label ids from `labels.json`.
 
 use gaze_types::{PiiClass, SafetyNetError, SafetyNetPiiClass};
 
@@ -36,10 +35,9 @@ pub fn validate_kiji_label(label: &str) -> Result<(), SafetyNetError> {
         return Err(invalid_label());
     }
 
-    if label
-        .bytes()
-        .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
-    {
+    if label.bytes().all(|byte| {
+        byte.is_ascii_lowercase() || byte.is_ascii_uppercase() || byte == b'_' || byte == b'-'
+    }) {
         Ok(())
     } else {
         Err(invalid_label())
@@ -50,10 +48,10 @@ pub fn validate_kiji_label(label: &str) -> Result<(), SafetyNetError> {
 pub fn map_kiji_label(label: &str) -> Result<KijiLabel, SafetyNetError> {
     validate_kiji_label(label)?;
     match label {
-        "person" => Ok(KijiLabel::Person),
-        "location" => Ok(KijiLabel::Location),
-        "organization" => Ok(KijiLabel::Organization),
-        "miscellaneous" => Ok(KijiLabel::Miscellaneous),
+        "person" | "PER" | "B-PER" | "I-PER" => Ok(KijiLabel::Person),
+        "location" | "LOC" | "B-LOC" | "I-LOC" => Ok(KijiLabel::Location),
+        "organization" | "ORG" | "B-ORG" | "I-ORG" => Ok(KijiLabel::Organization),
+        "miscellaneous" | "MISC" | "B-MISC" | "I-MISC" => Ok(KijiLabel::Miscellaneous),
         _ => Err(SafetyNetError::InvalidOutput {
             message: "kiji returned unsupported label".to_string(),
         }),
@@ -93,14 +91,18 @@ mod tests {
     fn official_labels_map_to_closed_classes() {
         let cases = [
             ("person", PiiClass::Name),
+            ("PER", PiiClass::Name),
+            ("B-PER", PiiClass::Name),
             ("location", PiiClass::Location),
+            ("LOC", PiiClass::Location),
             ("organization", PiiClass::Name),
+            ("ORG", PiiClass::Name),
             ("miscellaneous", PiiClass::Name),
+            ("MISC", PiiClass::Name),
         ];
 
         for (label, expected) in cases {
             let kiji_label = map_kiji_label(label).expect("official label");
-            assert_eq!(kiji_label.as_str(), label);
             assert_eq!(kiji_label_to_pii_class(kiji_label), expected);
         }
     }

--- a/docs/getting-started/kiji-safetynet-setup.md
+++ b/docs/getting-started/kiji-safetynet-setup.md
@@ -94,6 +94,29 @@ Source anchors:
    flag table lives in [`crates/gaze-cli/README.md`][cli-readme], and the
    activation path is implemented in [`crates/gaze-cli/src/pipeline/run.rs`][cli-run].
 
+4. Install the reference subprocess wrapper dependencies and point Gaze at the
+   wrapper:
+
+   ```sh
+   python3 -m pip install --user onnxruntime tokenizers numpy
+   chmod +x scripts/kiji-runner.py
+   export GAZE_KIJI_DISTILBERT_COMMAND=$PWD/scripts/kiji-runner.py
+   ```
+
+   If `python3 -m pip` is unavailable on macOS, bootstrap user-local pip first:
+
+   ```sh
+   python3 -m ensurepip --user
+   python3 -m pip install --user onnxruntime tokenizers numpy
+   ```
+
+   Some externally managed Python distributions, including common Homebrew
+   Python installs on macOS, reject `--user` installs under PEP 668. In that
+   case, use a Python distribution or prebuilt runtime environment where these
+   three packages are available without changing the system package manager.
+   Keep the model bundle and wrapper local; do not add network fetches to the
+   Gaze runtime path.
+
 Keep the fetch step in deployment automation, not inside the hot path. The
 SafetyNet backend is designed around a local pinned bundle: operators decide
 when artifacts move, verify them once, and then run `gaze clean` without
@@ -105,10 +128,11 @@ cannot produce the required artifact set.
 
 The Kiji subprocess command is deliberately separate from the model directory.
 That lets you ship a small wrapper around the runtime you operate while keeping
-the pinned model bundle under Gaze's artifact contract. The wrapper may be a
-Python entrypoint, a compiled helper, or another local executable, but it must
-obey the stdin/stdout contract described below. Do not emit diagnostics to
-stdout; stdout is reserved for the JSON span array.
+the pinned model bundle under Gaze's artifact contract. Gaze ships
+[`scripts/kiji-runner.py`][kiji-runner] as the reference wrapper. You may
+replace it with a compiled helper or another local executable, but it must obey
+the stdin/stdout contract described below. Do not emit diagnostics to stdout;
+stdout is reserved for the JSON span array.
 
 ## First Clean Run With Kiji
 
@@ -121,7 +145,7 @@ printf '%s' 'Contact alice@example.invalid for details.' \
       --policy quickstart-policy.toml \
       --safety-net kiji-distilbert \
       --safety-net-backend kiji-distilbert \
-      --kiji-distilbert-command /opt/kiji/bin/kiji \
+      --kiji-distilbert-command "$PWD/scripts/kiji-runner.py" \
       --kiji-distilbert-model-dir ~/.local/share/gaze/models/kiji-distilbert
 ```
 
@@ -131,8 +155,14 @@ when the model directory is configured. That subprocess must read the clean
 text from stdin and emit JSON spans shaped like:
 
 ```json
-[{"label":"person","start":0,"end":11,"score":0.97}]
+[{"label":"PER","start":0,"end":11,"score":0.97}]
 ```
+
+The reference wrapper emits bare upstream DistilBERT entity labels (`PER`,
+`LOC`, `ORG`, `MISC`) after BIO decoding. Gaze validates those labels and maps
+them into its closed SafetyNet classes before manifest diffing. Existing
+wrappers that emit lower-case Gaze label ids (`person`, `location`,
+`organization`, `miscellaneous`) remain accepted for compatibility.
 
 A clean run emits the normal `gaze clean` JSON plus `leak_report`:
 
@@ -182,7 +212,7 @@ gaze clean \
   --policy quickstart-policy.toml \
   --safety-net openai-filter \
   --safety-net-backend kiji-distilbert \
-  --kiji-distilbert-command /opt/kiji/bin/kiji \
+  --kiji-distilbert-command "$PWD/scripts/kiji-runner.py" \
   --kiji-distilbert-model-dir ~/.local/share/gaze/models/kiji-distilbert
 ```
 
@@ -313,4 +343,5 @@ fixtures whenever possible.
 [cli-safety-net]: ../../crates/gaze-cli/README.md#safety-net
 [kiji-class-map]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/class_map.rs
 [kiji-mod]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+[kiji-runner]: ../../scripts/kiji-runner.py
 [kiji-subprocess]: ../../crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs

--- a/scripts/kiji-runner.py
+++ b/scripts/kiji-runner.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Reference Kiji DistilBERT subprocess wrapper for Gaze SafetyNet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import onnxruntime as ort
+from tokenizers import Tokenizer
+
+
+MAX_INPUT_BYTES = 1024 * 1024
+LABEL_FALLBACK = {
+    0: "O",
+    1: "B-MISC",
+    2: "I-MISC",
+    3: "B-PER",
+    4: "I-PER",
+    5: "B-ORG",
+    6: "I-ORG",
+    7: "B-LOC",
+    8: "I-LOC",
+}
+
+
+class KijiRunnerError(RuntimeError):
+    pass
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run pinned Kiji DistilBERT ONNX NER and emit Gaze JSON spans."
+    )
+    parser.add_argument("--format", required=True, choices=["json"])
+    parser.add_argument("--output-mode", required=True, choices=["typed"])
+    parser.add_argument("--model-dir", required=True)
+    return parser.parse_args(argv)
+
+
+def read_stdin() -> str:
+    raw = sys.stdin.buffer.read(MAX_INPUT_BYTES + 1)
+    if len(raw) > MAX_INPUT_BYTES:
+        raise KijiRunnerError(f"stdin exceeds {MAX_INPUT_BYTES} byte cap")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise KijiRunnerError("stdin is not valid UTF-8") from exc
+
+
+def load_labels(path: Path) -> dict[int, str]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    id_to_label: dict[int, str] = {}
+    if isinstance(data, dict) and isinstance(data.get("id2label"), dict):
+        for key, value in data["id2label"].items():
+            id_to_label[int(key)] = str(value)
+    elif isinstance(data, dict) and isinstance(data.get("labels"), list):
+        # Gaze's pinned labels.json records the closed allowed upstream labels,
+        # not the ONNX classifier id order. The upstream DistilBERT NER export
+        # uses the standard id2label order below.
+        allowed = {
+            str(label)
+            for item in data["labels"]
+            for label in item.get("upstream", [])
+        }
+        id_to_label = {
+            key: value
+            for key, value in LABEL_FALLBACK.items()
+            if value == "O" or value in allowed
+        }
+
+    if not id_to_label:
+        id_to_label = dict(LABEL_FALLBACK)
+    return id_to_label
+
+
+def build_inputs(session: ort.InferenceSession, encoding: Any) -> dict[str, np.ndarray]:
+    ids = np.asarray([encoding.ids], dtype=np.int64)
+    mask = np.asarray([encoding.attention_mask], dtype=np.int64)
+    type_ids = np.asarray([encoding.type_ids], dtype=np.int64)
+
+    values: dict[str, np.ndarray] = {}
+    for input_meta in session.get_inputs():
+        name = input_meta.name
+        lowered = name.lower()
+        if "input_ids" in lowered:
+            values[name] = ids
+        elif "attention" in lowered or "mask" in lowered:
+            values[name] = mask
+        elif "token_type" in lowered or "segment" in lowered:
+            values[name] = type_ids
+        else:
+            raise KijiRunnerError(f"unsupported ONNX input: {name}")
+    return values
+
+
+def label_for(logits: np.ndarray, id_to_label: dict[int, str]) -> tuple[str, float]:
+    label_id = int(np.argmax(logits))
+    score = softmax_score(logits, label_id)
+    return id_to_label.get(label_id, "O"), score
+
+
+def softmax_score(logits: np.ndarray, label_id: int) -> float:
+    values = logits.astype(np.float64)
+    values = values - np.max(values)
+    exp = np.exp(values)
+    denom = float(np.sum(exp))
+    if denom == 0.0 or not np.isfinite(denom):
+        return 0.0
+    score = float(exp[label_id] / denom)
+    if not np.isfinite(score):
+        return 0.0
+    return score
+
+
+def split_bio(label: str) -> tuple[str, str | None]:
+    if label == "O" or not label:
+        return "O", None
+    if "-" not in label:
+        return "B", label
+    prefix, entity = label.split("-", 1)
+    if prefix not in {"B", "I"} or not entity:
+        return "O", None
+    return prefix, entity
+
+
+def spans_from_predictions(
+    predictions: Iterable[tuple[str, int, int, float]],
+) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    active: dict[str, Any] | None = None
+    active_scores: list[float] = []
+
+    def flush() -> None:
+        nonlocal active, active_scores
+        if active is not None:
+            active["score"] = sum(active_scores) / len(active_scores)
+            spans.append(active)
+        active = None
+        active_scores = []
+
+    for raw_label, start, end, score in predictions:
+        prefix, entity = split_bio(raw_label)
+        if prefix == "O" or entity is None or start == end:
+            flush()
+            continue
+
+        if (
+            active is None
+            or prefix == "B"
+            or active["label"] != entity
+            or active["end"] > start
+        ):
+            flush()
+            active = {"label": entity, "start": start, "end": end}
+            active_scores = [score]
+            continue
+
+        active["end"] = end
+        active_scores.append(score)
+
+    flush()
+    return spans
+
+
+def run(model_dir: Path, text: str) -> list[dict[str, Any]]:
+    if text == "":
+        return []
+
+    model_path = model_dir / "model.onnx"
+    tokenizer_path = model_dir / "tokenizer.json"
+    labels_path = model_dir / "labels.json"
+    for path in [model_path, tokenizer_path, labels_path]:
+        if not path.is_file():
+            raise KijiRunnerError(f"missing model artifact: {path.name}")
+
+    # Preserve caller byte offsets. Normalized NFC/NFKC inputs are supported as-is.
+    unicodedata.normalize("NFC", text)
+    unicodedata.normalize("NFKC", text)
+
+    tokenizer = Tokenizer.from_file(str(tokenizer_path))
+    encoding = tokenizer.encode(text)
+    if not encoding.ids:
+        return []
+
+    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    outputs = session.run(None, build_inputs(session, encoding))
+    if not outputs:
+        raise KijiRunnerError("ONNX model returned no outputs")
+
+    logits = np.asarray(outputs[0])
+    if logits.ndim == 3:
+        logits = logits[0]
+    if logits.ndim != 2:
+        raise KijiRunnerError(f"unexpected logits shape: {list(logits.shape)}")
+
+    id_to_label = load_labels(labels_path)
+    predictions: list[tuple[str, int, int, float]] = []
+    for index, offset in enumerate(encoding.offsets):
+        if index >= logits.shape[0]:
+            break
+        start, end = int(offset[0]), int(offset[1])
+        if start < 0 or end < start:
+            print(f"kiji-runner: skipping invalid token offset at {index}", file=sys.stderr)
+            continue
+        try:
+            label, score = label_for(logits[index], id_to_label)
+        except Exception as exc:  # keep one bad token from failing the whole request
+            print(f"kiji-runner: skipping token {index}: {exc}", file=sys.stderr)
+            continue
+        predictions.append((label, start, end, score))
+
+    return spans_from_predictions(predictions)
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        text = read_stdin()
+        spans = run(Path(args.model_dir), text)
+        json.dump(spans, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:
+        print(f"kiji-runner: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Adds scripts/kiji-runner.py as the reference local Kiji DistilBERT subprocess wrapper.
- Loads pinned model.onnx, tokenizer.json, and labels.json; runs ONNX Runtime inference; decodes BIO tags into byte-offset JSON spans with stdout reserved for JSON only.
- Updates the Kiji setup guide with user-local Python dependency install steps, the reference command export, and the observed PEP 668 install gap on externally managed Python.
- Extends the Rust Kiji label mapper to accept bare upstream labels (PER/LOC/ORG/MISC) and BIO labels while retaining lower-case compatibility.

## Benchmark status
- Cells were not populated. Host Python blocks `python3 -m pip install --user onnxruntime tokenizers numpy` with PEP 668 externally-managed-environment, and the modules are not already importable.
- Smoke test and `cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix` were deferred to a host with python3 + pip user-install support.

## Verification
- `python3 -m py_compile scripts/kiji-runner.py`
- `cargo fmt --manifest-path Cargo.toml --all -- --check`
- `cargo test --manifest-path Cargo.toml -p gaze-recognizers --features safety-net-kiji --lib class_map`

IMPL DONE: wrapper shipped; bench rerun blocked by host Python dependency install policy.