### PR TITLE
docs(readme): remove link to private demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Each layer's role is what it is built for.
 ### Try the loop
 
 - Drop-in Laravel package: [`EmpireTwo/gaze-ghostwriter`](https://github.com/EmpireTwo/gaze-ghostwriter)
-- Runnable demo with a per-message `See cleanup` modal: [`EmpireTwo/gaze-laravel-demo-gw-ticks`](https://github.com/EmpireTwo/gaze-laravel-demo-gw-ticks)
 
 Agentic workflows (browser automation, tool execution) hook the same restore boundary at tool-call args, on the same manifest contract — the agent stays on tokens end-to-end.
 


### PR DESCRIPTION
## Summary

- README.md line 58 linked to \`EmpireTwo/gaze-laravel-demo-gw-ticks\` which is a private repository.
- Public README must not link to private repos — readers without org access get a 404 and lose trust in the rest of the docs.
- Removed the line; the \`gaze-ghostwriter\` link above it remains as the public adopter entry point.

## Test plan

- [ ] Visit README.md on the PR branch and confirm the "Try the loop" section now has only the public ghostwriter link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)