### PR TITLE
feat(cli): gaze daemon mode (#367)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "tokio",
  "tracing",
@@ -3381,6 +3382,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -55,6 +55,7 @@ pdfium-render = { version = "0.9", optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+signal-hook = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 tracing = "0.1"
 url = "2"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -53,6 +53,7 @@ Current subcommands in [`src/commands/mod.rs`](src/commands/mod.rs):
 | Subcommand | Purpose |
 |------------|---------|
 | `clean` | Reads raw UTF-8 text from stdin and emits `{"clean_text","session_blob","stats"}` JSON. |
+| `daemon` | Runs a long-lived JSONL stdio cleaner with one process-level pipeline and per-`session_id` manifests. |
 | `restore` | Reads `{"session_blob","text"}` JSON from stdin and emits restored `{"text"}` JSON, plus `restore_warning` when tolerant restore allows an unknown token. |
 | `audit query` | Prints filtered audit metadata rows from a `--audit-db` SQLite log, opened read-only. |
 | `audit export` | Exports filtered audit metadata rows in JSONL (default) for downstream processing. |
@@ -64,6 +65,33 @@ Current subcommands in [`src/commands/mod.rs`](src/commands/mod.rs):
 
 Audit logging is captured on `clean` via `--audit-db <path>`; the
 `audit query` and `audit export` subcommands read the same database back.
+
+## Daemon mode
+
+`gaze daemon --policy policy.toml` keeps one pipeline alive and reads one JSON
+request per stdin line:
+
+```json
+{"session_id":"conversation-1","text":"Contact alice@example.invalid"}
+```
+
+Each stdout line is either a clean response:
+
+```json
+{"session_id":"conversation-1","clean_text":"Contact <...:Email_1>","manifest":[],"tokens":[]}
+```
+
+or a typed protocol/cleaning error:
+
+```json
+{"session_id":null,"error":"JsonMalformed","detail":"malformed JSON line"}
+```
+
+Sessions are isolated by `session_id`, evicted by LRU after `--session-cap`
+(default 1000), and evicted after `--session-idle-timeout` seconds (default
+3600). `--idle-timeout` exits the process after stdin inactivity (default 1800).
+SIGINT and SIGTERM finish the current line, flush stdout/audit writes, and exit.
+Daemon audit rows are stamped with `provenance_stage = "daemon"`.
 
 ## MCP installation
 

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -326,10 +326,10 @@ impl Daemon {
         let expired = self
             .sessions
             .iter()
-            .filter_map(|(session_id, entry)| {
-                (now.duration_since(entry.last_seen) >= self.session_idle_timeout)
-                    .then(|| session_id.clone())
+            .filter(|(_, entry)| {
+                now.duration_since(entry.last_seen) >= self.session_idle_timeout
             })
+            .map(|(session_id, _)| session_id.clone())
             .collect::<Vec<_>>();
         for session_id in expired {
             if let Some(entry) = self.sessions.remove(&session_id) {

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -1,0 +1,568 @@
+use std::collections::{HashMap, VecDeque};
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    mpsc, Arc,
+};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
+    SafetyNetFallback, SafetyNetKind, SafetyNetMode,
+};
+use crate::error::CliError;
+use crate::pipeline::build::{
+    build_pipeline_from_policy, dictionary_terms_from_rulepacks, load_rulepacks,
+    map_pipeline_error, map_policy_error, merged_rulepack_default_locales, resolve_ner_threshold,
+    ArcLogger,
+};
+use crate::pipeline::run::{
+    clean_overrides_from_options, enforce_safety_net_mode, entry_class_to_string,
+    map_safety_net_pipeline_error, maybe_register_safety_net, parse_cli_locales, safety_net_policy,
+    validate_safety_net_tolerant_gate, CleanOptions,
+};
+use gaze::{
+    dictionary_bundle_from_context, Action, ConflictTier, DictionaryBundle, DocumentKind,
+    EmittedTokenSpan, LeakReport, LocaleTag, PiiClass, Policy, RawDocument, RedactionEntry,
+    RedactionLogError, RedactionLogger, Result as GazeResult, Session, SessionSnapshotEntry,
+    TypedContext,
+};
+use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
+
+const DEFAULT_PROCESS_IDLE_TIMEOUT_SECS: u64 = 1_800;
+const DEFAULT_SESSION_IDLE_TIMEOUT_SECS: u64 = 3_600;
+const DEFAULT_SESSION_CAP: usize = 1_000;
+
+pub(crate) struct Args {
+    pub(crate) policy: PathBuf,
+    pub(crate) safety_net: Option<SafetyNetKind>,
+    pub(crate) safety_net_backend: Option<SafetyNetBackend>,
+    pub(crate) idle_timeout_secs: u64,
+    pub(crate) session_idle_timeout_secs: u64,
+    pub(crate) session_cap: usize,
+    pub(crate) audit_db: Option<PathBuf>,
+    pub(crate) locale: Vec<String>,
+    pub(crate) ner_threshold: Option<f32>,
+    pub(crate) ner_model_dir: Option<PathBuf>,
+    pub(crate) ner_locale: Option<String>,
+    pub(crate) openai_filter_command: Option<PathBuf>,
+    pub(crate) openai_filter_checkpoint: Option<PathBuf>,
+    pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+    pub(crate) openai_filter_device: OpenAiFilterDevice,
+    pub(crate) kiji_backend: KijiBackend,
+    pub(crate) kiji_distilbert_command: Option<PathBuf>,
+    pub(crate) kiji_distilbert_model_dir: Option<PathBuf>,
+    pub(crate) kiji_distilbert_locales: Vec<String>,
+    pub(crate) safety_net_timeout_ms: u64,
+    pub(crate) safety_net_input_limit_bytes: usize,
+    pub(crate) safety_net_mode: SafetyNetMode,
+    pub(crate) safety_net_fallback: SafetyNetFallback,
+}
+
+pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
+    let shutdown = install_signal_flags()?;
+    let mut daemon = Daemon::new(args)?;
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in io::stdin().lock().lines() {
+            match line {
+                Ok(line) => {
+                    if sender.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let idle_timeout = daemon.process_idle_timeout;
+    let mut stdout = io::stdout().lock();
+    loop {
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+        match receiver.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) => {
+                daemon.last_stdin_activity = Instant::now();
+                daemon.evict_idle_sessions();
+                let response = daemon.handle_line(&line);
+                write_json_line(&mut stdout, &response)?;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                daemon.evict_idle_sessions();
+                if daemon.last_stdin_activity.elapsed() >= idle_timeout {
+                    tracing::info!("gaze daemon exiting after stdin idle timeout");
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    stdout.flush().map_err(|_| CliError::Io)?;
+    Ok(())
+}
+
+fn install_signal_flags() -> std::result::Result<Arc<AtomicBool>, CliError> {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGTERM, Arc::clone(&shutdown))
+        .map_err(|_| CliError::Io)?;
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&shutdown))
+        .map_err(|_| CliError::Io)?;
+    Ok(shutdown)
+}
+
+fn write_json_line<W: Write>(writer: &mut W, response: &DaemonResponse) -> Result<(), CliError> {
+    serde_json::to_writer(&mut *writer, response).map_err(|_| CliError::Pipeline)?;
+    writer.write_all(b"\n").map_err(|_| CliError::Io)?;
+    writer.flush().map_err(|_| CliError::Io)
+}
+
+struct Daemon {
+    pipeline: gaze::Pipeline,
+    policy: Policy,
+    locale_chain: Vec<LocaleTag>,
+    dictionaries: DictionaryBundle,
+    safety_net_active: bool,
+    safety_net_mode: SafetyNetMode,
+    safety_net_fallback: SafetyNetFallback,
+    logger: Arc<DaemonLogger>,
+    sessions: HashMap<String, SessionEntry>,
+    lru: VecDeque<String>,
+    session_cap: usize,
+    session_idle_timeout: Duration,
+    process_idle_timeout: Duration,
+    last_stdin_activity: Instant,
+}
+
+impl Daemon {
+    fn new(args: Args) -> std::result::Result<Self, CliError> {
+        if args.session_cap == 0 {
+            return Err(CliError::PolicyConfigDetail(
+                "--session-cap must be greater than zero".to_string(),
+            ));
+        }
+        validate_safety_net_tolerant_gate(args.safety_net_mode, args.safety_net_fallback)?;
+        let logger =
+            Arc::new(DaemonLogger::new(args.audit_db.as_deref()).map_err(|_| CliError::Pipeline)?);
+        let options = clean_options(&args);
+        let cli_ner_threshold = args
+            .ner_threshold
+            .map(crate::pipeline::build::validate_ner_threshold)
+            .transpose()
+            .map_err(map_policy_error)?;
+        let clean_overrides = clean_overrides_from_options(&options)?;
+        let loaded_policy = Policy::load_for_cli(&args.policy)
+            .map_err(map_policy_error)
+            .map(|policy| clean_overrides.apply_to(&policy))?;
+        let loaded_rulepacks = load_rulepacks(&loaded_policy).map_err(map_pipeline_error)?;
+        let rulepack_dictionaries =
+            dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
+        let mut policy_dictionaries = loaded_policy.dictionaries.clone();
+        policy_dictionaries.extend(rulepack_dictionaries);
+        let dictionaries = DictionaryBundle::merge(
+            DictionaryBundle::from_rulepack_terms(&policy_dictionaries),
+            dictionary_bundle_from_context(&TypedContext {
+                dictionaries: std::collections::HashMap::new(),
+                class_map: std::collections::HashMap::new(),
+                fields: serde_json::Map::new(),
+            }),
+        );
+        let mut rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
+        if loaded_policy.rulepacks.auto_activate_locale_gated {
+            for locale in [
+                LocaleTag::EnUs,
+                LocaleTag::DeDe,
+                LocaleTag::DeAt,
+                LocaleTag::DeCh,
+            ] {
+                if !rulepack_default_locales
+                    .iter()
+                    .any(|existing| existing == &locale)
+                {
+                    rulepack_default_locales.push(locale);
+                }
+            }
+        }
+        let cli_locales = parse_cli_locales(&args.locale)?;
+        let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
+            cli_locales.as_deref(),
+            loaded_policy.locale.as_deref(),
+            Some(&rulepack_default_locales),
+        );
+        let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, Some(&loaded_policy));
+        let pipeline = build_pipeline_from_policy(
+            &loaded_policy,
+            &loaded_rulepacks,
+            None,
+            &locale_chain,
+            resolved_ner_threshold,
+        )?
+        .with_redaction_logger(ArcLogger(Arc::clone(&logger) as Arc<dyn RedactionLogger>));
+        let pipeline = maybe_register_safety_net(pipeline, &options)?;
+        Ok(Self {
+            pipeline,
+            policy: loaded_policy,
+            locale_chain: locale_chain.as_slice().to_vec(),
+            dictionaries,
+            safety_net_active: args.safety_net.is_some(),
+            safety_net_mode: args.safety_net_mode,
+            safety_net_fallback: args.safety_net_fallback,
+            logger,
+            sessions: HashMap::new(),
+            lru: VecDeque::new(),
+            session_cap: args.session_cap,
+            session_idle_timeout: Duration::from_secs(args.session_idle_timeout_secs),
+            process_idle_timeout: Duration::from_secs(args.idle_timeout_secs),
+            last_stdin_activity: Instant::now(),
+        })
+    }
+
+    fn handle_line(&mut self, line: &str) -> DaemonResponse {
+        let request = match serde_json::from_str::<DaemonRequest>(line) {
+            Ok(request) if !request.session_id.trim().is_empty() => request,
+            Ok(_) => return DaemonResponse::error(None, "ProtocolInvalid", "missing session_id"),
+            Err(_) => return DaemonResponse::error(None, "JsonMalformed", "malformed JSON line"),
+        };
+        match self.clean_request(request) {
+            Ok(response) => response,
+            Err((session_id, error)) => DaemonResponse::error(
+                Some(session_id),
+                error.variant(),
+                error.detail().unwrap_or("clean request failed"),
+            ),
+        }
+    }
+
+    fn clean_request(
+        &mut self,
+        request: DaemonRequest,
+    ) -> std::result::Result<DaemonResponse, (String, DaemonError)> {
+        self.ensure_session(&request.session_id)
+            .map_err(|err| (request.session_id.clone(), err))?;
+        let session = &self
+            .sessions
+            .get(&request.session_id)
+            .expect("session inserted")
+            .session;
+        let (clean_doc, manifest, leak_report) = self
+            .pipeline
+            .clean_with_safety_net_policy_detect_context(
+                session,
+                RawDocument::Text(request.text),
+                &self.locale_chain,
+                &self.dictionaries,
+                safety_net_policy(self.safety_net_mode, self.safety_net_fallback),
+            )
+            .map_err(|err| {
+                let cli_error = if self.safety_net_active {
+                    map_safety_net_pipeline_error(err)
+                } else {
+                    CliError::Pipeline
+                };
+                (request.session_id.clone(), DaemonError::Cli(cli_error))
+            })?;
+        self.logger
+            .log_safety_net_report(&leak_report, session, DocumentKind::Text)
+            .map_err(|_| {
+                (
+                    request.session_id.clone(),
+                    DaemonError::Cli(CliError::Pipeline),
+                )
+            })?;
+        enforce_safety_net_mode(&leak_report, self.safety_net_mode, self.safety_net_fallback)
+            .map_err(|err| (request.session_id.clone(), DaemonError::Cli(err)))?;
+        let clean_text = match clean_doc {
+            gaze::CleanDocument::Text(text) => text,
+            _ => return Err((request.session_id, DaemonError::Invariant)),
+        };
+        let tokens = session
+            .snapshot_entries()
+            .into_iter()
+            .map(TokenJson::from)
+            .collect();
+        Ok(DaemonResponse::Clean {
+            session_id: request.session_id,
+            clean_text,
+            manifest,
+            tokens,
+        })
+    }
+
+    fn ensure_session(&mut self, session_id: &str) -> std::result::Result<(), DaemonError> {
+        self.evict_idle_sessions();
+        if let Some(entry) = self.sessions.get_mut(session_id) {
+            entry.last_seen = Instant::now();
+            self.lru.retain(|existing| existing != session_id);
+            self.lru.push_back(session_id.to_string());
+            return Ok(());
+        }
+        while self.sessions.len() >= self.session_cap {
+            if let Some(evicted) = self.lru.pop_front() {
+                if let Some(entry) = self.sessions.remove(&evicted) {
+                    self.log_eviction(&evicted, &entry, "lru");
+                }
+            } else {
+                break;
+            }
+        }
+        let session = Session::from_policy(&self.policy).map_err(|_| DaemonError::Invariant)?;
+        self.sessions.insert(
+            session_id.to_string(),
+            SessionEntry {
+                session,
+                last_seen: Instant::now(),
+            },
+        );
+        self.lru.push_back(session_id.to_string());
+        Ok(())
+    }
+
+    fn evict_idle_sessions(&mut self) {
+        let now = Instant::now();
+        let expired = self
+            .sessions
+            .iter()
+            .filter_map(|(session_id, entry)| {
+                (now.duration_since(entry.last_seen) >= self.session_idle_timeout)
+                    .then(|| session_id.clone())
+            })
+            .collect::<Vec<_>>();
+        for session_id in expired {
+            if let Some(entry) = self.sessions.remove(&session_id) {
+                self.lru.retain(|existing| existing != &session_id);
+                self.log_eviction(&session_id, &entry, "idle_timeout");
+            }
+        }
+    }
+
+    fn log_eviction(&self, session_id: &str, entry: &SessionEntry, reason: &str) {
+        tracing::warn!(session_id = %session_id, reason = %reason, "gaze daemon evicted session");
+        let _ = self.logger.log_eviction(&entry.session, reason);
+    }
+}
+
+fn clean_options(args: &Args) -> CleanOptions<'_> {
+    CleanOptions {
+        policy: Some(args.policy.as_path()),
+        format: "json",
+        session_ttl: None,
+        session_scope: None,
+        locale: &args.locale,
+        ner_threshold: args.ner_threshold,
+        ner_model_dir: args.ner_model_dir.clone(),
+        ner_locale: args.ner_locale.as_deref(),
+        rulepack_bundled: &[],
+        rulepack_paths: Vec::new(),
+        max_bytes: u64::MAX,
+        context_json: None,
+        audit_db: args.audit_db.as_deref(),
+        safety_net: args.safety_net,
+        safety_net_backend: args.safety_net_backend,
+        safety_net_registry: false,
+        safety_net_add: &[],
+        openai_filter_command: args.openai_filter_command.as_deref(),
+        openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
+        openai_filter_operating_point: args.openai_filter_operating_point,
+        openai_filter_device: args.openai_filter_device,
+        kiji_backend: args.kiji_backend,
+        opf_locales: &[],
+        opf_command: None,
+        opf_checkpoint: None,
+        kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
+        kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
+        kiji_distilbert_locales: &args.kiji_distilbert_locales,
+        safety_net_timeout_ms: args.safety_net_timeout_ms,
+        safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
+        safety_net_mode: args.safety_net_mode,
+        safety_net_fallback: args.safety_net_fallback,
+    }
+}
+
+struct SessionEntry {
+    session: Session,
+    last_seen: Instant,
+}
+
+struct DaemonLogger {
+    detections: AtomicU64,
+    audit: Option<SqliteLogger>,
+}
+
+impl DaemonLogger {
+    fn new(audit_db: Option<&Path>) -> GazeResult<Self> {
+        Ok(Self {
+            detections: AtomicU64::new(0),
+            audit: audit_db
+                .map(SqliteLogger::new)
+                .transpose()
+                .map_err(|err| gaze::Error::Sqlite(err.to_string()))?,
+        })
+    }
+
+    fn log_safety_net_report(
+        &self,
+        report: &LeakReport,
+        session: &Session,
+        document_kind: DocumentKind,
+    ) -> gaze_audit::Result<()> {
+        let Some(audit) = &self.audit else {
+            return Ok(());
+        };
+        let created_at = chrono::Utc::now().timestamp_millis();
+        for suspect in &report.suspects {
+            let entry = LeakSuspectLogEntry::from_suspect(
+                suspect,
+                document_kind,
+                created_at,
+                Some(session.audit_session_id().to_string()),
+                report.replay_hash.clone(),
+            );
+            audit.log_leak_suspect(&entry)?;
+        }
+        Ok(())
+    }
+
+    fn log_eviction(&self, session: &Session, reason: &str) -> Result<(), RedactionLogError> {
+        let entry = RedactionEntry::new(
+            "daemon.session_eviction",
+            PiiClass::Custom("daemon_session".to_string()),
+            Action::Preserve,
+            Some(reason.to_string()),
+            DocumentKind::Text,
+            false,
+            ConflictTier::None,
+            chrono::Utc::now().timestamp_millis(),
+            Some(session.audit_session_id().to_string()),
+        )
+        .with_provenance_metadata(
+            Some("daemon".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("custom:daemon_session".to_string()),
+            Some("custom:daemon_session".to_string()),
+            None,
+            None,
+        );
+        self.log(&entry)
+    }
+}
+
+impl RedactionLogger for DaemonLogger {
+    fn log(&self, entry: &RedactionEntry) -> Result<(), RedactionLogError> {
+        let mut entry = entry.clone();
+        entry.provenance_stage = Some("daemon".to_string());
+        if let Some(audit) = &self.audit {
+            audit
+                .log(&entry)
+                .map_err(|err| RedactionLogError::Sqlite(err.to_string()))?;
+        }
+        if !entry.conflict_loser
+            && entry.document_kind == DocumentKind::Text
+            && entry.action != Action::Preserve
+        {
+            self.detections.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct DaemonRequest {
+    session_id: String,
+    text: String,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum DaemonResponse {
+    Clean {
+        session_id: String,
+        clean_text: String,
+        manifest: Vec<EmittedTokenSpan>,
+        tokens: Vec<TokenJson>,
+    },
+    Error {
+        session_id: Option<String>,
+        error: &'static str,
+        detail: String,
+    },
+}
+
+impl DaemonResponse {
+    fn error(session_id: Option<String>, error: &'static str, detail: impl Into<String>) -> Self {
+        Self::Error {
+            session_id,
+            error,
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct TokenJson {
+    class: String,
+    token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    family: Option<String>,
+}
+
+impl From<SessionSnapshotEntry> for TokenJson {
+    fn from(entry: SessionSnapshotEntry) -> Self {
+        Self {
+            class: entry_class_to_string(&entry.class),
+            token: entry.token,
+            family: Some(entry.family),
+        }
+    }
+}
+
+enum DaemonError {
+    Cli(CliError),
+    Invariant,
+}
+
+impl DaemonError {
+    fn variant(&self) -> &'static str {
+        match self {
+            Self::Cli(error) => match error {
+                CliError::SafetyNetFailure { variant } => variant,
+                CliError::SafetyNetConfigDetail(_) => "SafetyNetConfig",
+                CliError::PolicyConfigDetail(_) => "PolicyConfig",
+                CliError::PolicyOpen => "PolicyOpen",
+                CliError::Pipeline => "Pipeline",
+                CliError::Io => "Io",
+                _ => "CliError",
+            },
+            Self::Invariant => "PipelineInvariant",
+        }
+    }
+
+    fn detail(&self) -> Option<&str> {
+        match self {
+            Self::Cli(CliError::SafetyNetConfigDetail(detail))
+            | Self::Cli(CliError::PolicyConfigDetail(detail)) => Some(detail.as_str()),
+            Self::Cli(_) => Some("gaze daemon request failed closed"),
+            Self::Invariant => Some("unexpected non-text clean document"),
+        }
+    }
+}
+
+pub(crate) fn default_process_idle_timeout_secs() -> u64 {
+    DEFAULT_PROCESS_IDLE_TIMEOUT_SECS
+}
+
+pub(crate) fn default_session_idle_timeout_secs() -> u64 {
+    DEFAULT_SESSION_IDLE_TIMEOUT_SECS
+}
+
+pub(crate) fn default_session_cap() -> usize {
+    DEFAULT_SESSION_CAP
+}

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -367,6 +367,7 @@ fn clean_options(args: &Args) -> CleanOptions<'_> {
         openai_filter_operating_point: args.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
+        kiji_distilbert_precision: super::KijiDistilbertPrecision::Fp32,
         opf_locales: &[],
         opf_command: None,
         opf_checkpoint: None,

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -326,9 +326,7 @@ impl Daemon {
         let expired = self
             .sessions
             .iter()
-            .filter(|(_, entry)| {
-                now.duration_since(entry.last_seen) >= self.session_idle_timeout
-            })
+            .filter(|(_, entry)| now.duration_since(entry.last_seen) >= self.session_idle_timeout)
             .map(|(session_id, _)| session_id.clone())
             .collect::<Vec<_>>();
         for session_id in expired {

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod clean;
+mod daemon;
 #[cfg(feature = "document")]
 mod document;
 #[cfg(feature = "mcp")]
@@ -122,6 +123,78 @@ enum Cmd {
         #[arg(long)]
         kiji_distilbert_model_dir: Option<PathBuf>,
         /// Locale list for the Kiji DistilBERT registry entry.
+        #[arg(long, value_delimiter = ',')]
+        kiji_distilbert_locales: Vec<String>,
+        /// Safety-net subprocess timeout in milliseconds.
+        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
+        safety_net_timeout_ms: u64,
+        /// Maximum clean-text bytes submitted to the safety net.
+        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES)]
+        safety_net_input_limit_bytes: usize,
+        /// Safety-net handling mode for suspected leaks.
+        #[arg(long, value_enum, default_value_t = SafetyNetMode::Resolve)]
+        safety_net_mode: SafetyNetMode,
+        /// Fallback when safety-net resolve or redact cannot complete.
+        #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
+        safety_net_fallback: SafetyNetFallback,
+    },
+    /// Run a long-lived JSON-lines stdio cleaning daemon.
+    Daemon {
+        /// Path to policy.toml.
+        #[arg(long)]
+        policy: PathBuf,
+        /// Optional observer-only privacy safety net.
+        #[arg(long, value_enum)]
+        safety_net: Option<SafetyNetKind>,
+        /// v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins.
+        #[arg(long, value_enum)]
+        safety_net_backend: Option<SafetyNetBackend>,
+        /// Exit when stdin is idle for this many seconds.
+        #[arg(long, default_value_t = daemon::default_process_idle_timeout_secs())]
+        idle_timeout: u64,
+        /// Evict sessions idle for this many seconds.
+        #[arg(long, default_value_t = daemon::default_session_idle_timeout_secs())]
+        session_idle_timeout: u64,
+        /// Maximum live sessions before LRU eviction.
+        #[arg(long, default_value_t = daemon::default_session_cap())]
+        session_cap: usize,
+        /// Optional SQLite redaction-log database path.
+        #[arg(long)]
+        audit_db: Option<PathBuf>,
+        /// Active locale fallback chain, comma separated and priority ordered.
+        #[arg(long, value_delimiter = ',')]
+        locale: Vec<String>,
+        /// Override policy [ner] threshold. Must be between 0.0 and 1.0 inclusive.
+        #[arg(long)]
+        ner_threshold: Option<f32>,
+        /// Override policy [ner].model_dir.
+        #[arg(long)]
+        ner_model_dir: Option<PathBuf>,
+        /// Override policy [ner].locale.
+        #[arg(long)]
+        ner_locale: Option<String>,
+        /// Path to the local OpenAI Privacy Filter `opf` command.
+        #[arg(long)]
+        openai_filter_command: Option<PathBuf>,
+        /// Path to the local OpenAI Privacy Filter checkpoint or model directory.
+        #[arg(long)]
+        openai_filter_checkpoint: Option<PathBuf>,
+        /// OpenAI Privacy Filter operating point, when supported by the command.
+        #[arg(long, value_enum)]
+        openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+        /// Device selection for the OpenAI safety-net subprocess.
+        #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
+        openai_filter_device: OpenAiFilterDevice,
+        /// Kiji DistilBERT runtime backend.
+        #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
+        kiji_backend: KijiBackend,
+        /// Path to the local Kiji DistilBERT subprocess command.
+        #[arg(long)]
+        kiji_distilbert_command: Option<PathBuf>,
+        /// Path to the pinned Kiji DistilBERT model directory.
+        #[arg(long)]
+        kiji_distilbert_model_dir: Option<PathBuf>,
+        /// Locale list for the Kiji DistilBERT backend.
         #[arg(long, value_delimiter = ',')]
         kiji_distilbert_locales: Vec<String>,
         /// Safety-net subprocess timeout in milliseconds.
@@ -608,6 +681,55 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             format,
             restore_mode,
             max_bytes,
+        }),
+        Cmd::Daemon {
+            policy,
+            safety_net,
+            safety_net_backend,
+            idle_timeout,
+            session_idle_timeout,
+            session_cap,
+            audit_db,
+            locale,
+            ner_threshold,
+            ner_model_dir,
+            ner_locale,
+            openai_filter_command,
+            openai_filter_checkpoint,
+            openai_filter_operating_point,
+            openai_filter_device,
+            kiji_backend,
+            kiji_distilbert_command,
+            kiji_distilbert_model_dir,
+            kiji_distilbert_locales,
+            safety_net_timeout_ms,
+            safety_net_input_limit_bytes,
+            safety_net_mode,
+            safety_net_fallback,
+        } => daemon::run(daemon::Args {
+            policy,
+            safety_net,
+            safety_net_backend,
+            idle_timeout_secs: idle_timeout,
+            session_idle_timeout_secs: session_idle_timeout,
+            session_cap,
+            audit_db,
+            locale,
+            ner_threshold,
+            ner_model_dir,
+            ner_locale,
+            openai_filter_command,
+            openai_filter_checkpoint,
+            openai_filter_operating_point,
+            openai_filter_device,
+            kiji_backend,
+            kiji_distilbert_command,
+            kiji_distilbert_model_dir,
+            kiji_distilbert_locales,
+            safety_net_timeout_ms,
+            safety_net_input_limit_bytes,
+            safety_net_mode,
+            safety_net_fallback,
         }),
         Cmd::Audit { command } => match command {
             AuditCmd::Query {

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -269,7 +269,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     Ok(())
 }
 
-fn maybe_register_safety_net(
+pub(crate) fn maybe_register_safety_net(
     pipeline: gaze::Pipeline,
     options: &CleanOptions<'_>,
 ) -> std::result::Result<gaze::Pipeline, CliError> {
@@ -613,7 +613,7 @@ fn validate_no_backend_options(options: &CleanOptions<'_>) -> std::result::Resul
     Ok(())
 }
 
-fn map_safety_net_pipeline_error(err: gaze::Error) -> CliError {
+pub(crate) fn map_safety_net_pipeline_error(err: gaze::Error) -> CliError {
     match err {
         gaze::Error::SafetyNet(err) => map_safety_net_error(err),
         _ => CliError::Pipeline,
@@ -648,7 +648,7 @@ fn map_safety_net_error(err: gaze::SafetyNetError) -> CliError {
     }
 }
 
-fn clean_overrides_from_options(
+pub(crate) fn clean_overrides_from_options(
     options: &CleanOptions<'_>,
 ) -> std::result::Result<CleanOverrides, CliError> {
     let session_scope = options
@@ -700,11 +700,11 @@ fn normalize_rulepack_bundles(raw: &[String]) -> (Vec<String>, bool) {
     (bundled, auto_activate_locale_gated)
 }
 
-fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
+pub(crate) fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
     !options.rulepack_bundled.is_empty() || !options.rulepack_paths.is_empty()
 }
 
-fn policy_for_rulepack_overrides(
+pub(crate) fn policy_for_rulepack_overrides(
     clean_overrides: &CleanOverrides,
 ) -> std::result::Result<Policy, CliError> {
     let mut rules = class_rules_for_bundled_overrides(clean_overrides)?;
@@ -764,7 +764,7 @@ fn class_rules_for_bundled_overrides(
         .collect())
 }
 
-fn scope_for_cli_without_policy(
+pub(crate) fn scope_for_cli_without_policy(
     scope: Option<&SessionScope>,
     ttl_secs: Option<u64>,
 ) -> std::result::Result<Scope, CliError> {
@@ -780,7 +780,9 @@ fn scope_for_cli_without_policy(
     }
 }
 
-fn parse_cli_locales(raw: &[String]) -> std::result::Result<Option<Vec<LocaleTag>>, CliError> {
+pub(crate) fn parse_cli_locales(
+    raw: &[String],
+) -> std::result::Result<Option<Vec<LocaleTag>>, CliError> {
     if raw.is_empty() {
         return Ok(None);
     }
@@ -880,7 +882,7 @@ impl From<SessionSnapshotEntry> for EntryJson {
     }
 }
 
-fn entry_class_to_string(class: &PiiClass) -> String {
+pub(crate) fn entry_class_to_string(class: &PiiClass) -> String {
     match class {
         PiiClass::Email => "Email".to_string(),
         PiiClass::Name => "Name".to_string(),
@@ -1042,7 +1044,7 @@ fn document_kind_label(kind: DocumentKind) -> &'static str {
     }
 }
 
-fn enforce_safety_net_mode(
+pub(crate) fn enforce_safety_net_mode(
     report: &LeakReport,
     mode: SafetyNetMode,
     fallback: SafetyNetFallback,
@@ -1069,7 +1071,7 @@ fn enforce_safety_net_mode(
     Ok(())
 }
 
-fn validate_safety_net_tolerant_gate(
+pub(crate) fn validate_safety_net_tolerant_gate(
     mode: SafetyNetMode,
     fallback: SafetyNetFallback,
 ) -> std::result::Result<(), CliError> {
@@ -1083,7 +1085,10 @@ fn validate_safety_net_tolerant_gate(
     Ok(())
 }
 
-fn safety_net_policy(mode: SafetyNetMode, fallback: SafetyNetFallback) -> gaze::SafetyNetPolicy {
+pub(crate) fn safety_net_policy(
+    mode: SafetyNetMode,
+    fallback: SafetyNetFallback,
+) -> gaze::SafetyNetPolicy {
     gaze::SafetyNetPolicy::new(
         match mode {
             SafetyNetMode::Strict => gaze::SafetyNetMode::Strict,

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -1,0 +1,174 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+use tempfile::tempdir;
+
+fn write_policy() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "emails"
+pattern = 'alice@example[.]invalid'
+class = "email"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+    (dir, path)
+}
+
+#[test]
+fn daemon_processes_jsonl_and_isolates_sessions() {
+    let (_dir, policy) = write_policy();
+    let audit_dir = tempdir().unwrap();
+    let audit_db = audit_dir.path().join("audit.db");
+    let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args([
+            "daemon",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--audit-db",
+            audit_db.to_str().unwrap(),
+            "--idle-timeout",
+            "30",
+            "--session-cap",
+            "1000",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let started = Instant::now();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        for idx in 0..100 {
+            let session_id = if idx % 2 == 0 {
+                "session-a"
+            } else {
+                "session-b"
+            };
+            let request = json!({
+                "session_id": session_id,
+                "text": format!("Contact alice@example.invalid for ticket {idx}")
+            });
+            writeln!(stdin, "{request}").unwrap();
+        }
+    }
+
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "100 daemon requests took {elapsed:?}"
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let responses = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), 100);
+    assert!(responses
+        .iter()
+        .all(|value| value["clean_text"].as_str().unwrap().contains("<")));
+    assert!(responses.iter().all(|value| value["manifest"]
+        .as_array()
+        .is_some_and(|spans| !spans.is_empty())));
+
+    let token_a = responses
+        .iter()
+        .find(|value| value["session_id"] == "session-a")
+        .unwrap()["tokens"][0]["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let token_b = responses
+        .iter()
+        .find(|value| value["session_id"] == "session-b")
+        .unwrap()["tokens"][0]["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_ne!(token_a, token_b, "session manifests must not bleed");
+
+    let conn = rusqlite::Connection::open(audit_db).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT provenance_stage FROM redaction_log ORDER BY created_at")
+        .unwrap();
+    let stages = stmt
+        .query_map([], |row| row.get::<_, Option<String>>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert!(!stages.is_empty());
+    assert!(stages
+        .iter()
+        .all(|stage| stage.as_deref() == Some("daemon")));
+}
+
+#[test]
+fn daemon_malformed_json_fails_closed_and_continues() {
+    let (_dir, policy) = write_policy();
+    let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args([
+            "daemon",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--idle-timeout",
+            "30",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(stdin, "{{not-json").unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            json!({"session_id": "session-a", "text": "alice@example.invalid"})
+        )
+        .unwrap();
+    }
+
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let responses = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0]["error"], "JsonMalformed");
+    assert_eq!(responses[1]["session_id"], "session-a");
+    assert!(responses[1]["clean_text"].as_str().unwrap().contains("<"));
+}

--- a/docs/architecture/daemon-mode.md
+++ b/docs/architecture/daemon-mode.md
@@ -1,0 +1,82 @@
+# Gaze Daemon Mode
+
+`gaze daemon` is the long-lived stdio runtime for adapters that need repeated
+low-latency pseudonymization without paying a binary startup and model-load cost
+for every request.
+
+## Protocol
+
+The wire format is JSON per line over stdin/stdout.
+
+Request:
+
+```json
+{"session_id":"conversation-1","text":"input text"}
+```
+
+Success:
+
+```json
+{"session_id":"conversation-1","clean_text":"output text","manifest":[],"tokens":[]}
+```
+
+Error:
+
+```json
+{"session_id":"conversation-1","error":"Pipeline","detail":"gaze daemon request failed closed"}
+```
+
+Malformed JSON is fail-closed per line: the daemon emits `JsonMalformed` with a
+null `session_id` and continues reading. Errors never echo the input line.
+
+## Runtime Shape
+
+The daemon constructs one `Pipeline` at launch from `--policy`. Optional
+Pass-3 safety nets, including the in-process Kiji ORT backend, are initialized
+through the same CLI build path as `gaze clean`, so pinned bundle SHA checks
+still run during daemon startup/backend initialization.
+
+Each request looks up a `Session` by client-provided `session_id`. First use
+creates a new session from the policy. Reuse of the same `session_id` reuses the
+same manifest and token map. Distinct `session_id` values never share a
+manifest.
+
+## Session Lifecycle
+
+The registry defaults to 1000 live sessions. When it exceeds `--session-cap`,
+the least recently used session is evicted. Sessions idle longer than
+`--session-idle-timeout` seconds are also evicted. Eviction logs a
+`tracing::warn!` row and an audit metadata row with source
+`daemon.session_eviction`.
+
+`--idle-timeout` is process-level stdin inactivity. When no request line arrives
+for that duration, the daemon exits cleanly.
+
+## Signals
+
+SIGINT and SIGTERM set a shutdown flag. The foreground loop finishes the current
+line, flushes stdout and audit writes, then exits. SIGHUP policy reload is not
+part of the v1 daemon contract.
+
+## Audit
+
+Daemon-mode redaction audit rows are passed through a logger wrapper that sets
+`provenance_stage = "daemon"`. This lets adopters query daemon-emitted metadata
+separately from one-shot `gaze clean` invocations without storing raw PII.
+
+## Five-Axis Check
+
+Reliability: malformed protocol input produces typed JSON errors and the daemon
+continues. Safety-net artifact verification remains fail-closed.
+
+Reversibility: session manifests are owned by one `session_id` and live only in
+that session entry. Eviction drops the restore map for that session.
+
+Agentic-first: JSONL keeps a single stdio connection hot for keystroke and
+multi-turn agent workflows.
+
+Trust: audit rows identify daemon provenance and session IDs remain opaque audit
+IDs, not token session hexes.
+
+Adopter ergonomics: adapters can start one process, stream line-delimited JSON,
+and avoid per-call binary startup or model cold starts.


### PR DESCRIPTION
## Summary

Adds `gaze daemon`, a long-lived JSONL stdio cleaner for adapters that need repeated low-latency pseudonymization without per-call binary startup or safety-net/model cold start.

Protocol:
- request: `{ "session_id": "<id>", "text": "<input>" }` per stdin line
- success: `{ "session_id", "clean_text", "manifest", "tokens" }` per stdout line
- error: `{ "session_id", "error", "detail" }` per stdout line

Lifecycle/state:
- one `Pipeline` is built at daemon startup from `--policy`
- optional safety-net flags reuse the existing clean-path backend registration, including Kiji ORT bundle verification on backend init
- per-`session_id` `Session` registry with isolation, LRU cap (`--session-cap`, default 1000), per-session idle eviction (`--session-idle-timeout`, default 3600s), and process stdin idle exit (`--idle-timeout`, default 1800s)
- SIGINT/SIGTERM finish the current line, flush stdout/audit writes, and exit cleanly
- daemon audit rows are stamped with `provenance_stage = "daemon"`; evictions warn and emit `daemon.session_eviction` metadata rows

## 100-line latency snapshot

`cargo test -p gaze-cli --test daemon_smoke --all-features` exercises 100 daemon JSONL requests through a spawned daemon process plus malformed-JSON continuation and audit checks. Finished test runtime after build: `0.13s` in the full workspace gate on this worker.

## Five-axis check

- Reliability: malformed JSON emits typed `JsonMalformed` and the daemon keeps reading; safety-net configuration and artifact checks remain fail-closed.
- Reversibility: each client `session_id` owns exactly one manifest/session map; eviction drops only that session restore state.
- Agentic-first: JSONL stdio keeps one process hot for real-time keystroke/multi-turn workflows.
- Trust: audit rows identify daemon provenance without raw PII; session audit IDs stay opaque.
- Adopter ergonomics: one command, one stdio protocol, no replacement or behavior change for `gaze clean`.

## Tests

- `cargo test -p gaze-cli --test daemon_smoke --all-features`
- `cargo test --workspace --all-features`