### PR TITLE
fix(ci): free preinstalled bloat to unblock ubuntu-latest disk-full

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space (ubuntu-latest preinstalled bloat removal)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Tesseract + English language pack (gaze-document)


### PR DESCRIPTION
## Summary

- Recent `test` workflow runs failed at worker startup with `System.IO.IOException: No space left on device` before any `cargo` step ran. Pattern is GitHub-hosted `ubuntu-latest` filling its disk via preinstalled Android SDK / .NET / Haskell / Docker images while the Rust target dir grows.
- Prepend `jlumbroso/free-disk-space@main` to the test job. Reclaims ~30 GB. Keeps `large-packages` and `swap-storage` off since those are slow to clear and not needed.

## Why this is safe

- Code on main is clean — verified locally:
  - `cargo fmt --all -- --check` ✓
  - `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✓
  - `cargo test --workspace --all-features` ✓ (44 test groups, 0 failed)
- Affected failing runs all showed the same trace-listener IO error with no cargo step started.

## Affected runs (all infra, not code)

25919430065, 25931362038, 25931398494, 25931433680, 25931703045, 25931817881, 25931906962

## Test plan

- [ ] CI on this PR passes (proves the fix works on the same runner pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)