### PR TITLE
feat(bench): runtime comparison — ort vs tract vs candle (#369)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install protoc (candle-onnx build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: cargo doc (warnings as errors)
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
           swap-storage: false
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install Tesseract + English language pack (gaze-document)
+      - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
         run: |
           sudo apt-get update
-          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng protobuf-compiler
       - name: Install pdfium dynamic library (gaze-document PDF input)
         run: |
           set -eu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +123,12 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "anymap3"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
 
 [[package]]
 name = "approx"
@@ -245,6 +257,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +311,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -299,6 +343,58 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "tokenizers",
+ "yoke",
+ "zip",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+dependencies = [
+ "candle-core",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-onnx"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c26833f7747d202a47a1678c0fe11ab85c67b765a8aa99335672e4d81407a32"
+dependencies = [
+ "candle-core",
+ "candle-nn",
+ "prost",
+ "prost-build",
+]
 
 [[package]]
 name = "cast"
@@ -758,6 +854,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,10 +971,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dyn-eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d035d21af5cde1a6f5c7b444a5bf963520a9f142e5d06931178433d7d5388"
+
+[[package]]
+name = "dyn-hash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdab65db9274e0168143841eb8f864a0a21f8b1b8d2ba6812bbe6024346e99e"
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "ed25519"
@@ -912,10 +1053,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -977,10 +1141,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -990,6 +1170,18 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -1003,6 +1195,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1292,6 +1490,8 @@ name = "gaze-recognizers"
 version = "0.8.1"
 dependencies = [
  "aho-corasick",
+ "candle-core",
+ "candle-onnx",
  "criterion",
  "gaze-assembly",
  "gaze-pii",
@@ -1310,6 +1510,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers",
  "tracing",
+ "tract-onnx",
  "unicode-normalization",
 ]
 
@@ -1322,6 +1523,125 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
 ]
 
 [[package]]
@@ -1495,8 +1815,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
  "zerocopy",
 ]
 
