### PR TITLE
feat(bench): tiny-model leaderboard (#371)

### DIFF
--- a/benches/ner_models.toml
+++ b/benches/ner_models.toml
@@ -56,3 +56,51 @@ native_locales = ["EnUs", "DeDe", "FrFr", "ItIt", "EsEs", "PtBr", "Global"]
 label_set = ["PER", "LOC", "ORG", "DATE"]
 label_map = { PER = "Name", LOC = "Location", ORG = "Organization", DATE = "Custom:date" }
 shippable_default = true
+
+[[model]]
+id = "openobscure-tinybert4l-pii-ner-int8"
+display_name = "openobscure TinyBERT4L PII NER int8"
+hf_repo = "openobscure/tinybert4l-pii-ner-int8"
+hf_commit = "f8399a9431b0202e78e20b2d38a3385521472f3f"
+bundle_sha = "f5fa446a02c7d71251749a37c31b5f8ae3c450360b97e3df99539d688ff43d9a"
+license = "apache-2.0"
+runtime = "onnxruntime"
+wrapper = "scripts/onnx-token-classification-runner.py"
+model_file = "model_int8.onnx"
+default_checkpoint = ".huggingface-cache/models/openobscure-tinybert4l-pii-ner-int8"
+native_locales = ["Global"]
+label_set = ["PER", "LOC", "ORG", "HEALTH", "CHILD"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", HEALTH = "Custom:health", CHILD = "Custom:child" }
+shippable_default = true
+default_caveat = "PII-specific TinyBERT head; not a strict CoNLL label-set match."
+
+[[model]]
+id = "mrm8488-mobilebert-ner"
+display_name = "mrm8488 MobileBERT NER"
+hf_repo = "mrm8488/mobilebert-finetuned-ner"
+hf_commit = "3f9a1f308e4272219bd43e9127cb65fa5504d9ec"
+bundle_sha = "2c867d5c7117ef864d82dc2b47089c45550ddabf4c24bd9dfaa6e96026e6f19a"
+license = "mit"
+runtime = "transformers"
+wrapper = "scripts/transformers-runner.py"
+default_checkpoint = ".huggingface-cache/models/mrm8488-mobilebert-ner"
+native_locales = ["EnUs", "EnGb"]
+label_set = ["PER", "LOC", "ORG", "MISC"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+shippable_default = true
+
+[[model]]
+id = "osiria-minilm-italian-ner"
+display_name = "osiria MiniLM-L6-H384 Italian NER"
+hf_repo = "osiria/minilm-l6-h384-italian-cased-ner"
+hf_commit = "125c646df9361d4bc764a6b1710bee21b50cd924"
+bundle_sha = "46c82257388b9727b752679cc13d4594fb9eae19dfbf2d2f225f4d5bae841f0a"
+license = "mit"
+runtime = "transformers"
+wrapper = "scripts/transformers-runner.py"
+default_checkpoint = ".huggingface-cache/models/osiria-minilm-italian-ner"
+native_locales = ["ItIt"]
+label_set = ["PER", "LOC", "ORG", "MISC"]
+label_map = { PER = "Name", LOC = "Location", ORG = "Organization", MISC = "Custom:other" }
+shippable_default = true
+default_caveat = "MiniLM-family NER head is Italian-native; no permissive English/Multi MiniLM NER head was found."

--- a/crates/gaze-recognizers/benches/ner_models_snapshot.json
+++ b/crates/gaze-recognizers/benches/ner_models_snapshot.json
@@ -8,9 +8,11 @@
     "fixture_count": 150
   },
   "run_environment": {
-    "os": "macOS-26.5-arm64-arm-64bit-Mach-O",
+    "os": "macOS-26.5-arm64-arm-64bit",
     "machine": "arm64",
-    "python": "3.14.5"
+    "python": "3.10.20",
+    "warm_latency_python": "3.10.20",
+    "host_note": "Apple M5 Max host; warm candidate latency measured after model load; Kiji int8 warm row measured by Rust ORT live bench."
   },
   "models": {
     "kiji-distilbert": {
@@ -18,10 +20,11 @@
       "hf_repo": "onnx-community/distilbert-NER-ONNX",
       "hf_commit": "3a19fe9404a4469d91aa3d551558a97f68872f67",
       "bundle_sha256_config": "c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f",
-      "bundle_sha256_observed": "34c2b83bc54b6fe3b96b74b360425c483f01be7a28feb91a37aaa65476d03aa4",
+      "bundle_sha256_observed": "4294e3b6fa7f3529d2ec6cd2efee2499c56e9b6a16280e4d045a77fcd5921e7b",
       "license": "apache-2.0",
       "runtime": "onnxruntime",
       "wrapper": "scripts/kiji-runner.py",
+      "model_file": null,
       "checkpoint": "/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67",
       "native_locales": [
         "Global"
@@ -41,15 +44,22 @@
       "shippable_default": true,
       "default_caveat": null,
       "latency": {
-        "cold_start_ms": 2455.891792,
-        "per_fixture_median_ms": 323.346375,
-        "per_fixture_p95_ms": 490.053498,
-        "per_fixture_p99_ms": 680.605004,
-        "per_fixture_mean_ms": 349.494284,
-        "throughput_bytes_per_sec": 816.970919,
+        "cold_start_ms": 159.783041,
+        "per_fixture_median_ms": 163.161312,
+        "per_fixture_p95_ms": 176.925015,
+        "per_fixture_p99_ms": 180.087747,
+        "per_fixture_mean_ms": 165.143185,
+        "throughput_bytes_per_sec": 1728.964275,
         "fixture_count": 150,
         "device": "cpu",
         "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      },
+      "warm_latency": {
+        "fixture": "Alice Smith visited Berlin before meeting Dr. Schmidt at Example Corp.",
+        "iterations": 100,
+        "warm_p50_ms": 2.562,
+        "cold_start_ms": 544.124,
+        "measurement_scope": "in-process ORT backend after one warmup inference"
       }
     },
     "wikineural-multilingual": {
@@ -180,402 +190,186 @@
         "device": "cpu",
         "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
       }
+    },
+    "openobscure-tinybert4l-pii-ner-int8": {
+      "display_name": "openobscure TinyBERT4L PII NER int8",
+      "hf_repo": "openobscure/tinybert4l-pii-ner-int8",
+      "hf_commit": "f8399a9431b0202e78e20b2d38a3385521472f3f",
+      "bundle_sha256_config": "f5fa446a02c7d71251749a37c31b5f8ae3c450360b97e3df99539d688ff43d9a",
+      "bundle_sha256_observed": "f5fa446a02c7d71251749a37c31b5f8ae3c450360b97e3df99539d688ff43d9a",
+      "license": "apache-2.0",
+      "runtime": "onnxruntime",
+      "wrapper": "scripts/onnx-token-classification-runner.py",
+      "model_file": "model_int8.onnx",
+      "checkpoint": ".huggingface-cache/models/openobscure-tinybert4l-pii-ner-int8",
+      "native_locales": [
+        "Global"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "HEALTH",
+        "CHILD"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "HEALTH": "Custom:health",
+        "CHILD": "Custom:child"
+      },
+      "shippable_default": true,
+      "default_caveat": "PII-specific TinyBERT head; not a strict CoNLL label-set match.",
+      "latency": {
+        "cold_start_ms": 75.117042,
+        "per_fixture_median_ms": 76.547895,
+        "per_fixture_p95_ms": 78.320183,
+        "per_fixture_p99_ms": 78.746177,
+        "per_fixture_mean_ms": 76.617194,
+        "throughput_bytes_per_sec": 3726.665662,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      },
+      "warm_latency": {
+        "fixture_count": 150,
+        "warm_p50_ms": 1.086937,
+        "warm_p95_ms": 2.220792,
+        "warm_mean_ms": 1.31441,
+        "measurement_scope": "persistent Python process with model/session loaded once; direct corpus texts"
+      }
+    },
+    "mrm8488-mobilebert-ner": {
+      "display_name": "mrm8488 MobileBERT NER",
+      "hf_repo": "mrm8488/mobilebert-finetuned-ner",
+      "hf_commit": "3f9a1f308e4272219bd43e9127cb65fa5504d9ec",
+      "bundle_sha256_config": "2c867d5c7117ef864d82dc2b47089c45550ddabf4c24bd9dfaa6e96026e6f19a",
+      "bundle_sha256_observed": "2c867d5c7117ef864d82dc2b47089c45550ddabf4c24bd9dfaa6e96026e6f19a",
+      "license": "mit",
+      "runtime": "transformers",
+      "wrapper": "scripts/transformers-runner.py",
+      "model_file": null,
+      "checkpoint": ".huggingface-cache/models/mrm8488-mobilebert-ner",
+      "native_locales": [
+        "EnUs",
+        "EnGb"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Custom:other"
+      },
+      "shippable_default": true,
+      "default_caveat": null,
+      "latency": {
+        "cold_start_ms": 1782.920125,
+        "per_fixture_median_ms": 1760.778375,
+        "per_fixture_p95_ms": 1778.697129,
+        "per_fixture_p99_ms": 1783.6371,
+        "per_fixture_mean_ms": 1761.919148,
+        "throughput_bytes_per_sec": 162.054353,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      },
+      "warm_latency": {
+        "fixture_count": 150,
+        "warm_p50_ms": 16.493916,
+        "warm_p95_ms": 21.804541,
+        "warm_mean_ms": 15.030467,
+        "measurement_scope": "persistent Python process with Transformers pipeline loaded once; direct corpus texts"
+      }
+    },
+    "osiria-minilm-italian-ner": {
+      "display_name": "osiria MiniLM-L6-H384 Italian NER",
+      "hf_repo": "osiria/minilm-l6-h384-italian-cased-ner",
+      "hf_commit": "125c646df9361d4bc764a6b1710bee21b50cd924",
+      "bundle_sha256_config": "46c82257388b9727b752679cc13d4594fb9eae19dfbf2d2f225f4d5bae841f0a",
+      "bundle_sha256_observed": "46c82257388b9727b752679cc13d4594fb9eae19dfbf2d2f225f4d5bae841f0a",
+      "license": "mit",
+      "runtime": "transformers",
+      "wrapper": "scripts/transformers-runner.py",
+      "model_file": null,
+      "checkpoint": ".huggingface-cache/models/osiria-minilm-italian-ner",
+      "native_locales": [
+        "ItIt"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Custom:other"
+      },
+      "shippable_default": true,
+      "default_caveat": "MiniLM-family NER head is Italian-native; no permissive English/Multi MiniLM NER head was found.",
+      "latency": {
+        "cold_start_ms": 1564.524125,
+        "per_fixture_median_ms": 1566.990562,
+        "per_fixture_p95_ms": 1583.862771,
+        "per_fixture_p99_ms": 1639.894385,
+        "per_fixture_mean_ms": 1570.615786,
+        "throughput_bytes_per_sec": 181.792816,
+        "fixture_count": 150,
+        "device": "cpu",
+        "measurement_scope": "per-fixture subprocess wall clock; includes fork/import/model load because the published wrappers are one-shot CLIs"
+      },
+      "warm_latency": {
+        "fixture_count": 150,
+        "warm_p50_ms": 4.702688,
+        "warm_p95_ms": 9.075,
+        "warm_mean_ms": 5.77294,
+        "measurement_scope": "persistent Python process with Transformers pipeline loaded once; direct corpus texts"
+      }
+    },
+    "kiji-distilbert-int8-ort": {
+      "display_name": "Kiji DistilBERT int8 ORT",
+      "hf_repo": "onnx-community/distilbert-NER-ONNX",
+      "hf_commit": "3a19fe9404a4469d91aa3d551558a97f68872f67",
+      "bundle_sha256_config": "6e7f238f38c5ee7977052ec391f6a8c68bbef038091f2ecff4747cc2268210cb",
+      "license": "apache-2.0",
+      "runtime": "onnxruntime-rust",
+      "wrapper": null,
+      "native_locales": [
+        "Global"
+      ],
+      "label_set": [
+        "PER",
+        "LOC",
+        "ORG",
+        "MISC"
+      ],
+      "label_map": {
+        "PER": "Name",
+        "LOC": "Location",
+        "ORG": "Organization",
+        "MISC": "Name"
+      },
+      "shippable_default": true,
+      "default_caveat": "Tier 2 int8 ORT comparison row; recall cells are identical to Kiji DistilBERT by gate.",
+      "warm_latency": {
+        "fixture": "Alice Smith visited Berlin before meeting Dr. Schmidt at Example Corp.",
+        "iterations": 100,
+        "warm_p50_ms": 1.849,
+        "cold_start_ms": 192.613,
+        "measurement_scope": "in-process ORT backend after one warmup inference"
+      }
     }
   },
   "cells": [
-    {
-      "model": "kiji-distilbert",
-      "locale": "Global",
-      "native_locale": true,
-      "mode": "direct_detector",
-      "metrics": {
-        "precision": 0.084746,
-        "recall": 0.125,
-        "f1": 0.10101,
-        "per_class": {
-          "Email": {
-            "support": 59,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 59,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "Name": {
-            "support": 5,
-            "predicted": 59,
-            "true_positive": 5,
-            "false_positive": 54,
-            "false_negative": 0,
-            "precision": 0.084746,
-            "recall": 1.0,
-            "f1": 0.15625
-          },
-          "custom:credit_card": {
-            "support": 18,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 18,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:eth_address": {
-            "support": 21,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 21,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:iban": {
-            "support": 18,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 18,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:ip_address": {
-            "support": 25,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 25,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:phone": {
-            "support": 11,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 11,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:postal_code": {
-            "support": 6,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 6,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          }
-        }
-      }
-    },
-    {
-      "model": "kiji-distilbert",
-      "locale": "EnUs",
-      "native_locale": false,
-      "mode": "direct_detector",
-      "metrics": {
-        "precision": 0.54717,
-        "recall": 0.125,
-        "f1": 0.203509,
-        "per_class": {
-          "Email": {
-            "support": 48,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 48,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "Name": {
-            "support": 29,
-            "predicted": 53,
-            "true_positive": 29,
-            "false_positive": 24,
-            "false_negative": 0,
-            "precision": 0.54717,
-            "recall": 1.0,
-            "f1": 0.707317
-          },
-          "custom:credit_card": {
-            "support": 10,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 10,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:eth_address": {
-            "support": 5,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 5,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:iban": {
-            "support": 8,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 8,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:ip_address": {
-            "support": 7,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 7,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:phone": {
-            "support": 15,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 15,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:postal_code": {
-            "support": 10,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 10,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          }
-        }
-      }
-    },
-    {
-      "model": "kiji-distilbert",
-      "locale": "DeDe",
-      "native_locale": false,
-      "mode": "direct_detector",
-      "metrics": {
-        "precision": 0.108614,
-        "recall": 0.125,
-        "f1": 0.116232,
-        "per_class": {
-          "Email": {
-            "support": 55,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 55,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "Name": {
-            "support": 29,
-            "predicted": 267,
-            "true_positive": 29,
-            "false_positive": 238,
-            "false_negative": 0,
-            "precision": 0.108614,
-            "recall": 1.0,
-            "f1": 0.195946
-          },
-          "custom:credit_card": {
-            "support": 7,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 7,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:eth_address": {
-            "support": 4,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 4,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:iban": {
-            "support": 22,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 22,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:ip_address": {
-            "support": 6,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 6,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:phone": {
-            "support": 17,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 17,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          },
-          "custom:postal_code": {
-            "support": 13,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 13,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          }
-        }
-      }
-    },
-    {
-      "model": "kiji-distilbert",
-      "locale": "Global",
-      "native_locale": true,
-      "mode": "observer_residual",
-      "metrics": {
-        "precision": 0.081967,
-        "recall": 0.5,
-        "f1": 0.140845,
-        "per_class": {
-          "Location": {
-            "support": 0,
-            "predicted": 2,
-            "true_positive": 0,
-            "false_positive": 2,
-            "false_negative": 0,
-            "precision": 0.0,
-            "recall": null,
-            "f1": null
-          },
-          "Name": {
-            "support": 5,
-            "predicted": 59,
-            "true_positive": 5,
-            "false_positive": 54,
-            "false_negative": 0,
-            "precision": 0.084746,
-            "recall": 1.0,
-            "f1": 0.15625
-          },
-          "custom:postal_code": {
-            "support": 6,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 6,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          }
-        },
-        "observer_residual_recall": 0.5,
-        "agreement_with_rule_floor": null,
-        "expansion_fraction": null,
-        "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 0.5
-      }
-    },
-    {
-      "model": "kiji-distilbert",
-      "locale": "EnUs",
-      "native_locale": false,
-      "mode": "observer_residual",
-      "metrics": {
-        "precision": 0.54717,
-        "recall": 0.5,
-        "f1": 0.522523,
-        "per_class": {
-          "Name": {
-            "support": 29,
-            "predicted": 53,
-            "true_positive": 29,
-            "false_positive": 24,
-            "false_negative": 0,
-            "precision": 0.54717,
-            "recall": 1.0,
-            "f1": 0.707317
-          },
-          "custom:phone": {
-            "support": 15,
-            "predicted": 0,
-            "true_positive": 0,
-            "false_positive": 0,
-            "false_negative": 15,
-            "precision": null,
-            "recall": 0.0,
-            "f1": null
-          }
-        },
-        "observer_residual_recall": 0.5,
-        "agreement_with_rule_floor": null,
-        "expansion_fraction": null,
-        "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 0.5
-      }
-    },
-    {
-      "model": "kiji-distilbert",
-      "locale": "DeDe",
-      "native_locale": false,
-      "mode": "observer_residual",
-      "metrics": {
-        "precision": 0.107407,
-        "recall": 1.0,
-        "f1": 0.19398,
-        "per_class": {
-          "Name": {
-            "support": 29,
-            "predicted": 270,
-            "true_positive": 29,
-            "false_positive": 241,
-            "false_negative": 0,
-            "precision": 0.107407,
-            "recall": 1.0,
-            "f1": 0.19398
-          }
-        },
-        "observer_residual_recall": 1.0,
-        "agreement_with_rule_floor": null,
-        "expansion_fraction": null,
-        "contradiction_fraction": null,
-        "novel_tp_over_rule_floor": 1.0
-      }
-    },
     {
       "model": "wikineural-multilingual",
       "locale": "Global",
@@ -1992,6 +1786,1838 @@
             "predicted": 20,
             "true_positive": 0,
             "false_positive": 20,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.084746,
+        "recall": 0.125,
+        "f1": 0.10101,
+        "per_class": {
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 59,
+            "true_positive": 5,
+            "false_positive": 54,
+            "false_negative": 0,
+            "precision": 0.084746,
+            "recall": 1.0,
+            "f1": 0.15625
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.54717,
+        "recall": 0.125,
+        "f1": 0.203509,
+        "per_class": {
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 53,
+            "true_positive": 29,
+            "false_positive": 24,
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.108614,
+        "recall": 0.125,
+        "f1": 0.116232,
+        "per_class": {
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 267,
+            "true_positive": 29,
+            "false_positive": 238,
+            "false_negative": 0,
+            "precision": 0.108614,
+            "recall": 1.0,
+            "f1": 0.195946
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.084746,
+        "recall": 0.5,
+        "f1": 0.144928,
+        "per_class": {
+          "Location": {
+            "support": 0,
+            "predicted": 1,
+            "true_positive": 0,
+            "false_positive": 1,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 58,
+            "true_positive": 5,
+            "false_positive": 53,
+            "false_negative": 0,
+            "precision": 0.086207,
+            "recall": 1.0,
+            "f1": 0.15873
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.54717,
+        "recall": 0.5,
+        "f1": 0.522523,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 53,
+            "true_positive": 29,
+            "false_positive": 24,
+            "false_negative": 0,
+            "precision": 0.54717,
+            "recall": 1.0,
+            "f1": 0.707317
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "kiji-distilbert",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.107011,
+        "recall": 1.0,
+        "f1": 0.193333,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 271,
+            "true_positive": 29,
+            "false_positive": 242,
+            "false_negative": 0,
+            "precision": 0.107011,
+            "recall": 1.0,
+            "f1": 0.193333
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.428571,
+        "recall": 0.075,
+        "f1": 0.12766,
+        "per_class": {
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 3,
+            "true_positive": 3,
+            "false_positive": 0,
+            "false_negative": 2,
+            "precision": 1.0,
+            "recall": 0.6,
+            "f1": 0.75
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 4,
+            "true_positive": 0,
+            "false_positive": 4,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.73913,
+        "recall": 0.073276,
+        "f1": 0.133333,
+        "per_class": {
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 18,
+            "true_positive": 17,
+            "false_positive": 1,
+            "false_negative": 12,
+            "precision": 0.944444,
+            "recall": 0.586207,
+            "f1": 0.723404
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 5,
+            "true_positive": 0,
+            "false_positive": 5,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.105263,
+        "recall": 0.060345,
+        "f1": 0.076712,
+        "per_class": {
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 16,
+            "true_positive": 14,
+            "false_positive": 2,
+            "false_negative": 15,
+            "precision": 0.875,
+            "recall": 0.482759,
+            "f1": 0.622222
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 117,
+            "true_positive": 0,
+            "false_positive": 117,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "Global",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.5,
+        "recall": 0.4,
+        "f1": 0.444444,
+        "per_class": {
+          "Name": {
+            "support": 5,
+            "predicted": 4,
+            "true_positive": 4,
+            "false_positive": 0,
+            "false_negative": 1,
+            "precision": 1.0,
+            "recall": 0.8,
+            "f1": 0.888889
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 4,
+            "true_positive": 0,
+            "false_positive": 4,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.4,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.4
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.857143,
+        "recall": 0.206897,
+        "f1": 0.333333,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 12,
+            "true_positive": 12,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": 1.0,
+            "recall": 0.413793,
+            "f1": 0.585366
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.206897,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.206897
+      }
+    },
+    {
+      "model": "openobscure-tinybert4l-pii-ner-int8",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.075949,
+        "recall": 0.206897,
+        "f1": 0.111111,
+        "per_class": {
+          "Name": {
+            "support": 29,
+            "predicted": 7,
+            "true_positive": 6,
+            "false_positive": 1,
+            "false_negative": 23,
+            "precision": 0.857143,
+            "recall": 0.206897,
+            "f1": 0.333333
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 72,
+            "true_positive": 0,
+            "false_positive": 72,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.206897,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.206897
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.138889,
+        "recall": 0.125,
+        "f1": 0.131579,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 26,
+            "true_positive": 0,
+            "false_positive": 26,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 8,
+            "true_positive": 5,
+            "false_positive": 3,
+            "false_negative": 0,
+            "precision": 0.625,
+            "recall": 1.0,
+            "f1": 0.769231
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.474576,
+        "recall": 0.12069,
+        "f1": 0.19244,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 14,
+            "true_positive": 0,
+            "false_positive": 14,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 44,
+            "true_positive": 28,
+            "false_positive": 16,
+            "false_negative": 1,
+            "precision": 0.636364,
+            "recall": 0.965517,
+            "f1": 0.767123
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 1,
+            "true_positive": 0,
+            "false_positive": 1,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.083815,
+        "recall": 0.125,
+        "f1": 0.100346,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 75,
+            "true_positive": 0,
+            "false_positive": 75,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Location": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 47,
+            "true_positive": 29,
+            "false_positive": 18,
+            "false_negative": 0,
+            "precision": 0.617021,
+            "recall": 1.0,
+            "f1": 0.763158
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 222,
+            "true_positive": 0,
+            "false_positive": 222,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.294118,
+        "recall": 0.5,
+        "f1": 0.37037,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 12,
+            "true_positive": 0,
+            "false_positive": 12,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "EnUs",
+      "native_locale": true,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.7,
+        "recall": 0.482758,
+        "f1": 0.571428,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 11,
+            "true_positive": 0,
+            "false_positive": 11,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 28,
+            "true_positive": 28,
+            "false_positive": 0,
+            "false_negative": 1,
+            "precision": 1.0,
+            "recall": 0.965517,
+            "f1": 0.982456
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 1,
+            "true_positive": 0,
+            "false_positive": 1,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.482758,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.482758
+      }
+    },
+    {
+      "model": "mrm8488-mobilebert-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.090909,
+        "recall": 1.0,
+        "f1": 0.166667,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 79,
+            "true_positive": 0,
+            "false_positive": 79,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 35,
+            "true_positive": 29,
+            "false_positive": 6,
+            "false_negative": 0,
+            "precision": 0.828571,
+            "recall": 1.0,
+            "f1": 0.90625
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 205,
+            "true_positive": 0,
+            "false_positive": 205,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 1.0,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 1.0
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.02551,
+        "recall": 0.125,
+        "f1": 0.042373,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 125,
+            "true_positive": 0,
+            "false_positive": 125,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 59,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 59,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 66,
+            "true_positive": 0,
+            "false_positive": 66,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 21,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 21,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 18,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 18,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 25,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 25,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 11,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 11,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.215385,
+        "recall": 0.12069,
+        "f1": 0.154696,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 39,
+            "true_positive": 0,
+            "false_positive": 39,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 48,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 48,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 28,
+            "true_positive": 28,
+            "false_positive": 0,
+            "false_negative": 1,
+            "precision": 1.0,
+            "recall": 0.965517,
+            "f1": 0.982456
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 63,
+            "true_positive": 0,
+            "false_positive": 63,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 5,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 5,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 8,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 8,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 10,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 10,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "direct_detector",
+      "metrics": {
+        "precision": 0.111111,
+        "recall": 0.125,
+        "f1": 0.117647,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 104,
+            "true_positive": 0,
+            "false_positive": 104,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Email": {
+            "support": 55,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 55,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 128,
+            "true_positive": 0,
+            "false_positive": 128,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:credit_card": {
+            "support": 7,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 7,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:eth_address": {
+            "support": 4,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 4,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:iban": {
+            "support": 22,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 22,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:ip_address": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:phone": {
+            "support": 17,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 17,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 13,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 13,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        }
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "Global",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.041322,
+        "recall": 0.5,
+        "f1": 0.076336,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 114,
+            "true_positive": 0,
+            "false_positive": 114,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 5,
+            "predicted": 5,
+            "true_positive": 5,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 2,
+            "true_positive": 0,
+            "false_positive": 2,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "custom:postal_code": {
+            "support": 6,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 6,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "EnUs",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.432836,
+        "recall": 0.5,
+        "f1": 0.464,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 38,
+            "true_positive": 0,
+            "false_positive": 38,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "custom:phone": {
+            "support": 15,
+            "predicted": 0,
+            "true_positive": 0,
+            "false_positive": 0,
+            "false_negative": 15,
+            "precision": null,
+            "recall": 0.0,
+            "f1": null
+          }
+        },
+        "observer_residual_recall": 0.5,
+        "agreement_with_rule_floor": null,
+        "expansion_fraction": null,
+        "contradiction_fraction": null,
+        "novel_tp_over_rule_floor": 0.5
+      }
+    },
+    {
+      "model": "osiria-minilm-italian-ner",
+      "locale": "DeDe",
+      "native_locale": false,
+      "mode": "observer_residual",
+      "metrics": {
+        "precision": 0.143564,
+        "recall": 1.0,
+        "f1": 0.251082,
+        "per_class": {
+          "Custom:other": {
+            "support": 0,
+            "predicted": 123,
+            "true_positive": 0,
+            "false_positive": 123,
+            "false_negative": 0,
+            "precision": 0.0,
+            "recall": null,
+            "f1": null
+          },
+          "Name": {
+            "support": 29,
+            "predicted": 29,
+            "true_positive": 29,
+            "false_positive": 0,
+            "false_negative": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0
+          },
+          "Organization": {
+            "support": 0,
+            "predicted": 50,
+            "true_positive": 0,
+            "false_positive": 50,
             "false_negative": 0,
             "precision": 0.0,
             "recall": null,

--- a/docs/research/v0.9-ner-model-leaderboard.md
+++ b/docs/research/v0.9-ner-model-leaderboard.md
@@ -1,6 +1,6 @@
 # v0.9 NER Model Leaderboard
 
-This benchmark compares Hugging Face NER candidates as Gaze safety-net backends on the same committed coverage-loop corpus. The run uses the config in `benches/ner_models.toml` and writes the frozen evidence snapshot to `crates/gaze-recognizers/benches/ner_models_snapshot.json`.
+This benchmark compares pinned Hugging Face NER candidates as Gaze safety-net backends on the same committed coverage-loop corpus. The run uses `benches/ner_models.toml` and writes evidence to `crates/gaze-recognizers/benches/ner_models_snapshot.json`.
 
 Related docs:
 
@@ -8,75 +8,68 @@ Related docs:
 - Runtime contract: [`docs/architecture/safety-nets.md`](../architecture/safety-nets.md)
 - Kiji setup: [`docs/getting-started/kiji-safetynet-setup.md`](../getting-started/kiji-safetynet-setup.md)
 
-Command:
+Commands:
 
 ```bash
 cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture
-.bench-venv/bin/python scripts/ner-bench-scorer.py --repo-root . --python .bench-venv/bin/python --mode all
+.bench-venv/bin/python scripts/ner-bench-scorer.py --repo-root . --python .bench-venv/bin/python --mode all --model kiji-distilbert --model openobscure-tinybert4l-pii-ner-int8 --model mrm8488-mobilebert-ner --model osiria-minilm-italian-ner --snapshot target/tier5-ner-models-snapshot.json
+.bench-venv/bin/python scripts/ner-warm-latency.py --repo-root .
+GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort GAZE_KIJI_DISTILBERT_MODEL_DIR=/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 GAZE_KIJI_DISTILBERT_PRECISION=int8 cargo bench -p gaze-recognizers --bench safety_net_matrix --features safety-net-kiji --no-default-features
 ```
 
-Run date: 2026-05-15.
+Run date: 2026-05-15. Host: macOS-26.5 arm64 on Apple M5 Max. The scorer used Python 3.10.20 for Tiny/Mobile/Mini candidates; Kiji warm ORT rows used the Rust ORT backend. Corpus: 150 fixtures, `target/coverage-report.json` SHA256 `760f96163a68ce5f7dbc0409aa5109aa1a3ed190001536647e1881ba9d40a49c`.
 
-Corpus: 150 fixtures, `target/coverage-report.json` SHA256 `760f96163a68ce5f7dbc0409aa5109aa1a3ed190001536647e1881ba9d40a49c`.
+## Tier 5 Tiny Candidates
 
-## Leaderboard
+Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cells. Direct and observer-residual recall come from the same config-driven scorer. Warm p50 keeps the model/session loaded and runs the same 150 direct fixture texts, except Kiji ORT warm rows use the existing live ORT bench fixture.
 
-Macro averages are across the committed `Global`, `EnUs`, and `DeDe` locale cells. Latency is median per fixture on CPU with one subprocess invocation per fixture, including Python import and model load.
+| Model | HF repo @ commit | License | Params | Bundle | Direct recall | Observer recall | Warm p50 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| Kiji DistilBERT fp32 ORT | `onnx-community/distilbert-NER-ONNX@3a19fe9` | Apache-2.0 | 66M | 249MB model | 0.125 | 0.667 | 2.562ms |
+| Kiji DistilBERT int8 ORT | same source, local int8 artifact | Apache-2.0 | 66M | 63MB model | 0.125 | 0.667 | 1.849ms |
+| openobscure TinyBERT4L PII NER int8 | `openobscure/tinybert4l-pii-ner-int8@f8399a9` | Apache-2.0 | 14M | 13.95MB | 0.070 | 0.271 | 1.087ms |
+| mrm8488 MobileBERT NER | `mrm8488/mobilebert-finetuned-ner@3f9a1f3` | MIT | 25M | 94.29MB | 0.124 | 0.661 | 16.494ms |
+| osiria MiniLM-L6-H384 Italian NER | `osiria/minilm-l6-h384-italian-cased-ner@125c646` | MIT | 22.6M | 174.30MB | 0.124 | 0.667 | 4.703ms |
+
+Recommendation:
+
+| Need | Use | Reason |
+|---|---|---|
+| `<50MB` total model bundle | openobscure TinyBERT4L PII NER int8 | Only measured candidate below 50MB; fastest warm p50. Do not use as a Kiji replacement where observer-residual recall matters. |
+| `<100ms` warm p50 with recall preserved | Kiji DistilBERT int8 ORT | Warm p50 is 1.849ms and recall matches fp32 Kiji under the existing int8 gate. |
+| Highest recall among permissive tiny candidates | osiria MiniLM-L6-H384 Italian NER | Ties Kiji observer recall in this corpus, but it is Italian-native and its 174MB bundle misses the low-spec storage target. |
+
+Low-spec reference read:
+
+| Reference profile target | Pass? | Recommendation |
+|---|---:|---|
+| 1vCPU / 1GB RAM, `<50MB` bundle | Partial | TinyBERT is the only measured `<50MB` bundle and should fit the storage envelope, but its observer recall drops to 0.271. It is not a safe default. |
+| 1vCPU / 1GB RAM, `<100ms` warm p50 and recall preserved | Yes by host-proxy latency; not cgroup-proven | Kiji int8 ORT is the best recommendation: 1.849ms warm p50 on this host and identical scorer recall to fp32 Kiji. A true 1vCPU/1GB cgroup or VM run remains the final deployment proof. |
+
+## Full Leaderboard
+
+This table retains the prior multi-NER rows and adds Tier 5 candidates. `Median ms` is the scorer's direct-mode one-shot subprocess median, not warm in-process latency.
 
 | Rank | Model | License | Shippable default? | Direct P/R/F1 | Observer-residual P/R/F1 | Median ms |
 |---:|---|---|---|---:|---:|---:|
 | 1 | Davlan multilingual BERT-NER (HRL) | AFL-3.0 | Yes | 0.558 / 0.125 / 0.200 | 0.518 / 0.661 / 0.558 | 1911.349 |
 | 2 | Babelscape WikiNeural Multilingual | CC-BY-NC-SA-4.0 | No, non-commercial | 0.476 / 0.125 / 0.194 | 0.507 / 0.667 / 0.547 | 1786.361 |
-| 3 | dslim/bert-base-NER (English) | MIT | Yes | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 |
-| 4 | Kiji DistilBERT | Apache-2.0 | Yes | 0.247 / 0.125 / 0.140 | 0.246 / 0.667 / 0.286 | 323.346 |
+| 3 | osiria MiniLM-L6-H384 Italian NER | MIT | Yes, locale caveat | 0.117 / 0.124 / 0.105 | 0.206 / 0.667 / 0.264 | 1566.991 |
+| 4 | mrm8488 MobileBERT NER | MIT | Yes | 0.232 / 0.124 / 0.141 | 0.362 / 0.661 / 0.369 | 1760.778 |
+| 5 | dslim/bert-base-NER (English) | MIT | Yes | 0.300 / 0.124 / 0.152 | 0.290 / 0.655 / 0.323 | 1737.297 |
+| 6 | Kiji DistilBERT | Apache-2.0 | Yes | 0.247 / 0.125 / 0.140 | 0.246 / 0.667 / 0.287 | 163.161 |
+| 7 | openobscure TinyBERT4L PII NER int8 | Apache-2.0 | Yes, recall caveat | 0.424 / 0.070 / 0.113 | 0.478 / 0.271 / 0.296 | 76.548 |
 
-## Strategic Read for v0.9 Default Backend
+## Candidate Screening Notes
 
-The default-backend decision uses the shipping axes adopters actually inherit: license posture, observer-residual recall, and checked-in subprocess latency.
+TinyBERT: `onnx-community/TinyBERT-finetuned-NER-ONNX` and `adel-cybral/TinyBERT-finetuned-NER` did not publish a clean permissive license in HF metadata, so they were skipped. `openobscure/tinybert4l-pii-ner-int8` is Apache-2.0 and was pinned, but it is a PII-specific TinyBERT head rather than a strict CoNLL clone.
 
-| Candidate | License | Observer Recall | Latency |
-|---|---|---:|---:|
-| Kiji DistilBERT | ✓ Apache-2.0 | ✓ 0.667 | ✓ 323ms |
-| Babelscape WikiNeural Multilingual | ✗ CC-BY-NC-SA-4.0 | ✓ 0.667 | ✗ 1786ms |
-| Davlan multilingual BERT-NER (HRL) | ⚠ AFL-3.0 | ✗ 0.661 | ✗ 1911ms |
-| dslim/bert-base-NER (English) | ✓ MIT | ✗ 0.655 | ✗ 1737ms |
-| Axis winner | Kiji DistilBERT | Kiji DistilBERT / WikiNeural tie | Kiji DistilBERT |
+MobileBERT: `mrm8488/mobilebert-finetuned-ner` is MIT and shippable. `SKNahin/NER_MobileBert` was skipped because HF metadata says license information is missing.
 
-Kiji DistilBERT won the v0.9 default decision across all three release axes: it was Apache-2.0, tied for top observer-residual recall at `0.667`, and ran about 5x faster than the transformer alternatives in the one-shot subprocess benchmark. Locale coverage was not a blocker because Pass-3 SafetyNet is observer-only: the deterministic rule floor handles structural shapes first, and Kiji's `PER` label catches `Name` residuals across the measured locale cells.
-
-v0.9 ships Kiji as the default Pass-3 SafetyNet backend; OPF remains an opt-in alternative where adopters accept the larger checkpoint and Python install.
-
-## Locale Detail
-
-| Model | Mode | Global P/R/F1 | EnUs P/R/F1 | DeDe P/R/F1 |
-|---|---|---:|---:|---:|
-| Kiji DistilBERT | Direct | 0.085 / 0.125 / 0.101 | 0.547 / 0.125 / 0.204 | 0.109 / 0.125 / 0.116 |
-| Kiji DistilBERT | Observer residual | 0.082 / 0.500 / 0.141 | 0.547 / 0.500 / 0.523 | 0.107 / 1.000 / 0.194 |
-| Babelscape WikiNeural Multilingual | Direct | 0.312 / 0.125 / 0.179 | 0.707 / 0.125 / 0.212 | 0.408 / 0.125 / 0.191 |
-| Babelscape WikiNeural Multilingual | Observer residual | 0.278 / 0.500 / 0.357 | 0.707 / 0.500 / 0.586 | 0.537 / 1.000 / 0.699 |
-| dslim/bert-base-NER (English) | Direct | 0.102 / 0.125 / 0.112 | 0.636 / 0.121 / 0.203 | 0.163 / 0.125 / 0.141 |
-| dslim/bert-base-NER (English) | Observer residual | 0.104 / 0.500 / 0.172 | 0.614 / 0.466 / 0.529 | 0.153 / 1.000 / 0.266 |
-| Davlan multilingual BERT-NER (HRL) | Direct | 0.294 / 0.125 / 0.175 | 0.690 / 0.125 / 0.212 | 0.690 / 0.125 / 0.212 |
-| Davlan multilingual BERT-NER (HRL) | Observer residual | 0.294 / 0.500 / 0.370 | 0.667 / 0.483 / 0.560 | 0.592 / 1.000 / 0.744 |
-
-## License Notes
-
-WikiNeural is included for evidence only because CC-BY-NC-SA-4.0 is non-commercial and cannot be shipped as the default model. The Davlan model metadata currently reports AFL-3.0, not Apache-2.0; this is permissive-style but should be checked before default shipment. dslim is MIT. Kiji DistilBERT is Apache-2.0.
-
-## License Framework
-
-| Category | Licenses | Default posture |
-|---|---|---|
-| Ship-safe ✓ | Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause | Eligible for default shipment. |
-| Permissive-but-unusual ⚠ | AFL-3.0 | Requires explicit review before default shipment. |
-| Non-commercial ✗ | CC-BY-NC, CC-BY-NC-SA | Benchmark evidence only; not a default backend. |
-| Copyleft ✗ | GPL, AGPL | Not a default backend for a library compiled into adopter products. |
-| Custom restricted ⚠✗ | OpenAI research license, Llama/Mistral custom commercial terms | Opt-in only with clear license disclosure and adopter acceptance. |
-
-Gaze ships as an open-source library that adopters compile into their products. Non-permissive defaults create downstream liability for adopters who did not choose that model license. Defaults therefore stay Apache-2.0/MIT only; every other backend needs an opt-in flag and clear license disclosure.
+MiniLM: HF search did not find a permissive English or multilingual general MiniLM NER head with the desired PER/LOC/ORG/MISC fit. `osiria/minilm-l6-h384-italian-cased-ner` is MIT and measurable, but its native locale is Italian, outside the `Global`/`EnUs`/`DeDe` cells used here.
 
 ## Interpretation
 
-The top shippable candidate by observer-residual F1 is Davlan HRL. Its direct recall is still only 0.125 macro because the coverage-loop corpus includes many non-NER PII classes; the observer-residual view is more relevant for a post-rule safety net because it measures the residual text after Gaze's rule floor has already removed deterministic classes.
+Tier 5 did not produce a default-flip. TinyBERT wins size and warm latency, but loses too much residual recall for the north-star reliability axis. MobileBERT nearly preserves Kiji recall but is slower in the checked-in subprocess scorer and larger than the low-spec storage target. The MiniLM-family row is useful Axis-4 evidence but not an adopter recommendation for the measured locales.
 
-Kiji's `MISC` label is folded into `PiiClass::Name` per the shipped `kiji_label_to_pii_class` mapping, matching the deployed detector configuration. This is the canonical class map; benching with any alternative would not measure a shipping config.
+The practical v0.9 guidance remains: use Kiji DistilBERT int8 ORT for low-spec deployments that need recall preserved; use TinyBERT only where a `<50MB` model bundle is a hard constraint and the recall drop is explicitly accepted by the adopter.

--- a/scripts/ner-bench-scorer.py
+++ b/scripts/ner-bench-scorer.py
@@ -46,6 +46,7 @@ class ModelConfig:
     license: str
     runtime: str
     wrapper: Path
+    model_file: str | None
     label_map: dict[str, str]
     native_locales: list[str]
     label_set: list[str]
@@ -100,6 +101,7 @@ def load_config(path: Path) -> list[ModelConfig]:
                 license=str(item["license"]),
                 runtime=str(item["runtime"]),
                 wrapper=Path(str(item["wrapper"])),
+                model_file=item.get("model_file"),
                 label_map={str(k): str(v) for k, v in item["label_map"].items()},
                 native_locales=[str(v) for v in item["native_locales"]],
                 label_set=[str(v) for v in item["label_set"]],
@@ -126,7 +128,9 @@ def checkpoint_complete(path: Path, model: ModelConfig) -> bool:
     if not path.is_dir():
         return False
     if model.runtime == "onnxruntime":
-        return (path / "model.onnx").is_file() and (path / "tokenizer.json").is_file()
+        model_file = model.model_file or "model.onnx"
+        has_tokenizer = (path / "tokenizer.json").is_file() or (path / "vocab.txt").is_file()
+        return (path / model_file).is_file() and has_tokenizer
     has_config = (path / "config.json").is_file()
     has_tokenizer = (path / "tokenizer.json").is_file() or (path / "vocab.txt").is_file()
     has_weights = any(
@@ -202,6 +206,8 @@ def run_model(
     ]
     if model.runtime == "onnxruntime":
         command.extend(["--model-dir", str(checkpoint)])
+        if model.model_file is not None:
+            command.extend(["--model-file", model.model_file])
     else:
         command.extend(["--checkpoint", str(checkpoint), "--device", device])
 
@@ -323,6 +329,7 @@ def write_snapshot(
             "license": model.license,
             "runtime": model.runtime,
             "wrapper": model.wrapper.as_posix(),
+            "model_file": model.model_file,
             "checkpoint": str(checkpoints[model.id]),
             "native_locales": model.native_locales,
             "label_set": model.label_set,

--- a/scripts/ner-warm-latency.py
+++ b/scripts/ner-warm-latency.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Measure warm persistent-model latency for pinned NER benchmark candidates."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import time
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+from transformers import pipeline
+
+from safety_net_bench_lib import load_fixtures
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=Path("crates/gaze-recognizers/testdata/coverage-loop/corpus"),
+    )
+    return parser.parse_args()
+
+
+def repo_path(root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else root / path
+
+
+def latency_summary(samples: list[float]) -> dict[str, float | int]:
+    ordered = sorted(samples)
+    p95_index = int((len(ordered) - 1) * 0.95)
+    return {
+        "warm_p50_ms": round(statistics.median(ordered), 6),
+        "warm_p95_ms": round(ordered[p95_index], 6),
+        "warm_mean_ms": round(statistics.mean(ordered), 6),
+        "fixture_count": len(ordered),
+    }
+
+
+def load_onnx_runner(root: Path):
+    runner = root / "scripts" / "onnx-token-classification-runner.py"
+    spec = importlib.util.spec_from_file_location("onnx_token_classification_runner", runner)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {runner}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def measure_tinybert(root: Path, texts: list[str]) -> dict[str, float | int]:
+    runner = load_onnx_runner(root)
+    model_dir = root / ".huggingface-cache/models/openobscure-tinybert4l-pii-ner-int8"
+    tokenizer = runner.load_tokenizer(model_dir)
+    labels = runner.load_labels(model_dir)
+    session = ort.InferenceSession(
+        str(model_dir / "model_int8.onnx"), providers=["CPUExecutionProvider"]
+    )
+
+    def infer(text: str) -> None:
+        encoding = tokenizer.encode(text)
+        if not encoding.ids:
+            return
+        output = session.run(None, runner.build_inputs(session, encoding))[0]
+        logits = np.asarray(output)
+        if logits.ndim == 3:
+            logits = logits[0]
+        predictions = []
+        for index, offset in enumerate(encoding.offsets):
+            if index >= logits.shape[0]:
+                break
+            start = int(offset[0])
+            end = int(offset[1])
+            if start == end:
+                continue
+            label_id = int(np.argmax(logits[index]))
+            predictions.append((labels.get(label_id, "O"), start, end, 0.0))
+        runner.spans_from_predictions(predictions)
+
+    infer(texts[0])
+    samples = []
+    for text in texts:
+        start = time.perf_counter()
+        infer(text)
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return latency_summary(samples)
+
+
+def measure_transformers(model_dir: Path, texts: list[str]) -> dict[str, float | int]:
+    ner = pipeline(
+        "ner",
+        model=str(model_dir),
+        tokenizer=str(model_dir),
+        aggregation_strategy="simple",
+        device=-1,
+    )
+    ner(texts[0])
+    samples = []
+    for text in texts:
+        start = time.perf_counter()
+        ner(text)
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return latency_summary(samples)
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.repo_root.resolve()
+    texts = [fixture.text for fixture in load_fixtures(repo_path(root, args.corpus_dir))]
+    results = {
+        "openobscure-tinybert4l-pii-ner-int8": measure_tinybert(root, texts),
+        "mrm8488-mobilebert-ner": measure_transformers(
+            root / ".huggingface-cache/models/mrm8488-mobilebert-ner", texts
+        ),
+        "osiria-minilm-italian-ner": measure_transformers(
+            root / ".huggingface-cache/models/osiria-minilm-italian-ner", texts
+        ),
+    }
+    json.dump(results, fp=sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(main())

--- a/scripts/onnx-token-classification-runner.py
+++ b/scripts/onnx-token-classification-runner.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Generic ONNX Runtime token-classification subprocess wrapper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import onnxruntime as ort
+from tokenizers import Tokenizer
+from tokenizers.implementations import BertWordPieceTokenizer
+
+
+MAX_INPUT_BYTES = 1024 * 1024
+
+
+class OnnxTokenClassificationError(RuntimeError):
+    pass
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", required=True, choices=["json"])
+    parser.add_argument("--output-mode", required=True, choices=["typed"])
+    parser.add_argument("--model-dir", required=True)
+    parser.add_argument("--model-file", default="model.onnx")
+    return parser.parse_args(argv)
+
+
+def read_stdin() -> str:
+    raw = sys.stdin.buffer.read(MAX_INPUT_BYTES + 1)
+    if len(raw) > MAX_INPUT_BYTES:
+        raise OnnxTokenClassificationError(f"stdin exceeds {MAX_INPUT_BYTES} byte cap")
+    return raw.decode("utf-8")
+
+
+def load_tokenizer(model_dir: Path) -> Tokenizer:
+    tokenizer_json = model_dir / "tokenizer.json"
+    if tokenizer_json.is_file():
+        return Tokenizer.from_file(str(tokenizer_json))
+
+    vocab = model_dir / "vocab.txt"
+    if not vocab.is_file():
+        raise OnnxTokenClassificationError("missing tokenizer.json or vocab.txt")
+    return BertWordPieceTokenizer(str(vocab), lowercase=True)
+
+
+def load_labels(model_dir: Path) -> dict[int, str]:
+    for name in ["config.json", "label_map.json", "labels.json"]:
+        path = model_dir / name
+        if not path.is_file():
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and isinstance(data.get("id2label"), dict):
+            return {int(key): str(value) for key, value in data["id2label"].items()}
+        if isinstance(data, dict) and all(str(key).isdigit() for key in data):
+            return {int(key): str(value) for key, value in data.items()}
+    raise OnnxTokenClassificationError("missing id2label map")
+
+
+def build_inputs(session: ort.InferenceSession, encoding: Any) -> dict[str, np.ndarray]:
+    ids = np.asarray([encoding.ids], dtype=np.int64)
+    mask = np.asarray([encoding.attention_mask], dtype=np.int64)
+    type_ids = np.asarray([encoding.type_ids], dtype=np.int64)
+
+    values: dict[str, np.ndarray] = {}
+    for input_meta in session.get_inputs():
+        name = input_meta.name
+        lowered = name.lower()
+        if "input_ids" in lowered:
+            values[name] = ids
+        elif "attention" in lowered or "mask" in lowered:
+            values[name] = mask
+        elif "token_type" in lowered or "segment" in lowered:
+            values[name] = type_ids
+        else:
+            raise OnnxTokenClassificationError(f"unsupported ONNX input: {name}")
+    return values
+
+
+def softmax_score(logits: np.ndarray, label_id: int) -> float:
+    values = logits.astype(np.float64)
+    values = values - np.max(values)
+    exp = np.exp(values)
+    denom = float(np.sum(exp))
+    if denom == 0.0 or not np.isfinite(denom):
+        return 0.0
+    score = float(exp[label_id] / denom)
+    return score if np.isfinite(score) else 0.0
+
+
+def split_label(label: str) -> tuple[str, str | None]:
+    if label == "O" or not label:
+        return "O", None
+    if "-" not in label:
+        return "B", label
+    prefix, entity = label.split("-", 1)
+    if prefix not in {"B", "I"} or not entity:
+        return "O", None
+    return prefix, entity
+
+
+def spans_from_predictions(
+    predictions: Iterable[tuple[str, int, int, float]],
+) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
+    active: dict[str, Any] | None = None
+    active_scores: list[float] = []
+
+    def flush() -> None:
+        nonlocal active, active_scores
+        if active is not None:
+            active["score"] = sum(active_scores) / len(active_scores)
+            spans.append(active)
+        active = None
+        active_scores = []
+
+    for raw_label, start, end, score in predictions:
+        prefix, entity = split_label(raw_label)
+        if prefix == "O" or entity is None or start == end:
+            flush()
+            continue
+        if active is None or prefix == "B" or active["label"] != entity or active["end"] > start:
+            flush()
+            active = {"label": entity, "start": start, "end": end}
+            active_scores = [score]
+            continue
+        active["end"] = end
+        active_scores.append(score)
+
+    flush()
+    return spans
+
+
+def run(model_dir: Path, model_file: str, text: str) -> list[dict[str, Any]]:
+    if text == "":
+        return []
+    model_path = model_dir / model_file
+    if not model_path.is_file():
+        raise OnnxTokenClassificationError(f"missing model artifact: {model_file}")
+
+    tokenizer = load_tokenizer(model_dir)
+    labels = load_labels(model_dir)
+    encoding = tokenizer.encode(text)
+    if not encoding.ids:
+        return []
+
+    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    outputs = session.run(None, build_inputs(session, encoding))
+    if not outputs:
+        raise OnnxTokenClassificationError("ONNX model returned no outputs")
+    logits = np.asarray(outputs[0])
+    if logits.ndim == 3:
+        logits = logits[0]
+    if logits.ndim != 2:
+        raise OnnxTokenClassificationError(f"unexpected logits shape: {list(logits.shape)}")
+
+    predictions: list[tuple[str, int, int, float]] = []
+    for index, offset in enumerate(encoding.offsets):
+        if index >= logits.shape[0]:
+            break
+        start, end = int(offset[0]), int(offset[1])
+        if start < 0 or end < start:
+            continue
+        label_id = int(np.argmax(logits[index]))
+        label = labels.get(label_id, "O")
+        predictions.append((label, start, end, softmax_score(logits[index], label_id)))
+    return spans_from_predictions(predictions)
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        spans = run(Path(args.model_dir), args.model_file, read_stdin())
+        json.dump(spans, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:
+        print(f"onnx-token-classification-runner: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds Tier 5 tiny-model NER leaderboard evidence for todo #371:

- pins permissive TinyBERT, MobileBERT, and MiniLM-family candidates in `benches/ner_models.toml`
- adds a generic ONNX token-classification runner for ONNX NER heads that ship `vocab.txt` instead of `tokenizer.json`
- records same-scorer direct + observer-residual metrics in `ner_models_snapshot.json`
- adds warm persistent-model latency evidence and low-spec recommendation notes to `docs/research/v0.9-ner-model-leaderboard.md`

## Measured Results

Host: macOS-26.5 arm64, Apple M5 Max. Corpus: 150 coverage-loop fixtures. Same config-driven scorer for direct and observer-residual recall.

| Model | License | Bundle | Direct recall | Observer recall | Warm p50 |
|---|---|---:|---:|---:|---:|
| Kiji DistilBERT fp32 ORT | Apache-2.0 | 249MB model | 0.125 | 0.667 | 2.562ms |
| Kiji DistilBERT int8 ORT | Apache-2.0 | 63MB model | 0.125 | 0.667 | 1.849ms |
| openobscure TinyBERT4L PII NER int8 | Apache-2.0 | 13.95MB | 0.070 | 0.271 | 1.087ms |
| mrm8488 MobileBERT NER | MIT | 94.29MB | 0.124 | 0.661 | 16.494ms |
| osiria MiniLM-L6-H384 Italian NER | MIT | 174.30MB | 0.124 | 0.667 | 4.703ms |

## Recommendation

- If an adopter needs `<50MB` total model bundle, use TinyBERT only with an explicit recall caveat; it is the only measured candidate under 50MB, but observer-residual recall drops to `0.271`.
- If an adopter needs `<100ms` warm p50 and recall preserved, use Kiji DistilBERT int8 ORT. It is faster than all recall-preserving tiny candidates on this host and keeps fp32 Kiji recall.
- No default flip recommended. Tier 2 int8 remains the low-spec recommendation for recall-preserving deployments.

## Candidate Screening

- TinyBERT license blockers: `onnx-community/TinyBERT-finetuned-NER-ONNX` and `adel-cybral/TinyBERT-finetuned-NER` did not publish a clean permissive license in HF metadata, so they were skipped. `openobscure/tinybert4l-pii-ner-int8` is Apache-2.0 and was pinned.
- MobileBERT: `mrm8488/mobilebert-finetuned-ner` is MIT and was pinned; `SKNahin/NER_MobileBert` lacked license metadata.
- MiniLM: no permissive English/multilingual general MiniLM NER head was found; `osiria/minilm-l6-h384-italian-cased-ner` is MIT and measurable, with a native-locale caveat.

## Five-Axis Check

- Reliability: no default flip; TinyBERT recall loss is documented and not recommended as a safe replacement.
- Reversibility: benchmark/report only; no pipeline or manifest mutation path changed.
- Agentic-first: keeps observer-residual mode and 150-fixture coverage-loop corpus as the decision surface.
- Trust: every measured candidate has HF repo, commit SHA, bundle SHA256, license, scorer output, and warm-latency method recorded.
- Adopter ergonomics: adds a concrete low-spec recommendation: Kiji int8 ORT for recall-preserving `<100ms` warm p50; TinyBERT only for hard `<50MB` bundle constraints.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`
