### PR TITLE
feat(kiji): in-process ort backend (#366)

### DIFF
--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -150,7 +150,7 @@ Flags:
 | `--safety-net-add <backend>` | Adds one backend to the registry. Repeatable. First resolved backend wins for v1. |
 | `--openai-filter-command <path>` | Path to the local OpenAI Privacy Filter `opf` command. Required with the `openai-filter` backend. |
 | `--openai-filter-checkpoint <path>` | Path to the OPF checkpoint or model directory. Required with the `openai-filter` backend. |
-| `--openai-filter-operating-point <point>` | Operating point: `high-recall`, `balanced`, `high-precision`. |
+| `--kiji-backend <backend>` | Kiji runtime backend: `subprocess` (default, compatibility path) or `ort` (in-process ONNX Runtime). |
 | `--opf-command <path>` / `--opf-checkpoint <path>` | Registry-example aliases for the OpenAI Privacy Filter command and checkpoint. |
 | `--opf-locales <tag[,tag...]>` | Native locales for the OpenAI Privacy Filter registry entry. Empty keeps the backend default. |
 | `--kiji-distilbert-command <path>` | Path to the local Kiji DistilBERT subprocess command. Required with the `kiji-distilbert` backend. |
@@ -188,14 +188,16 @@ mature upstream. Trade-offs: heavier model and slower per-clean latency;
 no first-party fetch path; runtime depends on a third-party Python install
 the operator pins.
 
-**`kiji-distilbert`** (v0.8+) wraps a pinned DistilBERT NER model as a
-subprocess. Strengths: lightweight ONNX-served weights, faster startup,
-straightforward fetch script, second NER opinion at the chokepoint that
-complements OPF's class set. Trade-offs: narrower closed label set
+**`kiji-distilbert`** (v0.8+) wraps a pinned DistilBERT NER model. It
+supports `--kiji-backend=subprocess` for the existing external command path
+and `--kiji-backend=ort` for in-process ONNX Runtime inference without a
+Python install. Strengths: lightweight ONNX-served weights, straightforward
+fetch script, second NER opinion at the chokepoint that complements OPF's
+class set. Trade-offs: narrower closed label set
 (`person`, `location`, `organization`, `miscellaneous`) so financial-secret
 or account-number suspects are not surfaced; pinned-artifact contract
 requires `SHA256SUMS` present on disk (Axis-1 fail-closed — no silent
-disable).
+disable). The default remains `subprocess` for backwards compatibility.
 
 #### Setup
 

--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use super::{
-    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetFallback,
-    SafetyNetKind, SafetyNetMode,
+    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
+    SafetyNetFallback, SafetyNetKind, SafetyNetMode,
 };
 use crate::error::CliError;
 use crate::pipeline::{run_clean, CleanOptions};
