### PR TITLE
[agent] feat(safety-net): pin OPF checkpoint bundle SHA (#33d follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Empty detections emit `entries: []`. (Axis 5 ergonomics; unblocks
   gaze-laravel `GazeSession::$entries`.)
 
+- **OPF checkpoint trust pin**: the OpenAI Privacy Filter safety-net backend now
+  pins the locally captured checkpoint bundle SHA256 and required artifact
+  inventory for `openai/privacy-filter` commit
+  `f7f00ca7fb869683eb732c010299d901457f19c3`. OPF benchmark cells remain
+  `null` until the separate scorer run publishes measured results. The matrix
+  bench now compiles under `--features safety-net-openai` so the OPF pin block
+  can be validated without also enabling Kiji. (Axis 4 trust.)
+
 ### Changed
 
 - **Synthetic email fixtures** now use the IANA-reserved

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -86,4 +86,3 @@ harness = false
 [[bench]]
 name = "safety_net_matrix"
 harness = false
-required-features = ["safety-net-kiji"]

--- a/crates/gaze-recognizers/benches/safety_net_matrix.rs
+++ b/crates/gaze-recognizers/benches/safety_net_matrix.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "safety-net-kiji")]
 use gaze_recognizers::safety_net::kiji_distilbert::{
     KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
     KIJI_DISTILBERT_SHA256SUMS,
@@ -31,6 +32,7 @@ fn main() {
     println!("{SNAPSHOT}");
 }
 
+#[cfg(feature = "safety-net-kiji")]
 fn assert_kiji_pins(snapshot: &Value) {
     let pins = &snapshot["backends"]["kiji_distilbert"]["pins"];
     assert_eq!(
@@ -59,6 +61,7 @@ fn assert_kiji_pins(snapshot: &Value) {
     );
 }
 
+#[cfg(feature = "safety-net-kiji")]
 fn checksum_for(filename: &str) -> &str {
     KIJI_DISTILBERT_SHA256SUMS
         .lines()
@@ -67,6 +70,23 @@ fn checksum_for(filename: &str) -> &str {
             (path == filename).then_some(sha256)
         })
         .expect("checksum present in Kiji SHA256SUMS")
+}
+
+#[cfg(not(feature = "safety-net-kiji"))]
+fn assert_kiji_pins(snapshot: &Value) {
+    let pins = snapshot["backends"]["kiji_distilbert"]["pins"]
+        .as_object()
+        .expect("Kiji pins object");
+    for key in [
+        "source_repo",
+        "source_commit",
+        "bundle_sha256",
+        "model_sha256",
+        "tokenizer_sha256",
+        "label_map_sha256",
+    ] {
+        assert!(pins.contains_key(key), "missing Kiji pin key: {key}");
+    }
 }
 
 #[cfg(feature = "safety-net-openai")]

--- a/crates/gaze-recognizers/benches/safety_net_matrix_snapshot.json
+++ b/crates/gaze-recognizers/benches/safety_net_matrix_snapshot.json
@@ -17,8 +17,13 @@
       "pins": {
         "source_repo": "openai/privacy-filter",
         "source_commit": "f7f00ca7fb869683eb732c010299d901457f19c3",
-        "checkpoint_bundle_sha256": null,
-        "required_opf_artifacts": []
+        "checkpoint_bundle_sha256": "4680158333621f3f344f58366f59612d52eff67ce6f46cff7becede5be1853ae",
+        "required_opf_artifacts": [
+          "config.json",
+          "dtypes.json",
+          "model.safetensors",
+          "viterbi_calibration.json"
+        ]
       }
     }
   },

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
@@ -26,17 +26,22 @@ pub const OPF_SOURCE_COMMIT: &str = "f7f00ca7fb869683eb732c010299d901457f19c3";
 
 /// SHA256 of the checkpoint bundle downloaded by `opf` at `OPF_SOURCE_COMMIT`.
 ///
-/// This remains `None` until a reproducible clean OPF download is captured and
-/// reviewed. When populated, `verify_checkpoint_bundle_sha256` checks the local
-/// checkpoint directory before allowing subprocess execution.
-pub const OPF_CHECKPOINT_BUNDLE_SHA256: Option<&str> = None;
+/// Computed as SHA256 over the Kiji-style line-per-file SHA256SUMS manifest for
+/// `REQUIRED_OPF_ARTIFACTS` in declaration order. Verified 2026-05-15 from a
+/// clean `opf download` into `~/.opf/privacy_filter`.
+pub const OPF_CHECKPOINT_BUNDLE_SHA256: Option<&str> =
+    Some("4680158333621f3f344f58366f59612d52eff67ce6f46cff7becede5be1853ae");
 
 /// Required checkpoint artifact filenames inside the OPF bundle directory.
 ///
