### PR TITLE
feat(kiji): int8 dynamic quantization (#368)

### DIFF
--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use super::{
-    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
-    SafetyNetFallback, SafetyNetKind, SafetyNetMode,
+    KijiBackend, KijiDistilbertPrecision, OpenAiFilterDevice, OpenAiFilterOperatingPoint,
+    SafetyNetBackend, SafetyNetFallback, SafetyNetKind, SafetyNetMode,
 };
 use crate::error::CliError;
 use crate::pipeline::{run_clean, CleanOptions};
@@ -30,6 +30,7 @@ pub(crate) struct Args {
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
     pub(crate) kiji_backend: KijiBackend,
+    pub(crate) kiji_distilbert_precision: KijiDistilbertPrecision,
     pub(crate) opf_locales: Vec<String>,
     pub(crate) opf_command: Option<PathBuf>,
     pub(crate) opf_checkpoint: Option<PathBuf>,
@@ -66,6 +67,7 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         openai_filter_operating_point: args.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
+        kiji_distilbert_precision: args.kiji_distilbert_precision,
         opf_locales: &args.opf_locales,
         opf_command: args.opf_command.as_deref(),
         opf_checkpoint: args.opf_checkpoint.as_deref(),

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -102,6 +102,9 @@ enum Cmd {
         /// Kiji DistilBERT runtime backend. Default: subprocess for compatibility.
         #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
         kiji_backend: KijiBackend,
+        /// Kiji DistilBERT ONNX precision. Default: fp32.
+        #[arg(long, value_enum, default_value_t = KijiDistilbertPrecision::Fp32)]
+        kiji_distilbert_precision: KijiDistilbertPrecision,
         /// Locale list for the OpenAI Privacy Filter registry entry.
         #[arg(long, value_delimiter = ',')]
         opf_locales: Vec<String>,
@@ -506,6 +509,12 @@ pub(crate) enum KijiBackend {
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum KijiDistilbertPrecision {
+    Fp32,
+    Int8,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SafetyNetMode {
     Strict,
     Tolerant,
@@ -545,6 +554,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_operating_point,
             openai_filter_device,
             kiji_backend,
+            kiji_distilbert_precision,
             opf_locales,
             opf_command,
             opf_checkpoint,
@@ -578,6 +588,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             openai_filter_operating_point,
             openai_filter_device,
             kiji_backend,
+            kiji_distilbert_precision,
             opf_locales,
             opf_command,
             opf_checkpoint,

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -20,9 +20,9 @@ use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 
 use crate::clean_overrides::CleanOverrides;
 use crate::commands::{
-    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
-    SafetyNetFallback, SafetyNetKind, SafetyNetMode, DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES,
-    DEFAULT_SAFETY_NET_TIMEOUT_MS,
+    KijiBackend, KijiDistilbertPrecision, OpenAiFilterDevice, OpenAiFilterOperatingPoint,
+    SafetyNetBackend, SafetyNetFallback, SafetyNetKind, SafetyNetMode,
+    DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES, DEFAULT_SAFETY_NET_TIMEOUT_MS,
 };
 use crate::error::CliError;
 use crate::io::{read_stdin_text, require_json_format};
@@ -57,6 +57,7 @@ pub(crate) struct CleanOptions<'a> {
     pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
     pub(crate) openai_filter_device: OpenAiFilterDevice,
     pub(crate) kiji_backend: KijiBackend,
+    pub(crate) kiji_distilbert_precision: KijiDistilbertPrecision,
     pub(crate) opf_locales: &'a [String],
     pub(crate) opf_command: Option<&'a Path>,
     pub(crate) opf_checkpoint: Option<&'a Path>,
@@ -497,7 +498,8 @@ fn kiji_distilbert_config(
     CliError,
 > {
     use gaze_recognizers::safety_net::kiji_distilbert::{
-        KijiDistilbertConfig, OrtKijiConfig, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
+        KijiDistilbertConfig, KijiDistilbertPrecision as RecognizerKijiPrecision, OrtKijiConfig,
+        SubprocessKijiConfig,
     };
 
     let model_dir = options.kiji_distilbert_model_dir.ok_or_else(|| {
@@ -506,25 +508,15 @@ fn kiji_distilbert_config(
         ))
     })?;
 
-    // Pinned-artifact contract (Axis 1): the runtime never silently disables
-    // the backend. Surface the artifact-missing predicate as a config-level
-    // error (exit 2) with the install hint, so the activation predicate
-    // documented in docs/architecture/safety-nets.md is preserved.
-    for required in REQUIRED_KIJI_ARTIFACTS {
-        let artifact = model_dir.join(required);
-        if !artifact.exists() {
-            return Err(CliError::SafetyNetArtifactMissing {
-                backend: "kiji-distilbert",
-                path: format!(
-                    "{} (install via scripts/fetch-kiji-safetynet-model.sh)",
-                    artifact.display()
-                ),
-            });
-        }
-    }
+    validate_kiji_artifacts(model_dir, options.kiji_distilbert_precision)?;
 
     match options.kiji_backend {
         KijiBackend::Subprocess => {
+            if options.kiji_distilbert_precision != KijiDistilbertPrecision::Fp32 {
+                return Err(CliError::SafetyNetConfigDetail(
+                    "--kiji-distilbert-precision=int8 requires --kiji-backend=ort".to_string(),
+                ));
+            }
             let command = options.kiji_distilbert_command.ok_or_else(|| {
                 CliError::SafetyNetConfigDetail(format!(
                     "--kiji-distilbert-command is required for {activation} with --kiji-backend=subprocess"
@@ -543,11 +535,47 @@ fn kiji_distilbert_config(
                         .to_string(),
                 ));
             }
+            let precision = match options.kiji_distilbert_precision {
+                KijiDistilbertPrecision::Fp32 => RecognizerKijiPrecision::Fp32,
+                KijiDistilbertPrecision::Int8 => RecognizerKijiPrecision::Int8,
+            };
             let config = OrtKijiConfig::new(model_dir)
+                .with_precision(precision)
                 .with_max_input_bytes(options.safety_net_input_limit_bytes);
             Ok(KijiDistilbertConfig::from(config))
         }
     }
+}
+
+#[cfg(feature = "safety-net-kiji")]
+fn validate_kiji_artifacts(
+    model_dir: &Path,
+    precision: KijiDistilbertPrecision,
+) -> std::result::Result<(), CliError> {
+    use gaze_recognizers::safety_net::kiji_distilbert::{
+        REQUIRED_KIJI_ARTIFACTS, REQUIRED_KIJI_INT8_ARTIFACTS,
+    };
+
+    // Pinned-artifact contract (Axis 1): the runtime never silently disables
+    // the backend. Surface missing artifacts as a config-level error (exit 2)
+    // before backend construction; SHA mismatches still fail in the backend.
+    let required = match precision {
+        KijiDistilbertPrecision::Fp32 => REQUIRED_KIJI_ARTIFACTS,
+        KijiDistilbertPrecision::Int8 => REQUIRED_KIJI_INT8_ARTIFACTS,
+    };
+    for required in required {
+        let artifact = model_dir.join(required);
+        if !artifact.exists() {
+            return Err(CliError::SafetyNetArtifactMissing {
+                backend: "kiji-distilbert",
+                path: format!(
+                    "{} (install via scripts/fetch-kiji-safetynet-model.sh)",
+                    artifact.display()
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(not(feature = "safety-net-kiji"))]
@@ -567,6 +595,7 @@ fn validate_no_backend_options(options: &CleanOptions<'_>) -> std::result::Resul
         || options.openai_filter_operating_point.is_some()
         || options.openai_filter_device != OpenAiFilterDevice::Auto
         || options.kiji_backend != KijiBackend::Subprocess
+        || options.kiji_distilbert_precision != KijiDistilbertPrecision::Fp32
         || options.opf_command.is_some()
         || options.opf_checkpoint.is_some()
         || !options.opf_locales.is_empty()

--- a/crates/gaze-recognizers/benches/safety_net_matrix.rs
+++ b/crates/gaze-recognizers/benches/safety_net_matrix.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "safety-net-kiji")]
 use gaze_recognizers::safety_net::kiji_distilbert::{
-    KijiDistilbertBackend, OrtKijiBackend, OrtKijiConfig, KIJI_DISTILBERT_BUNDLE_SHA256,
-    KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO, KIJI_DISTILBERT_SHA256SUMS,
+    KijiDistilbertBackend, KijiDistilbertPrecision, OrtKijiBackend, OrtKijiConfig,
+    KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
+    KIJI_DISTILBERT_INT8_BUNDLE_SHA256, KIJI_DISTILBERT_INT8_SHA256SUMS,
+    KIJI_DISTILBERT_SHA256SUMS,
 };
 #[cfg(feature = "safety-net-openai")]
 use gaze_recognizers::safety_net::openai_filter::backend::subprocess::{
@@ -12,7 +14,11 @@ use serde_json::Value;
 const SNAPSHOT: &str = include_str!("safety_net_matrix_snapshot.json");
 const PERF_SNAPSHOT: &str = include_str!("safety_net_perf_snapshot.json");
 
-const BACKENDS: [&str; 2] = ["kiji_distilbert", "openai_privacy_filter"];
+const BACKENDS: [&str; 3] = [
+    "kiji_distilbert",
+    "kiji_distilbert_int8",
+    "openai_privacy_filter",
+];
 const LOCALES: [&str; 3] = ["Global", "EnUs", "DeDe"];
 const MODES: [&str; 2] = ["direct_detector", "observer_residual"];
 
@@ -35,6 +41,7 @@ fn main() {
     assert_opf_pins(&snapshot);
     assert_strict_span_leak_rate_shape(&snapshot);
     assert_cells(&snapshot);
+    assert_kiji_int8_recall_gate(&snapshot);
     assert_perf_snapshot();
 
     println!("{SNAPSHOT}");
@@ -47,8 +54,12 @@ fn run_live_ort_bench() {
     let model_dir = std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR")
         .expect("GAZE_KIJI_DISTILBERT_MODEL_DIR is required for live ORT bench");
     let cold_start = Instant::now();
-    let backend =
-        OrtKijiBackend::new(OrtKijiConfig::new(model_dir)).expect("load Kiji ORT backend");
+    let precision = match std::env::var("GAZE_KIJI_DISTILBERT_PRECISION").as_deref() {
+        Ok("int8") => KijiDistilbertPrecision::Int8,
+        _ => KijiDistilbertPrecision::Fp32,
+    };
+    let backend = OrtKijiBackend::new(OrtKijiConfig::new(model_dir).with_precision(precision))
+        .expect("load Kiji ORT backend");
     let cold_start_ms = cold_start.elapsed().as_secs_f64() * 1000.0;
     let fixture = "Alice Smith visited Berlin before meeting Dr. Schmidt at Example Corp.";
     backend.infer(fixture).expect("warmup inference");
@@ -62,7 +73,8 @@ fn run_live_ort_bench() {
     samples.sort_by(f64::total_cmp);
     let p50_ms = samples[samples.len() / 2];
     println!(
-        "{{\"backend\":\"kiji_distilbert_ort\",\"cold_start_ms\":{cold_start_ms:.3},\"warm_p50_ms\":{p50_ms:.3},\"iterations\":{}}}",
+        "{{\"backend\":\"kiji_distilbert_ort\",\"precision\":\"{}\",\"cold_start_ms\":{cold_start_ms:.3},\"warm_p50_ms\":{p50_ms:.3},\"iterations\":{}}}",
+        precision.as_str(),
         samples.len()
     );
 }
@@ -94,6 +106,31 @@ fn assert_kiji_pins(snapshot: &Value) {
         pins["label_map_sha256"],
         Value::String(checksum_for("labels.json").to_string())
     );
+    let int8_pins = &snapshot["backends"]["kiji_distilbert_int8"]["pins"];
+    assert_eq!(
+        int8_pins["source_repo"],
+        Value::String(KIJI_DISTILBERT_HF_REPO.to_string())
+    );
+    assert_eq!(
+        int8_pins["source_commit"],
+        Value::String(KIJI_DISTILBERT_HF_COMMIT.to_string())
+    );
+    assert_eq!(
+        int8_pins["bundle_sha256"],
+        Value::String(KIJI_DISTILBERT_INT8_BUNDLE_SHA256.to_string())
+    );
+    assert_eq!(
+        int8_pins["model_sha256"],
+        Value::String(int8_checksum_for("model.int8.onnx").to_string())
+    );
+    assert_eq!(
+        int8_pins["tokenizer_sha256"],
+        Value::String(int8_checksum_for("tokenizer.json").to_string())
+    );
+    assert_eq!(
+        int8_pins["label_map_sha256"],
+        Value::String(int8_checksum_for("labels.json").to_string())
+    );
 }
 
 #[cfg(feature = "safety-net-kiji")]
@@ -105,6 +142,17 @@ fn checksum_for(filename: &str) -> &str {
             (path == filename).then_some(sha256)
         })
         .expect("checksum present in Kiji SHA256SUMS")
+}
+
+#[cfg(feature = "safety-net-kiji")]
+fn int8_checksum_for(filename: &str) -> &str {
+    KIJI_DISTILBERT_INT8_SHA256SUMS
+        .lines()
+        .find_map(|line| {
+            let (sha256, path) = line.split_once("  ")?;
+            (path == filename).then_some(sha256)
+        })
+        .expect("checksum present in Kiji int8 SHA256SUMS")
 }
 
 #[cfg(not(feature = "safety-net-kiji"))]
@@ -121,6 +169,22 @@ fn assert_kiji_pins(snapshot: &Value) {
         "label_map_sha256",
     ] {
         assert!(pins.contains_key(key), "missing Kiji pin key: {key}");
+    }
+    let int8_pins = snapshot["backends"]["kiji_distilbert_int8"]["pins"]
+        .as_object()
+        .expect("Kiji int8 pins object");
+    for key in [
+        "source_repo",
+        "source_commit",
+        "bundle_sha256",
+        "model_sha256",
+        "tokenizer_sha256",
+        "label_map_sha256",
+    ] {
+        assert!(
+            int8_pins.contains_key(key),
+            "missing Kiji int8 pin key: {key}"
+        );
     }
 }
 
@@ -212,6 +276,31 @@ fn assert_cells(snapshot: &Value) {
             }
         }
     }
+}
+
+fn assert_kiji_int8_recall_gate(snapshot: &Value) {
+    const MAX_RECALL_DELTA: f64 = 0.02;
+
+    for locale in LOCALES {
+        for mode in MODES {
+            let fp32 = recall_for(snapshot, "kiji_distilbert", locale, mode);
+            let int8 = recall_for(snapshot, "kiji_distilbert_int8", locale, mode);
+            assert!(
+                fp32 - int8 <= MAX_RECALL_DELTA,
+                "kiji int8 recall regression exceeds {MAX_RECALL_DELTA:.2} for {locale}.{mode}: fp32={fp32:.6}, int8={int8:.6}"
+            );
+        }
+    }
+}
+
+fn recall_for(snapshot: &Value, backend: &str, locale: &str, mode: &str) -> f64 {
+    snapshot["cells"]
+        .as_array()
+        .expect("cells array")
+        .iter()
+        .find(|cell| cell["backend"] == backend && cell["locale"] == locale && cell["mode"] == mode)
+        .and_then(|cell| cell["metrics"]["recall"].as_f64())
+        .unwrap_or_else(|| panic!("missing numeric recall for {backend}.{locale}.{mode}"))
 }
 
 fn assert_cell_schema(cell: &Value, mode: &str) {

--- a/crates/gaze-recognizers/benches/safety_net_matrix_snapshot.json
+++ b/crates/gaze-recognizers/benches/safety_net_matrix_snapshot.json
@@ -25,6 +25,16 @@
           "viterbi_calibration.json"
         ]
       }
+    },
+    "kiji_distilbert_int8": {
+      "pins": {
+        "source_repo": "onnx-community/distilbert-NER-ONNX",
+        "source_commit": "3a19fe9404a4469d91aa3d551558a97f68872f67",
+        "bundle_sha256": "6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb",
+        "model_sha256": "bd909cc924b7e10a8d2cdffb0e3bb6036f12d6ae6740cc45420fe82682f5a867",
+        "tokenizer_sha256": "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34",
+        "label_map_sha256": "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97"
+      }
     }
   },
   "corpus": {
@@ -40,7 +50,10 @@
     "kiji_distilbert.DeDe": 0.875,
     "openai_privacy_filter.Global": 0.635593,
     "openai_privacy_filter.EnUs": 0.744271,
-    "openai_privacy_filter.DeDe": 0.649332
+    "openai_privacy_filter.DeDe": 0.649332,
+    "kiji_distilbert_int8.Global": 0.875,
+    "kiji_distilbert_int8.EnUs": 0.875,
+    "kiji_distilbert_int8.DeDe": 0.875
   },
   "cells": [
     {
@@ -1136,12 +1149,420 @@
         "contradiction_fraction": null,
         "novel_tp_over_rule_floor": 1.0
       }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "Global",
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.076923,
+        "recall": 0.125,
+        "f1": 0.095238,
+        "per_class": {
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Location": {
+            "support": 0,
+            "predicted": 4,
+            "true_positive": 0,
+            "false_positive": 4,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 61,
+            "true_positive": 5,
+            "false_positive": 56,
+            "false_negative": 0,
+            "precision": 0.081967,
+            "recall": 1.0,
+            "f1": 0.151515
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "EnUs",
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.54717,
+        "recall": 0.125,
+        "f1": 0.203509,
+        "per_class": {
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 53,
+            "true_positive": 29,
+            "false_positive": 24,
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "DeDe",
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.116,
+        "recall": 0.125,
+        "f1": 0.120332,
+        "per_class": {
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Location": {
+            "support": 0,
+            "predicted": 3,
+            "true_positive": 0,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 247,
+            "true_positive": 29,
+            "false_positive": 218,
+            "false_negative": 0,
+            "precision": 0.117409,
+            "recall": 1.0,
+            "f1": 0.210145
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "Global",
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.080645,
+        "recall": 0.5,
+        "f1": 0.138889,
+        "per_class": {
+          "Location": {
+            "support": 0,
+            "predicted": 3,
+            "true_positive": 0,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 59,
+            "true_positive": 5,
+            "false_positive": 54,
+            "false_negative": 0,
+            "precision": 0.084746,
+            "recall": 1.0,
+            "f1": 0.15625
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "EnUs",
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.54717,
+        "recall": 0.5,
+        "f1": 0.522523,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 53,
+            "true_positive": 29,
+            "false_positive": 24,
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "backend": "kiji_distilbert_int8",
+      "locale": "DeDe",
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.118852,
+        "recall": 1.0,
+        "f1": 0.212454,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 244,
+            "true_positive": 29,
+            "false_positive": 215,
+            "false_negative": 0,
+            "precision": 0.118852,
+            "recall": 1.0,
+            "f1": 0.212454
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
     }
   ],
   "run_environment": {
     "os": "macOS-26.5-arm64-arm-64bit-Mach-O",
     "machine": "arm64",
     "python": "3.14.5",
-    "opf_device": "cpu"
+    "onnxruntime_threads": "default",
+    "precision": "int8"
   }
 }

--- a/crates/gaze-recognizers/benches/safety_net_perf_snapshot.json
+++ b/crates/gaze-recognizers/benches/safety_net_perf_snapshot.json
@@ -23,6 +23,17 @@
       "fixture_count": 150,
       "device": "cpu",
       "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+    },
+    "kiji_distilbert_int8": {
+      "cold_start_ms": 155.45675,
+      "per_fixture_median_ms": 151.879855,
+      "per_fixture_p95_ms": 159.788914,
+      "per_fixture_p99_ms": 162.623382,
+      "per_fixture_mean_ms": 152.522085,
+      "throughput_bytes_per_sec": 1872.034901,
+      "fixture_count": 150,
+      "device": "cpu",
+      "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
     }
   },
   "host": {

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/artifacts.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/artifacts.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use gaze_types::SafetyNetError;
 use sha2::{Digest, Sha256};
 
+use super::KijiDistilbertPrecision;
+
 /// Files Kiji must ship under `model_dir` for the pinned-artifact contract.
 ///
 /// Missing `SHA256SUMS` is an Axis-1 reliability defect: the runtime must
@@ -10,6 +12,14 @@ use sha2::{Digest, Sha256};
 /// in `crates/gaze/testdata/ner/`.
 pub const REQUIRED_KIJI_ARTIFACTS: &[&str] =
     &["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"];
+
+/// Files Kiji must ship for the opt-in int8 dynamic-quantized artifact.
+pub const REQUIRED_KIJI_INT8_ARTIFACTS: &[&str] = &[
+    "SHA256SUMS.int8",
+    "labels.json",
+    "model.int8.onnx",
+    "tokenizer.json",
+];
 
 /// Hugging Face repository for the canonical Kiji DistilBERT ONNX bundle.
 pub const KIJI_DISTILBERT_HF_REPO: &str = "onnx-community/distilbert-NER-ONNX";
@@ -25,6 +35,10 @@ pub const KIJI_DISTILBERT_HF_COMMIT: &str = "3a19fe9404a4469d91aa3d551558a97f688
 pub const KIJI_DISTILBERT_BUNDLE_SHA256: &str =
     "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f";
 
+/// SHA256 of the canonical `SHA256SUMS.int8` file for the quantized bundle.
+pub const KIJI_DISTILBERT_INT8_BUNDLE_SHA256: &str =
+    "6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb";
+
 /// Canonical checksum file content. The model hash is the Hugging Face LFS
 /// SHA256 for `onnx/model.onnx` at `KIJI_DISTILBERT_HF_COMMIT`.
 pub const KIJI_DISTILBERT_SHA256SUMS: &str = concat!(
@@ -33,10 +47,25 @@ pub const KIJI_DISTILBERT_SHA256SUMS: &str = concat!(
     "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34  tokenizer.json\n",
 );
 
+/// Canonical int8 checksum file content generated from the pinned fp32 ONNX.
+pub const KIJI_DISTILBERT_INT8_SHA256SUMS: &str = concat!(
+    "d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97  labels.json\n",
+    "bd909cc924b7e10a8d2cdffb0e3bb6036f12d6ae6740cc45420fe82682f5a867  model.int8.onnx\n",
+    "cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34  tokenizer.json\n",
+);
+
 /// Pinned-artifact contract: every entry in `REQUIRED_KIJI_ARTIFACTS` must exist
 /// under `model_dir`. Missing `SHA256SUMS` is a fail-closed condition (Axis 1).
 pub(crate) fn verify_model_dir(
     model_dir: Option<&Path>,
+    expected_sha256: &str,
+) -> Result<(), SafetyNetError> {
+    verify_model_dir_for_precision(model_dir, KijiDistilbertPrecision::Fp32, expected_sha256)
+}
+
+pub(crate) fn verify_model_dir_for_precision(
+    model_dir: Option<&Path>,
+    precision: KijiDistilbertPrecision,
     expected_sha256: &str,
 ) -> Result<(), SafetyNetError> {
     let Some(dir) = model_dir else {
@@ -50,7 +79,7 @@ pub(crate) fn verify_model_dir(
     }
     verify_sensitive_tree(dir)?;
 
-    for required in REQUIRED_KIJI_ARTIFACTS {
+    for required in required_artifacts(precision) {
         let artifact = dir.join(required);
         if !artifact.exists() {
             return Err(SafetyNetError::WeightsMissing {
@@ -58,15 +87,16 @@ pub(crate) fn verify_model_dir(
             });
         }
     }
-    verify_bundle_integrity(dir, expected_sha256)?;
+    verify_bundle_integrity_for_precision(dir, precision, expected_sha256)?;
     Ok(())
 }
 
-pub(crate) fn verify_bundle_integrity(
+pub(crate) fn verify_bundle_integrity_for_precision(
     dir: &Path,
+    precision: KijiDistilbertPrecision,
     expected_sha256: &str,
 ) -> Result<(), SafetyNetError> {
-    let sha256sums_path = dir.join("SHA256SUMS");
+    let sha256sums_path = dir.join(checksum_filename(precision));
     let sha256sums =
         std::fs::read(&sha256sums_path).map_err(|_| SafetyNetError::WeightsMissing {
             path: sanitize_path(&sha256sums_path),
@@ -79,9 +109,9 @@ pub(crate) fn verify_bundle_integrity(
         });
     }
 
-    let checksums = parse_sha256sums(&sha256sums)?;
-    for required in REQUIRED_KIJI_ARTIFACTS {
-        if *required == "SHA256SUMS" {
+    let checksums = parse_sha256sums(&sha256sums, precision)?;
+    for required in required_artifacts(precision) {
+        if *required == checksum_filename(precision) {
             continue;
         }
         let Some(expected_artifact_sha256) = checksums
@@ -114,7 +144,10 @@ pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
     hex::encode(digest)
 }
 
-fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetError> {
+fn parse_sha256sums(
+    bytes: &[u8],
+    precision: KijiDistilbertPrecision,
+) -> Result<Vec<(String, String)>, SafetyNetError> {
     let text = std::str::from_utf8(bytes).map_err(|_| SafetyNetError::ModelIntegrityMismatch {
         expected: "valid UTF-8 SHA256SUMS".to_string(),
         actual: "<invalid-utf8>".to_string(),
@@ -127,8 +160,8 @@ fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetErro
         if fields.next().is_some()
             || sha256.len() != 64
             || !sha256.bytes().all(|byte| byte.is_ascii_hexdigit())
-            || !REQUIRED_KIJI_ARTIFACTS.contains(&name)
-            || name == "SHA256SUMS"
+            || !required_artifacts(precision).contains(&name)
+            || name == checksum_filename(precision)
             || name.contains('/')
             || name.contains('\\')
         {
@@ -140,6 +173,27 @@ fn parse_sha256sums(bytes: &[u8]) -> Result<Vec<(String, String)>, SafetyNetErro
         entries.push((sha256.to_ascii_lowercase(), name.to_string()));
     }
     Ok(entries)
+}
+
+pub(crate) fn required_artifacts(precision: KijiDistilbertPrecision) -> &'static [&'static str] {
+    match precision {
+        KijiDistilbertPrecision::Fp32 => REQUIRED_KIJI_ARTIFACTS,
+        KijiDistilbertPrecision::Int8 => REQUIRED_KIJI_INT8_ARTIFACTS,
+    }
+}
+
+pub(crate) fn checksum_filename(precision: KijiDistilbertPrecision) -> &'static str {
+    match precision {
+        KijiDistilbertPrecision::Fp32 => "SHA256SUMS",
+        KijiDistilbertPrecision::Int8 => "SHA256SUMS.int8",
+    }
+}
+
+pub(crate) fn model_filename(precision: KijiDistilbertPrecision) -> &'static str {
+    match precision {
+        KijiDistilbertPrecision::Fp32 => "model.onnx",
+        KijiDistilbertPrecision::Int8 => "model.int8.onnx",
+    }
 }
 
 fn verify_sensitive_tree(path: &Path) -> Result<(), SafetyNetError> {

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
@@ -6,6 +6,22 @@ pub mod artifacts;
 pub mod ort;
 pub mod subprocess;
 
+/// Precision variant for the pinned Kiji DistilBERT ONNX artifact.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum KijiDistilbertPrecision {
+    Fp32,
+    Int8,
+}
+
+impl KijiDistilbertPrecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fp32 => "fp32",
+            Self::Int8 => "int8",
+        }
+    }
+}
+
 /// Internal Kiji span after PII-bearing upstream fields have been dropped.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawSpan {

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
@@ -3,12 +3,14 @@ use std::sync::Mutex;
 
 use gaze_types::SafetyNetError;
 
-use super::artifacts::{verify_model_dir, KIJI_DISTILBERT_BUNDLE_SHA256};
-use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
+use super::artifacts::{
+    model_filename, verify_model_dir_for_precision, KIJI_DISTILBERT_BUNDLE_SHA256,
+    KIJI_DISTILBERT_INT8_BUNDLE_SHA256,
+};
+use super::{normalize_raw_spans, KijiDistilbertBackend, KijiDistilbertPrecision, RawSpan};
 use crate::ner::decode::{softmax_confidence, split_bio};
 
 const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
-const MODEL_FILE: &str = "model.onnx";
 const TOKENIZER_FILE: &str = "tokenizer.json";
 const ID2LABEL: [&str; 9] = [
     "O", "B-PER", "I-PER", "B-LOC", "I-LOC", "B-ORG", "I-ORG", "B-MISC", "I-MISC",
@@ -18,6 +20,7 @@ const ID2LABEL: [&str; 9] = [
 #[derive(Debug, Clone)]
 pub struct OrtKijiConfig {
     model_dir: PathBuf,
+    precision: KijiDistilbertPrecision,
     max_input_bytes: usize,
     version: String,
     decoding_params: Vec<(&'static str, String)>,
@@ -29,9 +32,16 @@ impl OrtKijiConfig {
     pub fn new(model_dir: impl Into<PathBuf>) -> Self {
         Self {
             model_dir: model_dir.into(),
+            precision: KijiDistilbertPrecision::Fp32,
             max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
             version: "kiji/distilbert:ort".to_string(),
-            decoding_params: vec![("runtime", "ort".to_string())],
+            decoding_params: vec![
+                ("runtime", "ort".to_string()),
+                (
+                    "precision",
+                    KijiDistilbertPrecision::Fp32.as_str().to_string(),
+                ),
+            ],
             #[cfg(any(test, feature = "test-support"))]
             expected_bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
         }
@@ -48,6 +58,22 @@ impl OrtKijiConfig {
 
     pub fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
         self.max_input_bytes = max_input_bytes;
+        self
+    }
+
+    pub fn with_precision(mut self, precision: KijiDistilbertPrecision) -> Self {
+        self.precision = precision;
+        self.version = format!("kiji/distilbert:ort-{}", precision.as_str());
+        self.decoding_params.retain(|(key, _)| *key != "precision");
+        self.decoding_params
+            .push(("precision", precision.as_str().to_string()));
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            self.expected_bundle_sha256 = match precision {
+                KijiDistilbertPrecision::Fp32 => KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
+                KijiDistilbertPrecision::Int8 => KIJI_DISTILBERT_INT8_BUNDLE_SHA256.to_string(),
+            };
+        }
         self
     }
 
@@ -72,6 +98,10 @@ impl OrtKijiConfig {
         &self.model_dir
     }
 
+    pub fn precision(&self) -> KijiDistilbertPrecision {
+        self.precision
+    }
+
     fn expected_bundle_sha256(&self) -> &str {
         #[cfg(any(test, feature = "test-support"))]
         {
@@ -79,7 +109,10 @@ impl OrtKijiConfig {
         }
         #[cfg(not(any(test, feature = "test-support")))]
         {
-            KIJI_DISTILBERT_BUNDLE_SHA256
+            match self.precision {
+                KijiDistilbertPrecision::Fp32 => KIJI_DISTILBERT_BUNDLE_SHA256,
+                KijiDistilbertPrecision::Int8 => KIJI_DISTILBERT_INT8_BUNDLE_SHA256,
+            }
         }
     }
 }
@@ -95,7 +128,11 @@ pub struct OrtKijiBackend {
 
 impl OrtKijiBackend {
     pub fn new(config: OrtKijiConfig) -> Result<Self, SafetyNetError> {
-        verify_model_dir(Some(config.model_dir()), config.expected_bundle_sha256())?;
+        verify_model_dir_for_precision(
+            Some(config.model_dir()),
+            config.precision(),
+            config.expected_bundle_sha256(),
+        )?;
         let tokenizer = tokenizers::Tokenizer::from_file(config.model_dir.join(TOKENIZER_FILE))
             .map_err(|err| SafetyNetError::ModelUnavailable {
                 reason: format!(
@@ -110,7 +147,7 @@ impl OrtKijiBackend {
                     sanitize_error(&err.to_string())
                 ),
             })?
-            .commit_from_file(config.model_dir.join(MODEL_FILE))
+            .commit_from_file(config.model_dir.join(model_filename(config.precision())))
             .map_err(|err| SafetyNetError::ModelUnavailable {
                 reason: format!(
                     "failed to load kiji ort model: {}",

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
@@ -532,6 +532,7 @@ fn verify_command_path(command: &Path) -> Result<(), SafetyNetError> {
 mod tests {
     use super::super::artifacts::{
         hex_sha256, KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT,
+        KIJI_DISTILBERT_INT8_BUNDLE_SHA256, KIJI_DISTILBERT_INT8_SHA256SUMS,
         KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS,
     };
     use super::*;
@@ -661,6 +662,10 @@ mod tests {
             hex_sha256(KIJI_DISTILBERT_SHA256SUMS.as_bytes()),
             KIJI_DISTILBERT_BUNDLE_SHA256
         );
+        assert_eq!(
+            hex_sha256(KIJI_DISTILBERT_INT8_SHA256SUMS.as_bytes()),
+            KIJI_DISTILBERT_INT8_BUNDLE_SHA256
+        );
 
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let workspace = manifest_dir.parent().unwrap().parent().unwrap();
@@ -674,6 +679,7 @@ mod tests {
         for content in [setup_doc, fetcher] {
             assert!(content.contains(KIJI_DISTILBERT_HF_COMMIT));
             assert!(content.contains(KIJI_DISTILBERT_BUNDLE_SHA256));
+            assert!(content.contains(KIJI_DISTILBERT_INT8_BUNDLE_SHA256));
         }
     }
 

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -22,11 +22,12 @@ pub mod class_map;
 
 pub use backend::artifacts::{
     KIJI_DISTILBERT_BUNDLE_SHA256, KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO,
-    KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS,
+    KIJI_DISTILBERT_INT8_BUNDLE_SHA256, KIJI_DISTILBERT_INT8_SHA256SUMS,
+    KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS, REQUIRED_KIJI_INT8_ARTIFACTS,
 };
 pub use backend::ort::{OrtKijiBackend, OrtKijiConfig};
 pub use backend::subprocess::{SubprocessKijiBackend, SubprocessKijiConfig};
-pub use backend::{KijiBackendKind, KijiDistilbertBackend, RawSpan};
+pub use backend::{KijiBackendKind, KijiDistilbertBackend, KijiDistilbertPrecision, RawSpan};
 pub use class_map::{
     kiji_label_to_pii_class, kiji_label_to_safety_net_class, map_kiji_label, validate_kiji_label,
     KijiLabel,

--- a/docs/architecture/safety-nets.md
+++ b/docs/architecture/safety-nets.md
@@ -14,11 +14,11 @@ and do not participate in conflict resolution.
 
 ## Benchmark
 
-The v0.9 benchmark populated direct-detector cells for both shipped backends
-against the same 150-fixture coverage-loop corpus: Kiji DistilBERT stayed at
-`0.125000` macro strict recall across locales, while OPF measured `0.364407`
-global, `0.255729` en-US, and `0.350668` de-DE. Observer-residual cells remain
-deferred until the cleaned-output harness is run. Full numbers, pins, and
+The v0.9 benchmark populates direct-detector and observer-residual cells for
+both shipped backends against the same 150-fixture coverage-loop corpus. Kiji
+DistilBERT fp32 stays at `0.125000` macro strict recall across locales; the
+opt-in int8 dynamic-quantized Kiji artifact also stays at `0.125000` macro
+strict recall across locales in direct-detector mode. Full numbers, pins, and
 caveats are in [`docs/research/v0.9-safety-net-benchmark.md`](../research/v0.9-safety-net-benchmark.md).
 
 This document describes the safety-net contract introduced in v0.6 through
@@ -84,7 +84,16 @@ can land without changing the trait shape or audit schema.
 
 ## Locale-Aware Registry Dispatch
 
-Kiji DistilBERT has two runtime backends under the same observer-only safety-net contract. `--kiji-backend=subprocess` remains the default for backwards compatibility and for adopters who already pin an external Kiji command; `--kiji-backend=ort` loads the same tokenizer and ONNX model in-process through ONNX Runtime, removing the Python/subprocess install path. Both backends must verify the pinned bundle first: `SHA256SUMS` is hashed against `KIJI_DISTILBERT_BUNDLE_SHA256`, every listed artifact is re-hashed before model load, and any mismatch returns a typed `SafetyNetError` without silent fallback.
+Kiji DistilBERT has two runtime backends under the same observer-only safety-net contract. `--kiji-backend=subprocess` remains the default for backwards compatibility and for adopters who already pin an external Kiji command; `--kiji-backend=ort` loads the same tokenizer and ONNX model in-process through ONNX Runtime, removing the Python/subprocess install path. Both backends must verify the pinned bundle first: fp32 uses `SHA256SUMS` and `KIJI_DISTILBERT_BUNDLE_SHA256`; int8 uses `SHA256SUMS.int8` and `KIJI_DISTILBERT_INT8_BUNDLE_SHA256`. Every listed artifact is re-hashed before model load, and any mismatch returns a typed `SafetyNetError` without silent fallback.
+
+The ORT backend also accepts `--kiji-distilbert-precision {fp32,int8}`. `fp32`
+is the default and remains the compatibility posture. `int8` loads
+`model.int8.onnx`, shares the same tokenizer and class map, and is allowed only
+with `--kiji-backend=ort`; requesting int8 without the quantized artifact fails
+closed at construction. The committed safety-net matrix enforces the precision
+trade-off: int8 macro recall must remain within `0.02` of fp32 for every
+locale and mode, otherwise the bench gate fails and the int8 path must not
+ship.
 
 `Pipeline::with_safety_net(single_backend)` remains the compatibility path. For deployments with language-specific safety nets, `Pipeline::with_safety_net_registry(LocaleAwareModelRegistry)` activates locale-aware Pass-3 dispatch instead. The registry resolves one backend per clean segment using the existing four-tier order: exact locale, parent language, `Global`, then fail-closed.
 

--- a/docs/getting-started/kiji-safetynet-setup.md
+++ b/docs/getting-started/kiji-safetynet-setup.md
@@ -28,6 +28,9 @@ before it will run. The canonical upstream source is
 `3a19fe9404a4469d91aa3d551558a97f68872f67`; the runtime pins the canonical
 bundle checksum file to SHA256
 `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f`.
+The opt-in ORT int8 path adds `SHA256SUMS.int8` and `model.int8.onnx`; its
+checksum file is pinned to SHA256
+`6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb`.
 The local adapter validates emitted labels and maps them into Gaze's closed
 SafetyNet classes before manifest diffing.
 
@@ -71,6 +74,18 @@ Source anchors:
    returning. The script fails closed if the pinned upstream commit is not set,
    if the release checksum cannot be resolved, or if any required file is
    missing.
+
+   To prepare the opt-in int8 ORT artifact, install `onnxruntime` with its
+   quantization extras available and run:
+
+   ```sh
+   python3 scripts/quantize-kiji-int8.py \
+     "${XDG_DATA_HOME:-$HOME/.local/share}/gaze/models/kiji-distilbert"
+   ```
+
+   The helper writes `model.int8.onnx` and `SHA256SUMS.int8`. Gaze verifies the
+   int8 manifest against the separate int8 SHA pin and will not fall back to
+   fp32 if `--kiji-distilbert-precision=int8` is requested.
 
 2. Install the CLI with Kiji support:
 

--- a/scripts/fetch-kiji-safetynet-model.sh
+++ b/scripts/fetch-kiji-safetynet-model.sh
@@ -23,6 +23,7 @@ set -euo pipefail
 HF_REPO="onnx-community/distilbert-NER-ONNX"
 HF_COMMIT_SHA="3a19fe9404a4469d91aa3d551558a97f68872f67"
 KIJI_BUNDLE_SHA256="c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f"
+KIJI_INT8_BUNDLE_SHA256="6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb"
 GITHUB_REPO="${GAZE_GITHUB_REPO:-EmpireTwo/gaze}"
 
 # Files that must end up in the destination directory.
@@ -234,4 +235,5 @@ log "verifying checksums"
 verify_sha256sums
 
 log "done. model dir: $DEST"
+log "int8 precision is opt-in: run scripts/quantize-kiji-int8.py \"$DEST\" and verify SHA256SUMS.int8=$KIJI_INT8_BUNDLE_SHA256"
 log "next: pass --safety-net-backend=kiji-distilbert --kiji-distilbert-model-dir=\"$DEST\" to gaze clean"

--- a/scripts/kiji-runner.py
+++ b/scripts/kiji-runner.py
@@ -39,6 +39,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--format", required=True, choices=["json"])
     parser.add_argument("--output-mode", required=True, choices=["typed"])
     parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--precision", choices=["fp32", "int8"], default="fp32")
     return parser.parse_args(argv)
 
 
@@ -169,11 +170,12 @@ def spans_from_predictions(
     return spans
 
 
-def run(model_dir: Path, text: str) -> list[dict[str, Any]]:
+def run(model_dir: Path, text: str, precision: str = "fp32") -> list[dict[str, Any]]:
     if text == "":
         return []
 
-    model_path = model_dir / "model.onnx"
+    model_name = "model.int8.onnx" if precision == "int8" else "model.onnx"
+    model_path = model_dir / model_name
     tokenizer_path = model_dir / "tokenizer.json"
     labels_path = model_dir / "labels.json"
     for path in [model_path, tokenizer_path, labels_path]:
@@ -219,7 +221,7 @@ def main(argv: list[str]) -> int:
     try:
         args = parse_args(argv)
         text = read_stdin()
-        spans = run(Path(args.model_dir), text)
+        spans = run(Path(args.model_dir), text, args.precision)
         json.dump(spans, sys.stdout, separators=(",", ":"))
         sys.stdout.write("\n")
         return 0

--- a/scripts/quantize-kiji-int8.py
+++ b/scripts/quantize-kiji-int8.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Quantize the pinned Kiji DistilBERT ONNX model to int8.
+
+This helper is intentionally offline: it reads an already-fetched fp32 Kiji
+bundle, emits `model.int8.onnx`, and writes a separate `SHA256SUMS.int8`
+manifest so fp32 and int8 keep independent integrity pins.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+from onnxruntime.quantization import QuantType, quantize_dynamic
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Quantize pinned Kiji DistilBERT ONNX bundle to int8."
+    )
+    parser.add_argument(
+        "model_dir",
+        type=Path,
+        help="Directory containing SHA256SUMS, labels.json, model.onnx, tokenizer.json.",
+    )
+    parser.add_argument(
+        "--output-name",
+        default="model.int8.onnx",
+        help="Quantized ONNX filename inside model_dir.",
+    )
+    parser.add_argument(
+        "--manifest-name",
+        default="SHA256SUMS.int8",
+        help="Quantized checksum manifest filename inside model_dir.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_dir = args.model_dir.expanduser().resolve()
+    input_model = model_dir / "model.onnx"
+    output_model = model_dir / args.output_name
+    manifest_path = model_dir / args.manifest_name
+
+    for required in [input_model, model_dir / "labels.json", model_dir / "tokenizer.json"]:
+        if not required.is_file():
+            raise SystemExit(f"missing required Kiji artifact: {required}")
+
+    quantize_dynamic(str(input_model), str(output_model), weight_type=QuantType.QInt8)
+
+    entries = [
+        f"{sha256(model_dir / 'labels.json')}  labels.json\n",
+        f"{sha256(output_model)}  {output_model.name}\n",
+        f"{sha256(model_dir / 'tokenizer.json')}  tokenizer.json\n",
+    ]
+    manifest = "".join(entries)
+    manifest_path.write_text(manifest, encoding="utf-8")
+
+    print(f"{output_model.name} {sha256(output_model)}")
+    print(f"{manifest_path.name} {hashlib.sha256(manifest.encode('utf-8')).hexdigest()}")
+    print(manifest, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/safety_net_bench_lib.py
+++ b/scripts/safety_net_bench_lib.py
@@ -153,6 +153,7 @@ def add_common_args(parser: argparse.ArgumentParser, backend: Literal["kiji", "o
     )
     parser.add_argument("--no-update", action="store_true")
     if backend == "kiji":
+        parser.add_argument("--precision", choices=["fp32", "int8"], default="fp32")
         parser.add_argument(
             "--model-dir",
             type=Path,
@@ -226,6 +227,8 @@ def run_kiji(args: argparse.Namespace, fixture_id: str, text: str) -> list[Span]
             "typed",
             "--model-dir",
             str(args.model_dir),
+            "--precision",
+            args.precision,
         ],
         input=text,
         text=True,
@@ -507,6 +510,7 @@ def update_matrix_snapshot(
     corpus_sha256: str | None,
     fixture_count: int,
     run_environment: dict[str, Any],
+    backend_pins: dict[str, Any] | None = None,
 ) -> None:
     snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
     snapshot["status"] = "observer_residual_and_direct_run_v1"
@@ -515,6 +519,8 @@ def update_matrix_snapshot(
     snapshot["corpus"]["coverage_report_sha256"] = coverage_sha256
     snapshot["corpus"]["fixture_count"] = fixture_count
     snapshot["run_environment"] = run_environment
+    if backend_pins is not None:
+        snapshot["backends"][backend_name] = {"pins": backend_pins}
     for locale, metrics in metrics_by_locale.items():
         if mode == "direct_detector":
             snapshot["strict_span_leak_rate"][f"{backend_name}.{locale}"] = rounded(
@@ -523,6 +529,16 @@ def update_matrix_snapshot(
         for cell in snapshot["cells"]:
             if cell["backend"] == backend_name and cell["locale"] == locale and cell["mode"] == mode:
                 cell["metrics"] = metrics
+                break
+        else:
+            snapshot["cells"].append(
+                {
+                    "backend": backend_name,
+                    "locale": locale,
+                    "mode": mode,
+                    "metrics": metrics,
+                }
+            )
     snapshot_path.write_text(json.dumps(snapshot, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
@@ -599,6 +615,8 @@ def validate_inputs(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -
 
 def scorer_main(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -> int:
     backend_name = "kiji_distilbert" if backend == "kiji" else "openai_privacy_filter"
+    if backend == "kiji" and args.precision == "int8":
+        backend_name = "kiji_distilbert_int8"
     root, coverage_report, corpus_dir, corpus_sha256 = validate_inputs(args, backend)
     coverage_sha256 = sha256_file(coverage_report)
     fixtures = load_fixtures(corpus_dir)
@@ -647,6 +665,7 @@ def scorer_main(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -> in
                 corpus_sha256,
                 len(fixtures),
                 run_environment(args, backend),
+                kiji_int8_pins(args) if backend_name == "kiji_distilbert_int8" else None,
             )
 
     if not args.no_update:
@@ -673,6 +692,17 @@ def scorer_main(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -> in
     return 0
 
 
+def kiji_int8_pins(args: argparse.Namespace) -> dict[str, Any]:
+    fp32_pins = json.loads(args.snapshot.read_text(encoding="utf-8"))["backends"][
+        "kiji_distilbert"
+    ]["pins"]
+    return {
+        **fp32_pins,
+        "bundle_sha256": sha256_file(args.model_dir / "SHA256SUMS.int8"),
+        "model_sha256": sha256_file(args.model_dir / "model.int8.onnx"),
+    }
+
+
 def run_environment(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -> dict[str, Any]:
     env = {
         "os": platform.platform(),
@@ -681,6 +711,7 @@ def run_environment(args: argparse.Namespace, backend: Literal["kiji", "opf"]) -
     }
     if backend == "kiji":
         env["onnxruntime_threads"] = "default"
+        env["precision"] = args.precision
     else:
         env["opf_device"] = args.device
     return env


### PR DESCRIPTION
## Summary

- Adds opt-in `--kiji-distilbert-precision {fp32,int8}` with fp32 as the default and no silent fallback when int8 artifacts are missing.
- Adds precision-aware ORT loading, independent fp32/int8 bundle verification, and exported int8 artifact pins.
- Adds `scripts/quantize-kiji-int8.py`, int8 scorer plumbing, safety-net matrix int8 cells, and a closed recall-regression gate.
- Documents the int8 tradeoff and fail-closed F1 invariant.

## Artifact pins

- `model.int8.onnx`: `bd909cc924b7e10a8d2cdffb0e3bb6036f12d6ae6740cc45420fe82682f5a867`
- `SHA256SUMS.int8`: `6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb`

## F1 / recall gate

Safety-net matrix recall deltas are measured against fp32 and fail closed above `0.02` per locale/mode.

| Mode | Locale | fp32 recall | int8 recall | delta |
| --- | --- | ---: | ---: | ---: |
| direct | Global | 0.125 | 0.125 | 0.000 |
| direct | EnUs | 0.125 | 0.125 | 0.000 |
| direct | DeDe | 0.125 | 0.125 | 0.000 |
| observer | Global | 0.500 | 0.500 | 0.000 |
| observer | EnUs | 0.500 | 0.500 | 0.000 |
| observer | DeDe | 1.000 | 1.000 | 0.000 |

## Latency snapshot

Live in-process ORT bench on the pinned local bundle:

| Precision | cold start | warm p50 |
| --- | ---: | ---: |
| fp32 | 854.914 ms | 4.911 ms |
| int8 | 297.026 ms | 3.471 ms |

Subprocess scorer snapshot for int8 was also captured in `safety_net_perf_snapshot.json` for the existing matrix tooling.

## Five-axis check

- Reliability: int8 requests fail closed if int8 bundle artifacts or SHA pins do not match; no precision fallback.
- Reversibility: quantization changes only the safety-net model bytes; manifest restore semantics and shared class map are unchanged.
- Agentic-first: ORT precision is selectable through CLI and programmatic config for Pass-3 safety-net workflows.
- Trust: int8 bytes are pinned separately, verified separately, and covered by a per-locale recall regression gate.
- Adopter ergonomics: fp32 remains default; int8 is an explicit opt-in with documented tradeoffs and a regeneration script.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix -- --test`
- `cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture`
- `scripts/kiji-bench-scorer.py --precision int8 --mode all`
- `GAZE_KIJI_DISTILBERT_PRECISION=fp32 cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix -- --test`
- `GAZE_KIJI_DISTILBERT_PRECISION=int8 cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix -- --test`
- `cargo run -p xtask -- ci-feature-matrix`
