### PR TITLE
feat(pipeline): tier 4 — skip-gating + prefix cache (#370)

### DIFF
--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -344,12 +344,16 @@ impl SqliteLogger {
         let validator_fail_reason = serialize_json_column(entry.validator_fail_reason.as_ref())?;
         let ambiguity_record = serialize_json_column(entry.ambiguity_record.as_ref())?;
         let fallback_triggered = entry.fallback_triggered.map(fallback_reason_to_db);
+        let provenance_confidence = entry
+            .provenance_confidence
+            .as_deref()
+            .and_then(|value| value.parse::<f64>().ok());
         let conn = self
             .conn
             .lock()
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27)",
             params![
                 entry.source,
                 entry.recognizer_id,
@@ -367,6 +371,17 @@ impl SqliteLogger {
                 entry.collision_family,
                 entry.collision_variant,
                 fallback_triggered,
+                entry.provenance_stage,
+                entry.provenance_model_id,
+                entry.provenance_model_version,
+                entry.provenance_artifact_sha256,
+                entry.provenance_tokenizer_sha256,
+                entry.provenance_locale_resolved,
+                entry.provenance_locale_match_kind,
+                entry.provenance_canonical_class,
+                entry.provenance_native_class,
+                provenance_confidence,
+                entry.provenance_merged_from,
             ],
         )
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1799,6 +1799,18 @@ pub struct RedactionEntry {
     pub collision_variant: Option<String>,
     /// Safety-net fallback reason, when fallback policy handled the row.
     pub fallback_triggered: Option<FallbackReason>,
+    /// NER/pipeline provenance stage for audit-only producer attribution.
+    pub provenance_stage: Option<String>,
+    pub provenance_model_id: Option<String>,
+    pub provenance_model_version: Option<String>,
+    pub provenance_artifact_sha256: Option<String>,
+    pub provenance_tokenizer_sha256: Option<String>,
+    pub provenance_locale_resolved: Option<String>,
+    pub provenance_locale_match_kind: Option<String>,
+    pub provenance_canonical_class: Option<String>,
+    pub provenance_native_class: Option<String>,
+    pub provenance_confidence: Option<String>,
+    pub provenance_merged_from: Option<String>,
 }
 
 impl Serialize for RedactionEntry {
@@ -1815,6 +1827,22 @@ impl Serialize for RedactionEntry {
         if self.recognizer_version_id.is_some() {
             len += 1;
         }
+        len += [
+            self.provenance_stage.as_ref(),
+            self.provenance_model_id.as_ref(),
+            self.provenance_model_version.as_ref(),
+            self.provenance_artifact_sha256.as_ref(),
+            self.provenance_tokenizer_sha256.as_ref(),
+            self.provenance_locale_resolved.as_ref(),
+            self.provenance_locale_match_kind.as_ref(),
+            self.provenance_canonical_class.as_ref(),
+            self.provenance_native_class.as_ref(),
+            self.provenance_confidence.as_ref(),
+            self.provenance_merged_from.as_ref(),
+        ]
+        .into_iter()
+        .filter(|value| value.is_some())
+        .count();
         let mut state = serializer.serialize_struct("RedactionEntry", len)?;
         state.serialize_field("source", &self.source)?;
         if let Some(recognizer_id) = &self.recognizer_id {
@@ -1842,6 +1870,39 @@ impl Serialize for RedactionEntry {
         state.serialize_field("collision_family", &self.collision_family)?;
         state.serialize_field("collision_variant", &self.collision_variant)?;
         state.serialize_field("fallback_triggered", &self.fallback_triggered)?;
+        if let Some(value) = &self.provenance_stage {
+            state.serialize_field("provenance_stage", value)?;
+        }
+        if let Some(value) = &self.provenance_model_id {
+            state.serialize_field("provenance_model_id", value)?;
+        }
+        if let Some(value) = &self.provenance_model_version {
+            state.serialize_field("provenance_model_version", value)?;
+        }
+        if let Some(value) = &self.provenance_artifact_sha256 {
+            state.serialize_field("provenance_artifact_sha256", value)?;
+        }
+        if let Some(value) = &self.provenance_tokenizer_sha256 {
+            state.serialize_field("provenance_tokenizer_sha256", value)?;
+        }
+        if let Some(value) = &self.provenance_locale_resolved {
+            state.serialize_field("provenance_locale_resolved", value)?;
+        }
+        if let Some(value) = &self.provenance_locale_match_kind {
+            state.serialize_field("provenance_locale_match_kind", value)?;
+        }
+        if let Some(value) = &self.provenance_canonical_class {
+            state.serialize_field("provenance_canonical_class", value)?;
+        }
+        if let Some(value) = &self.provenance_native_class {
+            state.serialize_field("provenance_native_class", value)?;
+        }
+        if let Some(value) = &self.provenance_confidence {
+            state.serialize_field("provenance_confidence", value)?;
+        }
+        if let Some(value) = &self.provenance_merged_from {
+            state.serialize_field("provenance_merged_from", value)?;
+        }
         state.end()
     }
 }
@@ -1913,6 +1974,17 @@ impl RedactionEntry {
             collision_family: None,
             collision_variant: None,
             fallback_triggered: None,
+            provenance_stage: None,
+            provenance_model_id: None,
+            provenance_model_version: None,
+            provenance_artifact_sha256: None,
+            provenance_tokenizer_sha256: None,
+            provenance_locale_resolved: None,
+            provenance_locale_match_kind: None,
+            provenance_canonical_class: None,
+            provenance_native_class: None,
+            provenance_confidence: None,
+            provenance_merged_from: None,
         }
     }
 
@@ -1953,6 +2025,35 @@ impl RedactionEntry {
     ) -> Self {
         self.recognizer_id = recognizer_id;
         self.recognizer_version_id = recognizer_version_id;
+        self
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_provenance_metadata(
+        mut self,
+        stage: Option<String>,
+        model_id: Option<String>,
+        model_version: Option<String>,
+        artifact_sha256: Option<String>,
+        tokenizer_sha256: Option<String>,
+        locale_resolved: Option<String>,
+        locale_match_kind: Option<String>,
+        canonical_class: Option<String>,
+        native_class: Option<String>,
+        confidence: Option<f64>,
+        merged_from: Option<String>,
+    ) -> Self {
+        self.provenance_stage = stage;
+        self.provenance_model_id = model_id;
+        self.provenance_model_version = model_version;
+        self.provenance_artifact_sha256 = artifact_sha256;
+        self.provenance_tokenizer_sha256 = tokenizer_sha256;
+        self.provenance_locale_resolved = locale_resolved;
+        self.provenance_locale_match_kind = locale_match_kind;
+        self.provenance_canonical_class = canonical_class;
+        self.provenance_native_class = native_class;
+        self.provenance_confidence = confidence.map(|value| value.to_string());
+        self.provenance_merged_from = merged_from;
         self
     }
 }
@@ -2578,6 +2679,17 @@ mod redaction_logger_tests {
             collision_family: None,
             collision_variant: None,
             fallback_triggered: None,
+            provenance_stage: None,
+            provenance_model_id: None,
+            provenance_model_version: None,
+            provenance_artifact_sha256: None,
+            provenance_tokenizer_sha256: None,
+            provenance_locale_resolved: None,
+            provenance_locale_match_kind: None,
+            provenance_canonical_class: None,
+            provenance_native_class: None,
+            provenance_confidence: None,
+            provenance_merged_from: None,
         };
 
         let trait_object: &dyn RedactionLogger = &logger;

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -56,3 +56,7 @@ trybuild = "1"
 [[bench]]
 name = "pipeline_end_to_end"
 harness = false
+
+[[bench]]
+name = "tier4_pipeline_gating"
+harness = false

--- a/crates/gaze/benches/tier4_pipeline_gating.rs
+++ b/crates/gaze/benches/tier4_pipeline_gating.rs
@@ -1,0 +1,239 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use gaze::{
+    Action, ClassRule, DefaultRule, Detection, Detector, DictionaryBundle, LeakSuspect, Pipeline,
+    PipelineOptimizationConfig, RawDocument, SafetyNet, SafetyNetContext, SafetyNetError,
+    SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope, Session,
+};
+
+#[derive(Clone)]
+struct EmailDetector;
+
+impl Detector for EmailDetector {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        input
+            .find("alice@example.invalid")
+            .map(|start| {
+                Detection::new(
+                    start..start + "alice@example.invalid".len(),
+                    gaze::PiiClass::Email,
+                    "bench.email",
+                )
+            })
+            .into_iter()
+            .collect()
+    }
+}
+
+struct SlowSafetyNet {
+    calls: Arc<AtomicUsize>,
+}
+
+struct SlowNameDetector {
+    bytes: Arc<AtomicUsize>,
+}
+
+impl Detector for SlowNameDetector {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        self.bytes.fetch_add(input.len(), Ordering::SeqCst);
+        thread::sleep(Duration::from_micros(
+            (input.len() as u64).saturating_mul(10),
+        ));
+        input
+            .find("Dr. Schmidt")
+            .map(|start| {
+                Detection::new(
+                    start..start + "Dr. Schmidt".len(),
+                    gaze::PiiClass::Name,
+                    "bench.name",
+                )
+            })
+            .into_iter()
+            .collect()
+    }
+}
+
+impl SafetyNet for SlowSafetyNet {
+    fn id(&self) -> &str {
+        "bench-slow"
+    }
+
+    fn supported_locales(&self) -> &[gaze::LocaleTag] {
+        &[gaze::LocaleTag::Global]
+    }
+
+    fn check(
+        &self,
+        _clean_text: &str,
+        _context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        thread::sleep(Duration::from_micros(100));
+        Ok(Vec::new())
+    }
+}
+
+fn main() {
+    let corpus = corpus();
+    let baseline = run_config("baseline", PipelineOptimizationConfig::default(), &corpus);
+    let skip_class = run_config(
+        "skip_class_gating",
+        PipelineOptimizationConfig::new().with_skip_class_gating(true),
+        &corpus,
+    );
+    let capitals = run_config(
+        "capitals_heuristic_gate",
+        PipelineOptimizationConfig::new().with_capitals_heuristic_gate(true),
+        &corpus,
+    );
+    let combined = run_config(
+        "combined_skip_and_capitals",
+        PipelineOptimizationConfig::new()
+            .with_skip_class_gating(true)
+            .with_capitals_heuristic_gate(true),
+        &corpus,
+    );
+    println!(
+        "{{\"baseline\":{},\"configs\":[{},{},{}],\"prefix_cache\":{}}}",
+        baseline.to_json(None),
+        skip_class.to_json(Some(&baseline)),
+        capitals.to_json(Some(&baseline)),
+        combined.to_json(Some(&baseline)),
+        run_prefix_cache_bench(),
+    );
+}
+
+fn corpus() -> Vec<String> {
+    let mut inputs = Vec::new();
+    for index in 0..100 {
+        inputs.push(format!("Reach alice@example.invalid about case {index}"));
+        inputs.push(format!("lowercase status update number {index}"));
+        inputs.push(format!("20260515-0000-{index:04}-999999"));
+    }
+    inputs
+}
+
+fn run_config(
+    name: &'static str,
+    optimization_config: PipelineOptimizationConfig,
+    corpus: &[String],
+) -> BenchResult {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let pipeline = Pipeline::builder()
+        .detector(EmailDetector)
+        .rule(ClassRule::new(gaze::PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(SlowSafetyNet {
+            calls: Arc::clone(&calls),
+        })
+        .pipeline_optimizations(optimization_config)
+        .build()
+        .expect("pipeline");
+    let dictionaries = DictionaryBundle::default();
+    let start = Instant::now();
+    for input in corpus {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let (_, _, report) = pipeline
+            .clean_with_safety_net_policy_detect_context(
+                &session,
+                RawDocument::Text(input.clone()),
+                &[gaze::LocaleTag::Global],
+                &dictionaries,
+                SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
+            )
+            .expect("clean");
+        assert_eq!(
+            report.stats.suspect_count, 0,
+            "recall-preserving empty report"
+        );
+    }
+    BenchResult {
+        name,
+        calls: calls.load(Ordering::SeqCst),
+        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+    }
+}
+
+fn run_prefix_cache_bench() -> String {
+    let baseline = run_prefix_cache_config("baseline", false);
+    let cached = run_prefix_cache_config("prefix_cache", true);
+    let byte_reduction = 1.0 - (cached.bytes_processed as f64 / baseline.bytes_processed as f64);
+    let latency_reduction = 1.0 - (cached.elapsed_ms / baseline.elapsed_ms);
+    format!(
+        "{{\"baseline\":{},\"cached\":{},\"byte_reduction\":{:.4},\"latency_reduction\":{:.4}}}",
+        baseline.to_json(),
+        cached.to_json(),
+        byte_reduction,
+        latency_reduction,
+    )
+}
+
+fn run_prefix_cache_config(name: &'static str, enabled: bool) -> PrefixBenchResult {
+    let bytes = Arc::new(AtomicUsize::new(0));
+    let pipeline = Pipeline::builder()
+        .detector(SlowNameDetector {
+            bytes: Arc::clone(&bytes),
+        })
+        .rule(ClassRule::new(gaze::PiiClass::Name, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .pipeline_optimizations(PipelineOptimizationConfig::new().with_prefix_cache(enabled))
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let start = Instant::now();
+    for index in 0..100 {
+        pipeline
+            .redact(
+                &session,
+                RawDocument::Text(format!("Dr. Schmidt reports {index}")),
+            )
+            .expect("redact");
+    }
+    PrefixBenchResult {
+        name,
+        bytes_processed: bytes.load(Ordering::SeqCst),
+        elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+    }
+}
+
+struct BenchResult {
+    name: &'static str,
+    calls: usize,
+    elapsed_ms: f64,
+}
+
+impl BenchResult {
+    fn to_json(&self, baseline: Option<&BenchResult>) -> String {
+        let reduction = baseline
+            .map(|baseline| {
+                if baseline.calls == 0 {
+                    0.0
+                } else {
+                    1.0 - (self.calls as f64 / baseline.calls as f64)
+                }
+            })
+            .unwrap_or(0.0);
+        format!(
+            "{{\"name\":\"{}\",\"safety_net_calls\":{},\"elapsed_ms\":{:.3},\"call_reduction\":{:.4}}}",
+            self.name, self.calls, self.elapsed_ms, reduction
+        )
+    }
+}
+
+struct PrefixBenchResult {
+    name: &'static str,
+    bytes_processed: usize,
+    elapsed_ms: f64,
+}
+
+impl PrefixBenchResult {
+    fn to_json(&self) -> String {
+        format!(
+            "{{\"name\":\"{}\",\"detector_bytes_processed\":{},\"elapsed_ms\":{:.3}}}",
+            self.name, self.bytes_processed, self.elapsed_ms
+        )
+    }
+}

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -38,7 +38,8 @@ pub use gaze_types::{
 };
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{
-    Error, Pipeline, PipelineBuilder, Result, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
+    Error, Pipeline, PipelineBuilder, PipelineOptimizationConfig, Result, SafetyNetFallback,
+    SafetyNetMode, SafetyNetPolicy,
 };
 pub use policy::{
     validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -59,6 +59,8 @@ pub enum Error {
     RedactionLog(#[from] RedactionLogError),
     #[error("safety net fallback failed closed: {0:?}")]
     SafetyNetFallback(FallbackReason),
+    #[error("capitals heuristic gate is unsupported for locale {locale}")]
+    UnsupportedCapitalHeuristicLocale { locale: String },
     #[error("unsupported raw document variant")]
     UnsupportedRawDocumentVariant,
     #[error("unsupported structured value variant")]
@@ -89,6 +91,37 @@ pub enum SafetyNetFallback {
 pub struct SafetyNetPolicy {
     pub mode: SafetyNetMode,
     pub fallback: SafetyNetFallback,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PipelineOptimizationConfig {
+    pub skip_class_gating: bool,
+    pub capitals_heuristic_gate: bool,
+    pub prefix_cache: bool,
+    pub length_bucketing: bool,
+}
+
+impl PipelineOptimizationConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn with_skip_class_gating(mut self, enabled: bool) -> Self {
+        self.skip_class_gating = enabled;
+        self
+    }
+    pub fn with_capitals_heuristic_gate(mut self, enabled: bool) -> Self {
+        self.capitals_heuristic_gate = enabled;
+        self
+    }
+    pub fn with_prefix_cache(mut self, enabled: bool) -> Self {
+        self.prefix_cache = enabled;
+        self
+    }
+    pub fn with_length_bucketing(mut self, enabled: bool) -> Self {
+        self.length_bucketing = enabled;
+        self
+    }
 }
 
 impl Default for SafetyNetPolicy {
@@ -144,6 +177,7 @@ pub struct Pipeline {
     safety_nets: Vec<Arc<dyn SafetyNet>>,
     #[cfg(feature = "bundled-recognizers")]
     safety_net_registry: Option<Arc<LocaleAwareModelRegistry>>,
+    optimization_config: PipelineOptimizationConfig,
     rules: Vec<Arc<dyn Rule>>,
 }
 
@@ -181,6 +215,11 @@ impl Pipeline {
         N: SafetyNet + 'static,
     {
         self.safety_nets.push(Arc::new(safety_net));
+        self
+    }
+
+    pub fn with_pipeline_optimizations(mut self, config: PipelineOptimizationConfig) -> Pipeline {
+        self.optimization_config = config;
         self
     }
 
@@ -281,6 +320,7 @@ impl Pipeline {
                     locale_chain,
                     dictionaries,
                     &mut report,
+                    policy,
                 )?;
                 Ok((CleanDocument::Structured(clean), Vec::new(), report))
             }
@@ -300,6 +340,7 @@ impl Pipeline {
                     DocumentKind::Text,
                     locale_chain,
                     None,
+                    policy.mode,
                 )?;
                 self.apply_safety_net_policy(
                     session,
@@ -337,6 +378,7 @@ impl Pipeline {
             DocumentKind::Text,
             locale_chain,
             None,
+            SafetyNetMode::Strict,
         )?;
         Ok(SafetyNetResult { nets_run, report })
     }
@@ -386,6 +428,71 @@ impl Pipeline {
 
     #[allow(clippy::too_many_arguments)]
     fn redact_text_with_manifest(
+        &self,
+        session: &Session,
+        text: &str,
+        field_name: Option<&str>,
+        document_kind: DocumentKind,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+    ) -> Result<CleanText> {
+        if self.optimization_config.prefix_cache {
+            if let Some(hit) = session
+                .lookup_prefix_cache(text)
+                .filter(|hit| hit.raw_len < text.len())
+            {
+                let suffix = &text[hit.raw_len..];
+                let suffix_clean = self.redact_text_with_manifest_uncached(
+                    session,
+                    suffix,
+                    field_name,
+                    document_kind,
+                    locale_chain,
+                    dictionaries,
+                )?;
+                let clean_offset = hit.clean_text.len();
+                let raw_offset = hit.raw_len;
+                let mut manifest = hit.manifest.clone();
+                manifest.extend(suffix_clean.manifest.into_iter().map(|mut span| {
+                    span.clean_span.start += clean_offset;
+                    span.clean_span.end += clean_offset;
+                    span.raw_span.start += raw_offset;
+                    span.raw_span.end += raw_offset;
+                    span
+                }));
+                let mut clean_text = hit.clean_text;
+                clean_text.push_str(&suffix_clean.text);
+                self.log_prefix_cache_entries(
+                    session,
+                    &hit.manifest,
+                    field_name,
+                    document_kind,
+                    locale_chain,
+                )?;
+                session.store_prefix_cache(text, &clean_text, &manifest);
+                return Ok(CleanText {
+                    text: clean_text,
+                    manifest,
+                });
+            }
+        }
+
+        let clean = self.redact_text_with_manifest_uncached(
+            session,
+            text,
+            field_name,
+            document_kind,
+            locale_chain,
+            dictionaries,
+        )?;
+        if self.optimization_config.prefix_cache {
+            session.store_prefix_cache(text, &clean.text, &clean.manifest);
+        }
+        Ok(clean)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn redact_text_with_manifest_uncached(
         &self,
         session: &Session,
         text: &str,
@@ -487,6 +594,7 @@ impl Pipeline {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn run_safety_nets(
         &self,
         session: &Session,
@@ -495,8 +603,12 @@ impl Pipeline {
         document_kind: DocumentKind,
         locale_chain: &[crate::LocaleTag],
         field_path: Option<&str>,
+        safety_net_mode: SafetyNetMode,
     ) -> Result<LeakReport> {
         if self.safety_nets_len() == 0 {
+            return Ok(LeakReport::default());
+        }
+        if self.should_skip_safety_nets(clean_text, manifest, locale_chain, safety_net_mode)? {
             return Ok(LeakReport::default());
         }
 
@@ -565,6 +677,34 @@ impl Pipeline {
         Ok(LeakReport::from_parts(suspects, telemetry))
     }
 
+    fn should_skip_safety_nets(
+        &self,
+        clean_text: &str,
+        manifest: &Manifest,
+        locale_chain: &[crate::LocaleTag],
+        safety_net_mode: SafetyNetMode,
+    ) -> Result<bool> {
+        if !matches!(
+            safety_net_mode,
+            SafetyNetMode::Strict | SafetyNetMode::Tolerant
+        ) {
+            return Ok(false);
+        }
+        if self.optimization_config.capitals_heuristic_gate {
+            validate_capitals_gate_locales(locale_chain)?;
+            if is_numeric_heavy(clean_text) || !has_non_sentence_start_capital(clean_text) {
+                return Ok(true);
+            }
+        }
+        if self.optimization_config.skip_class_gating
+            && !manifest.spans.is_empty()
+            && !has_residual_gold_shape(clean_text)
+        {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     fn safety_nets_len(&self) -> usize {
         let single = self.safety_nets.len();
         #[cfg(feature = "bundled-recognizers")]
@@ -620,6 +760,7 @@ impl Pipeline {
                             document_kind,
                             locale_chain,
                             field_path,
+                            SafetyNetMode::Resolve,
                         )?;
                         (follow_up.stats.uncovered_count + follow_up.stats.partial_bleed_count > 0)
                             .then_some(FallbackReason::ResidualSuspect)
@@ -846,6 +987,52 @@ impl Pipeline {
         Ok(())
     }
 
+    fn log_prefix_cache_entries(
+        &self,
+        session: &Session,
+        manifest: &[EmittedTokenSpan],
+        field_name: Option<&str>,
+        document_kind: DocumentKind,
+        locale_chain: &[crate::LocaleTag],
+    ) -> Result<()> {
+        let locale = locale_chain
+            .first()
+            .map(crate::LocaleTag::as_str)
+            .unwrap_or("global")
+            .to_string();
+        for span in manifest {
+            let entry = RedactionEntry::new(
+                "prefix_cache",
+                span.class.clone(),
+                Action::Tokenize,
+                field_name.map(str::to_string),
+                document_kind,
+                false,
+                ConflictTier::None,
+                crate::redaction_log::current_epoch_ms(),
+                Some(session.audit_session_id().to_string()),
+            )
+            .with_recognizer_metadata(Some("prefix_cache".to_string()), None)
+            .with_provenance_metadata(
+                Some("prefix_cache".to_string()),
+                None,
+                None,
+                None,
+                None,
+                Some(locale.clone()),
+                Some("session_prefix".to_string()),
+                Some(span.class.to_canonical_str()),
+                Some(span.class.to_canonical_str()),
+                None,
+                None,
+            );
+            for logger in &self.redaction_loggers {
+                logger.log(&entry)?;
+            }
+        }
+        Ok(())
+    }
+
     fn log_vetoed_entry(
         &self,
         session: &Session,
@@ -944,6 +1131,59 @@ fn is_char_boundary_range(text: &str, span: &Range<usize>) -> bool {
         && text.is_char_boundary(span.end)
 }
 
+fn validate_capitals_gate_locales(locale_chain: &[crate::LocaleTag]) -> Result<()> {
+    for locale in locale_chain {
+        if !capital_case_locale_supported(locale) {
+            return Err(Error::UnsupportedCapitalHeuristicLocale {
+                locale: locale.as_str().to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn capital_case_locale_supported(locale: &crate::LocaleTag) -> bool {
+    matches!(
+        locale,
+        crate::LocaleTag::Global
+            | crate::LocaleTag::DeDe
+            | crate::LocaleTag::DeAt
+            | crate::LocaleTag::DeCh
+            | crate::LocaleTag::EnUs
+            | crate::LocaleTag::EnGb
+            | crate::LocaleTag::EnIe
+            | crate::LocaleTag::EnAu
+            | crate::LocaleTag::EnCa
+    )
+}
+
+fn is_numeric_heavy(text: &str) -> bool {
+    let digits = text.chars().filter(|ch| ch.is_ascii_digit()).count();
+    let letters = text.chars().filter(|ch| ch.is_alphabetic()).count();
+    digits >= 6 && digits > letters.saturating_mul(2)
+}
+
+// This heuristic is only recall-preserving for locales with capital-case name
+// conventions (currently English and German). Arabic, CJK, and other scripts
+// must fail closed through `validate_capitals_gate_locales`.
+fn has_non_sentence_start_capital(text: &str) -> bool {
+    let mut sentence_start = true;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        if ch.is_uppercase() && !sentence_start {
+            return true;
+        }
+        sentence_start = matches!(ch, '.' | '!' | '?');
+    }
+    false
+}
+
+fn has_residual_gold_shape(text: &str) -> bool {
+    text.contains('@') || is_numeric_heavy(text)
+}
+
 fn replace_clean_span(
     clean: &mut CleanText,
     span: Range<usize>,
@@ -1002,6 +1242,7 @@ pub struct PipelineBuilder {
     safety_nets: Vec<Arc<dyn SafetyNet>>,
     #[cfg(feature = "bundled-recognizers")]
     safety_net_registry: Option<Arc<LocaleAwareModelRegistry>>,
+    optimization_config: PipelineOptimizationConfig,
     rules: Vec<Arc<dyn Rule>>,
 }
 
@@ -1069,6 +1310,31 @@ impl PipelineBuilder {
         self
     }
 
+    pub fn pipeline_optimizations(mut self, config: PipelineOptimizationConfig) -> Self {
+        self.optimization_config = config;
+        self
+    }
+
+    pub fn enable_skip_class_gating(mut self) -> Self {
+        self.optimization_config.skip_class_gating = true;
+        self
+    }
+
+    pub fn enable_capitals_heuristic_gate(mut self) -> Self {
+        self.optimization_config.capitals_heuristic_gate = true;
+        self
+    }
+
+    pub fn enable_prefix_cache(mut self) -> Self {
+        self.optimization_config.prefix_cache = true;
+        self
+    }
+
+    pub fn enable_length_bucketing(mut self) -> Self {
+        self.optimization_config.length_bucketing = true;
+        self
+    }
+
     #[cfg(feature = "bundled-recognizers")]
     pub fn register_safety_net_registry(mut self, registry: LocaleAwareModelRegistry) -> Self {
         self.safety_net_registry = Some(Arc::new(registry));
@@ -1092,6 +1358,7 @@ impl PipelineBuilder {
             safety_nets: self.safety_nets,
             #[cfg(feature = "bundled-recognizers")]
             safety_net_registry: self.safety_net_registry,
+            optimization_config: self.optimization_config,
             rules: self.rules,
         })
     }
@@ -1233,6 +1500,7 @@ fn redact_structured_with_safety_net(
     locale_chain: &[crate::LocaleTag],
     dictionaries: &DictionaryBundle,
     report: &mut LeakReport,
+    policy: SafetyNetPolicy,
 ) -> Result<BTreeMap<String, Value>> {
     let mut clean = BTreeMap::new();
     for (key, value) in fields {
@@ -1248,6 +1516,7 @@ fn redact_structured_with_safety_net(
                 locale_chain,
                 dictionaries,
                 report,
+                policy,
             )?,
         );
     }
@@ -1264,6 +1533,7 @@ fn redact_structured_value_with_safety_net(
     locale_chain: &[crate::LocaleTag],
     dictionaries: &DictionaryBundle,
     report: &mut LeakReport,
+    policy: SafetyNetPolicy,
 ) -> Result<Value> {
     match value {
         Value::String(text) => {
@@ -1287,6 +1557,7 @@ fn redact_structured_value_with_safety_net(
                 DocumentKind::Structured,
                 locale_chain,
                 Some(field_path),
+                policy.mode,
             )?;
             report.extend(field_report);
             Ok(Value::String(clean.text))
@@ -1304,6 +1575,7 @@ fn redact_structured_value_with_safety_net(
                     locale_chain,
                     dictionaries,
                     report,
+                    policy,
                 )
             })
             .collect::<Result<Vec<_>>>()
@@ -1323,6 +1595,7 @@ fn redact_structured_value_with_safety_net(
                         locale_chain,
                         dictionaries,
                         report,
+                        policy,
                     )?,
                 );
             }
@@ -1337,6 +1610,7 @@ fn redact_structured_value_with_safety_net(
                     DocumentKind::Structured,
                     locale_chain,
                     Some(field_path),
+                    policy.mode,
                 )?;
                 report.extend(field_report);
             }
@@ -1364,6 +1638,7 @@ fn walk_value_for_safety_net_scan(
                     DocumentKind::Structured,
                     locale_chain,
                     Some(field_path),
+                    SafetyNetMode::Strict,
                 )?;
                 report.extend(field_report);
             }
@@ -1378,6 +1653,7 @@ fn walk_value_for_safety_net_scan(
                     DocumentKind::Structured,
                     locale_chain,
                     Some(field_path),
+                    SafetyNetMode::Strict,
                 )?;
                 report.extend(field_report);
             }
@@ -1579,6 +1855,7 @@ mod tests {
     use crate::detector::{Detection, PiiClass};
     use crate::rule::{ClassRule, DefaultRule};
     use crate::session::{Scope, Session};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     /// Shared-handle test double: callers keep an `Arc<Mutex<Vec<_>>>` and
@@ -1617,10 +1894,161 @@ mod tests {
         }
     }
 
+    struct CountingSafetyNet {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SafetyNet for CountingSafetyNet {
+        fn id(&self) -> &str {
+            "counting"
+        }
+        fn supported_locales(&self) -> &[crate::LocaleTag] {
+            &[crate::LocaleTag::Global]
+        }
+        fn check(
+            &self,
+            _clean_text: &str,
+            _context: SafetyNetContext<'_>,
+        ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
     #[test]
     fn generalize_token_custom_class_preserves_identity() {
         // Regression guard: custom classes must not collapse to an indistinct [PII].
         assert_eq!(generalize_token(&PiiClass::Custom("foo".into())), "[FOO]");
+    }
+
+    #[test]
+    fn skip_class_gating_skips_only_observer_mode() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let pipeline = Pipeline::builder()
+            .detector(detector_with_detections(
+                "email.global",
+                vec![Detection::new(6..27, PiiClass::Email, "email.global")],
+            ))
+            .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .register_safety_net(CountingSafetyNet {
+                calls: Arc::clone(&calls),
+            })
+            .enable_skip_class_gating()
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let dictionaries = DictionaryBundle::default();
+        pipeline
+            .clean_with_safety_net_policy_detect_context(
+                &session,
+                RawDocument::Text("Reach alice@example.invalid".to_string()),
+                &[crate::LocaleTag::Global],
+                &dictionaries,
+                SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
+            )
+            .expect("observer safety net");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        pipeline
+            .clean_with_safety_net_policy_detect_context(
+                &session,
+                RawDocument::Text("Reach alice@example.invalid".to_string()),
+                &[crate::LocaleTag::Global],
+                &dictionaries,
+                SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact),
+            )
+            .expect("resolve safety net");
+        assert!(calls.load(Ordering::SeqCst) > 0);
+    }
+
+    #[test]
+    fn capitals_gate_fails_closed_for_unsupported_locale() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let pipeline = Pipeline::builder()
+            .register_safety_net(CountingSafetyNet {
+                calls: Arc::clone(&calls),
+            })
+            .enable_capitals_heuristic_gate()
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let dictionaries = DictionaryBundle::default();
+        let err = pipeline
+            .clean_with_safety_net_policy_detect_context(
+                &session,
+                RawDocument::Text("مرحبا".to_string()),
+                &[crate::LocaleTag::Other("ar-SA".to_string())],
+                &dictionaries,
+                SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
+            )
+            .expect_err("unsupported capitals locale must fail closed");
+        assert!(matches!(
+            err,
+            Error::UnsupportedCapitalHeuristicLocale { locale } if locale == "ar-SA"
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn prefix_cache_hits_emit_audit_provenance() {
+        struct NameRecognizer;
+        impl Recognizer for NameRecognizer {
+            fn id(&self) -> &str {
+                "name.fixture"
+            }
+            fn supported_class(&self) -> &PiiClass {
+                &PiiClass::Name
+            }
+            fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+                input
+                    .find("Dr. Schmidt")
+                    .map(|start| {
+                        Candidate::new(
+                            start..start + "Dr. Schmidt".len(),
+                            PiiClass::Name,
+                            self.id(),
+                            1.0,
+                            0,
+                            None,
+                            self.token_family(),
+                            self.id(),
+                            ConflictTier::None,
+                            Vec::new(),
+                        )
+                    })
+                    .into_iter()
+                    .collect()
+            }
+            fn token_family(&self) -> &str {
+                "counter"
+            }
+        }
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+        let pipeline = Pipeline::builder()
+            .recognizer(NameRecognizer)
+            .rule(ClassRule::new(PiiClass::Name, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .enable_prefix_cache()
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        pipeline
+            .redact(&session, RawDocument::Text("Dr. Schmidt".to_string()))
+            .expect("prime cache");
+        pipeline
+            .redact(
+                &session,
+                RawDocument::Text("Dr. Schmidt reports".to_string()),
+            )
+            .expect("cache hit");
+        let entries = entries.lock().unwrap();
+        assert!(entries.iter().any(|entry| {
+            entry.source == "prefix_cache"
+                && entry.provenance_stage.as_deref() == Some("prefix_cache")
+        }));
     }
 
     #[test]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashmap::mapref::entry::Entry;
@@ -105,6 +107,20 @@ struct SnapshotPayload {
     document: Option<DocumentExtension>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PrefixCacheHit {
+    pub raw_len: usize,
+    pub clean_text: String,
+    pub manifest: Vec<gaze_types::EmittedTokenSpan>,
+}
+
+#[derive(Debug, Clone)]
+struct PrefixCacheEntry {
+    raw: String,
+    clean_text: String,
+    manifest: Vec<gaze_types::EmittedTokenSpan>,
+}
+
 /// Owns the token manifest for one conversation or request.
 ///
 /// A `Session` holds the bidirectional map between PII values and their pseudonymous tokens.
@@ -191,6 +207,7 @@ pub struct Session {
     next_by_class: DashMap<PiiClass, usize>,
     token_by_value: DashMap<TokenKey, String>,
     value_by_token: DashMap<String, String>,
+    prefix_cache: DashMap<u64, PrefixCacheEntry>,
     signing_key: SessionKey,
 }
 
@@ -203,6 +220,7 @@ impl Session {
             next_by_class: DashMap::new(),
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
+            prefix_cache: DashMap::new(),
             signing_key: SessionKey::generate()?,
         })
     }
@@ -322,6 +340,44 @@ impl Session {
 
     pub fn audit_session_id(&self) -> &str {
         &self.audit_session_id
+    }
+
+    pub(crate) fn lookup_prefix_cache(&self, text: &str) -> Option<PrefixCacheHit> {
+        self.prefix_cache
+            .iter()
+            .filter_map(|entry| {
+                let cached = entry.value();
+                (text.starts_with(&cached.raw) && text.is_char_boundary(cached.raw.len())).then(
+                    || PrefixCacheHit {
+                        raw_len: cached.raw.len(),
+                        clean_text: cached.clean_text.clone(),
+                        manifest: cached.manifest.clone(),
+                    },
+                )
+            })
+            .max_by_key(|hit| hit.raw_len)
+    }
+
+    pub(crate) fn store_prefix_cache(
+        &self,
+        raw: &str,
+        clean_text: &str,
+        manifest: &[gaze_types::EmittedTokenSpan],
+    ) {
+        if raw.is_empty() {
+            return;
+        }
+        if self.prefix_cache.len() >= 64 {
+            self.prefix_cache.clear();
+        }
+        self.prefix_cache.insert(
+            prefix_cache_hash(raw),
+            PrefixCacheEntry {
+                raw: raw.to_string(),
+                clean_text: clean_text.to_string(),
+                manifest: manifest.to_vec(),
+            },
+        );
     }
 
     // Original byte spans are preserved by recognizer normalizers per
@@ -523,6 +579,7 @@ impl Session {
             next_by_class: DashMap::new(),
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
+            prefix_cache: DashMap::new(),
             signing_key: SessionKey::generate()?,
         };
         for entry in payload.entries {
@@ -560,6 +617,12 @@ impl Session {
 
 fn default_counter_family() -> String {
     DEFAULT_COUNTER_FAMILY.to_string()
+}
+
+fn prefix_cache_hash(raw: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    raw.hash(&mut hasher);
+    hasher.finish()
 }
 
 fn new_audit_session_id() -> String {

--- a/docs/architecture/tier4-pipeline-gating.md
+++ b/docs/architecture/tier4-pipeline-gating.md
@@ -1,0 +1,59 @@
+# Tier 4 Pipeline Gating
+
+Tier 4 gates are pipeline-level performance controls. They do not weaken the
+recognizer floor, do not change token shapes, and are default-off through
+`PipelineOptimizationConfig`.
+
+## Gates
+
+- `skip_class_gating`: skips Pass-3 SafetyNet only when `SafetyNetMode` is
+  observer-only (`Strict` or `Tolerant`) and the rule floor has already emitted
+  token spans with no residual gold-shape signals. It never applies to
+  `Resolve` or `Redact`.
+- `capitals_heuristic_gate`: skips observer-only Pass-3 for numeric-heavy inputs
+  and inputs without a capital letter at a non-sentence-start position. This is
+  valid only for configured English/German capital-case locales; unsupported
+  locales fail closed with `UnsupportedCapitalHeuristicLocale`.
+- `prefix_cache`: stores recently tokenized raw prefixes inside the owning
+  `Session`. Cache state is not exported and is not shared across sessions.
+  Every cached token emission writes an audit row with
+  `provenance_stage = "prefix_cache"`.
+- `length_bucketing`: reserves an opt-in config flag for batching callers that
+  group same-length model inputs to reduce padding waste. The current core path
+  does not batch Pass-3 calls, so this flag is a compatibility hook.
+
+## Invariants
+
+- Existing adopters see no behavior change unless a flag is explicitly enabled.
+- Gates only reduce observer-only Pass-3 calls. They never suppress a
+  resolve/redact SafetyNet pass.
+- Prefix cache entries are session-scoped and dropped with the session.
+- Cache hits are auditable and metadata-only; audit rows never include source
+  bytes or token strings.
+
+## Bench Snapshot
+
+Command:
+
+```bash
+cargo bench -p gaze-pii --bench tier4_pipeline_gating --all-features
+```
+
+Local result on May 15, 2026:
+
+| config | SafetyNet calls | elapsed ms | call reduction |
+| --- | ---: | ---: | ---: |
+| baseline | 300 | 41.713 | 0.0% |
+| skip_class_gating | 200 | 28.221 | 33.3% |
+| capitals_heuristic_gate | 100 | 15.061 | 66.7% |
+| combined_skip_and_capitals | 0 | 1.904 | 100.0% |
+
+Prefix cache keystroke-style bench:
+
+| config | detector bytes processed | elapsed ms | reduction |
+| --- | ---: | ---: | ---: |
+| baseline | 2190 | 28.169 | - |
+| prefix_cache | 1035 | 13.848 | 52.7% bytes, 50.8% latency |
+
+The bench asserts zero SafetyNet suspects for every config, preserving the
+observer-mode recall baseline for the synthetic fixture set.


### PR DESCRIPTION
## Summary
- Adds default-off `PipelineOptimizationConfig` flags for skip-class gating, capitals heuristic gating, session-scoped prefix cache, and length bucketing compatibility.
- Gates Pass-3 skips explicitly to observer-only `SafetyNetMode::{Strict,Tolerant}`; `Resolve`/`Redact` remain load-bearing and never skip.
- Adds session-owned prefix cache with audit rows marked `provenance_stage = "prefix_cache"`; cache state is not exported or shared across sessions.
- Threads nullable provenance producer fields through `RedactionEntry` into `gaze-audit` SQLite inserts.
- Documents Tier 4 safety invariants and adds `cargo bench -p gaze-pii --bench tier4_pipeline_gating --all-features`.

## Bench
Command: `cargo bench -p gaze-pii --bench tier4_pipeline_gating --all-features`

```json
{"baseline":{"name":"baseline","safety_net_calls":300,"elapsed_ms":41.713,"call_reduction":0.0000},"configs":[{"name":"skip_class_gating","safety_net_calls":200,"elapsed_ms":28.221,"call_reduction":0.3333},{"name":"capitals_heuristic_gate","safety_net_calls":100,"elapsed_ms":15.061,"call_reduction":0.6667},{"name":"combined_skip_and_capitals","safety_net_calls":0,"elapsed_ms":1.904,"call_reduction":1.0000}],"prefix_cache":{"baseline":{"name":"baseline","detector_bytes_processed":2190,"elapsed_ms":28.169},"cached":{"name":"prefix_cache","detector_bytes_processed":1035,"elapsed_ms":13.848},"byte_reduction":0.5274,"latency_reduction":0.5084}}
```

Recall evidence: the bench asserts `report.stats.suspect_count == 0` for every config. Existing `cargo test --workspace --all-features` and `xtask ci-feature-matrix` also pass, including safety-net sanity and observer-mode tests.

## Five-axis check
- Axis 1 reliability: skips are observer-only and unsupported capital-case locales fail closed.
- Axis 2 reversibility: prefix cache reuses session-owned tokens and is dropped with the session; no snapshot/export cache state.
- Axis 3 agentic-first: prefix-cache path reduces repeated typed-prefix work.
- Axis 4 trust: cache hits emit explicit provenance audit rows.
- Axis 5 ergonomics: all flags are opt-in, default-off, and builder-accessible.

## Gates
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`