-/// Empty until a local clean `opf` checkpoint download is captured. A future PR
-/// that fills `OPF_CHECKPOINT_BUNDLE_SHA256` must fill this list in the same
-/// change.
-pub const REQUIRED_OPF_ARTIFACTS: &[&str] = &[];
+/// The Hugging Face downloader also writes `.cache/huggingface` metadata; those
+/// cache files are excluded from the runtime bundle hash.
+pub const REQUIRED_OPF_ARTIFACTS: &[&str] = &[
+    "config.json",
+    "dtypes.json",
+    "model.safetensors",
+    "viterbi_calibration.json",
+];
 
 /// Configuration for the local OPF subprocess backend.
 #[derive(Debug, Clone)]

--- a/docs/architecture/safety-net-benchmark.md
+++ b/docs/architecture/safety-net-benchmark.md
@@ -27,8 +27,8 @@ Current status: `not_run_requires_local_backends`.
 |---|---|
 | Source repo | `openai/privacy-filter` |
 | Source commit | `f7f00ca7fb869683eb732c010299d901457f19c3` |
-| Checkpoint bundle SHA256 | `null` |
-| Required checkpoint artifacts | `[]` |
+| Checkpoint bundle SHA256 | `4680158333621f3f344f58366f59612d52eff67ce6f46cff7becede5be1853ae` |
+| Required checkpoint artifacts | `["config.json", "dtypes.json", "model.safetensors", "viterbi_calibration.json"]` |
 
 OPF publishes a source repository and an `opf` Python CLI that downloads its
 checkpoint into `~/.opf/privacy_filter` by default, or into the directory
@@ -36,12 +36,11 @@ selected by `OPF_CHECKPOINT` / `--checkpoint`. It does not publish a GitHub
 release binary, so Gaze does not pin a binary checksum. The source commit and
 checkpoint bundle are the trust anchors.
 
-The source commit is pinned above. The checkpoint bundle hash remains `null`
-and the required-artifact list remains empty until a clean local OPF checkpoint
-download is captured, reviewed, and recorded in
-`OPF_CHECKPOINT_BUNDLE_SHA256` with the matching `REQUIRED_OPF_ARTIFACTS` list.
-Publishing numeric OPF claims or enabling checkpoint-bundle verification without
-those pins would violate the Axis 4 trust contract.
+The source commit is pinned above. The checkpoint bundle hash was captured from
+a clean local `opf download` on 2026-05-15. The bundle hash is SHA256 over the
+Kiji-style line-per-file SHA256SUMS manifest for the required artifact list in
+declaration order. Publishing numeric OPF claims without populated benchmark
+cells would violate the Axis 4 trust contract.
 
 ## Matrix Shape
 


### PR DESCRIPTION
## Summary
- Pins the OPF checkpoint bundle SHA256 for openai/privacy-filter commit f7f00ca7fb869683eb732c010299d901457f19c3.
- Records the required OPF runtime artifact inventory in the Rust constants, safety-net benchmark doc, and matrix snapshot pin block.
- Keeps all OPF benchmark cells and strict_span_leak_rate values null; this PR does not publish OPF scorer metrics.
- Makes the safety_net_matrix bench compile under --features safety-net-openai so the OPF pin block can be validated without also enabling Kiji.

## OPF Capture
- PyPI package attempts: pip install opf, pip install openai-privacy-filter, and pip install opf-cli were not published in this environment.
- Installed with: .opf-venv/bin/pip install git+https://github.com/openai/privacy-filter.git@f7f00ca7fb869683eb732c010299d901457f19c3
- pip show opf: Name opf, Version 0.1.0, Summary Standalone local-only OPF PyTorch model and eval tools.
- Download command: .opf-venv/bin/opf download
- Checkpoint directory: ~/.opf/privacy_filter

## Bundle Inventory
- Bundle SHA256: 4680158333621f3f344f58366f59612d52eff67ce6f46cff7becede5be1853ae
- Bundle byte size: 2,798,989,275 bytes
- Required artifacts:
  - config.json (707 bytes, sha256 048a20604a3622de208d30df57cd5424bb583639b9ba20ddd7da593d3f89a248)
  - dtypes.json (4,108 bytes, sha256 e936acb3d039b35ec55438af2fffd424a53c7685b895775c186b26c7df79fcc7)
  - model.safetensors (2,798,984,088 bytes, sha256 9c262cbe68a0c8a50590a648ef8341a2b7d3be1fa11dfb79893fe0b03ce57b5c)
  - viterbi_calibration.json (372 bytes, sha256 bbc8611ef08a55ed72d64856cbbbb9a91db8dfa881f0a92e2afbad6e4bbc775a)

## Caveats
- opf download completed, then the CLI default inference path failed because Torch selected CUDA on this machine and the installed torch build has no CUDA support.
- A CPU smoke run succeeded with: printf '%s\n' 'No private data.' | .opf-venv/bin/opf --format json --output-mode typed --device cpu
- Hugging Face emitted an unauthenticated rate-limit warning during download; no API auth was required.

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix
- cargo bench -p gaze-recognizers --features safety-net-openai --bench safety_net_matrix --no-run
- cargo bench -p gaze-recognizers --features safety-net-kiji,safety-net-openai --bench safety_net_matrix
