### PR TITLE
[agent] docs(readme): correct ghostwriter flow (app owns lookup, LLM owns prose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,46 @@ Your agent never sees a real email, phone number, or order ID. Your server keeps
 
 ## In production: AI support drafts that never see the customer
 
-[`EmpireTwo/gaze-ghostwriter`](https://github.com/EmpireTwo/gaze-ghostwriter) is a Laravel package that watches a support inbox over IMAP and drafts replies with an LLM. Every prompt and response crosses Gaze at one boundary:
+[`EmpireTwo/gaze-ghostwriter`](https://github.com/EmpireTwo/gaze-ghostwriter) is a Laravel package that watches a support inbox over IMAP and drafts replies with an LLM. The application does the data lookup. Gaze pseudonymizes the resulting context. The LLM only composes prose.
 
 ```text
 1. Customer email arrives via IMAP:
    "Hi Support, I'm Alice Schmidt, order #INV-2026-04-1872,
     my refund of €128.40 hasn't shown up..."
        ↓
-2. gaze redact tokenizes:
-   "Hi Support, I'm <Name_1>, order #<OrderId_1>,
-    my refund of <Amount_1> hasn't shown up..."
+2. App parses email → extracts identifiers:
+   sender=customer@..., order_id=INV-2026-04-1872, amount=€128.40
+       ↓
+3. App looks up order in DB (real PII, no LLM involved):
+   order #INV-2026-04-1872 → refund processed 2026-05-12,
+   customer = Alice Schmidt
+       ↓
+4. App builds context bundle (still real PII):
+   { name: "Alice Schmidt", order_id: "INV-2026-04-1872",
+     amount: "€128.40", refund_processed: "2026-05-12",
+     issue: "delayed refund" }
+       ↓
+5. gaze clean — pseudonymizes the bundle:
+   { name: "<Name_1>", order_id: "<OrderId_1>",
+     amount: "<Amount_1>", refund_processed: "<Date_1>",
+     issue: "delayed refund" }
    + per-session manifest stored
        ↓
-3. LLM drafts reply (sees only tokens):
-   "Hi <Name_1>, I've checked <OrderId_1> and confirmed your
-    refund of <Amount_1> was processed on..."
+6. LLM drafts reply (sees only tokens + facts):
+   "Hi <Name_1>, your refund of <Amount_1> for order <OrderId_1>
+    was processed on <Date_1>. Please allow 3-5 business days to
+    appear on your statement."
        ↓
-4. gaze restore rehydrates draft:
-   "Hi Alice Schmidt, I've checked #INV-2026-04-1872 and
-    confirmed your refund of €128.40 was processed on..."
+7. gaze restore rehydrates draft:
+   "Hi Alice Schmidt, your refund of €128.40 for order
+    #INV-2026-04-1872 was processed on 2026-05-12. Please allow
+    3-5 business days to appear on your statement."
        ↓
-5. Support agent reviews → approves → reply sent.
+8. Support agent reviews → approves → reply sent.
 
-LLM never saw "Alice Schmidt", "#INV-2026-04-1872", "€128.40".
-Manifest is the only mapping.
-Audit row records each token's recognizer-id + decided_by.
+LLM never saw "Alice Schmidt", "#INV-2026-04-1872", "€128.40", "2026-05-12".
+App owns the lookup. gaze owns the manifest. LLM owns the prose.
+Each layer's role is what it is built for.
 ```
 
 `OrderId` and refund-amount shapes are tenant-specific custom recognizers in the host policy; email, names, IBAN, phone, postal, and credit-card shapes come from the bundled `core` rulepack.


### PR DESCRIPTION
## Summary
- Corrects the README ghostwriter narrative so the application resolves order facts before pseudonymization.
- Replaces the misleading LLM “checked/confirmed” draft with an 8-step app lookup → gaze clean → LLM prose → gaze restore flow.
- Clarifies the layer split: app owns lookup, gaze owns the manifest, LLM owns prose.

## North star
Axis 5 (adopter mental model): this prevents engineers from thinking they need to expose order-lookup tools or DB access to the LLM. The LLM receives only pseudonymized tokens plus already-resolved facts.

## Also affected survey
gaze-ghostwriter README already framed correctly. The requested scan found no matches for `I've checked`, `confirmed your refund`, or `Alice Schmidt` in README/docs.

## Verification
- `cargo test --workspace --doc`