@@ -29,6 +29,7 @@ pub(crate) struct Args {
     pub(crate) openai_filter_checkpoint: Option<PathBuf>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    pub(crate) kiji_backend: KijiBackend,
     pub(crate) opf_locales: Vec<String>,
     pub(crate) opf_command: Option<PathBuf>,
     pub(crate) opf_checkpoint: Option<PathBuf>,
@@ -64,6 +65,7 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
         openai_filter_operating_point: args.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
+        kiji_backend: args.kiji_backend,
         opf_locales: &args.opf_locales,
         opf_command: args.opf_command.as_deref(),
         opf_checkpoint: args.opf_checkpoint.as_deref(),

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -99,6 +99,9 @@ enum Cmd {
         /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
         #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
         openai_filter_device: OpenAiFilterDevice,
+        /// Kiji DistilBERT runtime backend. Default: subprocess for compatibility.
+        #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
+        kiji_backend: KijiBackend,
         /// Locale list for the OpenAI Privacy Filter registry entry.
         #[arg(long, value_delimiter = ',')]
         opf_locales: Vec<String>,
@@ -497,6 +500,12 @@ impl OpenAiFilterDevice {
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum KijiBackend {
+    Subprocess,
+    Ort,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SafetyNetMode {
     Strict,
     Tolerant,
@@ -535,6 +544,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_checkpoint,
             openai_filter_operating_point,
             openai_filter_device,
+            kiji_backend,
             opf_locales,
             opf_command,
             opf_checkpoint,
@@ -567,6 +577,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_checkpoint,
             openai_filter_operating_point,
             openai_filter_device,
+            kiji_backend,
             opf_locales,
             opf_command,
             opf_checkpoint,

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -20,8 +20,8 @@ use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
-    OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetFallback,
-    SafetyNetKind, SafetyNetMode, DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES,
+    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
+    SafetyNetFallback, SafetyNetKind, SafetyNetMode, DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES,
     DEFAULT_SAFETY_NET_TIMEOUT_MS,
 };
 use crate::error::CliError;
@@ -56,6 +56,7 @@ pub(crate) struct CleanOptions<'a> {
     pub(crate) openai_filter_checkpoint: Option<&'a Path>,
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    pub(crate) kiji_backend: KijiBackend,
     pub(crate) opf_locales: &'a [String],
     pub(crate) opf_command: Option<&'a Path>,
     pub(crate) opf_checkpoint: Option<&'a Path>,
@@ -492,18 +493,13 @@ fn kiji_distilbert_config(
     options: &CleanOptions<'_>,
     activation: &str,
 ) -> std::result::Result<
-    gaze_recognizers::safety_net::kiji_distilbert::SubprocessKijiConfig,
+    gaze_recognizers::safety_net::kiji_distilbert::KijiDistilbertConfig,
     CliError,
 > {
     use gaze_recognizers::safety_net::kiji_distilbert::{
-        SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+        KijiDistilbertConfig, OrtKijiConfig, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
     };
 
-    let command = options.kiji_distilbert_command.ok_or_else(|| {
-        CliError::SafetyNetConfigDetail(format!(
-            "--kiji-distilbert-command is required for {activation}"
-        ))
-    })?;
     let model_dir = options.kiji_distilbert_model_dir.ok_or_else(|| {
         CliError::SafetyNetConfigDetail(format!(
             "--kiji-distilbert-model-dir is required for {activation}"
@@ -527,10 +523,31 @@ fn kiji_distilbert_config(
         }
     }
 
-    Ok(SubprocessKijiConfig::new(command)
-        .with_model_dir(model_dir)
-        .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
-        .with_max_input_bytes(options.safety_net_input_limit_bytes))
+    match options.kiji_backend {
+        KijiBackend::Subprocess => {
+            let command = options.kiji_distilbert_command.ok_or_else(|| {
+                CliError::SafetyNetConfigDetail(format!(
+                    "--kiji-distilbert-command is required for {activation} with --kiji-backend=subprocess"
+                ))
+            })?;
+            let config = SubprocessKijiConfig::new(command)
+                .with_model_dir(model_dir)
+                .with_timeout(Duration::from_millis(options.safety_net_timeout_ms))
+                .with_max_input_bytes(options.safety_net_input_limit_bytes);
+            Ok(KijiDistilbertConfig::from(config))
+        }
+        KijiBackend::Ort => {
+            if options.kiji_distilbert_command.is_some() {
+                return Err(CliError::SafetyNetConfigDetail(
+                    "--kiji-distilbert-command is only valid with --kiji-backend=subprocess"
+                        .to_string(),
+                ));
+            }
+            let config = OrtKijiConfig::new(model_dir)
+                .with_max_input_bytes(options.safety_net_input_limit_bytes);
+            Ok(KijiDistilbertConfig::from(config))
+        }
+    }
 }
 
 #[cfg(not(feature = "safety-net-kiji"))]
@@ -549,6 +566,7 @@ fn validate_no_backend_options(options: &CleanOptions<'_>) -> std::result::Resul
         || options.openai_filter_checkpoint.is_some()
         || options.openai_filter_operating_point.is_some()
         || options.openai_filter_device != OpenAiFilterDevice::Auto
+        || options.kiji_backend != KijiBackend::Subprocess
         || options.opf_command.is_some()
         || options.opf_checkpoint.is_some()
         || !options.opf_locales.is_empty()

--- a/crates/gaze-recognizers/benches/safety_net_matrix.rs
+++ b/crates/gaze-recognizers/benches/safety_net_matrix.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "safety-net-kiji")]
 use gaze_recognizers::safety_net::kiji_distilbert::{
-    KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
-    KIJI_DISTILBERT_SHA256SUMS,
+    KijiDistilbertBackend, OrtKijiBackend, OrtKijiConfig, KIJI_DISTILBERT_BUNDLE_SHA256,
+    KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO, KIJI_DISTILBERT_SHA256SUMS,
 };
 #[cfg(feature = "safety-net-openai")]
 use gaze_recognizers::safety_net::openai_filter::backend::subprocess::{
@@ -17,6 +17,12 @@ const LOCALES: [&str; 3] = ["Global", "EnUs", "DeDe"];
 const MODES: [&str; 2] = ["direct_detector", "observer_residual"];
 
 fn main() {
+    #[cfg(feature = "safety-net-kiji")]
+    if std::env::var("GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND").as_deref() == Ok("ort") {
+        run_live_ort_bench();
+        return;
+    }
+
     let snapshot: Value =
         serde_json::from_str(SNAPSHOT).expect("valid safety-net matrix benchmark snapshot");
 
@@ -32,6 +38,33 @@ fn main() {
     assert_perf_snapshot();
 
     println!("{SNAPSHOT}");
+}
+
+#[cfg(feature = "safety-net-kiji")]
+fn run_live_ort_bench() {
+    use std::time::Instant;
+
+    let model_dir = std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+        .expect("GAZE_KIJI_DISTILBERT_MODEL_DIR is required for live ORT bench");
+    let cold_start = Instant::now();
+    let backend =
+        OrtKijiBackend::new(OrtKijiConfig::new(model_dir)).expect("load Kiji ORT backend");
+    let cold_start_ms = cold_start.elapsed().as_secs_f64() * 1000.0;
+    let fixture = "Alice Smith visited Berlin before meeting Dr. Schmidt at Example Corp.";
+    backend.infer(fixture).expect("warmup inference");
+
+    let mut samples = Vec::new();
+    for _ in 0..100 {
+        let start = Instant::now();
+        backend.infer(fixture).expect("inference");
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+    samples.sort_by(f64::total_cmp);
+    let p50_ms = samples[samples.len() / 2];
+    println!(
+        "{{\"backend\":\"kiji_distilbert_ort\",\"cold_start_ms\":{cold_start_ms:.3},\"warm_p50_ms\":{p50_ms:.3},\"iterations\":{}}}",
+        samples.len()
+    );
 }
 
 #[cfg(feature = "safety-net-kiji")]

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -1,7 +1,7 @@
 //! Transformer-based NER detector with pluggable backends.
 
 mod backend;
-mod decode;
+pub(crate) mod decode;
 mod detector;
 mod error;
 mod loader;

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/artifacts.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/artifacts.rs
@@ -1,0 +1,243 @@
+use std::path::Path;
+
+use gaze_types::SafetyNetError;
+use sha2::{Digest, Sha256};
+
+/// Files Kiji must ship under `model_dir` for the pinned-artifact contract.
+///
+/// Missing `SHA256SUMS` is an Axis-1 reliability defect: the runtime must
+/// fail closed rather than silently degrade. Mirrors the NER load contract
+/// in `crates/gaze/testdata/ner/`.
+pub const REQUIRED_KIJI_ARTIFACTS: &[&str] =
+    &["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"];
+
+/// Hugging Face repository for the canonical Kiji DistilBERT ONNX bundle.
+pub const KIJI_DISTILBERT_HF_REPO: &str = "onnx-community/distilbert-NER-ONNX";
+
+/// Immutable upstream revision used by `scripts/fetch-kiji-safetynet-model.sh`.
+pub const KIJI_DISTILBERT_HF_COMMIT: &str = "3a19fe9404a4469d91aa3d551558a97f68872f67";
+
+/// SHA256 of the canonical `SHA256SUMS` file for the bundle.
+///
+/// The runtime first verifies this digest, then verifies every artifact listed
+/// in the checksum file. That keeps the release-published checksum contract and
+/// local bytes tied together at load time.
+pub const KIJI_DISTILBERT_BUNDLE_SHA256: &str =
+    "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f";
+
+/// Canonical checksum file content. The model hash is the Hugging Face LFS
+/// SHA256 for `onnx/model.onnx` at `KIJI_DISTILBERT_HF_COMMIT`.
+pub const KIJI_DISTILBERT_SHA256SUMS: &str = concat!(
+    "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97  labels.json\n",
+    "b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5  model.onnx\n",
+    "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34  tokenizer.json\n",
+);
+
+/// Pinned-artifact contract: every entry in `REQUIRED_KIJI_ARTIFACTS` must exist
+/// under `model_dir`. Missing `SHA256SUMS` is a fail-closed condition (Axis 1).
+pub(crate) fn verify_model_dir(
+    model_dir: Option<&Path>,
+    expected_sha256: &str,
+) -> Result<(), SafetyNetError> {
+    let Some(dir) = model_dir else {
+        return Ok(());
+    };
+
+    if !dir.exists() {
+        return Err(SafetyNetError::WeightsMissing {
+            path: sanitize_path(dir),
+        });
+    }
+    verify_sensitive_tree(dir)?;
+
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        let artifact = dir.join(required);
+        if !artifact.exists() {
+            return Err(SafetyNetError::WeightsMissing {
+                path: sanitize_path(&artifact),
+            });
+        }
+    }
+    verify_bundle_integrity(dir, expected_sha256)?;
+    Ok(())
+}
+
+pub(crate) fn verify_bundle_integrity(
+    dir: &Path,
+    expected_sha256: &str,
+) -> Result<(), SafetyNetError> {
+    let sha256sums_path = dir.join("SHA256SUMS");
+    let sha256sums =
+        std::fs::read(&sha256sums_path).map_err(|_| SafetyNetError::WeightsMissing {
+            path: sanitize_path(&sha256sums_path),
+        })?;
+    let actual_sha256 = hex_sha256(&sha256sums);
+    if actual_sha256 != expected_sha256 {
+        return Err(SafetyNetError::ModelIntegrityMismatch {
+            expected: expected_sha256.to_string(),
+            actual: actual_sha256,
+        });
+    }
+
+    let checksums = parse_sha256sums(&sha256sums)?;
+    for required in REQUIRED_KIJI_ARTIFACTS {
+        if *required == "SHA256SUMS" {
+            continue;
+        }
+        let Some(expected_artifact_sha256) = checksums
+            .iter()
+            .find_map(|(sha256, name)| (name == required).then_some(sha256.as_str()))
+        else {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: format!("<checksum-entry:{required}>"),
+                actual: "<missing>".to_string(),
+            });
+        };
+        let artifact = dir.join(required);
+        let bytes = std::fs::read(&artifact).map_err(|_| SafetyNetError::WeightsMissing {
+            path: sanitize_path(&artifact),
+        })?;
+        let actual_artifact_sha256 = hex_sha256(&bytes);
+        if actual_artifact_sha256 != expected_artifact_sha256 {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: expected_artifact_sha256.to_string(),
+                actual: actual_artifact_sha256,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex::encode(digest)
+}
+
+fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| SafetyNetError::ModelIntegrityMismatch {
+        expected: "valid UTF-8 SHA256SUMS".to_string(),
+        actual: "<invalid-utf8>".to_string(),
+    })?;
+    let mut entries = Vec::new();
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        let mut fields = line.split_whitespace();
+        let sha256 = fields.next().unwrap_or_default();
+        let name = fields.next().unwrap_or_default();
+        if fields.next().is_some()
+            || sha256.len() != 64
+            || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
+            || !REQUIRED_KIJI_ARTIFACTS.contains(&name)
+            || name == "SHA256SUMS"
+            || name.contains('/')
+            || name.contains('\\')
+        {
+            return Err(SafetyNetError::ModelIntegrityMismatch {
+                expected: "canonical SHA256SUMS entries".to_string(),
+                actual: "<invalid>".to_string(),
+            });
+        }
+        entries.push((sha256.to_ascii_lowercase(), name.to_string()));
+    }
+    Ok(entries)
+}
+
+fn verify_sensitive_tree(path: &Path) -> Result<(), SafetyNetError> {
+    let metadata = verify_one_sensitive_path(path)?;
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to read kiji sensitive directory".to_string(),
+        })? {
+            let entry = entry.map_err(|_| SafetyNetError::ModelUnavailable {
+                reason: "failed to read kiji sensitive directory entry".to_string(),
+            })?;
+            verify_sensitive_tree(&entry.path())?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to inspect kiji sensitive path".to_string(),
+        })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must not be a symlink".to_string(),
+        });
+    }
+
+    let uid = current_uid();
+    if metadata.uid() != uid {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path owner mismatch".to_string(),
+        });
+    }
+
+    let mode = metadata.permissions().mode() & 0o777;
+    if file_type.is_dir() {
+        if mode != 0o700 {
+            return Err(SafetyNetError::ModelUnavailable {
+                reason: "kiji sensitive directory must be mode 0700".to_string(),
+            });
+        }
+    } else if file_type.is_file() {
+        if mode & 0o022 != 0 {
+            return Err(SafetyNetError::ModelUnavailable {
+                reason: "kiji sensitive file must not be group/world writable".to_string(),
+            });
+        }
+    } else {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must be a regular file or directory".to_string(),
+        });
+    }
+
+    Ok(metadata)
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    std::fs::metadata(".")
+        .map(|metadata| {
+            use std::os::unix::fs::MetadataExt;
+            metadata.uid()
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(windows)]
+fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
+            reason: "failed to inspect kiji sensitive path".to_string(),
+        })?;
+    if metadata.file_type().is_symlink() {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must not be a symlink".to_string(),
+        });
+    }
+    if !(metadata.file_type().is_file() || metadata.file_type().is_dir()) {
+        return Err(SafetyNetError::ModelUnavailable {
+            reason: "kiji sensitive path must be a regular file or directory".to_string(),
+        });
+    }
+    if metadata.permissions().readonly() {
+        return Ok(metadata);
+    }
+    Err(SafetyNetError::ModelUnavailable {
+        reason: "kiji sensitive Windows ACL could not be verified".to_string(),
+    })
+}
+
+fn sanitize_path(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("<missing:{name}>"))
+        .unwrap_or_else(|| "<missing:model>".to_string())
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 
 use gaze_types::SafetyNetError;
 