@@ -1524,7 +1848,20 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1853,7 +2190,7 @@ dependencies = [
  "nalgebra",
  "num",
  "rand 0.9.4",
- "rand_distr",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -1866,6 +2203,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2061,6 +2407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,10 +2441,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2152,6 +2530,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nalgebra"
@@ -2227,6 +2611,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom-language"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2657,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2303,6 +2706,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2458,6 +2871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "phonenumber"
 version = "0.3.9+9.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,7 +2889,7 @@ checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
 dependencies = [
  "either",
  "fnv",
- "nom",
+ "nom 7.1.3",
  "once_cell",
  "postcard",
  "quick-xml",
@@ -2636,6 +3060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +3076,80 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pxfm"
@@ -2822,6 +3329,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3383,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -3085,6 +3617,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,12 +3701,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scan_fmt"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b53b0a5db882a8e2fdaae0a43f7b39e7e9082389e978398bdf223a55b581248"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -3224,6 +3790,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3479,7 +4051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
  "base64 0.13.1",
- "nom",
+ "nom 7.1.3",
  "serde",
  "unicode-segmentation",
 ]
@@ -3508,6 +4080,22 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -3577,6 +4165,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4005,6 +4618,203 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-core"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9563b458fc5cdb01121f59b6218e470ce8b8b84d1f387e3aa2ea0ef2c18d053"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "bit-set",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-eq",
+ "erased-serde",
+ "inventory",
+ "lazy_static",
+ "log",
+ "maplit",
+ "ndarray 0.17.2",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pastey",
+ "rustfft",
+ "serde",
+ "smallvec",
+ "tract-data",
+ "tract-linalg",
+]
+
+[[package]]
+name = "tract-data"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be77b1d203124c1da358c009e9d2be8a0ce8274a4bf9f742c5a2edd4deb3623b"
+dependencies = [
+ "anyhow",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
+ "half",
+ "itertools 0.14.0",
+ "lazy_static",
+ "libm",
+ "maplit",
+ "ndarray 0.17.2",
+ "nom 8.0.0",
+ "nom-language",
+ "num-integer",
+ "num-traits",
+ "parking_lot",
+ "scan_fmt",
+ "smallvec",
+ "string-interner",
+]
+
+[[package]]
+name = "tract-extra"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc6605493d8a190379ecb73bc53773f862650bce702b80189288a637e147f2"
+dependencies = [
+ "tract-nnef",
+ "tract-pulse",
+]
+
+[[package]]
+name = "tract-hir"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a09b57fe1725814b785cd6dcf0b990bf15336c5dbf0d4ab89a90d317c0b261b0"
+dependencies = [
+ "derive-new",
+ "log",
+ "tract-core",
+]
+
+[[package]]
+name = "tract-linalg"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4b542e8a202e035d1b979685c0fc8a4df1d2ca423ae398f758012dfb4c3c0f"
+dependencies = [
+ "byteorder",
+ "cc",
+ "derive-new",
+ "downcast-rs",
+ "dyn-clone",
+ "dyn-eq",
+ "dyn-hash",
+ "half",
+ "lazy_static",
+ "log",
+ "minijinja",
+ "num-traits",
+ "pastey",
+ "scan_fmt",
+ "tract-data",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-nnef"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3299e19cbf4a29e6143ae4ef9dca6b243a5a6e118b757db01caa91cac60f6b8b"
+dependencies = [
+ "byteorder",
+ "erased-serde",
+ "flate2",
+ "log",
+ "minijinja",
+ "nom 8.0.0",
+ "nom-language",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "simd-adler32",
+ "tar",
+ "tract-core",
+ "walkdir",
+]
+
+[[package]]
+name = "tract-onnx"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8dad9b6273fa0b6f103248833207710c09e73c28f91b97660f60b1f1b8a631"
+dependencies = [
+ "bytes",
+ "derive-new",
+ "dyn-eq",
+ "log",
+ "memmap2",
+ "num-integer",
+ "prost",
+ "smallvec",
+ "tract-extra",
+ "tract-hir",
+ "tract-nnef",
+ "tract-onnx-opl",
+]
+
+[[package]]
+name = "tract-onnx-opl"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200762853393666c436ce435fcfb58b05b94bbb280c6e1b19292ae224d038eef"
+dependencies = [
+ "dyn-eq",
+ "getrandom 0.4.2",
+ "log",
+ "rand 0.10.1",
+ "rand_distr 0.6.0",
+ "rustfft",
+ "tract-extra",
+ "tract-nnef",
+]
+
+[[package]]
+name = "tract-pulse"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8be6d7a6b9d63eab64fb2c4bfce728b070c0589064ab4507ef4fb90ee8b6fb"
+dependencies = [
+ "downcast-rs",
+ "dyn-eq",
+ "erased-serde",
+ "lazy_static",
+ "log",
+ "serde",
+ "tract-pulse-opl",
+]
+
+[[package]]
+name = "tract-pulse-opl"
+version = "0.23.0-dev.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc924701d4fb464e134e6289455ed4b3bbeafb891554c3db85c9671ea8fd906"
+dependencies = [
+ "downcast-rs",
+ "dyn-eq",
+ "lazy_static",
+ "tract-nnef",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4840,18 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4678,6 +5500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xtask"
 version = "0.0.1"
 dependencies = [
@@ -4796,6 +5628,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -19,6 +19,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["proxy"]
 safety-net-openai = ["gaze-recognizers/safety-net-openai"]
 safety-net-kiji = ["gaze-recognizers/safety-net-kiji"]
+runtime-tract = ["safety-net-kiji", "gaze-recognizers/runtime-tract"]
+runtime-candle = ["safety-net-kiji", "gaze-recognizers/runtime-candle"]
 document = ["dep:gaze-document"]
 mcp = [
     "dep:async-trait",

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -506,6 +506,10 @@ impl OpenAiFilterDevice {
 pub(crate) enum KijiBackend {
     Subprocess,
     Ort,
+    #[cfg(feature = "runtime-tract")]
+    Tract,
+    #[cfg(feature = "runtime-candle")]
+    Candle,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -544,6 +544,32 @@ fn kiji_distilbert_config(
                 .with_max_input_bytes(options.safety_net_input_limit_bytes);
             Ok(KijiDistilbertConfig::from(config))
         }
+        #[cfg(feature = "runtime-tract")]
+        KijiBackend::Tract => {
+            if options.kiji_distilbert_command.is_some() {
+                return Err(CliError::SafetyNetConfigDetail(
+                    "--kiji-distilbert-command is only valid with --kiji-backend=subprocess"
+                        .to_string(),
+                ));
+            }
+            let config =
+                gaze_recognizers::safety_net::kiji_distilbert::TractKijiConfig::new(model_dir)
+                    .with_max_input_bytes(options.safety_net_input_limit_bytes);
+            Ok(KijiDistilbertConfig::from(config))
+        }
+        #[cfg(feature = "runtime-candle")]
+        KijiBackend::Candle => {
+            if options.kiji_distilbert_command.is_some() {
+                return Err(CliError::SafetyNetConfigDetail(
+                    "--kiji-distilbert-command is only valid with --kiji-backend=subprocess"
+                        .to_string(),
+                ));
+            }
+            let config =
+                gaze_recognizers::safety_net::kiji_distilbert::CandleKijiConfig::new(model_dir)
+                    .with_max_input_bytes(options.safety_net_input_limit_bytes);
+            Ok(KijiDistilbertConfig::from(config))
+        }
     }
 }
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -23,6 +23,8 @@ phone-parser = ["dep:phonenumber", "gaze-types/phone-parser"]
 safety-net = []
 safety-net-openai = ["safety-net"]
 safety-net-kiji = ["safety-net"]
+runtime-tract = ["safety-net-kiji", "dep:tract-onnx"]
+runtime-candle = ["safety-net-kiji", "dep:candle-core", "dep:candle-onnx"]
 test-support = ["safety-net"]
 
 [dependencies]
@@ -31,6 +33,8 @@ gaze-types = { workspace = true }
 hex = "0.4"
 ndarray = "0.16"
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["ndarray", "std", "download-binaries", "tls-rustls"] }
+candle-core = { version = "0.10.2", optional = true }
+candle-onnx = { version = "0.10.2", optional = true }
 phonenumber = { version = "0.3.9", default-features = false, optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -40,6 +44,7 @@ sha3 = "0.10"
 thiserror = "1"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 tracing = "0.1"
+tract-onnx = { version = "=0.23.0-dev.5", optional = true }
 unicode-normalization = "0.1"
 
 [dev-dependencies]
@@ -86,3 +91,8 @@ harness = false
 [[bench]]
 name = "safety_net_matrix"
 harness = false
+
+[[bench]]
+name = "runtime_comparison"
+harness = false
+required-features = ["safety-net-kiji"]

--- a/crates/gaze-recognizers/benches/runtime_comparison.rs
+++ b/crates/gaze-recognizers/benches/runtime_comparison.rs
@@ -1,0 +1,330 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use gaze_recognizers::safety_net::kiji_distilbert::{
+    KijiDistilbertBackend, OrtKijiBackend, OrtKijiConfig, KIJI_DISTILBERT_BUNDLE_SHA256,
+    KIJI_DISTILBERT_HF_COMMIT, KIJI_DISTILBERT_HF_REPO, KIJI_DISTILBERT_SHA256SUMS,
+};
+use serde::Serialize;
+
+const WARM_ITERATIONS: usize = 100;
+const FIXTURE_LIMIT: usize = 12;
+
+#[derive(Debug, Serialize)]
+struct Report {
+    schema_version: u32,
+    benchmark: &'static str,
+    host: Host,
+    pins: Pins,
+    warm_iterations: usize,
+    fixture_count: usize,
+    runtimes: Vec<RuntimeReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct Host {
+    os: String,
+    arch: String,
+    cpu: String,
+    memory: String,
+    rustc: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Pins {
+    source_repo: &'static str,
+    source_commit: &'static str,
+    bundle_sha256: &'static str,
+    sha256sums: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum RuntimeReport {
+    Measured {
+        runtime: &'static str,
+        cold_start_ms: f64,
+        warm_p50_ms: f64,
+        warm_p95_ms: f64,
+    },
+    Unavailable {
+        runtime: &'static str,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct SpanKey {
+    start: usize,
+    end: usize,
+    label: String,
+}
+
+fn main() {
+    let model_dir = env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+        .map(PathBuf::from)
+        .expect("GAZE_KIJI_DISTILBERT_MODEL_DIR is required");
+    let fixtures = load_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "runtime comparison requires at least one fixture"
+    );
+
+    let (ort_report, baseline) = measure(
+        "ort",
+        || {
+            OrtKijiBackend::new(OrtKijiConfig::new(&model_dir))
+                .map(|backend| Box::new(backend) as Box<dyn KijiDistilbertBackend>)
+        },
+        &fixtures,
+        None,
+    );
+    let Some(baseline) = baseline else {
+        let report = Report {
+            schema_version: 1,
+            benchmark: "kiji-runtime-comparison",
+            host: host(),
+            pins: Pins {
+                source_repo: KIJI_DISTILBERT_HF_REPO,
+                source_commit: KIJI_DISTILBERT_HF_COMMIT,
+                bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256,
+                sha256sums: KIJI_DISTILBERT_SHA256SUMS,
+            },
+            warm_iterations: WARM_ITERATIONS,
+            fixture_count: fixtures.len(),
+            runtimes: vec![ort_report],
+        };
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+        panic!("BLOCKED: ort baseline must load and infer before comparing runtimes");
+    };
+
+    let mut runtimes = vec![ort_report];
+    runtimes.push(measure_tract(&model_dir, &fixtures, Some(&baseline)).0);
+    runtimes.push(measure_candle(&model_dir, &fixtures, Some(&baseline)).0);
+
+    let report = Report {
+        schema_version: 1,
+        benchmark: "kiji-runtime-comparison",
+        host: host(),
+        pins: Pins {
+            source_repo: KIJI_DISTILBERT_HF_REPO,
+            source_commit: KIJI_DISTILBERT_HF_COMMIT,
+            bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256,
+            sha256sums: KIJI_DISTILBERT_SHA256SUMS,
+        },
+        warm_iterations: WARM_ITERATIONS,
+        fixture_count: fixtures.len(),
+        runtimes,
+    };
+    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+}
+
+fn measure<F>(
+    runtime: &'static str,
+    load: F,
+    fixtures: &[String],
+    baseline: Option<&[Vec<SpanKey>]>,
+) -> (RuntimeReport, Option<Vec<Vec<SpanKey>>>)
+where
+    F: FnOnce() -> Result<Box<dyn KijiDistilbertBackend>, gaze_types::SafetyNetError>,
+{
+    let cold_start = Instant::now();
+    let backend = match load() {
+        Ok(backend) => backend,
+        Err(error) => {
+            return (
+                RuntimeReport::Unavailable {
+                    runtime,
+                    reason: error.to_string(),
+                },
+                None,
+            );
+        }
+    };
+    let cold_start_ms = cold_start.elapsed().as_secs_f64() * 1000.0;
+    let spans = match infer_all(&*backend, fixtures) {
+        Ok(spans) => spans,
+        Err(error) => {
+            return (
+                RuntimeReport::Unavailable {
+                    runtime,
+                    reason: error.to_string(),
+                },
+                None,
+            );
+        }
+    };
+    if let Some(expected) = baseline {
+        assert_eq!(
+            expected, spans,
+            "BLOCKED: {runtime} recall/span set drifted from ort baseline"
+        );
+    }
+
+    let mut samples = Vec::with_capacity(WARM_ITERATIONS);
+    for index in 0..WARM_ITERATIONS {
+        let fixture = &fixtures[index % fixtures.len()];
+        let start = Instant::now();
+        backend.infer(fixture).expect("warm inference must succeed");
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+    samples.sort_by(f64::total_cmp);
+    let p50 = percentile(&samples, 0.50);
+    let p95 = percentile(&samples, 0.95);
+
+    (
+        RuntimeReport::Measured {
+            runtime,
+            cold_start_ms,
+            warm_p50_ms: p50,
+            warm_p95_ms: p95,
+        },
+        Some(spans),
+    )
+}
+
+fn infer_all(
+    backend: &dyn KijiDistilbertBackend,
+    fixtures: &[String],
+) -> Result<Vec<Vec<SpanKey>>, gaze_types::SafetyNetError> {
+    fixtures
+        .iter()
+        .map(|fixture| {
+            let mut spans = backend
+                .infer(fixture)?
+                .into_iter()
+                .map(|span| SpanKey {
+                    start: span.start,
+                    end: span.end,
+                    label: span.label,
+                })
+                .collect::<Vec<_>>();
+            spans.sort_by(|left, right| {
+                (left.start, left.end, left.label.as_str()).cmp(&(
+                    right.start,
+                    right.end,
+                    right.label.as_str(),
+                ))
+            });
+            Ok(spans)
+        })
+        .collect()
+}
+
+#[cfg(feature = "runtime-tract")]
+fn measure_tract(
+    model_dir: &Path,
+    fixtures: &[String],
+    baseline: Option<&[Vec<SpanKey>]>,
+) -> (RuntimeReport, Option<Vec<Vec<SpanKey>>>) {
+    use gaze_recognizers::safety_net::kiji_distilbert::{TractKijiBackend, TractKijiConfig};
+    measure(
+        "tract",
+        || {
+            TractKijiBackend::new(TractKijiConfig::new(model_dir))
+                .map(|backend| Box::new(backend) as Box<dyn KijiDistilbertBackend>)
+        },
+        fixtures,
+        baseline,
+    )
+}
+
+#[cfg(not(feature = "runtime-tract"))]
+fn measure_tract(
+    _model_dir: &Path,
+    _fixtures: &[String],
+    _baseline: Option<&[Vec<SpanKey>]>,
+) -> (RuntimeReport, Option<Vec<Vec<SpanKey>>>) {
+    (
+        RuntimeReport::Unavailable {
+            runtime: "tract",
+            reason: "compile with gaze-recognizers feature runtime-tract".to_string(),
+        },
+        None,
+    )
+}
+
+#[cfg(feature = "runtime-candle")]
+fn measure_candle(
+    model_dir: &Path,
+    fixtures: &[String],
+    baseline: Option<&[Vec<SpanKey>]>,
+) -> (RuntimeReport, Option<Vec<Vec<SpanKey>>>) {
+    use gaze_recognizers::safety_net::kiji_distilbert::{CandleKijiBackend, CandleKijiConfig};
+    measure(
+        "candle",
+        || {
+            CandleKijiBackend::new(CandleKijiConfig::new(model_dir))
+                .map(|backend| Box::new(backend) as Box<dyn KijiDistilbertBackend>)
+        },
+        fixtures,
+        baseline,
+    )
+}
+
+#[cfg(not(feature = "runtime-candle"))]
+fn measure_candle(
+    _model_dir: &Path,
+    _fixtures: &[String],
+    _baseline: Option<&[Vec<SpanKey>]>,
+) -> (RuntimeReport, Option<Vec<Vec<SpanKey>>>) {
+    (
+        RuntimeReport::Unavailable {
+            runtime: "candle",
+            reason: "compile with gaze-recognizers feature runtime-candle".to_string(),
+        },
+        None,
+    )
+}
+
+fn load_fixtures() -> Vec<String> {
+    let corpus_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/coverage-loop/corpus");
+    let mut paths = fs::read_dir(corpus_dir)
+        .expect("coverage-loop corpus directory")
+        .map(|entry| entry.expect("corpus entry").path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("txt"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+        .into_iter()
+        .take(FIXTURE_LIMIT)
+        .map(|path| fs::read_to_string(path).expect("fixture text"))
+        .collect()
+}
+
+fn percentile(samples: &[f64], percentile: f64) -> f64 {
+    let index = ((samples.len() - 1) as f64 * percentile).ceil() as usize;
+    samples[index]
+}
+
+fn host() -> Host {
+    Host {
+        os: command("uname", &["-sr"]).unwrap_or_else(|| env::consts::OS.to_string()),
+        arch: command("uname", &["-m"]).unwrap_or_else(|| env::consts::ARCH.to_string()),
+        cpu: command("sysctl", &["-n", "machdep.cpu.brand_string"])
+            .or_else(|| command("lscpu", &[]))
+            .unwrap_or_else(|| "unknown".to_string()),
+        memory: command("sysctl", &["-n", "hw.memsize"])
+            .map(|bytes| format!("{bytes} bytes"))
+            .or_else(|| command("free", &["-h"]))
+            .unwrap_or_else(|| "unknown".to_string()),
+        rustc: command("rustc", &["--version"]).unwrap_or_else(|| "unknown".to_string()),
+    }
+}
+
+fn command(program: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    output.status.success().then(|| {
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    })
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/candle.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/candle.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use candle_core::{Device, Tensor};
+use gaze_types::SafetyNetError;
+
+use super::artifacts::{verify_model_dir, KIJI_DISTILBERT_BUNDLE_SHA256};
+use super::decode::decode_logits;
+use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
+
+const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
+const MODEL_FILE: &str = "model.onnx";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+#[derive(Debug, Clone)]
+pub struct CandleKijiConfig {
+    model_dir: PathBuf,
+    max_input_bytes: usize,
+    version: String,
+    decoding_params: Vec<(&'static str, String)>,
+    #[cfg(any(test, feature = "test-support"))]
+    expected_bundle_sha256: String,
+}
+
+impl CandleKijiConfig {
+    pub fn new(model_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            model_dir: model_dir.into(),
+            max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+            version: "kiji/distilbert:candle-onnx".to_string(),
+            decoding_params: vec![("runtime", "candle-onnx".to_string())],
+            #[cfg(any(test, feature = "test-support"))]
+            expected_bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
+        }
+    }
+
+    pub fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
+        self.max_input_bytes = max_input_bytes;
+        self
+    }
+
+    pub fn model_dir(&self) -> &Path {
+        &self.model_dir
+    }
+
+    fn expected_bundle_sha256(&self) -> &str {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            &self.expected_bundle_sha256
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            KIJI_DISTILBERT_BUNDLE_SHA256
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CandleKijiBackend {
+    config: CandleKijiConfig,
+    tokenizer: tokenizers::Tokenizer,
+    model: Mutex<candle_onnx::onnx::ModelProto>,
+    has_token_type_ids: bool,
+}
+
+impl CandleKijiBackend {
+    pub fn new(config: CandleKijiConfig) -> Result<Self, SafetyNetError> {
+        verify_model_dir(Some(config.model_dir()), config.expected_bundle_sha256())?;
+        let tokenizer = tokenizers::Tokenizer::from_file(config.model_dir.join(TOKENIZER_FILE))
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji tokenizer: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let model = candle_onnx::read_file(config.model_dir.join(MODEL_FILE)).map_err(|err| {
+            SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji candle onnx model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            }
+        })?;
+        let has_token_type_ids = model
+            .graph
+            .as_ref()
+            .map(|graph| {
+                graph
+                    .input
+                    .iter()
+                    .any(|input| input.name == "token_type_ids")
+            })
+            .unwrap_or(false);
+        Ok(Self {
+            config,
+            tokenizer,
+            model: Mutex::new(model),
+            has_token_type_ids,
+        })
+    }
+}
+
+impl KijiDistilbertBackend for CandleKijiBackend {
+    fn id(&self) -> &str {
+        "kiji-distilbert-candle"
+    }
+
+    fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    fn decoding_params(&self) -> &[(&str, String)] {
+        &self.config.decoding_params
+    }
+
+    fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError> {
+        let actual = clean.len();
+        if actual > self.config.max_input_bytes {
+            return Err(SafetyNetError::InputTooLarge {
+                limit: self.config.max_input_bytes,
+                actual,
+            });
+        }
+
+        let encoded =
+            self.tokenizer
+                .encode(clean, true)
+                .map_err(|err| SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji tokenizer failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                })?;
+        let offsets = encoded.get_offsets();
+        let ids = encoded.get_ids();
+        let attention = encoded.get_attention_mask();
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let seq_len = ids.len();
+        let input_ids: Vec<i64> = ids.iter().map(|&value| value as i64).collect();
+        let attn_mask: Vec<i64> = attention.iter().map(|&value| value as i64).collect();
+        let shape = (1usize, seq_len);
+        let mut inputs = HashMap::new();
+        inputs.insert(
+            "input_ids".to_string(),
+            Tensor::from_vec(input_ids, shape, &Device::Cpu).map_err(|err| {
+                SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji candle input_ids tensor failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                }
+            })?,
+        );
+        inputs.insert(
+            "attention_mask".to_string(),
+            Tensor::from_vec(attn_mask, shape, &Device::Cpu).map_err(|err| {
+                SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji candle attention_mask tensor failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                }
+            })?,
+        );
+        if self.has_token_type_ids {
+            inputs.insert(
+                "token_type_ids".to_string(),
+                Tensor::from_vec(vec![0i64; seq_len], shape, &Device::Cpu).map_err(|err| {
+                    SafetyNetError::Runtime {
+                        message: format!(
+                            "kiji candle token_type_ids tensor failed: {}",
+                            sanitize_error(&err.to_string())
+                        ),
+                    }
+                })?,
+            );
+        }
+
+        let model = self.model.lock().map_err(|err| SafetyNetError::Runtime {
+            message: format!(
+                "kiji candle model lock poisoned: {}",
+                sanitize_error(&err.to_string())
+            ),
+        })?;
+        let outputs =
+            candle_onnx::simple_eval(&model, inputs).map_err(|err| SafetyNetError::Runtime {
+                message: format!(
+                    "kiji candle inference failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let output = outputs
+            .values()
+            .next()
+            .ok_or_else(|| SafetyNetError::InvalidOutput {
+                message: "kiji candle returned no outputs".to_string(),
+            })?;
+        let shape = output.dims();
+        if shape.len() != 3 || shape[0] != 1 || shape[1] != seq_len {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "kiji candle returned invalid logits shape".to_string(),
+            });
+        }
+        let num_labels = shape[2];
+        let flat = output
+            .flatten_all()
+            .and_then(|tensor| tensor.to_vec1::<f32>())
+            .map_err(|err| SafetyNetError::Runtime {
+                message: format!(
+                    "kiji candle output failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+
+        normalize_raw_spans(
+            decode_logits(clean, offsets, &flat, seq_len, num_labels),
+            clean,
+        )
+    }
+}
+
+fn sanitize_error(message: &str) -> String {
+    message
+        .split_ascii_whitespace()
+        .map(sanitize_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_token(token: &str) -> String {
+    if token.contains('@') {
+        return "<redacted>".to_string();
+    }
+    let digit_count = token.bytes().filter(u8::is_ascii_digit).count();
+    if digit_count >= 7 {
+        return "<redacted>".to_string();
+    }
+    token.to_string()
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/decode.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/decode.rs
@@ -1,0 +1,145 @@
+use super::RawSpan;
+use crate::ner::decode::{softmax_confidence, split_bio};
+
+pub(crate) const ID2LABEL: [&str; 9] = [
+    "O", "B-PER", "I-PER", "B-LOC", "I-LOC", "B-ORG", "I-ORG", "B-MISC", "I-MISC",
+];
+
+pub(crate) fn decode_logits(
+    clean: &str,
+    offsets: &[(usize, usize)],
+    flat: &[f32],
+    seq_len: usize,
+    num_labels: usize,
+) -> Vec<RawSpan> {
+    let mut subword_labels: Vec<&str> = Vec::with_capacity(seq_len);
+    let mut subword_scores = Vec::with_capacity(seq_len);
+    for pos in 0..seq_len {
+        let base = pos * num_labels;
+        let row = &flat[base..base + num_labels];
+        let (argmax, _) =
+            row.iter()
+                .enumerate()
+                .fold((0usize, f32::NEG_INFINITY), |acc, (index, &value)| {
+                    if value > acc.1 {
+                        (index, value)
+                    } else {
+                        acc
+                    }
+                });
+        subword_labels.push(ID2LABEL.get(argmax).copied().unwrap_or("O"));
+        subword_scores.push(softmax_confidence(row, argmax));
+    }
+    merge_kiji_bio_spans(clean, offsets, &subword_labels, &subword_scores)
+}
+
+fn merge_kiji_bio_spans(
+    source: &str,
+    subword_spans: &[(usize, usize)],
+    subword_labels: &[&str],
+    subword_scores: &[f32],
+) -> Vec<RawSpan> {
+    let (effective_labels, effective_scores) =
+        bridge_joiner_tokens(source, subword_spans, subword_labels, subword_scores);
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while index < effective_labels.len() {
+        let tag = effective_labels[index].as_str();
+        let (prefix, entity) = split_bio(tag);
+        if prefix == 'O' || entity.is_empty() {
+            index += 1;
+            continue;
+        }
+        let Some(label) = kiji_entity_label(entity) else {
+            index += 1;
+            continue;
+        };
+        let (start, mut end) = subword_spans[index];
+        if start == end {
+            index += 1;
+            continue;
+        }
+        let mut span_score = *effective_scores.get(index).unwrap_or(&0.0);
+        let mut next = index + 1;
+        while next < effective_labels.len() {
+            let (next_prefix, next_entity) = split_bio(effective_labels[next].as_str());
+            if next_prefix == 'I' && next_entity == entity {
+                let (next_start, next_end) = subword_spans[next];
+                if next_start != next_end {
+                    end = next_end;
+                    span_score = span_score.min(*effective_scores.get(next).unwrap_or(&0.0));
+                }
+                next += 1;
+            } else {
+                break;
+            }
+        }
+        out.push(RawSpan::new(start, end, label, Some(span_score)));
+        index = next;
+    }
+    out
+}
+
+fn bridge_joiner_tokens(
+    source: &str,
+    subword_spans: &[(usize, usize)],
+    subword_labels: &[&str],
+    subword_scores: &[f32],
+) -> (Vec<String>, Vec<f32>) {
+    let mut effective_labels = subword_labels
+        .iter()
+        .map(|label| (*label).to_string())
+        .collect::<Vec<_>>();
+    let mut effective_scores = (0..subword_labels.len())
+        .map(|index| *subword_scores.get(index).unwrap_or(&0.0))
+        .collect::<Vec<_>>();
+
+    for index in 1..subword_labels.len().saturating_sub(1) {
+        let (prefix, _) = split_bio(subword_labels[index]);
+        if prefix != 'O' {
+            continue;
+        }
+        let (start, end) = subword_spans[index];
+        let Some(token_text) = source.get(start..end) else {
+            continue;
+        };
+        if !is_entity_joiner_token(token_text) {
+            continue;
+        }
+        let (prev_prefix, prev_entity) = split_bio(subword_labels[index - 1]);
+        if !matches!(prev_prefix, 'B' | 'I') || prev_entity.is_empty() {
+            continue;
+        }
+        let (next_prefix, next_entity) = split_bio(subword_labels[index + 1]);
+        if !matches!(next_prefix, 'B' | 'I') || next_entity != prev_entity {
+            continue;
+        }
+        if next_prefix == 'B' && token_text.trim() == "," {
+            continue;
+        }
+        effective_labels[index] = format!("I-{prev_entity}");
+        if next_prefix == 'B' {
+            effective_labels[index + 1] = format!("I-{prev_entity}");
+        }
+        let prev_score = *subword_scores.get(index - 1).unwrap_or(&0.0);
+        let next_score = *subword_scores.get(index + 1).unwrap_or(&0.0);
+        effective_scores[index] = (prev_score + next_score) / 2.0;
+    }
+
+    (effective_labels, effective_scores)
+}
+
+fn is_entity_joiner_token(text: &str) -> bool {
+    let trimmed = text.trim();
+    !trimmed.is_empty() && trimmed.chars().all(|ch| ".,@_-+:/#%&=".contains(ch))
+}
+
+fn kiji_entity_label(entity: &str) -> Option<&'static str> {
+    match entity {
+        "PER" => Some("person"),
+        "LOC" => Some("location"),
+        "ORG" => Some("organization"),
+        "MISC" => Some("miscellaneous"),
+        _ => None,
+    }
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/mod.rs
@@ -3,8 +3,14 @@ use std::cmp::Ordering;
 use gaze_types::SafetyNetError;
 
 pub mod artifacts;
+#[cfg(feature = "runtime-candle")]
+pub mod candle;
+#[cfg(any(feature = "runtime-candle", feature = "runtime-tract"))]
+pub(crate) mod decode;
 pub mod ort;
 pub mod subprocess;
+#[cfg(feature = "runtime-tract")]
+pub mod tract;
 
 /// Precision variant for the pinned Kiji DistilBERT ONNX artifact.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -58,6 +64,10 @@ pub trait KijiDistilbertBackend: Send + Sync {
 pub enum KijiBackendKind {
     Subprocess,
     Ort,
+    #[cfg(feature = "runtime-tract")]
+    Tract,
+    #[cfg(feature = "runtime-candle")]
+    Candle,
 }
 
 impl KijiBackendKind {
@@ -65,6 +75,10 @@ impl KijiBackendKind {
         match self {
             Self::Subprocess => "subprocess",
             Self::Ort => "ort",
+            #[cfg(feature = "runtime-tract")]
+            Self::Tract => "tract",
+            #[cfg(feature = "runtime-candle")]
+            Self::Candle => "candle",
         }
     }
 }

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/tract.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/tract.rs
@@ -1,0 +1,249 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use gaze_types::SafetyNetError;
+use tract_onnx::prelude::*;
+
+use super::artifacts::{verify_model_dir, KIJI_DISTILBERT_BUNDLE_SHA256};
+use super::decode::decode_logits;
+use super::{normalize_raw_spans, KijiDistilbertBackend, RawSpan};
+
+const DEFAULT_MAX_INPUT_BYTES: usize = 1024 * 1024;
+const MODEL_FILE: &str = "model.onnx";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+#[derive(Debug, Clone)]
+pub struct TractKijiConfig {
+    model_dir: PathBuf,
+    max_input_bytes: usize,
+    version: String,
+    decoding_params: Vec<(&'static str, String)>,
+    #[cfg(any(test, feature = "test-support"))]
+    expected_bundle_sha256: String,
+}
+
+impl TractKijiConfig {
+    pub fn new(model_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            model_dir: model_dir.into(),
+            max_input_bytes: DEFAULT_MAX_INPUT_BYTES,
+            version: "kiji/distilbert:tract".to_string(),
+            decoding_params: vec![("runtime", "tract".to_string())],
+            #[cfg(any(test, feature = "test-support"))]
+            expected_bundle_sha256: KIJI_DISTILBERT_BUNDLE_SHA256.to_string(),
+        }
+    }
+
+    pub fn with_max_input_bytes(mut self, max_input_bytes: usize) -> Self {
+        self.max_input_bytes = max_input_bytes;
+        self
+    }
+
+    pub fn model_dir(&self) -> &Path {
+        &self.model_dir
+    }
+
+    fn expected_bundle_sha256(&self) -> &str {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            &self.expected_bundle_sha256
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            KIJI_DISTILBERT_BUNDLE_SHA256
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TractKijiBackend {
+    config: TractKijiConfig,
+    tokenizer: tokenizers::Tokenizer,
+    model: Mutex<Arc<TypedRunnableModel>>,
+    has_token_type_ids: bool,
+}
+
+impl TractKijiBackend {
+    pub fn new(config: TractKijiConfig) -> Result<Self, SafetyNetError> {
+        verify_model_dir(Some(config.model_dir()), config.expected_bundle_sha256())?;
+        let tokenizer = tokenizers::Tokenizer::from_file(config.model_dir.join(TOKENIZER_FILE))
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji tokenizer: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let model = tract_onnx::onnx()
+            .model_for_path(config.model_dir.join(MODEL_FILE))
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to load kiji tract model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let has_token_type_ids = model
+            .input_outlets()
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to inspect kiji tract model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?
+            .iter()
+            .any(|outlet| model.node(outlet.node).name == "token_type_ids");
+        let model = model
+            .into_optimized()
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to optimize kiji tract model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let model = model
+            .into_runnable()
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to prepare kiji tract model: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        Ok(Self {
+            config,
+            tokenizer,
+            model: Mutex::new(model),
+            has_token_type_ids,
+        })
+    }
+}
+
+impl KijiDistilbertBackend for TractKijiBackend {
+    fn id(&self) -> &str {
+        "kiji-distilbert-tract"
+    }
+
+    fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    fn decoding_params(&self) -> &[(&str, String)] {
+        &self.config.decoding_params
+    }
+
+    fn infer(&self, clean: &str) -> Result<Vec<RawSpan>, SafetyNetError> {
+        let actual = clean.len();
+        if actual > self.config.max_input_bytes {
+            return Err(SafetyNetError::InputTooLarge {
+                limit: self.config.max_input_bytes,
+                actual,
+            });
+        }
+
+        let encoded =
+            self.tokenizer
+                .encode(clean, true)
+                .map_err(|err| SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji tokenizer failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                })?;
+        let offsets = encoded.get_offsets();
+        let ids = encoded.get_ids();
+        let attention = encoded.get_attention_mask();
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let seq_len = ids.len();
+        let shape = [1usize, seq_len];
+        let input_ids: Vec<i64> = ids.iter().map(|&value| value as i64).collect();
+        let attn_mask: Vec<i64> = attention.iter().map(|&value| value as i64).collect();
+        let input_ids_tensor = Tensor::from_shape(&shape, &input_ids)
+            .map_err(|err| SafetyNetError::Runtime {
+                message: format!(
+                    "kiji tract input_ids tensor failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?
+            .into_tvalue();
+        let attn_tensor = Tensor::from_shape(&shape, &attn_mask)
+            .map_err(|err| SafetyNetError::Runtime {
+                message: format!(
+                    "kiji tract attention_mask tensor failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?
+            .into_tvalue();
+        let inputs = if self.has_token_type_ids {
+            let token_type = vec![0i64; seq_len];
+            let type_tensor = Tensor::from_shape(&shape, &token_type)
+                .map_err(|err| SafetyNetError::Runtime {
+                    message: format!(
+                        "kiji tract token_type_ids tensor failed: {}",
+                        sanitize_error(&err.to_string())
+                    ),
+                })?
+                .into_tvalue();
+            tvec!(input_ids_tensor, attn_tensor, type_tensor)
+        } else {
+            tvec!(input_ids_tensor, attn_tensor)
+        };
+
+        let model = self.model.lock().map_err(|err| SafetyNetError::Runtime {
+            message: format!(
+                "kiji tract model lock poisoned: {}",
+                sanitize_error(&err.to_string())
+            ),
+        })?;
+        let outputs = model.run(inputs).map_err(|err| SafetyNetError::Runtime {
+            message: format!(
+                "kiji tract inference failed: {}",
+                sanitize_error(&err.to_string())
+            ),
+        })?;
+        let Some(output) = outputs.first() else {
+            return Ok(Vec::new());
+        };
+        let tensor: &Tensor = output;
+        let shape = tensor.shape();
+        if shape.len() != 3 || shape[0] != 1 || shape[1] != seq_len {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "kiji tract returned invalid logits shape".to_string(),
+            });
+        }
+        let num_labels = shape[2];
+        let flat = tensor
+            .try_as_plain()
+            .and_then(|view| view.as_slice::<f32>())
+            .map_err(|err| SafetyNetError::Runtime {
+                message: format!(
+                    "kiji tract output slice failed: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+
+        normalize_raw_spans(
+            decode_logits(clean, offsets, flat, seq_len, num_labels),
+            clean,
+        )
+    }
+}
+
+fn sanitize_error(message: &str) -> String {
+    message
+        .split_ascii_whitespace()
+        .map(sanitize_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_token(token: &str) -> String {
+    if token.contains('@') {
+        return "<redacted>".to_string();
+    }
+    let digit_count = token.bytes().filter(u8::is_ascii_digit).count();
+    if digit_count >= 7 {
+        return "<redacted>".to_string();
+    }
+    token.to_string()
+}

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs
@@ -25,8 +25,12 @@ pub use backend::artifacts::{
     KIJI_DISTILBERT_INT8_BUNDLE_SHA256, KIJI_DISTILBERT_INT8_SHA256SUMS,
     KIJI_DISTILBERT_SHA256SUMS, REQUIRED_KIJI_ARTIFACTS, REQUIRED_KIJI_INT8_ARTIFACTS,
 };
+#[cfg(feature = "runtime-candle")]
+pub use backend::candle::{CandleKijiBackend, CandleKijiConfig};
 pub use backend::ort::{OrtKijiBackend, OrtKijiConfig};
 pub use backend::subprocess::{SubprocessKijiBackend, SubprocessKijiConfig};
+#[cfg(feature = "runtime-tract")]
+pub use backend::tract::{TractKijiBackend, TractKijiConfig};
 pub use backend::{KijiBackendKind, KijiDistilbertBackend, KijiDistilbertPrecision, RawSpan};
 pub use class_map::{
     kiji_label_to_pii_class, kiji_label_to_safety_net_class, map_kiji_label, validate_kiji_label,
@@ -95,6 +99,10 @@ impl KijiDistilbertSafetyNet {
 pub enum KijiDistilbertConfig {
     Subprocess(SubprocessKijiConfig),
     Ort(OrtKijiConfig),
+    #[cfg(feature = "runtime-tract")]
+    Tract(TractKijiConfig),
+    #[cfg(feature = "runtime-candle")]
+    Candle(CandleKijiConfig),
 }
 
 impl KijiDistilbertConfig {
@@ -102,6 +110,10 @@ impl KijiDistilbertConfig {
         match self {
             Self::Subprocess(_) => KijiBackendKind::Subprocess,
             Self::Ort(_) => KijiBackendKind::Ort,
+            #[cfg(feature = "runtime-tract")]
+            Self::Tract(_) => KijiBackendKind::Tract,
+            #[cfg(feature = "runtime-candle")]
+            Self::Candle(_) => KijiBackendKind::Candle,
         }
     }
 
@@ -111,6 +123,14 @@ impl KijiDistilbertConfig {
                 .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
                 .map_err(Arc::new),
             Self::Ort(config) => OrtKijiBackend::new(config.clone())
+                .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
+                .map_err(Arc::new),
+            #[cfg(feature = "runtime-tract")]
+            Self::Tract(config) => TractKijiBackend::new(config.clone())
+                .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
+                .map_err(Arc::new),
+            #[cfg(feature = "runtime-candle")]
+            Self::Candle(config) => CandleKijiBackend::new(config.clone())
                 .map(|backend| Arc::new(backend) as Arc<dyn KijiDistilbertBackend>)
                 .map_err(Arc::new),
         }
@@ -126,6 +146,20 @@ impl From<SubprocessKijiConfig> for KijiDistilbertConfig {
 impl From<OrtKijiConfig> for KijiDistilbertConfig {
     fn from(config: OrtKijiConfig) -> Self {
         Self::Ort(config)
+    }
+}
+
+#[cfg(feature = "runtime-tract")]
+impl From<TractKijiConfig> for KijiDistilbertConfig {
+    fn from(config: TractKijiConfig) -> Self {
+        Self::Tract(config)
+    }
+}
+
+#[cfg(feature = "runtime-candle")]
+impl From<CandleKijiConfig> for KijiDistilbertConfig {
+    fn from(config: CandleKijiConfig) -> Self {
+        Self::Candle(config)
     }
 }
 

--- a/docs/research/v0.9-runtime-comparison.md
+++ b/docs/research/v0.9-runtime-comparison.md
@@ -1,0 +1,95 @@
+# v0.9 Runtime Comparison: ORT vs tract vs Candle
+
+Status: measured on one dispatch host. Do not extrapolate these numbers to Linux x86_64 or GPU hosts; adopters should rerun `runtime_comparison` on their deployment hardware.
+
+## Model Contract
+
+All measured runtimes loaded the same pinned Kiji DistilBERT ONNX bundle:
+
+| Field | Value |
+| --- | --- |
+| Source repo | `onnx-community/distilbert-NER-ONNX` |
+| Source commit | `3a19fe9404a4469d91aa3d551558a97f68872f67` |
+| Bundle SHA256 (`SHA256SUMS`) | `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f` |
+| `labels.json` | `d3753ce580a9d43b113d779c712494bd61341285317beec49cc1e848b86f9a97` |
+| `model.onnx` | `b5f77096d0d9f425d34a2e263f8a2dfb845cdc757dc00c7a1e69e9cbb93115d5` |
+| `tokenizer.json` | `cb26b43c98e8266ae3e99c2a583cf8315d73b33a17e6b20b4df7ff1f22392d34` |
+
+Candle did not require a safetensors conversion for this probe: `candle-onnx` loaded the pinned `model.onnx` directly. If a future Candle backend switches to native safetensors, that converted artifact must get its own SHA pin and verification gate before it can load.
+
+The local fetch script downloaded artifact bytes that matched the pinned per-file hashes. The release checksum URL for `v0.8.1` returned 404 during this run, so the local bench directory used the repo-pinned canonical `KIJI_DISTILBERT_SHA256SUMS` content and verified its digest before runtime load.
+
+## Host
+
+| Field | Value |
+| --- | --- |
+| OS | `Darwin 25.5.0` |
+| Arch | `arm64` |
+| CPU | `Apple M5 Max` |
+| RAM | `68719476736 bytes` |
+| Rust | `rustc 1.95.0 (59807616e 2026-04-14) (Homebrew)` |
+
+## Latency
+
+Command:
+
+```sh
+GAZE_KIJI_DISTILBERT_MODEL_DIR=/abs/path/to/target/kiji-distilbert \
+  cargo bench -p gaze-recognizers \
+  --features safety-net-kiji,runtime-tract,runtime-candle \
+  --bench runtime_comparison
+```
+
+Fixture set: first 12 checked-in coverage-loop text fixtures. Warm iterations: 100. Correctness gate: ORT, tract, and Candle produced identical `(start, end, label)` span sets for every fixture.
+
+| Runtime | Cold start ms | Warm p50 ms | Warm p95 ms | Correctness |
+| --- | ---: | ---: | ---: | --- |
+| `ort` | 570.241 | 6.911 | 10.889 | matched baseline |
+| `tract` | 566.230 | 26.221 | 52.193 | matched ORT |
+| `candle` | 508.318 | 54.570 | 122.917 | matched ORT |
+
+## Release Binary Size
+
+Command shape: `cargo build --release -p gaze-cli --features <feature-set> --target-dir target/runtime-size-<name>`, then `wc -c target/runtime-size-<name>/release/gaze`.
+
+| Build | Feature set | Bytes | MiB |
+| --- | --- | ---: | ---: |
+| Subprocess baseline | default features | 39,403,632 | 37.58 |
+| ORT | `safety-net-kiji` | 39,554,928 | 37.72 |
+| tract | `runtime-tract` | 59,429,920 | 56.68 |
+| Candle | `runtime-candle` | 43,472,016 | 41.46 |
+
+## Static-musl Probe
+
+Target: `x86_64-unknown-linux-musl`.
+
+This macOS host initially used Homebrew `cargo`/`rustc`, which could not see the rustup-installed musl stdlib. Retrying with `RUSTC=$(rustup which rustc)` reached the target build, but no `x86_64-linux-musl-gcc` toolchain was available.
+
+| Runtime | Command shape | Result |
+| --- | --- | --- |
+| ORT | `cargo build --release --target x86_64-unknown-linux-musl -p gaze-cli --no-default-features --features safety-net-kiji` | blocked by missing `x86_64-linux-musl-gcc` while building `onig_sys` |
+| tract | same with `--features runtime-tract` | blocked by missing `x86_64-linux-musl-gcc`; `onig_sys` and `tract-linalg` require C/assembly compilation |
+| Candle | same with `--features runtime-candle` | blocked by missing `x86_64-linux-musl-gcc` while building `onig_sys` |
+
+Interpretation: this probe is host-toolchain blocked, not a runtime pass/fail. The current tokenizer dependency (`tokenizers` with `onig`) prevents a clean C-toolchain-free musl verdict for every runtime. A follow-up static distribution pass should test in a Linux musl builder with `x86_64-linux-musl-gcc`, and should evaluate a tokenizer feature profile that avoids `onig` if fully static shops require no C build chain.
+
+## Recommendation Matrix
+
+| Adopter constraint | Recommendation | Reason |
+| --- | --- | --- |
+| Default distribution | `ort` | Fastest warm latency on the measured Apple Silicon host and already the current in-process default path. |
+| Static-binary distribution | `tract`, pending Linux musl builder confirmation | Pure-Rust runtime profile is still the right strategic fallback, but this host did not prove clean musl-static because tokenizer and tract build scripts need a musl C toolchain. |
+| macOS Apple Silicon optimal | `ort` | ORT beat tract by about 3.8x p50 and Candle by about 7.9x p50 on this host. |
+| CUDA / linux-x86_64 GPU | out of scope | No GPU backend was configured or measured in this bench. |
+
+## Five-Axis Check
+
+Reliability: all runtime loaders verify the pinned Kiji bundle before load, and the bench fails if span sets drift.
+
+Reversibility: unchanged; these are observer-only safety-net backends and do not mutate manifests.
+
+Agentic-first: fixture inputs include checked-in agent-workflow coverage-loop text.
+
+Trust: the report includes host metadata, exact pins, feature sets, and negative musl findings.
+
+Adopter ergonomics: ORT remains the default. tract and Candle are opt-in through feature flags plus `--kiji-backend`, so adopters choose the runtime explicitly.


### PR DESCRIPTION
## Summary
- add opt-in Kiji runtimes for tract and candle behind runtime-tract/runtime-candle features
- add runtime_comparison bench with SHA-verified pinned Kiji bundle, cold start, warm p50/p95, and recall parity checks
- document host, latency, binary size, musl probe, and adopter recommendation matrix

## Bench results
Host: Darwin 25.5.0 arm64, Apple M5 Max, 64 GiB RAM, rustc 1.95.0.
Warm iterations: 100. Fixtures: 12 coverage-loop inputs. Recall parity: ort, tract, and candle emitted identical span sets.

| runtime | cold ms | warm p50 ms | warm p95 ms | release gaze-cli size |
| --- | ---: | ---: | ---: | ---: |
| ort | 570.241 | 6.911 | 10.889 | 39,554,928 bytes |
| tract | 566.230 | 26.221 | 52.193 | 59,429,920 bytes |
| candle | 508.318 | 54.570 | 122.917 | 43,472,016 bytes |
| subprocess baseline | n/a | n/a | n/a | 39,403,632 bytes |

## Recommendation matrix
| adopter constraint | recommendation |
| --- | --- |
| default distribution | ort |
| static-binary distribution | tract as opt-in fallback, pending Linux musl builder follow-up |
| macOS Apple Silicon | ort on this host; candle did not win |
| CUDA/linux GPU | out of scope; leave for adopter-specific follow-up |

## Static musl probe
Attempted x86_64-unknown-linux-musl builds for default/ort, tract, and candle. The dispatch host lacks x86_64-linux-musl-gcc. With rustup rustc selected, builds reached native toolchain checks but failed before link. onig_sys blocks tokenizer builds across runtime variants; tract also reaches tract-linalg C/assembly. Documented as a negative finding, not fabricated as pass.

## Five-axis check
Reliability: loaders verify the pinned model dir before use; bench panics BLOCKED on span drift.
Reversibility: no restore contract changes.
Agentic-first: same fixture inputs and manifest-compatible span shape.
Trust: opt-in features and documented SHA-verified artifacts; no unverified converted model path.
Adopter ergonomics: default remains ort; tract/candle are explicit feature + CLI choices.

## Gates
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix