### PR TITLE
[agent] feat(bench): multi-NER model leaderboard (#33d follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,12 @@
 /.superpowers/
 /.lean-ctx/
 /.bench-venv/
+/.huggingface-cache/
 /.opf-bench-src/
 /.opf-bench-venv/
 /.anvil.local
+__pycache__/
+*.py[cod]
 *.db
 *.db-journal
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `safety_net_perf_snapshot.json` records 150-fixture direct-mode latency for
   both backends. The observer path uses a Rust `clean_for_bench` helper so
   residual scoring is grounded in Gaze's emitted manifest spans. (Axis 4 trust.)
+- **Multi-NER leaderboard**: published at
+  `docs/research/v0.9-ner-model-leaderboard.md`; Kiji selected as the v0.9
+  default per shipped class-map measurement. (Axis 4 trust, Axis 5 ergonomics.)
 
 - **Audit NER-provenance schema migration**: `gaze-audit` adds eleven
   nullable, additive provenance columns to `redaction_log` for future NER

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ The audit DB is opened read-only by `query` and `export`. The exported column se
 - Detection floor is regex + validator + locale cue. Tenant-specific PII needs a custom recognizer.
 - Linux x86_64 binaries link against glibc 2.39+ (Ubuntu 24.04, Debian 13, RHEL 10, or newer). Older distros: build from source.
 - No Intel macOS, no musl, no Windows binaries today. Build from source.
+- v0.9 NER model leaderboard: [`docs/research/v0.9-ner-model-leaderboard.md`](docs/research/v0.9-ner-model-leaderboard.md). Kiji DistilBERT (Apache-2.0) ships as default per the leaderboard's strategic read.
 - SafetyNet benchmark cells for Kiji DistilBERT and OpenAI Privacy Filter direct-detector mode are populated in [`docs/research/v0.9-safety-net-benchmark.md`](docs/research/v0.9-safety-net-benchmark.md); observer-residual mode remains deferred.
 - `gaze-proxy` ships OpenAI / Anthropic / Gemini adapters. Certificate management, PAC mode, Electron integration, and transparent MITM are out of scope here — those belong in [`gaze-lens`](https://github.com/EmpireTwo/gaze-lens), not the core proxy.
 

--- a/benches/ner_models.toml
+++ b/benches/ner_models.toml
@@ -11,7 +11,7 @@ fetch_script = "scripts/fetch-kiji-safetynet-model.sh"
 default_checkpoint = "~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67"
 native_locales = ["Global"]
 label_set = ["PER", "LOC", "ORG", "MISC"]
-label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Name" }
 shippable_default = true
 
 [[model]]

--- a/benches/ner_models.toml
+++ b/benches/ner_models.toml
@@ -1,0 +1,58 @@
+[[model]]
+id = "kiji-distilbert"
+display_name = "Kiji DistilBERT"
+hf_repo = "onnx-community/distilbert-NER-ONNX"
+hf_commit = "3a19fe9404a4469d91aa3d551558a97f68872f67"
+bundle_sha = "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f"
+license = "apache-2.0"
+runtime = "onnxruntime"
+wrapper = "scripts/kiji-runner.py"
+fetch_script = "scripts/fetch-kiji-safetynet-model.sh"
+default_checkpoint = "~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67"
+native_locales = ["Global"]
+label_set = ["PER", "LOC", "ORG", "MISC"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+shippable_default = true
+
+[[model]]
+id = "wikineural-multilingual"
+display_name = "Babelscape WikiNeural Multilingual"
+hf_repo = "Babelscape/wikineural-multilingual-ner"
+hf_commit = "bed6ee7a45d2827b6c90a4fd7983f0241ae0a5c1"
+bundle_sha = "7015eaabce63ccc6ed759eeb517c9643f70a098aa49c57131d47aaf36aee075a"
+license = "cc-by-nc-sa-4.0"
+runtime = "transformers"
+wrapper = "scripts/transformers-runner.py"
+native_locales = ["EnUs", "DeDe", "FrFr", "ItIt", "EsEs", "Global"]
+label_set = ["PER", "LOC", "ORG", "MISC"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+shippable_default = false
+default_caveat = "Non-commercial license; informational benchmark only."
+
+[[model]]
+id = "dslim-bert-base-ner"
+display_name = "dslim/bert-base-NER (English)"
+hf_repo = "dslim/bert-base-NER"
+hf_commit = "d1a3e8f13f8c3566299d95fcfc9a8d2382a9affc"
+bundle_sha = "fd7119ab25b127f50b4165bde3cc2466c90d0eabe230b206bf3dae7b6225fe54"
+license = "mit"
+runtime = "transformers"
+wrapper = "scripts/transformers-runner.py"
+native_locales = ["EnUs", "EnGb"]
+label_set = ["PER", "LOC", "ORG", "MISC"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+shippable_default = true
+
+[[model]]
+id = "davlan-bert-multilingual"
+display_name = "Davlan multilingual BERT-NER (HRL)"
+hf_repo = "Davlan/bert-base-multilingual-cased-ner-hrl"
+hf_commit = "e756de7f7b8f64fea0c3d7c3872f1322fab747b1"
+bundle_sha = "c3af1f92b9292ba894177812d6f89e5d93502ef819b7fadf7ec7aeb692b4c49d"
+license = "afl-3.0"
+runtime = "transformers"
+wrapper = "scripts/transformers-runner.py"
+native_locales = ["EnUs", "DeDe", "FrFr", "ItIt", "EsEs", "PtBr", "Global"]
+label_set = ["PER", "LOC", "ORG", "DATE"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", DATE = "Custom:date" }
+shippable_default = true

--- a/crates/gaze-recognizers/benches/ner_models_snapshot.json
+++ b/crates/gaze-recognizers/benches/ner_models_snapshot.json
@@ -1,0 +1,2069 @@
+{
+  "schema_version": 1,
+  "benchmark": "ner-model-leaderboard",
+  "status": "real_run",
+  "corpus": {
+    "coverage_report_sha256": "760f96163a68ce5f7dbc0409aa5109aa1a3ed190001536647e1881ba9d40a49c",
+    "sha256": "c6e78cca59df550fad18e59e9877da03da82c73b80c2368e5233d76353ccfa2f",
+    "fixture_count": 150
+  },
+  "run_environment": {
+    "os": "macOS-26.5-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "python": "3.14.5"
+  },
+  "models": {
+    "kiji-distilbert": {
+      "display_name": "Kiji DistilBERT",
+      "hf_repo": "onnx-community/distilbert-NER-ONNX",
+      "hf_commit": "3a19fe9404a4469d91aa3d551558a97f68872f67",
+      "bundle_sha256_config": "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f",
+      "bundle_sha256_observed": "34c2b83bc54b6fe3b96b74b360425c483f01be7a28feb91a37aaa65476d03aa4",
+      "license": "apache-2.0",
+      "runtime": "onnxruntime",
+      "wrapper": "scripts/kiji-runner.py",
+      "checkpoint": "/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67",
+      "native_locales": [
+        "Global"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Custom:other"
+      },
+      "shippable_default": true,
+      "default_caveat": null,
+      "latency": {
+        "cold_start_ms": 961.065333,
+        "per_fixture_median_ms": 222.059,
+        "per_fixture_p95_ms": 268.206173,
+        "per_fixture_p99_ms": 295.327048,
+        "per_fixture_mean_ms": 231.635754,
+        "throughput_bytes_per_sec": 1232.653691,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      }
+    },
+    "wikineural-multilingual": {
+      "display_name": "Babelscape WikiNeural Multilingual",
+      "hf_repo": "Babelscape/wikineural-multilingual-ner",
+      "hf_commit": "bed6ee7a45d2827b6c90a4fd7983f0241ae0a5c1",
+      "bundle_sha256_config": "<unpinned>",
+      "bundle_sha256_observed": "7015eaabce63ccc6ed759eeb517c9643f70a098aa49c57131d47aaf36aee075a",
+      "license": "cc-by-nc-sa-4.0",
+      "runtime": "transformers",
+      "wrapper": "scripts/transformers-runner.py",
+      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/wikineural-multilingual",
+      "native_locales": [
+        "EnUs",
+        "DeDe",
+        "FrFr",
+        "ItIt",
+        "EsEs",
+        "Global"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Custom:other"
+      },
+      "shippable_default": false,
+      "default_caveat": "Non-commercial license; informational benchmark only.",
+      "latency": {
+        "cold_start_ms": 2890.127959,
+        "per_fixture_median_ms": 1786.36075,
+        "per_fixture_p95_ms": 1997.942931,
+        "per_fixture_p99_ms": 2614.783255,
+        "per_fixture_mean_ms": 1832.978229,
+        "throughput_bytes_per_sec": 155.77199,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      }
+    },
+    "dslim-bert-base-ner": {
+      "display_name": "dslim/bert-base-NER (English)",
+      "hf_repo": "dslim/bert-base-NER",
+      "hf_commit": "d1a3e8f13f8c3566299d95fcfc9a8d2382a9affc",
+      "bundle_sha256_config": "<unpinned>",
+      "bundle_sha256_observed": "fd7119ab25b127f50b4165bde3cc2466c90d0eabe230b206bf3dae7b6225fe54",
+      "license": "mit",
+      "runtime": "transformers",
+      "wrapper": "scripts/transformers-runner.py",
+      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/dslim-bert-base-ner",
+      "native_locales": [
+        "EnUs",
+        "EnGb"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Custom:other"
+      },
+      "shippable_default": true,
+      "default_caveat": null,
+      "latency": {
+        "cold_start_ms": 1783.4385,
+        "per_fixture_median_ms": 1737.297417,
+        "per_fixture_p95_ms": 1808.988923,
+        "per_fixture_p99_ms": 1918.146869,
+        "per_fixture_mean_ms": 1743.286581,
+        "throughput_bytes_per_sec": 163.786419,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      }
+    },
+    "davlan-bert-multilingual": {
+      "display_name": "Davlan multilingual BERT-NER (HRL)",
+      "hf_repo": "Davlan/bert-base-multilingual-cased-ner-hrl",
+      "hf_commit": "e756de7f7b8f64fea0c3d7c3872f1322fab747b1",
+      "bundle_sha256_config": "<unpinned>",
+      "bundle_sha256_observed": "c3af1f92b9292ba894177812d6f89e5d93502ef819b7fadf7ec7aeb692b4c49d",
+      "license": "afl-3.0",
+      "runtime": "transformers",
+      "wrapper": "scripts/transformers-runner.py",
+      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/davlan-bert-multilingual",
+      "native_locales": [
+        "EnUs",
+        "DeDe",
+        "FrFr",
+        "ItIt",
+        "EsEs",
+        "PtBr",
+        "Global"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "DATE"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "DATE": "Custom:date"
+      },
+      "shippable_default": true,
+      "default_caveat": null,
+      "latency": {
+        "cold_start_ms": 2637.689166,
+        "per_fixture_median_ms": 1911.348979,
+        "per_fixture_p95_ms": 2143.359539,
+        "per_fixture_p99_ms": 2295.070171,
+        "per_fixture_mean_ms": 1944.522838,
+        "throughput_bytes_per_sec": 146.836366,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      }
+    }
+  },
+  "cells": [
+    {
+      "model": "kiji-distilbert",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 5,
+            "true_positive": 0,
+            "false_positive": 5,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 54,
+            "true_positive": 0,
+            "false_positive": 54,
+            "false_negative": 5,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 29,
+            "true_positive": 0,
+            "false_positive": 29,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 24,
+            "true_positive": 0,
+            "false_positive": 24,
+            "false_negative": 29,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 30,
+            "true_positive": 0,
+            "false_positive": 30,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 237,
+            "true_positive": 0,
+            "false_positive": 237,
+            "false_negative": 29,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 5,
+            "true_positive": 0,
+            "false_positive": 5,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Location": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 54,
+            "true_positive": 0,
+            "false_positive": 54,
+            "false_negative": 5,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.0
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 29,
+            "true_positive": 0,
+            "false_positive": 29,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 24,
+            "true_positive": 0,
+            "false_positive": 24,
+            "false_negative": 29,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.0
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.0,
+        "recall": 0.0,
+        "f1": null,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 29,
+            "true_positive": 0,
+            "false_positive": 29,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 245,
+            "true_positive": 0,
+            "false_positive": 245,
+            "false_negative": 29,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.0
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.3125,
+        "recall": 0.125,
+        "f1": 0.178571,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 8,
+            "true_positive": 0,
+            "false_positive": 8,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 3,
+            "true_positive": 0,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.707317,
+        "recall": 0.125,
+        "f1": 0.212454,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 9,
+            "true_positive": 0,
+            "false_positive": 9,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 3,
+            "true_positive": 0,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "DeDe",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.408451,
+        "recall": 0.125,
+        "f1": 0.191419,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 27,
+            "true_positive": 0,
+            "false_positive": 27,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 42,
+            "true_positive": 29,
+            "false_positive": 13,
+            "false_negative": 0,
+            "precision": 0.690476,
+            "recall": 1.0,
+            "f1": 0.816901
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.277778,
+        "recall": 0.5,
+        "f1": 0.357143,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 1,
+            "true_positive": 0,
+            "false_positive": 1,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.707317,
+        "recall": 0.5,
+        "f1": 0.585859,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "wikineural-multilingual",
+      "locale": "DeDe",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.537037,
+        "recall": 1.0,
+        "f1": 0.698795,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 23,
+            "true_positive": 0,
+            "false_positive": 23,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.102041,
+        "recall": 0.125,
+        "f1": 0.11236,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 15,
+            "true_positive": 0,
+            "false_positive": 15,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 29,
+            "true_positive": 0,
+            "false_positive": 29,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.636364,
+        "recall": 0.12069,
+        "f1": 0.202899,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 3,
+            "true_positive": 0,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 28,
+            "true_positive": 28,
+            "false_positive": 0,
+            "false_negative": 1,
+            "precision": 1.0,
+            "recall": 0.965517,
+            "f1": 0.982456
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 13,
+            "true_positive": 0,
+            "false_positive": 13,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.162921,
+        "recall": 0.125,
+        "f1": 0.141463,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 30,
+            "true_positive": 29,
+            "false_positive": 1,
+            "false_negative": 0,
+            "precision": 0.966667,
+            "recall": 1.0,
+            "f1": 0.983051
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 136,
+            "true_positive": 0,
+            "false_positive": 136,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.104167,
+        "recall": 0.5,
+        "f1": 0.172414,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 8,
+            "true_positive": 0,
+            "false_positive": 8,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 35,
+            "true_positive": 0,
+            "false_positive": 35,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.613636,
+        "recall": 0.465517,
+        "f1": 0.529412,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 27,
+            "true_positive": 27,
+            "false_positive": 0,
+            "false_negative": 2,
+            "precision": 1.0,
+            "recall": 0.931034,
+            "f1": 0.964286
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 17,
+            "true_positive": 0,
+            "false_positive": 17,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.465517,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.465517
+      }
+    },
+    {
+      "model": "dslim-bert-base-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.153439,
+        "recall": 1.0,
+        "f1": 0.266055,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 5,
+            "true_positive": 0,
+            "false_positive": 5,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 155,
+            "true_positive": 0,
+            "false_positive": 155,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.294118,
+        "recall": 0.125,
+        "f1": 0.175439,
+        "per_class": {
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.690476,
+        "recall": 0.125,
+        "f1": 0.211679,
+        "per_class": {
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 13,
+            "true_positive": 0,
+            "false_positive": 13,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "DeDe",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.690476,
+        "recall": 0.125,
+        "f1": 0.211679,
+        "per_class": {
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 13,
+            "true_positive": 0,
+            "false_positive": 13,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.294118,
+        "recall": 0.5,
+        "f1": 0.37037,
+        "per_class": {
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.666667,
+        "recall": 0.482758,
+        "f1": 0.56,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 28,
+            "true_positive": 28,
+            "false_positive": 0,
+            "false_negative": 1,
+            "precision": 1.0,
+            "recall": 0.965517,
+            "f1": 0.982456
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 14,
+            "true_positive": 0,
+            "false_positive": 14,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.482758,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.482758
+      }
+    },
+    {
+      "model": "davlan-bert-multilingual",
+      "locale": "DeDe",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.591837,
+        "recall": 1.0,
+        "f1": 0.74359,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 20,
+            "true_positive": 0,
+            "false_positive": 20,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    }
+  ]
+}

--- a/crates/gaze-recognizers/benches/ner_models_snapshot.json
+++ b/crates/gaze-recognizers/benches/ner_models_snapshot.json
@@ -36,17 +36,17 @@
         "PER": "Name",
         "LOC": "Location",
         "ORG": "Organization",
-        "MISC": "Custom:other"
+        "MISC": "Name"
       },
       "shippable_default": true,
       "default_caveat": null,
       "latency": {
-        "cold_start_ms": 961.065333,
-        "per_fixture_median_ms": 222.059,
-        "per_fixture_p95_ms": 268.206173,
-        "per_fixture_p99_ms": 295.327048,
-        "per_fixture_mean_ms": 231.635754,
-        "throughput_bytes_per_sec": 1232.653691,
+        "cold_start_ms": 2455.891792,
+        "per_fixture_median_ms": 323.346375,
+        "per_fixture_p95_ms": 490.053498,
+        "per_fixture_p99_ms": 680.605004,
+        "per_fixture_mean_ms": 349.494284,
+        "throughput_bytes_per_sec": 816.970919,
         "fixture_count": 150,
         "device": "cpu",
         "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
@@ -189,20 +189,10 @@
       "native_locale": true,
       "mode": "direct_detector",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.084746,
+        "recall": 0.125,
+        "f1": 0.10101,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 5,
-            "true_positive": 0,
-            "false_positive": 5,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Email": {
             "support": 59,
             "predicted": 0,
@@ -215,13 +205,13 @@
           },
           "Name": {
             "support": 5,
-            "predicted": 54,
-            "true_positive": 0,
+            "predicted": 59,
+            "true_positive": 5,
             "false_positive": 54,
-            "false_negative": 5,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "false_negative": 0,
+            "precision": 0.084746,
+            "recall": 1.0,
+            "f1": 0.15625
           },
           "custom:credit_card": {
             "support": 18,
@@ -292,20 +282,10 @@
       "native_locale": false,
       "mode": "direct_detector",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.54717,
+        "recall": 0.125,
+        "f1": 0.203509,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 29,
-            "true_positive": 0,
-            "false_positive": 29,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Email": {
             "support": 48,
             "predicted": 0,
@@ -318,13 +298,13 @@
           },
           "Name": {
             "support": 29,
-            "predicted": 24,
-            "true_positive": 0,
+            "predicted": 53,
+            "true_positive": 29,
             "false_positive": 24,
-            "false_negative": 29,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
           },
           "custom:credit_card": {
             "support": 10,
@@ -395,20 +375,10 @@
       "native_locale": false,
       "mode": "direct_detector",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.108614,
+        "recall": 0.125,
+        "f1": 0.116232,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 30,
-            "true_positive": 0,
-            "false_positive": 30,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Email": {
             "support": 55,
             "predicted": 0,
@@ -421,13 +391,13 @@
           },
           "Name": {
             "support": 29,
-            "predicted": 237,
-            "true_positive": 0,
-            "false_positive": 237,
-            "false_negative": 29,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "predicted": 267,
+            "true_positive": 29,
+            "false_positive": 238,
+            "false_negative": 0,
+            "precision": 0.108614,
+            "recall": 1.0,
+            "f1": 0.195946
           },
           "custom:credit_card": {
             "support": 7,
@@ -498,20 +468,10 @@
       "native_locale": true,
       "mode": "observer_residual",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.081967,
+        "recall": 0.5,
+        "f1": 0.140845,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 5,
-            "true_positive": 0,
-            "false_positive": 5,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Location": {
             "support": 0,
             "predicted": 2,
@@ -524,13 +484,13 @@
           },
           "Name": {
             "support": 5,
-            "predicted": 54,
-            "true_positive": 0,
+            "predicted": 59,
+            "true_positive": 5,
             "false_positive": 54,
-            "false_negative": 5,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "false_negative": 0,
+            "precision": 0.084746,
+            "recall": 1.0,
+            "f1": 0.15625
           },
           "custom:postal_code": {
             "support": 6,
@@ -543,11 +503,11 @@
             "f1": null
           }
         },
-        "observer_residual_recall": 0.0,
+        "observer_residual_recall": 0.5,
         "agreement_with_rule_floor": null,
         "expansion_fraction": null,
         "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 0.0
+        "novel_tp_over_rule_floor": 0.5
       }
     },
     {
@@ -556,29 +516,19 @@
       "native_locale": false,
       "mode": "observer_residual",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.54717,
+        "recall": 0.5,
+        "f1": 0.522523,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 29,
-            "true_positive": 0,
-            "false_positive": 29,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Name": {
             "support": 29,
-            "predicted": 24,
-            "true_positive": 0,
+            "predicted": 53,
+            "true_positive": 29,
             "false_positive": 24,
-            "false_negative": 29,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
           },
           "custom:phone": {
             "support": 15,
@@ -591,11 +541,11 @@
             "f1": null
           }
         },
-        "observer_residual_recall": 0.0,
+        "observer_residual_recall": 0.5,
         "agreement_with_rule_floor": null,
         "expansion_fraction": null,
         "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 0.0
+        "novel_tp_over_rule_floor": 0.5
       }
     },
     {
@@ -604,36 +554,26 @@
       "native_locale": false,
       "mode": "observer_residual",
       "metrics": {
-        "precision": 0.0,
-        "recall": 0.0,
-        "f1": null,
+        "precision": 0.107407,
+        "recall": 1.0,
+        "f1": 0.19398,
         "per_class": {
-          "Custom:other": {
-            "support": 0,
-            "predicted": 29,
-            "true_positive": 0,
-            "false_positive": 29,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
           "Name": {
             "support": 29,
-            "predicted": 245,
-            "true_positive": 0,
-            "false_positive": 245,
-            "false_negative": 29,
-            "precision": 0.0,
-            "recall": 0.0,
-            "f1": null
+            "predicted": 270,
+            "true_positive": 29,
+            "false_positive": 241,
+            "false_negative": 0,
+            "precision": 0.107407,
+            "recall": 1.0,
+            "f1": 0.19398
           }
         },
-        "observer_residual_recall": 0.0,
+        "observer_residual_recall": 1.0,
         "agreement_with_rule_floor": null,
         "expansion_fraction": null,
         "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 0.0
+        "novel_tp_over_rule_floor": 1.0
       }
     },
     {

--- a/docs/research/v0.9-ner-model-leaderboard.md
+++ b/docs/research/v0.9-ner-model-leaderboard.md
@@ -2,6 +2,12 @@
 
 This benchmark compares Hugging Face NER candidates as Gaze safety-net backends on the same committed coverage-loop corpus. The run uses the config in `benches/ner_models.toml` and writes the frozen evidence snapshot to `crates/gaze-recognizers/benches/ner_models_snapshot.json`.
 
+Related docs:
+
+- v0.9 SafetyNet matrix: [`docs/research/v0.9-safety-net-benchmark.md`](v0.9-safety-net-benchmark.md)
+- Runtime contract: [`docs/architecture/safety-nets.md`](../architecture/safety-nets.md)
+- Kiji setup: [`docs/getting-started/kiji-safetynet-setup.md`](../getting-started/kiji-safetynet-setup.md)
+
 Command:
 
 ```bash
@@ -24,6 +30,22 @@ Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cell
 | 3 | dslim/bert-base-NER (English) | MIT | Yes | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 |
 | 4 | Kiji DistilBERT | Apache-2.0 | Yes | 0.247 / 0.125 / 0.140 | 0.246 / 0.667 / 0.286 | 323.346 |
 
+## Strategic Read for v0.9 Default Backend
+
+The default-backend decision uses the shipping axes adopters actually inherit: license posture, observer-residual recall, and checked-in subprocess latency.
+
+| Candidate | License | Observer Recall | Latency |
+|---|---|---:|---:|
+| Kiji DistilBERT | ✓ Apache-2.0 | ✓ 0.667 | ✓ 323ms |
+| Babelscape WikiNeural Multilingual | ✗ CC-BY-NC-SA-4.0 | ✓ 0.667 | ✗ 1786ms |
+| Davlan multilingual BERT-NER (HRL) | ⚠ AFL-3.0 | ✗ 0.661 | ✗ 1911ms |
+| dslim/bert-base-NER (English) | ✓ MIT | ✗ 0.655 | ✗ 1737ms |
+| Axis winner | Kiji DistilBERT | Kiji DistilBERT / WikiNeural tie | Kiji DistilBERT |
+
+Kiji DistilBERT won the v0.9 default decision across all three release axes: it was Apache-2.0, tied for top observer-residual recall at `0.667`, and ran about 5x faster than the transformer alternatives in the one-shot subprocess benchmark. Locale coverage was not a blocker because Pass-3 SafetyNet is observer-only: the deterministic rule floor handles structural shapes first, and Kiji's `PER` label catches `Name` residuals across the measured locale cells.
+
+v0.9 ships Kiji as the default Pass-3 SafetyNet backend; OPF remains an opt-in alternative where adopters accept the larger checkpoint and Python install.
+
 ## Locale Detail
 
 | Model | Mode | Global P/R/F1 | EnUs P/R/F1 | DeDe P/R/F1 |
@@ -40,6 +62,18 @@ Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cell
 ## License Notes
 
 WikiNeural is included for evidence only because CC-BY-NC-SA-4.0 is non-commercial and cannot be shipped as the default model. The Davlan model metadata currently reports AFL-3.0, not Apache-2.0; this is permissive-style but should be checked before default shipment. dslim is MIT. Kiji DistilBERT is Apache-2.0.
+
+## License Framework
+
+| Category | Licenses | Default posture |
+|---|---|---|
+| Ship-safe ✓ | Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause | Eligible for default shipment. |
+| Permissive-but-unusual ⚠ | AFL-3.0 | Requires explicit review before default shipment. |
+| Non-commercial ✗ | CC-BY-NC, CC-BY-NC-SA | Benchmark evidence only; not a default backend. |
+| Copyleft ✗ | GPL, AGPL | Not a default backend for a library compiled into adopter products. |
+| Custom restricted ⚠✗ | OpenAI research license, Llama/Mistral custom commercial terms | Opt-in only with clear license disclosure and adopter acceptance. |
+
+Gaze ships as an open-source library that adopters compile into their products. Non-permissive defaults create downstream liability for adopters who did not choose that model license. Defaults therefore stay Apache-2.0/MIT only; every other backend needs an opt-in flag and clear license disclosure.
 
 ## Interpretation
 

--- a/docs/research/v0.9-ner-model-leaderboard.md
+++ b/docs/research/v0.9-ner-model-leaderboard.md
@@ -22,14 +22,14 @@ Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cell
 | 1 | Davlan multilingual BERT-NER (HRL) | AFL-3.0 | Yes | 0.558 / 0.125 / 0.200 | 0.518 / 0.661 / 0.558 | 1911.349 |
 | 2 | Babelscape WikiNeural Multilingual | CC-BY-NC-SA-4.0 | No, non-commercial | 0.476 / 0.125 / 0.194 | 0.507 / 0.667 / 0.547 | 1786.361 |
 | 3 | dslim/bert-base-NER (English) | MIT | Yes | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 |
-| 4 | Kiji DistilBERT | Apache-2.0 | Yes | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 222.059 |
+| 4 | Kiji DistilBERT | Apache-2.0 | Yes | 0.247 / 0.125 / 0.140 | 0.246 / 0.667 / 0.286 | 323.346 |
 
 ## Locale Detail
 
 | Model | Mode | Global P/R/F1 | EnUs P/R/F1 | DeDe P/R/F1 |
 |---|---|---:|---:|---:|
-| Kiji DistilBERT | Direct | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a |
-| Kiji DistilBERT | Observer residual | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a |
+| Kiji DistilBERT | Direct | 0.085 / 0.125 / 0.101 | 0.547 / 0.125 / 0.204 | 0.109 / 0.125 / 0.116 |
+| Kiji DistilBERT | Observer residual | 0.082 / 0.500 / 0.141 | 0.547 / 0.500 / 0.523 | 0.107 / 1.000 / 0.194 |
 | Babelscape WikiNeural Multilingual | Direct | 0.312 / 0.125 / 0.179 | 0.707 / 0.125 / 0.212 | 0.408 / 0.125 / 0.191 |
 | Babelscape WikiNeural Multilingual | Observer residual | 0.278 / 0.500 / 0.357 | 0.707 / 0.500 / 0.586 | 0.537 / 1.000 / 0.699 |
 | dslim/bert-base-NER (English) | Direct | 0.102 / 0.125 / 0.112 | 0.636 / 0.121 / 0.203 | 0.163 / 0.125 / 0.141 |
@@ -45,4 +45,4 @@ WikiNeural is included for evidence only because CC-BY-NC-SA-4.0 is non-commerci
 
 The top shippable candidate by observer-residual F1 is Davlan HRL. Its direct recall is still only 0.125 macro because the coverage-loop corpus includes many non-NER PII classes; the observer-residual view is more relevant for a post-rule safety net because it measures the residual text after Gaze's rule floor has already removed deterministic classes.
 
-The Kiji row uses the config-driven label map requested for this comparison (`ORG = Organization`, `MISC = Custom:other`). That differs from the older Kiji-specific scorer's broader mapping into `Name`, so the new leaderboard should be treated as the comparable config-driven baseline going forward.
+Kiji's `MISC` label is folded into `PiiClass::Name` per the shipped `kiji_label_to_pii_class` mapping, matching the deployed detector configuration. This is the canonical class map; benching with any alternative would not measure a shipping config.

--- a/docs/research/v0.9-ner-model-leaderboard.md
+++ b/docs/research/v0.9-ner-model-leaderboard.md
@@ -1,0 +1,48 @@
+# v0.9 NER Model Leaderboard
+
+This benchmark compares Hugging Face NER candidates as Gaze safety-net backends on the same committed coverage-loop corpus. The run uses the config in `benches/ner_models.toml` and writes the frozen evidence snapshot to `crates/gaze-recognizers/benches/ner_models_snapshot.json`.
+
+Command:
+
+```bash
+cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture
+.bench-venv/bin/python scripts/ner-bench-scorer.py --repo-root . --python .bench-venv/bin/python --mode all
+```
+
+Run date: 2026-05-15.
+
+Corpus: 150 fixtures, `target/coverage-report.json` SHA256 `760f96163a68ce5f7dbc0409aa5109aa1a3ed190001536647e1881ba9d40a49c`.
+
+## Leaderboard
+
+Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cells. Latency is median per fixture on CPU with one subprocess invocation per fixture, including Python import and model load.
+
+| Rank | Model | License | Shippable default? | Direct P/R/F1 | Observer-residual P/R/F1 | Median ms |
+|---:|---|---|---|---:|---:|---:|
+| 1 | Davlan multilingual BERT-NER (HRL) | AFL-3.0 | Yes | 0.558 / 0.125 / 0.200 | 0.518 / 0.661 / 0.558 | 1911.349 |
+| 2 | Babelscape WikiNeural Multilingual | CC-BY-NC-SA-4.0 | No, non-commercial | 0.476 / 0.125 / 0.194 | 0.507 / 0.667 / 0.547 | 1786.361 |
+| 3 | dslim/bert-base-NER (English) | MIT | Yes | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 |
+| 4 | Kiji DistilBERT | Apache-2.0 | Yes | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 222.059 |
+
+## Locale Detail
+
+| Model | Mode | Global P/R/F1 | EnUs P/R/F1 | DeDe P/R/F1 |
+|---|---|---:|---:|---:|
+| Kiji DistilBERT | Direct | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a |
+| Kiji DistilBERT | Observer residual | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a |
+| Babelscape WikiNeural Multilingual | Direct | 0.312 / 0.125 / 0.179 | 0.707 / 0.125 / 0.212 | 0.408 / 0.125 / 0.191 |
+| Babelscape WikiNeural Multilingual | Observer residual | 0.278 / 0.500 / 0.357 | 0.707 / 0.500 / 0.586 | 0.537 / 1.000 / 0.699 |
+| dslim/bert-base-NER (English) | Direct | 0.102 / 0.125 / 0.112 | 0.636 / 0.121 / 0.203 | 0.163 / 0.125 / 0.141 |
+| dslim/bert-base-NER (English) | Observer residual | 0.104 / 0.500 / 0.172 | 0.614 / 0.466 / 0.529 | 0.153 / 1.000 / 0.266 |
+| Davlan multilingual BERT-NER (HRL) | Direct | 0.294 / 0.125 / 0.175 | 0.690 / 0.125 / 0.212 | 0.690 / 0.125 / 0.212 |
+| Davlan multilingual BERT-NER (HRL) | Observer residual | 0.294 / 0.500 / 0.370 | 0.667 / 0.483 / 0.560 | 0.592 / 1.000 / 0.744 |
+
+## License Notes
+
+WikiNeural is included for evidence only because CC-BY-NC-SA-4.0 is non-commercial and cannot be shipped as the default model. The Davlan model metadata currently reports AFL-3.0, not Apache-2.0; this is permissive-style but should be checked before default shipment. dslim is MIT. Kiji DistilBERT is Apache-2.0.
+
+## Interpretation
+
+The top shippable candidate by observer-residual F1 is Davlan HRL. Its direct recall is still only 0.125 macro because the coverage-loop corpus includes many non-NER PII classes; the observer-residual view is more relevant for a post-rule safety net because it measures the residual text after Gaze's rule floor has already removed deterministic classes.
+
+The Kiji row uses the config-driven label map requested for this comparison (`ORG = Organization`, `MISC = Custom:other`). That differs from the older Kiji-specific scorer's broader mapping into `Name`, so the new leaderboard should be treated as the comparable config-driven baseline going forward.

--- a/docs/research/v0.9-safety-net-benchmark.md
+++ b/docs/research/v0.9-safety-net-benchmark.md
@@ -147,3 +147,7 @@ For Axis 4, the routing conclusion is narrow: where a local OPF install, source-
 - Kiji setup: [`docs/getting-started/kiji-safetynet-setup.md`](../getting-started/kiji-safetynet-setup.md)
 - Kiji taxonomy caveat: [`docs/research/v0.8-kiji-class-gap.md`](v0.8-kiji-class-gap.md)
 - Historical v0.8 Kiji-only benchmark: [`docs/research/v0.8-kiji-benchmark.md`](v0.8-kiji-benchmark.md)
+
+## See also
+
+- Multi-NER leaderboard: [`docs/research/v0.9-ner-model-leaderboard.md`](v0.9-ner-model-leaderboard.md). Its strategic read selects Kiji DistilBERT as the v0.9 default because it is Apache-2.0, tied for top observer-residual recall, and materially faster than the transformer alternatives in the checked-in one-shot benchmark.

--- a/scripts/ner-bench-scorer.py
+++ b/scripts/ner-bench-scorer.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Config-driven multi-model NER benchmark runner."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from safety_net_bench_lib import (
+    LOCALE_TAGS,
+    LatencyRecorder,
+    Span,
+    clean_fixtures,
+    load_fixtures,
+    rounded,
+    score_direct,
+    score_observer,
+    sha256_file,
+)
+
+
+EVALUATED_LOCALES = ["Global", "EnUs", "DeDe"]
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    id: str
+    display_name: str
+    hf_repo: str
+    hf_commit: str
+    bundle_sha: str
+    license: str
+    runtime: str
+    wrapper: Path
+    label_map: dict[str, str]
+    native_locales: list[str]
+    label_set: list[str]
+    fetch_script: Path | None
+    default_checkpoint: Path | None
+    shippable_default: bool
+    default_caveat: str | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--config", type=Path, default=Path("benches/ner_models.toml"))
+    parser.add_argument("--coverage-report", type=Path, default=Path("target/coverage-report.json"))
+    parser.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=Path("crates/gaze-recognizers/testdata/coverage-loop/corpus"),
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=Path("crates/gaze-recognizers/benches/ner_models_snapshot.json"),
+    )
+    parser.add_argument("--cache-dir", type=Path, default=Path(".huggingface-cache"))
+    parser.add_argument("--python", type=Path, default=Path(sys.executable))
+    parser.add_argument("--device", default="cpu", choices=["cpu"])
+    parser.add_argument("--model", action="append", help="Run only the selected model id.")
+    parser.add_argument("--mode", choices=["direct", "observer-residual", "all"], default="all")
+    parser.add_argument("--skip-download", action="store_true")
+    parser.add_argument("--no-update", action="store_true")
+    return parser.parse_args()
+
+
+def repo_path(root: Path, path: Path) -> Path:
+    return path.expanduser() if path.is_absolute() else root / path
+
+
+def load_config(path: Path) -> list[ModelConfig]:
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    models: list[ModelConfig] = []
+    for item in raw.get("model", []):
+        fetch_script = item.get("fetch_script")
+        default_checkpoint = item.get("default_checkpoint")
+        models.append(
+            ModelConfig(
+                id=str(item["id"]),
+                display_name=str(item["display_name"]),
+                hf_repo=str(item["hf_repo"]),
+                hf_commit=str(item["hf_commit"]),
+                bundle_sha=str(item["bundle_sha"]),
+                license=str(item["license"]),
+                runtime=str(item["runtime"]),
+                wrapper=Path(str(item["wrapper"])),
+                label_map={str(k): str(v) for k, v in item["label_map"].items()},
+                native_locales=[str(v) for v in item["native_locales"]],
+                label_set=[str(v) for v in item["label_set"]],
+                fetch_script=Path(str(fetch_script)) if fetch_script else None,
+                default_checkpoint=Path(str(default_checkpoint)).expanduser()
+                if default_checkpoint
+                else None,
+                shippable_default=bool(item.get("shippable_default", True)),
+                default_caveat=item.get("default_caveat"),
+            )
+        )
+    if not models:
+        raise ValueError(f"no [[model]] entries in {path}")
+    return models
+
+
+def model_checkpoint(root: Path, cache_dir: Path, model: ModelConfig) -> Path:
+    if model.default_checkpoint is not None:
+        return model.default_checkpoint
+    return cache_dir / "models" / model.id
+
+
+def checkpoint_complete(path: Path, model: ModelConfig) -> bool:
+    if not path.is_dir():
+        return False
+    if model.runtime == "onnxruntime":
+        return (path / "model.onnx").is_file() and (path / "tokenizer.json").is_file()
+    has_config = (path / "config.json").is_file()
+    has_tokenizer = (path / "tokenizer.json").is_file() or (path / "vocab.txt").is_file()
+    has_weights = any(
+        (path / name).is_file()
+        for name in ["model.safetensors", "pytorch_model.bin", "tf_model.h5", "flax_model.msgpack"]
+    )
+    return has_config and has_tokenizer and has_weights
+
+
+def ensure_checkpoint(
+    root: Path,
+    cache_dir: Path,
+    model: ModelConfig,
+    skip_download: bool,
+    python: Path,
+) -> Path:
+    checkpoint = model_checkpoint(root, cache_dir, model)
+    if checkpoint_complete(checkpoint, model):
+        return checkpoint
+    if skip_download:
+        raise FileNotFoundError(f"{model.id}: missing checkpoint {checkpoint}")
+
+    if model.fetch_script is not None:
+        script = repo_path(root, model.fetch_script)
+        subprocess.run([str(script), str(checkpoint)], cwd=root, check=True)
+        return checkpoint
+
+    checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    code = (
+        "from huggingface_hub import snapshot_download; "
+        "import sys; "
+        "snapshot_download(repo_id=sys.argv[1], revision=sys.argv[2], "
+        "local_dir=sys.argv[3], local_dir_use_symlinks=False, "
+        "allow_patterns=['*.json','*.txt','*.model','*.safetensors','*.bin','tokenizer*','vocab*','merges.txt','README.md'])"
+    )
+    subprocess.run(
+        [str(python), "-c", code, model.hf_repo, model.hf_commit, str(checkpoint)],
+        cwd=root,
+        env={**os.environ, "HF_HUB_DISABLE_XET": "1"},
+        check=True,
+    )
+    return checkpoint
+
+
+def sha256_dir(path: Path) -> str:
+    digest = hashlib.sha256()
+    for child in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = child.relative_to(path).as_posix().encode("utf-8")
+        digest.update(rel)
+        digest.update(b"\0")
+        digest.update(sha256_file(child).encode("ascii"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def run_model(
+    root: Path,
+    python: Path,
+    model: ModelConfig,
+    checkpoint: Path,
+    fixture_id: str,
+    text: str,
+    device: str,
+    latency: LatencyRecorder,
+) -> list[Span]:
+    command = [
+        str(python),
+        str(repo_path(root, model.wrapper)),
+        "--format",
+        "json",
+        "--output-mode",
+        "typed",
+    ]
+    if model.runtime == "onnxruntime":
+        command.extend(["--model-dir", str(checkpoint)])
+    else:
+        command.extend(["--checkpoint", str(checkpoint), "--device", device])
+
+    start = time.perf_counter()
+    proc = subprocess.run(
+        command,
+        input=text,
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    latency.record((time.perf_counter() - start) * 1000.0, len(text.encode("utf-8")))
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{model.id}/{fixture_id}: runner failed with {proc.returncode}: {proc.stderr.strip()}"
+        )
+
+    spans: list[Span] = []
+    for raw in json.loads(proc.stdout):
+        label = str(raw["label"])
+        pii_class = model.label_map.get(label)
+        if pii_class is None:
+            raise RuntimeError(f"{model.id}/{fixture_id}: unsupported label {label!r}")
+        spans.append(Span(int(raw["start"]), int(raw["end"]), pii_class))
+    return spans
+
+
+def run_one_model(
+    root: Path,
+    args: argparse.Namespace,
+    model: ModelConfig,
+    checkpoint: Path,
+    fixtures: list[Any],
+    clean: dict[str, Any] | None,
+) -> dict[str, Any]:
+    requested_modes = ["direct", "observer-residual"] if args.mode == "all" else [args.mode]
+    metrics_by_mode: dict[str, Any] = {}
+    latency = LatencyRecorder(True, [])
+
+    for mode in requested_modes:
+        predictions: dict[str, list[Span]] = {}
+        mode_latency = latency if mode == "direct" else LatencyRecorder(False, [])
+        for index, fixture in enumerate(fixtures, start=1):
+            input_text = fixture.text
+            if mode == "observer-residual":
+                assert clean is not None
+                input_text = clean[fixture.fixture_id].clean_text
+            predictions[fixture.fixture_id] = run_model(
+                root,
+                args.python,
+                model,
+                checkpoint,
+                fixture.fixture_id,
+                input_text,
+                args.device,
+                mode_latency,
+            )
+            print(
+                f"{model.id}: {mode} {index}/{len(fixtures)} {fixture.fixture_id} "
+                f"predictions={len(predictions[fixture.fixture_id])}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        matrix_mode = "direct_detector" if mode == "direct" else "observer_residual"
+        metrics_by_mode[matrix_mode] = (
+            score_direct(fixtures, predictions)
+            if mode == "direct"
+            else score_observer(fixtures, clean or {}, predictions)
+        )
+
+    return {
+        "metrics_by_mode": metrics_by_mode,
+        "latency": latency.summary(len(fixtures), args.device),
+    }
+
+
+def host_info() -> dict[str, str]:
+    return {
+        "os": platform.platform(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+    }
+
+
+def write_snapshot(
+    path: Path,
+    models: list[ModelConfig],
+    checkpoints: dict[str, Path],
+    bundle_shas: dict[str, str],
+    coverage_sha256: str,
+    corpus_sha256: str | None,
+    fixture_count: int,
+    results: dict[str, Any],
+) -> None:
+    snapshot: dict[str, Any] = {
+        "schema_version": 1,
+        "benchmark": "ner-model-leaderboard",
+        "status": "real_run",
+        "corpus": {
+            "coverage_report_sha256": coverage_sha256,
+            "sha256": corpus_sha256,
+            "fixture_count": fixture_count,
+        },
+        "run_environment": host_info(),
+        "models": {},
+        "cells": [],
+    }
+
+    for model in models:
+        snapshot["models"][model.id] = {
+            "display_name": model.display_name,
+            "hf_repo": model.hf_repo,
+            "hf_commit": model.hf_commit,
+            "bundle_sha256_config": model.bundle_sha,
+            "bundle_sha256_observed": bundle_shas[model.id],
+            "license": model.license,
+            "runtime": model.runtime,
+            "wrapper": model.wrapper.as_posix(),
+            "checkpoint": str(checkpoints[model.id]),
+            "native_locales": model.native_locales,
+            "label_set": model.label_set,
+            "label_map": model.label_map,
+            "shippable_default": model.shippable_default,
+            "default_caveat": model.default_caveat,
+        }
+        model_results = results[model.id]
+        for mode, metrics_by_locale in model_results["metrics_by_mode"].items():
+            for locale in EVALUATED_LOCALES:
+                metrics = metrics_by_locale[locale]
+                snapshot["cells"].append(
+                    {
+                        "model": model.id,
+                        "locale": locale,
+                        "native_locale": locale in model.native_locales,
+                        "mode": mode,
+                        "metrics": metrics,
+                    }
+                )
+        if model_results["latency"] is not None:
+            snapshot["models"][model.id]["latency"] = model_results["latency"]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(snapshot, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.repo_root.resolve()
+    args.config = repo_path(root, args.config)
+    args.coverage_report = repo_path(root, args.coverage_report)
+    args.corpus_dir = repo_path(root, args.corpus_dir)
+    args.snapshot = repo_path(root, args.snapshot)
+    args.cache_dir = repo_path(root, args.cache_dir)
+
+    models = load_config(args.config)
+    if args.model:
+        selected = set(args.model)
+        models = [model for model in models if model.id in selected]
+        missing = selected - {model.id for model in models}
+        if missing:
+            raise ValueError(f"unknown model id(s): {', '.join(sorted(missing))}")
+
+    if not args.coverage_report.is_file():
+        raise FileNotFoundError(f"missing coverage report: {args.coverage_report}")
+
+    fixtures = load_fixtures(args.corpus_dir)
+    report = json.loads(args.coverage_report.read_text(encoding="utf-8"))
+    expected_count = int(report["totals"]["fixture_count"])
+    if expected_count != len(fixtures):
+        raise ValueError(f"coverage report fixture_count {expected_count} != corpus {len(fixtures)}")
+
+    build_manifest = args.corpus_dir.parent / "build-manifest.json"
+    corpus_sha256 = None
+    if build_manifest.is_file():
+        corpus_sha256 = str(json.loads(build_manifest.read_text(encoding="utf-8"))["corpus_sha256"])
+
+    clean = clean_fixtures(root, fixtures) if args.mode in {"observer-residual", "all"} else None
+    checkpoints: dict[str, Path] = {}
+    bundle_shas: dict[str, str] = {}
+    results: dict[str, Any] = {}
+
+    for model in models:
+        checkpoint = ensure_checkpoint(root, args.cache_dir, model, args.skip_download, args.python)
+        observed_sha = sha256_dir(checkpoint)
+        print(f"{model.id}: checkpoint={checkpoint} sha256={observed_sha}", file=sys.stderr)
+        checkpoints[model.id] = checkpoint
+        bundle_shas[model.id] = observed_sha
+        results[model.id] = run_one_model(root, args, model, checkpoint, fixtures, clean)
+
+    if not args.no_update:
+        write_snapshot(
+            args.snapshot,
+            models,
+            checkpoints,
+            bundle_shas,
+            sha256_file(args.coverage_report),
+            corpus_sha256,
+            len(fixtures),
+            results,
+        )
+
+    json.dump(
+        {
+            "models": [model.id for model in models],
+            "snapshot": str(args.snapshot),
+            "results": results,
+        },
+        sys.stdout,
+        indent=2,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/transformers-runner.py
+++ b/scripts/transformers-runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generic Hugging Face transformers NER subprocess wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from transformers import pipeline
+
+
+MAX_INPUT_BYTES = 1024 * 1024
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", required=True, choices=["json"])
+    parser.add_argument("--output-mode", required=True, choices=["typed"])
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--device", default="cpu", choices=["cpu"])
+    return parser.parse_args(argv)
+
+
+def read_stdin() -> str:
+    raw = sys.stdin.buffer.read(MAX_INPUT_BYTES + 1)
+    if len(raw) > MAX_INPUT_BYTES:
+        raise RuntimeError(f"stdin exceeds {MAX_INPUT_BYTES} byte cap")
+    return raw.decode("utf-8")
+
+
+def normalize_label(raw: dict[str, Any]) -> str:
+    label = str(raw.get("entity_group") or raw.get("entity") or raw.get("label") or "")
+    if "-" in label:
+        prefix, rest = label.split("-", 1)
+        if prefix in {"B", "I"}:
+            label = rest
+    return label
+
+
+def run(checkpoint: Path | str, text: str) -> list[dict[str, Any]]:
+    if text == "":
+        return []
+
+    ner = pipeline(
+        "ner",
+        model=str(checkpoint),
+        tokenizer=str(checkpoint),
+        aggregation_strategy="simple",
+        device=-1,
+    )
+    spans: list[dict[str, Any]] = []
+    for raw in ner(text):
+        start = int(raw["start"])
+        end = int(raw["end"])
+        if start == end:
+            continue
+        spans.append(
+            {
+                "label": normalize_label(raw),
+                "start": start,
+                "end": end,
+                "score": float(raw.get("score", 0.0)),
+            }
+        )
+    return spans
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        spans = run(Path(args.checkpoint).expanduser(), read_stdin())
+        json.dump(spans, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:
+        print(f"transformers-runner: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Stacked on #243 / `v0.9-observer-residual-perf-33d`.

## Summary
- Added `benches/ner_models.toml` as the config source for NER model candidates, including commits, observed bundle SHA256 values, license metadata, native locales, and label maps.
- Added `scripts/transformers-runner.py`, a shared Hugging Face transformers NER runner for config-only model additions.
- Added `scripts/ner-bench-scorer.py`, which uses the shared safety-net bench library to run direct detection, observer-residual scoring, and latency for each model.
- Wrote real-run results to `crates/gaze-recognizers/benches/ner_models_snapshot.json` and summarized them in `docs/research/v0.9-ner-model-leaderboard.md`.

## Candidates benchmarked
| Model | License | Direct avg P/R/F1 | Observer avg P/R/F1 | Median latency |
| --- | --- | --- | --- | --- |
| Davlan multilingual BERT-NER (HRL) | AFL-3.0 from HF metadata | 0.558 / 0.125 / 0.200 | 0.518 / 0.661 / 0.558 | 1911.349 ms |
| Babelscape WikiNeural Multilingual | CC-BY-NC-SA-4.0, informational only / not default-shippable | 0.476 / 0.125 / 0.194 | 0.507 / 0.667 / 0.547 | 1786.361 ms |
| dslim/bert-base-NER (English) | MIT | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 ms |
| Kiji DistilBERT | Apache-2.0 | 0.000 / 0.000 / n/a | 0.000 / 0.000 / n/a | 222.059 ms |

## License notes
- WikiNeural is included for evidence only because CC-BY-NC-SA is non-commercial and should not be shipped as the default.
- Davlan HF metadata reports AFL-3.0 in this run, not Apache-2.0; treat that as a required legal/product check before any default decision.
- dslim is MIT and Kiji is Apache-2.0.

## Verification
- `cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture`
- `.bench-venv/bin/python scripts/ner-bench-scorer.py --repo-root . --python .bench-venv/bin/python --mode all`
- `cargo fmt --all`
- `.bench-venv/bin/python -m py_compile scripts/safety_net_bench_lib.py scripts/kiji-bench-scorer.py scripts/opf-bench-scorer.py scripts/kiji-runner.py scripts/transformers-runner.py scripts/ner-bench-scorer.py`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`