+pub mod artifacts;
+pub mod ort;
 pub mod subprocess;
 
 /// Internal Kiji span after PII-bearing upstream fields have been dropped.
@@ -34,6 +36,21 @@ pub trait KijiDistilbertBackend: Send + Sync {
     fn version(&self) -> &str;
     fn decoding_params(&self) -> &[(&str, String)];
     fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError>;
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum KijiBackendKind {
+    Subprocess,
+    Ort,
+}
+
+impl KijiBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Subprocess => "subprocess",
+            Self::Ort => "ort",
+        }
+    }
 }
 
 pub(crate) fn normalize_raw_spans(

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
@@ -1,0 +1,429 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use gaze_types::SafetyNetError;
+
+use super::artifacts::{verify_model_dir, KIJI_DISTILBERT_BUNDLE_SHA256};
+use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
+use crate::ner::decode::{softmax_confidence, split_bio};
+
+const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
+const MODEL_FILE: &str = "model.onnx";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+const ID2LABEL: [&str; 9] = [
+    "O", "B-PER", "I-PER", "B-LOC", "I-LOC", "B-ORG", "I-ORG", "B-MISC", "I-MISC",
+];
+
+/// Configuration for the in-process Kiji DistilBERT ONNX Runtime backend.
+#[derive(Debug, Clone)]
+pub struct OrtKijiConfig {
+    model_dir: PathBuf,
+    max_input_bytes: usize,
+    version: String,
+    decoding_params: Vec<(&'static str, String)>,
+    #[cfg(any(test, feature = "test-support"))]
+    expected_bundle_sha256: String,
+}
+
+impl OrtKijiConfig {
+    pub fn new(model_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            model_dir: model_dir.into(),
+            max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+            version: "kiji/distilbert:ort".to_string(),
+            decoding_params: vec![("runtime", "ort".to_string())],
+            #[cfg(any(test, feature = "test-support"))]
+            expected_bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
+        }
+    }
+
+    pub fn from_env() -> Result<Self, SafetyNetError> {
+        let model_dir = std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR").ok_or_else(|| {
+            SafetyNetError::Unavailable {
+                reason: "GAZE_KIJI_DISTILBERT_MODEL_DIR is not set".to_string(),
+            }
+        })?;
+        Ok(Self::new(model_dir))
+    }
+
+    pub fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
+        self.max_input_bytes = max_input_bytes;
+        self
+    }
+
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = version.into();
+        self
+    }
+
+    pub fn with_decoding_param(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.decoding_params.push((key, value.into()));
+        self
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn with_expected_bundle_sha256_for_tests(mut self, sha256: impl Into<String>) -> Self {
+        self.expected_bundle_sha256 = sha256.into();
+        self
+    }
+
+    pub fn model_dir(&self) -> &Path {
+        &self.model_dir
+    }
+
+    fn expected_bundle_sha256(&self) -> &str {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            &self.expected_bundle_sha256
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            KIJI_DISTILBERT_BUNDLE_SHA256
+        }
+    }
+}
+
+/// In-process Kiji DistilBERT ONNX Runtime backend.
+#[derive(Debug)]
+pub struct OrtKijiBackend {
+    config: OrtKijiConfig,
+    tokenizer: tokenizers::Tokenizer,
+    session: Mutex<ort::session::Session>,
+    has_token_type_ids: bool,
+}
+
+impl OrtKijiBackend {
+    pub fn new(config: OrtKijiConfig) -> Result<Self, SafetyNetError> {
+        verify_model_dir(Some(config.model_dir()), config.expected_bundle_sha256())?;
+        let tokenizer = tokenizers::Tokenizer::from_file(config.model_dir.join(TOKENIZER_FILE))
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji tokenizer: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let session = ort::session::Session::builder()
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to initialize kiji ort session: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?
+            .commit_from_file(config.model_dir.join(MODEL_FILE))
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji ort model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let has_token_type_ids = session
+            .inputs()
+            .iter()
+            .any(|input| input.name() == "token_type_ids");
+        Ok(Self {
+            config,
+            tokenizer,
+            session: Mutex::new(session),
+            has_token_type_ids,
+        })
+    }
+
+    pub fn config(&self) -> &OrtKijiConfig {
+        &self.config
+    }
+}
+
+impl KijiDistilbertBackend for OrtKijiBackend {
+    fn id(&self) -> &str {
+        "kiji-distilbert-ort"
+    }
+
+    fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    fn decoding_params(&self) -> &[(&str, String)] {
+        &self.config.decoding_params
+    }
+
+    fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError> {
+        let actual = clean.len();
+        if actual > self.config.max_input_bytes {
+            return Err(SafetyNetError::InputTooLarge {
+                limit: self.config.max_input_bytes,
+                actual,
+            });
+        }
+
+        let encoded =
+            self.tokenizer
+                .encode(clean, true)
+                .map_err(|err| SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji tokenizer failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                })?;
+        let offsets = encoded.get_offsets();
+        let ids = encoded.get_ids();
+        let attention = encoded.get_attention_mask();
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let seq_len = ids.len();
+        let input_ids: Vec<i64> = ids.iter().map(|&value| value as i64).collect();
+        let attn_mask: Vec<i64> = attention.iter().map(|&value| value as i64).collect();
+        let shape = [1usize, seq_len];
+        let input_ids_tensor =
+            ort::value::Tensor::from_array((shape, input_ids)).map_err(|err| {
+                SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji input_ids tensor failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                }
+            })?;
+        let attn_tensor = ort::value::Tensor::from_array((shape, attn_mask)).map_err(|err| {
+            SafetyNetError::Runtime {
+                message: format!(
+                    "kiji attention_mask tensor failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            }
+        })?;
+        let inputs = if self.has_token_type_ids {
+            let token_type: Vec<i64> = vec![0; seq_len];
+            let type_tensor =
+                ort::value::Tensor::from_array((shape, token_type)).map_err(|err| {
+                    SafetyNetError::Runtime {
+                        message: format!(
+                            "kiji token_type_ids tensor failed: {}",
+                            sanitize_error(&err.to_string())
+                        ),
+                    }
+                })?;
+            ort::inputs![
+                "input_ids" => input_ids_tensor,
+                "attention_mask" => attn_tensor,
+                "token_type_ids" => type_tensor,
+            ]
+        } else {
+            ort::inputs![
+                "input_ids" => input_ids_tensor,
+                "attention_mask" => attn_tensor,
+            ]
+        };
+
+        let mut session = self.session.lock().map_err(|err| SafetyNetError::Runtime {
+            message: format!(
+                "kiji ort session lock poisoned: {}",
+                sanitize_error(&err.to_string())
+            ),
+        })?;
+        let outputs = session.run(inputs).map_err(|err| SafetyNetError::Runtime {
+            message: format!(
+                "kiji ort inference failed: {}",
+                sanitize_error(&err.to_string())
+            ),
+        })?;
+        let logits = match outputs.iter().next() {
+            Some((_, value)) => value,
+            None => return Ok(Vec::new()),
+        };
+        let (shape_obj, flat) =
+            logits
+                .try_extract_tensor::<f32>()
+                .map_err(|err| SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji ort output failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                })?;
+        let shape: Vec<usize> = shape_obj.iter().map(|dim| *dim as usize).collect();
+        if shape.len() != 3 || shape[0] != 1 || shape[1] != seq_len {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "kiji ort returned invalid logits shape".to_string(),
+            });
+        }
+
+        let num_labels = shape[2];
+        let mut subword_labels: Vec<&str> = Vec::with_capacity(seq_len);
+        let mut subword_scores = Vec::with_capacity(seq_len);
+        for pos in 0..seq_len {
+            let base = pos * num_labels;
+            let row = &flat[base..base + num_labels];
+            let (argmax, _) =
+                row.iter()
+                    .enumerate()
+                    .fold((0usize, f32::NEG_INFINITY), |acc, (index, &value)| {
+                        if value > acc.1 {
+                            (index, value)
+                        } else {
+                            acc
+                        }
+                    });
+            subword_labels.push(ID2LABEL.get(argmax).copied().unwrap_or("O"));
+            subword_scores.push(softmax_confidence(row, argmax));
+        }
+
+        normalize_raw_spans(
+            merge_kiji_bio_spans(clean, offsets, &subword_labels, &subword_scores),
+            clean,
+        )
+    }
+}
+
+fn merge_kiji_bio_spans(
+    source: &str,
+    subword_spans: &[(usize, usize)],
+    subword_labels: &[&str],
+    subword_scores: &[f32],
+) -> Vec<RawSpan> {
+    let (effective_labels, effective_scores) =
+        bridge_joiner_tokens(source, subword_spans, subword_labels, subword_scores);
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < effective_labels.len() {
+        let tag = effective_labels[index].as_str();
+        let (prefix, entity) = split_bio(tag);
+        if prefix == 'O' || entity.is_empty() {
+            index += 1;
+            continue;
+        }
+        let Some(label) = kiji_entity_label(entity) else {
+            index += 1;
+            continue;
+        };
+        let (start, mut end) = subword_spans[index];
+        if start == end {
+            index += 1;
+            continue;
+        }
+        let mut span_score = *effective_scores.get(index).unwrap_or(&0.0);
+        let mut next = index + 1;
+        while next < effective_labels.len() {
+            let (next_prefix, next_entity) = split_bio(effective_labels[next].as_str());
+            if next_prefix == 'I' && next_entity == entity {
+                let (next_start, next_end) = subword_spans[next];
+                if next_start != next_end {
+                    end = next_end;
+                    span_score = span_score.min(*effective_scores.get(next).unwrap_or(&0.0));
+                }
+                next += 1;
+            } else {
+                break;
+            }
+        }
+        out.push(RawSpan::new(start, end, label, Some(span_score)));
+        index = next;
+    }
+    out
+}
+
+fn bridge_joiner_tokens(
+    source: &str,
+    subword_spans: &[(usize, usize)],
+    subword_labels: &[&str],
+    subword_scores: &[f32],
+) -> (Vec<String>, Vec<f32>) {
+    let mut effective_labels = subword_labels
+        .iter()
+        .map(|label| (*label).to_string())
+        .collect::<Vec<_>>();
+    let mut effective_scores = (0..subword_labels.len())
+        .map(|index| *subword_scores.get(index).unwrap_or(&0.0))
+        .collect::<Vec<_>>();
+
+    for index in 1..subword_labels.len().saturating_sub(1) {
+        let (prefix, _) = split_bio(subword_labels[index]);
+        if prefix != 'O' {
+            continue;
+        }
+        let (start, end) = subword_spans[index];
+        let Some(token_text) = source.get(start..end) else {
+            continue;
+        };
+        if !is_entity_joiner_token(token_text) {
+            continue;
+        }
+        let (prev_prefix, prev_entity) = split_bio(subword_labels[index - 1]);
+        if !matches!(prev_prefix, 'B' | 'I') || prev_entity.is_empty() {
+            continue;
+        }
+        let (next_prefix, next_entity) = split_bio(subword_labels[index + 1]);
+        if !matches!(next_prefix, 'B' | 'I') || next_entity != prev_entity {
+            continue;
+        }
+        if next_prefix == 'B' && token_text.trim() == "," {
+            continue;
+        }
+        effective_labels[index] = format!("I-{prev_entity}");
+        if next_prefix == 'B' {
+            effective_labels[index + 1] = format!("I-{prev_entity}");
+        }
+        let prev_score = *subword_scores.get(index - 1).unwrap_or(&0.0);
+        let next_score = *subword_scores.get(index + 1).unwrap_or(&0.0);
+        effective_scores[index] = (prev_score + next_score) / 2.0;
+    }
+
+    (effective_labels, effective_scores)
+}
+
+fn is_entity_joiner_token(text: &str) -> bool {
+    let trimmed = text.trim();
+    !trimmed.is_empty() && trimmed.chars().all(|ch| ".,@_-+:/#%&=".contains(ch))
+}
+
+fn kiji_entity_label(entity: &str) -> Option<&'static str> {
+    match entity {
+        "PER" => Some("person"),
+        "LOC" => Some("location"),
+        "ORG" => Some("organization"),
+        "MISC" => Some("miscellaneous"),
+        _ => None,
+    }
+}
+
+fn sanitize_error(message: &str) -> String {
+    message
+        .split_ascii_whitespace()
+        .map(sanitize_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_token(token: &str) -> String {
+    if token.contains('@') {
+        return "<redacted>".to_string();
+    }
+
+    let digit_count = token.bytes().filter(u8::is_ascii_digit).count();
+    if digit_count >= 7 {
+        return "<redacted>".to_string();
+    }
+
+    token.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merges_kiji_bio_to_private_labels() {
+        let source = "Alice visits Berlin";
+        let spans = [(0, 5), (6, 12), (13, 19)];
+        let labels = ["B-PER", "O", "B-LOC"];
+        let scores = [0.9, 0.1, 0.8];
+        let out = merge_kiji_bio_spans(source, &spans, &labels, &scores);
+        assert_eq!(
+            out,
+            vec![
+                RawSpan::new(0, 5, "person", Some(0.9)),
+                RawSpan::new(13, 19, "location", Some(0.8)),
+            ]
+        );
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
@@ -7,8 +7,8 @@ use std::time::{Duration, Instant};
 
 use gaze_types::SafetyNetError;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 
+use super::artifacts::{verify_model_dir, KIJI_DISTILBERT_BUNDLE_SHA256};
 use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
 use crate::safety_net::kiji_distilbert::class_map::map_kiji_label;
 
@@ -17,36 +17,6 @@ const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
 const DEFAULT_MAX_STDOUT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_VERBOSE_STDERR_BYTES: usize = 256;
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
-
-/// Files Kiji must ship under `model_dir` for the pinned-artifact contract.
-///
-/// Missing `SHA256SUMS` is an Axis-1 reliability defect: the runtime must
-/// fail closed rather than silently degrade. Mirrors the NER load contract
-/// in `crates/gaze/testdata/ner/`.
-pub const REQUIRED_KIJI_ARTIFACTS: &[&str] =
-    &["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"];
-
-/// Hugging Face repository for the canonical Kiji DistilBERT ONNX bundle.
-pub const KIJI_DISTILBERT_HF_REPO: &str = "onnx-community/distilbert-NER-ONNX";
-
-/// Immutable upstream revision used by `scripts/fetch-kiji-safetynet-model.sh`.
-pub const KIJI_DISTILBERT_HF_COMMIT: &str = "3a19fe9404a4469d91aa3d551558a97f68872f67";
-
-/// SHA256 of the canonical `SHA256SUMS` file for the bundle.
-///
-/// The runtime first verifies this digest, then verifies every artifact listed
-/// in the checksum file. That keeps the release-published checksum contract and
-/// local bytes tied together at load time.
-pub const KIJI_DISTILBERT_BUNDLE_SHA256: &str =
-    "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f";
-
-/// Canonical checksum file content. The model hash is the Hugging Face LFS
-/// SHA256 for `onnx/model.onnx` at `KIJI_DISTILBERT_HF_COMMIT`.
-pub const KIJI_DISTILBERT_SHA256SUMS: &str = concat!(
-    "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97  labels.json\n",
-    "b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5  model.onnx\n",
-    "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34  tokenizer.json\n",
-);
 
 /// Configuration for the local Kiji DistilBERT subprocess backend.
 #[derive(Debug, Clone)]
@@ -558,211 +528,12 @@ fn verify_command_path(command: &Path) -> Result<(), SafetyNetError> {
     Ok(())
 }
 
-/// Pinned-artifact contract: every entry in `REQUIRED_KIJI_ARTIFACTS` must exist
-/// under `model_dir`. Missing `SHA256SUMS` is a fail-closed condition (Axis 1).
-fn verify_model_dir(model_dir: Option<&Path>, expected_sha256: &str) -> Result<(), SafetyNetError> {
-    let Some(dir) = model_dir else {
-        return Ok(());
-    };
-
-    if !dir.exists() {
-        return Err(SafetyNetError::WeightsMissing {
-            path: sanitize_path(dir),
-        });
-    }
-    verify_sensitive_tree(dir)?;
-
-    for required in REQUIRED_KIJI_ARTIFACTS {
-        let artifact = dir.join(required);
-        if !artifact.exists() {
-            return Err(SafetyNetError::WeightsMissing {
-                path: sanitize_path(&artifact),
-            });
-        }
-    }
-    verify_bundle_integrity(dir, expected_sha256)?;
-    Ok(())
-}
-
-fn verify_bundle_integrity(dir: &Path, expected_sha256: &str) -> Result<(), SafetyNetError> {
-    let sha256sums_path = dir.join("SHA256SUMS");
-    let sha256sums =
-        std::fs::read(&sha256sums_path).map_err(|_| SafetyNetError::WeightsMissing {
-            path: sanitize_path(&sha256sums_path),
-        })?;
-    let actual_sha256 = hex_sha256(&sha256sums);
-    if actual_sha256 != expected_sha256 {
-        return Err(SafetyNetError::ModelIntegrityMismatch {
-            expected: expected_sha256.to_string(),
-            actual: actual_sha256,
-        });
-    }
-
-    let checksums = parse_sha256sums(&sha256sums)?;
-    for required in REQUIRED_KIJI_ARTIFACTS {
-        if *required == "SHA256SUMS" {
-            continue;
-        }
-        let Some(expected_artifact_sha256) = checksums
-            .iter()
-            .find_map(|(sha256, name)| (name == required).then_some(sha256.as_str()))
-        else {
-            return Err(SafetyNetError::ModelIntegrityMismatch {
-                expected: format!("<checksum-entry:{required}>"),
-                actual: "<missing>".to_string(),
-            });
-        };
-        let artifact = dir.join(required);
-        let bytes = std::fs::read(&artifact).map_err(|_| SafetyNetError::WeightsMissing {
-            path: sanitize_path(&artifact),
-        })?;
-        let actual_artifact_sha256 = hex_sha256(&bytes);
-        if actual_artifact_sha256 != expected_artifact_sha256 {
-            return Err(SafetyNetError::ModelIntegrityMismatch {
-                expected: expected_artifact_sha256.to_string(),
-                actual: actual_artifact_sha256,
-            });
-        }
-    }
-
-    Ok(())
-}
-
-fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetError> {
-    let text = std::str::from_utf8(bytes).map_err(|_| SafetyNetError::ModelIntegrityMismatch {
-        expected: "valid UTF-8 SHA256SUMS".to_string(),
-        actual: "<invalid-utf8>".to_string(),
-    })?;
-    let mut entries = Vec::new();
-    for line in text.lines().filter(|line| !line.trim().is_empty()) {
-        let mut fields = line.split_whitespace();
-        let sha256 = fields.next().unwrap_or_default();
-        let name = fields.next().unwrap_or_default();
-        if fields.next().is_some()
-            || sha256.len() != 64
-            || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
-            || !REQUIRED_KIJI_ARTIFACTS.contains(&name)
-            || name == "SHA256SUMS"
-            || name.contains('/')
-            || name.contains('\\')
-        {
-            return Err(SafetyNetError::ModelIntegrityMismatch {
-                expected: "canonical SHA256SUMS entries".to_string(),
-                actual: "<invalid>".to_string(),
-            });
-        }
-        entries.push((sha256.to_ascii_lowercase(), name.to_string()));
-    }
-    Ok(entries)
-}
-
-fn hex_sha256(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    hex::encode(digest)
-}
-
-fn verify_sensitive_tree(path: &Path) -> Result<(), SafetyNetError> {
-    let metadata = verify_one_sensitive_path(path)?;
-    if metadata.is_dir() {
-        for entry in std::fs::read_dir(path).map_err(|_| SafetyNetError::ModelUnavailable {
-            reason: "failed to read kiji sensitive directory".to_string(),
-        })? {
-            let entry = entry.map_err(|_| SafetyNetError::ModelUnavailable {
-                reason: "failed to read kiji sensitive directory entry".to_string(),
-            })?;
-            verify_sensitive_tree(&entry.path())?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
-
-    let metadata =
-        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
-            reason: "failed to inspect kiji sensitive path".to_string(),
-        })?;
-    let file_type = metadata.file_type();
-    if file_type.is_symlink() {
-        return Err(SafetyNetError::ModelUnavailable {
-            reason: "kiji sensitive path must not be a symlink".to_string(),
-        });
-    }
-
-    let uid = current_uid();
-    if metadata.uid() != uid {
-        return Err(SafetyNetError::ModelUnavailable {
-            reason: "kiji sensitive path owner mismatch".to_string(),
-        });
-    }
-
-    let mode = metadata.permissions().mode() & 0o777;
-    if file_type.is_dir() {
-        if mode != 0o700 {
-            return Err(SafetyNetError::ModelUnavailable {
-                reason: "kiji sensitive directory must be mode 0700".to_string(),
-            });
-        }
-    } else if file_type.is_file() {
-        if mode & 0o022 != 0 {
-            return Err(SafetyNetError::ModelUnavailable {
-                reason: "kiji sensitive file must not be group/world writable".to_string(),
-            });
-        }
-    } else {
-        return Err(SafetyNetError::ModelUnavailable {
-            reason: "kiji sensitive path must be a regular file or directory".to_string(),
-        });
-    }
-
-    Ok(metadata)
-}
-
-#[cfg(unix)]
-fn current_uid() -> u32 {
-    std::fs::metadata(".")
-        .map(|metadata| {
-            use std::os::unix::fs::MetadataExt;
-            metadata.uid()
-        })
-        .unwrap_or(0)
-}
-
-#[cfg(windows)]
-fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNetError> {
-    let metadata =
-        std::fs::symlink_metadata(path).map_err(|_| SafetyNetError::ModelUnavailable {
-            reason: "failed to inspect kiji sensitive path".to_string(),
-        })?;
-    if metadata.file_type().is_symlink() {
-        return Err(SafetyNetError::ModelUnavailable {
-            reason: "kiji sensitive path must not be a symlink".to_string(),
-        });
-    }
-    if !(metadata.file_type().is_file() || metadata.file_type().is_dir()) {
-        return Err(SafetyNetError::ModelUnavailable {
-            reason: "kiji sensitive path must be a regular file or directory".to_string(),
-        });
-    }
-    if metadata.permissions().readonly() {
-        return Ok(metadata);
-    }
-    Err(SafetyNetError::ModelUnavailable {
-        reason: "kiji sensitive Windows ACL could not be verified".to_string(),
-    })
-}
-
-fn sanitize_path(path: &Path) -> String {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| format!("<missing:{name}>"))
-        .unwrap_or_else(|| "<missing:model>".to_string())
-}
-
 #[cfg(test)]
 mod tests {
+    use super::super::artifacts::{
+        hex_sha256, KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT,
+        KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS,
+    };
     use super::*;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -20,34 +20,47 @@ use crate::{LocaleAwareModel, ModelError, ModelHints, ModelInput, ModelSpan};
 pub mod backend;
 pub mod class_map;
 
-pub use backend::subprocess::{
-    SubprocessKijiBackend, SubprocessKijiConfig, KIJI_DISTILBERT_BUNDLE_SHA256,
-    KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO, KIJI_DISTILBERT_SHA256SUMS,
-    REQUIRED_KIJI_ARTIFACTS,
+pub use backend::artifacts::{
+    KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
+    KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS,
 };
-pub use backend::{KijiDistilbertBackend, RawSpan};
+pub use backend::ort::{OrtKijiBackend, OrtKijiConfig};
+pub use backend::subprocess::{SubprocessKijiBackend, SubprocessKijiConfig};
+pub use backend::{KijiBackendKind, KijiDistilbertBackend, RawSpan};
 pub use class_map::{
     kiji_label_to_pii_class, kiji_label_to_safety_net_class, map_kiji_label, validate_kiji_label,
     KijiLabel,
 };
+
+pub type KijiOrtBackend = OrtKijiBackend;
+pub type KijiOrtConfig = OrtKijiConfig;
 
 /// Safety-net implementation backed by a lazily initialized Kiji subprocess.
 ///
 /// Same caching strategy as `OpenAiFilterSafetyNet`: deterministic init
 /// failures (missing SHA256SUMS, missing artifacts, bad perms) cache in a
 /// `OnceLock` so we never retry-storm on every check.
-#[derive(Debug)]
 pub struct KijiDistilbertSafetyNet {
     locales: Vec<LocaleTag>,
-    config: SubprocessKijiConfig,
-    backend: OnceLock<Result<Arc<SubprocessKijiBackend>, Arc<SafetyNetError>>>,
+    config: KijiDistilbertConfig,
+    backend: OnceLock<Result<Arc<dyn KijiDistilbertBackend>, Arc<SafetyNetError>>>,
+}
+
+impl std::fmt::Debug for KijiDistilbertSafetyNet {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("KijiDistilbertSafetyNet")
+            .field("locales", &self.locales)
+            .field("backend_kind", &self.backend_kind())
+            .finish_non_exhaustive()
+    }
 }
 
 impl KijiDistilbertSafetyNet {
-    pub fn new(config: SubprocessKijiConfig) -> Self {
+    pub fn new(config: impl Into<KijiDistilbertConfig>) -> Self {
         Self {
             locales: vec![LocaleTag::Global],
-            config,
+            config: config.into(),
             backend: OnceLock::new(),
         }
     }
@@ -56,20 +69,62 @@ impl KijiDistilbertSafetyNet {
         Ok(Self::new(SubprocessKijiConfig::from_env()?))
     }
 
+    pub fn from_env_ort() -> Result<Self, SafetyNetError> {
+        Ok(Self::new(OrtKijiConfig::from_env()?))
+    }
+
+    pub fn backend_kind(&self) -> KijiBackendKind {
+        self.config.kind()
+    }
+
     pub fn with_locales(mut self, locales: Vec<LocaleTag>) -> Self {
         self.locales = locales;
         self
     }
 
-    fn backend(&self) -> Result<Arc<SubprocessKijiBackend>, SafetyNetError> {
-        match self.backend.get_or_init(|| {
-            SubprocessKijiBackend::new(self.config.clone())
-                .map(Arc::new)
-                .map_err(Arc::new)
-        }) {
+    fn backend(&self) -> Result<Arc<dyn KijiDistilbertBackend>, SafetyNetError> {
+        match self.backend.get_or_init(|| self.config.load_backend()) {
             Ok(backend) => Ok(Arc::clone(backend)),
             Err(error) => Err((**error).clone()),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum KijiDistilbertConfig {
+    Subprocess(SubprocessKijiConfig),
+    Ort(OrtKijiConfig),
+}
+
+impl KijiDistilbertConfig {
+    pub fn kind(&self) -> KijiBackendKind {
+        match self {
+            Self::Subprocess(_) => KijiBackendKind::Subprocess,
+            Self::Ort(_) => KijiBackendKind::Ort,
+        }
+    }
+
+    fn load_backend(&self) -> Result<Arc<dyn KijiDistilbertBackend>, Arc<SafetyNetError>> {
+        match self {
+            Self::Subprocess(config) => SubprocessKijiBackend::new(config.clone())
+                .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
+                .map_err(Arc::new),
+            Self::Ort(config) => OrtKijiBackend::new(config.clone())
+                .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
+                .map_err(Arc::new),
+        }
+    }
+}
+
+impl From<SubprocessKijiConfig> for KijiDistilbertConfig {
+    fn from(config: SubprocessKijiConfig) -> Self {
+        Self::Subprocess(config)
+    }
+}
+
+impl From<OrtKijiConfig> for KijiDistilbertConfig {
+    fn from(config: OrtKijiConfig) -> Self {
+        Self::Ort(config)
     }
 }
 

--- a/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
+++ b/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
@@ -12,7 +12,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use gaze_recognizers::safety_net::kiji_distilbert::{
-    KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+    KijiDistilbertBackend, KijiDistilbertSafetyNet, OrtKijiBackend, OrtKijiConfig,
+    SubprocessKijiBackend, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
 };
 use gaze_types::{DocumentKind, LocaleTag, Manifest, SafetyNet, SafetyNetContext, SafetyNetError};
 use sha2::{Digest, Sha256};
@@ -122,4 +123,31 @@ fn subprocess_span_round_trips_through_manifest_diff() {
     assert_eq!(suspect.raw_label, "person");
     assert_eq!(suspect.span, 0..11);
     assert_eq!(suspect.score, Some(0.97));
+}
+
+#[test]
+fn ort_matches_subprocess_for_fixture_inputs_when_real_kiji_is_configured() {
+    let Some(command) = std::env::var_os("GAZE_KIJI_DISTILBERT_COMMAND") else {
+        eprintln!("skipping parity test: GAZE_KIJI_DISTILBERT_COMMAND is not set");
+        return;
+    };
+    let Some(model_dir) = std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR") else {
+        eprintln!("skipping parity test: GAZE_KIJI_DISTILBERT_MODEL_DIR is not set");
+        return;
+    };
+
+    let subprocess = SubprocessKijiBackend::new(
+        SubprocessKijiConfig::new(command).with_model_dir(PathBuf::from(&model_dir)),
+    )
+    .unwrap();
+    let ort = OrtKijiBackend::new(OrtKijiConfig::new(PathBuf::from(model_dir))).unwrap();
+    for fixture in [
+        "Alice Smith visited Berlin.",
+        "Dr. Schmidt works at Example Corp.",
+        "The package moved from Paris to Example Labs.",
+    ] {
+        let left = subprocess.infer(fixture).unwrap();
+        let right = ort.infer(fixture).unwrap();
+        assert_eq!(right, left, "fixture: {fixture}");
+    }
 }

--- a/docs/architecture/safety-nets.md
+++ b/docs/architecture/safety-nets.md
@@ -61,13 +61,13 @@ can land without changing the trait shape or audit schema.
    │   │                      │  │                            │     │
    │   │  ─ heavier weights   │  │  ─ 8.8 MB DistilBERT       │     │
    │   │  ─ OpenAI's PII set  │  │  ─ 26 PII classes (Kiji)   │     │
-   │   │  ─ requires `opf`    │  │  ─ ONNX subprocess         │     │
+   │   │  ─ requires `opf`    │  │  ─ subprocess or ORT       │     │
    │   │    binary install    │  │  ─ tokenizers crate        │     │
    │   └──────────┬───────────┘  └────────────┬───────────────┘     │
    │              │                            │                     │
    │              └──────────────┬─────────────┘                     │
    │                             ▼                                   │
-   │   Subprocess contract identical for both:                       │
+   │   External subprocess contract:                                 │
    │       stdin  ← clean_text (post-tokenization!)                  │
    │       stdout → JSON span array [{start, end, label, score}, …]  │
    │                                                                 │
@@ -83,6 +83,8 @@ can land without changing the trait shape or audit schema.
 ```
 
 ## Locale-Aware Registry Dispatch
+
+Kiji DistilBERT has two runtime backends under the same observer-only safety-net contract. `--kiji-backend=subprocess` remains the default for backwards compatibility and for adopters who already pin an external Kiji command; `--kiji-backend=ort` loads the same tokenizer and ONNX model in-process through ONNX Runtime, removing the Python/subprocess install path. Both backends must verify the pinned bundle first: `SHA256SUMS` is hashed against `KIJI_DISTILBERT_BUNDLE_SHA256`, every listed artifact is re-hashed before model load, and any mismatch returns a typed `SafetyNetError` without silent fallback.
 
 `Pipeline::with_safety_net(single_backend)` remains the compatibility path. For deployments with language-specific safety nets, `Pipeline::with_safety_net_registry(LocaleAwareModelRegistry)` activates locale-aware Pass-3 dispatch instead. The registry resolves one backend per clean segment using the existing four-tier order: exact locale, parent language, `Global`, then fail-closed.
 


### PR DESCRIPTION
## Scope

- Adds `OrtKijiBackend` alongside the existing subprocess backend; subprocess remains the default for backwards compatibility.
- Extracts shared Kiji bundle artifact verification so both backends run the same pinned `KIJI_DISTILBERT_BUNDLE_SHA256` gate before any model/session load.
- Adds explicit backend selection through `KijiDistilbertConfig`, `KijiDistilbertSafetyNet::from_env_ort`, CLI `--kiji-backend {subprocess|ort}`, and the existing pipeline registration path.
- Extends the safety-net matrix bench to run ORT when `GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort` is set.
- Documents the subprocess vs ORT backend choice and shared checksum contract.

## Bench

Command:

```sh
GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort \
GAZE_KIJI_DISTILBERT_MODEL_DIR=/tmp/gaze-kiji-distilbert-bench \
cargo bench -p gaze-recognizers --bench safety_net_matrix --features safety-net-kiji
```

Result:

```json
{"backend":"kiji_distilbert_ort","cold_start_ms":609.969,"warm_p50_ms":2.981,"iterations":100}
```

Warm p50 meets the <10ms target. Cold start missed the <200ms target on this machine; the observed pinned ONNX artifact was ~248MB, and session initialization dominated cold start.

## Five-axis check

- Reliability: strengthens fail-closed model loading by sharing the same checksum gate across subprocess and ORT; no silent fallback.
- Reversibility: unchanged manifest/restore contract; backend only emits suspect spans.
- Agentic-first: keeps runtime backend selection explicit for CLI and programmatic adopters.
- Trust: ORT errors are mapped to typed `SafetyNetError` variants; backend identity/version remains explicit.
- Adopter ergonomics: ORT path removes the Python subprocess requirement while preserving subprocess for existing adopters.

## Gates

- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: passed
- `cargo test --workspace --all-features`: passed
- `cargo run -p xtask -- ci-feature-matrix`: passed
