### PR TITLE
[agent] refactor(api): rename redact_* → pseudonymize_* per north-star (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `LeakSuspectLogger::log_leak_suspect` instead. This is a pre-1.0 breaking API
   cleanup for adopter ergonomics; the SQLite schema and write behavior are
   unchanged. (Axis 5 ergonomics.)
+
+- **Pre-1.0 breaking API cleanup:** `CorePipeline::redact_text` is now
+  `pseudonymize_text`, and `Pipeline::redact_with_context` is now
+  `pseudonymize_with_context`; the detector-aware sibling is now
+  `pseudonymize_with_detect_context`. Operation is reversible pseudonymization,
+  not one-way redaction. (Axis 4 trust naming.)
+
 - **Safety-net benchmark snapshot schema v2**: the internal benchmark artifact
   moves from the single-backend Kiji schema to a backend × locale × mode matrix
   with mode-independent `strict_span_leak_rate` entries. Adopter impact is

--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -114,12 +114,12 @@ impl CorePipeline {
         self.pipeline
     }
 
-    pub fn redact_text(
+    pub fn pseudonymize_text(
         &self,
         session: &Session,
         input: impl Into<String>,
     ) -> Result<CleanDocument, gaze::Error> {
-        self.pipeline.redact_with_context(
+        self.pipeline.pseudonymize_with_context(
             session,
             RawDocument::Text(input.into()),
             self.locale_chain.as_slice(),

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -176,7 +176,7 @@ fn build_pipeline_context_only_still_succeeds() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let dictionaries = gaze::dictionary_bundle_from_context(&context);
     let clean = pipeline
-        .redact_with_detect_context(
+        .pseudonymize_with_detect_context(
             &session,
             RawDocument::Text("track context-song-123".to_string()),
             active_locales.as_slice(),
@@ -245,7 +245,7 @@ fn core_pipeline_config_tokenizes_synthetic_email() {
     let core = CorePipelineConfig::new().build().expect("core pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
     let text = clean_text(
-        core.redact_text(&session, "Email alice@example.invalid")
+        core.pseudonymize_text(&session, "Email alice@example.invalid")
             .expect("redact"),
     );
 
@@ -260,7 +260,7 @@ fn core_pipeline_config_core_tokenizes_safe_default_phone() {
         .expect("core pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
     let input = "Phone +12025550100";
-    let text = clean_text(core.redact_text(&session, input).expect("redact"));
+    let text = clean_text(core.pseudonymize_text(&session, input).expect("redact"));
 
     assert!(text.contains(":Custom:phone_"), "{text}");
 }
@@ -274,7 +274,7 @@ fn core_pipeline_config_core_extended_alias_tokenizes_synthetic_phone() {
         .expect("extended pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
     let text = clean_text(
-        core.redact_text(&session, "Phone +12025550100")
+        core.pseudonymize_text(&session, "Phone +12025550100")
             .expect("redact"),
     );
 
@@ -291,7 +291,7 @@ fn core_pipeline_config_core_extended_alias_tokenizes_synthetic_iban() {
         .expect("extended pipeline");
     let session = Session::new(Scope::Ephemeral).expect("session");
     let text = clean_text(
-        core.redact_text(&session, "IBAN DE89 3704 0044 0532 0130 00")
+        core.pseudonymize_text(&session, "IBAN DE89 3704 0044 0532 0130 00")
             .expect("redact"),
     );
 
@@ -304,7 +304,7 @@ fn core_pipeline_restore_round_trip() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let original = "alice@example.invalid";
     let text = clean_text(
-        core.redact_text(&session, format!("Email {original}"))
+        core.pseudonymize_text(&session, format!("Email {original}"))
             .expect("redact"),
     );
     let token = regex::Regex::new(r"<[^>]+:Email_\d+>")
@@ -417,7 +417,7 @@ fn t20_context_class_map_overrides_policy_dict_class() {
     let dictionaries = gaze::dictionary_bundle_from_context(&context);
     let session = Session::new(Scope::Ephemeral).expect("session");
     let clean = pipeline
-        .redact_with_detect_context(
+        .pseudonymize_with_detect_context(
             &session,
             RawDocument::Text("track context-song-123".to_string()),
             active_locales.as_slice(),

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -202,7 +202,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         (doc, _report)
     } else {
         let doc = pipeline
-            .redact_with_detect_context(
+            .pseudonymize_with_detect_context(
                 &session,
                 RawDocument::Text(raw),
                 locale_chain.as_slice(),

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -189,7 +189,7 @@ fn required_string<'a>(args: &'a serde_json::Value, field: &str) -> Result<&'a s
 fn redact_document_text(text: &str, ctx: &ToolCtx<'_>) -> Result<String, ToolError> {
     let pipeline = crate::bundle::build_document_pipeline().map_err(map_document_error)?;
     let clean = pipeline
-        .redact_with_context(
+        .pseudonymize_with_context(
             ctx.resources().session(),
             RawDocument::Text(text.to_string()),
             ctx.resources().locale_chain(),

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -169,7 +169,7 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
 
 fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: LocaleTag) -> String {
     let clean = pipeline
-        .redact_with_context(
+        .pseudonymize_with_context(
             session,
             RawDocument::Text(input.to_string()),
             &[locale, LocaleTag::Global],

--- a/crates/gaze-recognizers/tests/invariants.rs
+++ b/crates/gaze-recognizers/tests/invariants.rs
@@ -78,7 +78,7 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
 
 fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: LocaleTag) -> String {
     let clean = pipeline
-        .redact_with_context(
+        .pseudonymize_with_context(
             session,
             RawDocument::Text(input.to_string()),
             &[locale, LocaleTag::Global],

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let core = CorePipelineConfig::new().build()?;
     let session = Session::new(Scope::Conversation("conv-42".into()))?;
 
-    let CleanDocument::Text(clean) = core.redact_text(
+    let CleanDocument::Text(clean) = core.pseudonymize_text(
         &session,
         "Email alice@example.invalid about ORD-789012.",
     )? else { unreachable!() };

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -178,26 +178,26 @@ impl Pipeline {
         self
     }
 
-    /// Redacts using the default `[Global]` locale chain.
+    /// Pseudonymizes using the default `[Global]` locale chain.
     ///
-    /// Prefer `redact_with_context` when policy, CLI, or rulepack locale
+    /// Prefer `pseudonymize_with_context` when policy, CLI, or rulepack locale
     /// defaults should constrain which recognizers run.
     pub fn redact(&self, session: &Session, raw: RawDocument) -> Result<CleanDocument> {
         let locale_chain = [crate::LocaleTag::Global];
-        self.redact_with_context(session, raw, &locale_chain)
+        self.pseudonymize_with_context(session, raw, &locale_chain)
     }
 
-    pub fn redact_with_context(
+    pub fn pseudonymize_with_context(
         &self,
         session: &Session,
         raw: RawDocument,
         locale_chain: &[crate::LocaleTag],
     ) -> Result<CleanDocument> {
         let dictionaries = DictionaryBundle::default();
-        self.redact_with_detect_context(session, raw, locale_chain, &dictionaries)
+        self.pseudonymize_with_detect_context(session, raw, locale_chain, &dictionaries)
     }
 
-    pub fn redact_with_detect_context(
+    pub fn pseudonymize_with_detect_context(
         &self,
         session: &Session,
         raw: RawDocument,
@@ -213,7 +213,7 @@ impl Pipeline {
                 locale_chain,
                 dictionaries,
             ),
-            RawDocument::Text(text) => Ok(CleanDocument::Text(self.redact_text(
+            RawDocument::Text(text) => Ok(CleanDocument::Text(self.pseudonymize_text(
                 session,
                 &text,
                 None,
@@ -351,7 +351,7 @@ impl Pipeline {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn redact_text(
+    fn pseudonymize_text(
         &self,
         session: &Session,
         text: &str,
@@ -1068,7 +1068,7 @@ fn redact_structured_value(
     dictionaries: &DictionaryBundle,
 ) -> Result<Value> {
     match value {
-        Value::String(text) => Ok(Value::String(pipeline.redact_text(
+        Value::String(text) => Ok(Value::String(pipeline.pseudonymize_text(
             session,
             &text,
             Some(field_name),

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -446,7 +446,7 @@ fn mandatory_anchor_missing_emits_family_token_and_no_anchor_ambiguity() {
     let pipeline = mandatory_anchor_iban_pipeline(logger.clone());
 
     let clean = pipeline
-        .redact_with_context(
+        .pseudonymize_with_context(
             &session,
             RawDocument::Text("DE89 3704 0044 0532 0130 00".to_string()),
             &[gaze::LocaleTag::DeDe],
@@ -499,7 +499,7 @@ fn mandatory_anchor_present_keeps_variant_token_without_ambiguity() {
     let pipeline = mandatory_anchor_iban_pipeline(logger.clone());
 
     let clean = pipeline
-        .redact_with_context(
+        .pseudonymize_with_context(
             &session,
             RawDocument::Text("IBAN: DE89 3704 0044 0532 0130 00".to_string()),
             &[gaze::LocaleTag::DeDe],


### PR DESCRIPTION
## Summary
- Rename `CorePipeline::redact_text` to `pseudonymize_text`.
- Rename `Pipeline::redact_with_context` to `pseudonymize_with_context`, plus the detector-aware sibling to `pseudonymize_with_detect_context`.
- Update workspace callers, tests, rustdoc/README usage, and CHANGELOG `[Unreleased]` with the pre-1.0 breaking API cleanup voice.

## Axis / trust note
This is an Axis 4 trust naming cleanup: the operation is reversible pseudonymization with manifest restore, not one-way redaction. CLI `clean` remains unchanged. Existing `RedactionEntry` / `RedactionLogger` data-type names are untouched.

## Verification
- `cargo fmt --manifest-path /Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.8x-pseudonymize-rename-293/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path /Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.8x-pseudonymize-rename-293/Cargo.toml --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`

IMPL DONE: todo #293 pseudonymize API rename complete.