### PR TITLE
feat: add restore telemetry foundation

### DIFF
--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -40,6 +40,7 @@ pub struct AuditFilter {
     pub provenance_native_class: Option<String>,
     pub provenance_confidence: Option<f64>,
     pub provenance_merged_from: Option<String>,
+    pub restore_events_only: bool,
 }
 
 /// Metadata-only redaction audit row returned by [`crate::SqliteLogger::query`].
@@ -79,6 +80,12 @@ pub struct AuditLogRow {
     pub provenance_native_class: Option<String>,
     pub provenance_confidence: Option<f64>,
     pub provenance_merged_from: Option<String>,
+    pub restore_policy: Option<String>,
+    pub restore_decision: Option<String>,
+    pub restore_unknown_token_count: Option<i64>,
+    pub restore_manifest_bypass_count: Option<i64>,
+    pub restore_fresh_pii_count: Option<i64>,
+    pub restore_phase_mask: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -140,6 +147,12 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "provenance_native_class",
     "provenance_confidence",
     "provenance_merged_from",
+    "restore_policy",
+    "restore_decision",
+    "restore_unknown_token_count",
+    "restore_manifest_bypass_count",
+    "restore_fresh_pii_count",
+    "restore_phase_mask",
 ];
 
 pub const SAFETY_NET_RESTRICTED_COLUMNS: &[&str] = &[
@@ -192,6 +205,12 @@ pub fn build_audit_query_sql(
     has_provenance_native_class: bool,
     has_provenance_confidence: bool,
     has_provenance_merged_from: bool,
+    has_restore_policy: bool,
+    has_restore_decision: bool,
+    has_restore_unknown_token_count: bool,
+    has_restore_manifest_bypass_count: bool,
+    has_restore_fresh_pii_count: bool,
+    has_restore_phase_mask: bool,
 ) -> (String, Vec<Value>) {
     let decided_by_column = if has_decided_by {
         "decided_by"
@@ -283,8 +302,21 @@ pub fn build_audit_query_sql(
         nullable_column(has_provenance_confidence, "provenance_confidence");
     let provenance_merged_from_column =
         nullable_column(has_provenance_merged_from, "provenance_merged_from");
+    let restore_policy_column = nullable_column(has_restore_policy, "restore_policy");
+    let restore_decision_column = nullable_column(has_restore_decision, "restore_decision");
+    let restore_unknown_token_count_column = nullable_column(
+        has_restore_unknown_token_count,
+        "restore_unknown_token_count",
+    );
+    let restore_manifest_bypass_count_column = nullable_column(
+        has_restore_manifest_bypass_count,
+        "restore_manifest_bypass_count",
+    );
+    let restore_fresh_pii_count_column =
+        nullable_column(has_restore_fresh_pii_count, "restore_fresh_pii_count");
+    let restore_phase_mask_column = nullable_column(has_restore_phase_mask, "restore_phase_mask");
     let mut sql = format!(
-        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column}, {fallback_triggered_column}, {provenance_stage_column}, {provenance_model_id_column}, {provenance_model_version_column}, {provenance_artifact_sha256_column}, {provenance_tokenizer_sha256_column}, {provenance_locale_resolved_column}, {provenance_locale_match_kind_column}, {provenance_canonical_class_column}, {provenance_native_class_column}, {provenance_confidence_column}, {provenance_merged_from_column} FROM redaction_log"
+        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column}, {fallback_triggered_column}, {provenance_stage_column}, {provenance_model_id_column}, {provenance_model_version_column}, {provenance_artifact_sha256_column}, {provenance_tokenizer_sha256_column}, {provenance_locale_resolved_column}, {provenance_locale_match_kind_column}, {provenance_canonical_class_column}, {provenance_native_class_column}, {provenance_confidence_column}, {provenance_merged_from_column}, {restore_policy_column}, {restore_decision_column}, {restore_unknown_token_count_column}, {restore_manifest_bypass_count_column}, {restore_fresh_pii_count_column}, {restore_phase_mask_column} FROM redaction_log"
     );
     let mut predicates = Vec::new();
     let mut values = Vec::new();
@@ -485,6 +517,13 @@ pub fn build_audit_query_sql(
         "provenance_merged_from",
         &filter.provenance_merged_from,
     );
+    if filter.restore_events_only {
+        if has_restore_policy {
+            predicates.push("restore_policy IS NOT NULL");
+        } else {
+            predicates.push("NULL IS NOT NULL");
+        }
+    }
     if !predicates.is_empty() {
         sql.push_str(" WHERE ");
         sql.push_str(&predicates.join(" AND "));

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -166,7 +166,13 @@ impl SqliteLogger {
                 provenance_canonical_class TEXT NULL,
                 provenance_native_class TEXT NULL,
                 provenance_confidence REAL NULL,
-                provenance_merged_from TEXT NULL
+                provenance_merged_from TEXT NULL,
+                restore_policy TEXT NULL,
+                restore_decision TEXT NULL,
+                restore_unknown_token_count INTEGER NULL,
+                restore_manifest_bypass_count INTEGER NULL,
+                restore_fresh_pii_count INTEGER NULL,
+                restore_phase_mask INTEGER NULL
             );
 
             CREATE TABLE IF NOT EXISTS safety_net_log (
@@ -337,6 +343,12 @@ impl SqliteLogger {
             ("provenance_native_class", "TEXT"),
             ("provenance_confidence", "REAL"),
             ("provenance_merged_from", "TEXT"),
+            ("restore_policy", "TEXT"),
+            ("restore_decision", "TEXT"),
+            ("restore_unknown_token_count", "INTEGER"),
+            ("restore_manifest_bypass_count", "INTEGER"),
+            ("restore_fresh_pii_count", "INTEGER"),
+            ("restore_phase_mask", "INTEGER"),
         ] {
             if !columns.iter().any(|existing| existing == column) {
                 conn.execute(
@@ -366,7 +378,7 @@ impl SqliteLogger {
             .lock()
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, backend_silently_dropped) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)",
+            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34)",
             params![
                 entry.source,
                 entry.recognizer_id,
@@ -396,6 +408,12 @@ impl SqliteLogger {
                 provenance_confidence,
                 entry.provenance_merged_from,
                 backend_silently_dropped,
+                entry.restore_policy,
+                entry.restore_decision,
+                entry.restore_unknown_token_count.map(|value| value as i64),
+                entry.restore_manifest_bypass_count.map(|value| value as i64),
+                entry.restore_fresh_pii_count.map(|value| value as i64),
+                entry.restore_phase_mask.map(i64::from),
             ],
         )
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -409,7 +427,7 @@ impl SqliteLogger {
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, backend_silently_dropped FROM redaction_log",
+                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask FROM redaction_log",
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         let rows = stmt
@@ -446,6 +464,15 @@ impl SqliteLogger {
                 if let Some(dropped) = deserialize_json_column::<Vec<String>>(row.get(16)?, 16)? {
                     entry = entry.with_backend_silently_dropped(dropped);
                 }
+                entry.restore_policy = row.get(17)?;
+                entry.restore_decision = row.get(18)?;
+                entry.restore_unknown_token_count =
+                    row.get::<_, Option<i64>>(19)?.map(|value| value as u64);
+                entry.restore_manifest_bypass_count =
+                    row.get::<_, Option<i64>>(20)?.map(|value| value as u64);
+                entry.restore_fresh_pii_count =
+                    row.get::<_, Option<i64>>(21)?.map(|value| value as u64);
+                entry.restore_phase_mask = row.get::<_, Option<i64>>(22)?.map(|value| value as u32);
                 Ok(entry)
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -490,6 +517,14 @@ impl SqliteLogger {
         let has_provenance_native_class = table_has_column(&conn, "provenance_native_class")?;
         let has_provenance_confidence = table_has_column(&conn, "provenance_confidence")?;
         let has_provenance_merged_from = table_has_column(&conn, "provenance_merged_from")?;
+        let has_restore_policy = table_has_column(&conn, "restore_policy")?;
+        let has_restore_decision = table_has_column(&conn, "restore_decision")?;
+        let has_restore_unknown_token_count =
+            table_has_column(&conn, "restore_unknown_token_count")?;
+        let has_restore_manifest_bypass_count =
+            table_has_column(&conn, "restore_manifest_bypass_count")?;
+        let has_restore_fresh_pii_count = table_has_column(&conn, "restore_fresh_pii_count")?;
+        let has_restore_phase_mask = table_has_column(&conn, "restore_phase_mask")?;
         let (sql, values) = build_audit_query_sql(
             filter,
             has_decided_by,
@@ -516,6 +551,12 @@ impl SqliteLogger {
             has_provenance_native_class,
             has_provenance_confidence,
             has_provenance_merged_from,
+            has_restore_policy,
+            has_restore_decision,
+            has_restore_unknown_token_count,
+            has_restore_manifest_bypass_count,
+            has_restore_fresh_pii_count,
+            has_restore_phase_mask,
         );
         let mut stmt = conn
             .prepare(&sql)
@@ -553,6 +594,12 @@ impl SqliteLogger {
                     provenance_native_class: row.get(27)?,
                     provenance_confidence: row.get(28)?,
                     provenance_merged_from: row.get(29)?,
+                    restore_policy: row.get(30)?,
+                    restore_decision: row.get(31)?,
+                    restore_unknown_token_count: row.get(32)?,
+                    restore_manifest_bypass_count: row.get(33)?,
+                    restore_fresh_pii_count: row.get(34)?,
+                    restore_phase_mask: row.get(35)?,
                 })
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -895,6 +942,10 @@ fn document_kind_from_db(value: &str) -> std::result::Result<DocumentKind, rusql
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gaze_types::{
+        RestoreDecision, RestorePolicy, RestoreTelemetry, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
+        RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
+    };
 
     fn create_legacy_redaction_log(path: &Path) {
         let conn = Connection::open(path).expect("legacy sqlite");
@@ -1024,5 +1075,61 @@ mod tests {
             .expect_err("audit query connection must reject writes");
 
         assert_eq!(err.sqlite_error_code(), Some(rusqlite::ErrorCode::ReadOnly));
+    }
+
+    #[test]
+    fn restore_telemetry_persists_metadata_only_columns() {
+        let temp_db = tempfile::NamedTempFile::new().unwrap();
+        let logger = SqliteLogger::new(temp_db.path()).unwrap();
+        let mut telemetry = RestoreTelemetry::new(RestorePolicy::Lenient);
+        telemetry.unknown_token_count = 2;
+        telemetry.manifest_bypass_count = 2;
+        telemetry.fresh_pii_detected_count = 0;
+        telemetry.restore_decision = RestoreDecision::Partial;
+        telemetry.phase_execution_mask = RESTORE_PHASE_MANIFEST_LOOKUP
+            | RESTORE_PHASE_UNKNOWN_TOKEN_SCAN
+            | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
+
+        logger
+            .log(
+                &RedactionEntry::new(
+                    "restore",
+                    PiiClass::Custom("restore.telemetry".to_string()),
+                    Action::Preserve,
+                    None,
+                    DocumentKind::Text,
+                    false,
+                    ConflictTier::None,
+                    0,
+                    Some("audit-session".to_string()),
+                )
+                .with_restore_telemetry(telemetry.clone()),
+            )
+            .unwrap();
+
+        let rows = SqliteLogger::query(
+            temp_db.path(),
+            &AuditFilter {
+                restore_events_only: true,
+                ..AuditFilter::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].restore_policy.as_deref(), Some("lenient"));
+        assert_eq!(rows[0].restore_decision.as_deref(), Some("partial"));
+        assert_eq!(rows[0].restore_unknown_token_count, Some(2));
+        assert_eq!(rows[0].restore_manifest_bypass_count, Some(2));
+        assert_eq!(rows[0].restore_fresh_pii_count, Some(0));
+        assert_eq!(
+            rows[0].restore_phase_mask,
+            Some(i64::from(
+                RESTORE_PHASE_MANIFEST_LOOKUP
+                    | RESTORE_PHASE_UNKNOWN_TOKEN_SCAN
+                    | RESTORE_PHASE_MANIFEST_BYPASS_SCAN
+            ))
+        );
+        assert!(rows[0].field_name.is_none());
+        assert_eq!(rows[0].source, "restore");
     }
 }

--- a/crates/gaze-audit/tests/ner_provenance_migration.rs
+++ b/crates/gaze-audit/tests/ner_provenance_migration.rs
@@ -205,7 +205,8 @@ fn ner_provenance_filters_bind_expected_sql() {
 fn build_current_audit_query_sql(filter: &AuditFilter) -> (String, Vec<SqlValue>) {
     build_audit_query_sql(
         filter, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true, true, true, true, true, true, true, true, true, true,
+        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+        true,
     )
 }
 

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -176,6 +176,7 @@ fn safety_net_query_filter_maps_to_safety_net_columns() {
             provenance_native_class: None,
             provenance_confidence: None,
             provenance_merged_from: None,
+            restore_events_only: false,
         },
     )
     .expect("filtered query");
@@ -310,6 +311,12 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             provenance_native_class: None,
             provenance_confidence: None,
             provenance_merged_from: None,
+            restore_policy: None,
+            restore_decision: None,
+            restore_unknown_token_count: None,
+            restore_manifest_bypass_count: None,
+            restore_fresh_pii_count: None,
+            restore_phase_mask: None,
         },
         AuditLogRow {
             source: "dictionary".to_string(),
@@ -342,6 +349,12 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             provenance_native_class: None,
             provenance_confidence: None,
             provenance_merged_from: None,
+            restore_policy: None,
+            restore_decision: None,
+            restore_unknown_token_count: None,
+            restore_manifest_bypass_count: None,
+            restore_fresh_pii_count: None,
+            restore_phase_mask: None,
         },
     ]
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -27,6 +27,7 @@ pub(crate) struct Args {
     pub(crate) ambiguity_reason: Option<String>,
     pub(crate) collision_family: Option<String>,
     pub(crate) collision_variant: Option<String>,
+    pub(crate) restore_events_only: bool,
 }
 
 pub(crate) struct PurgeArgs {
@@ -69,7 +70,7 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     }
     for row in rows {
         let base = format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.recognizer_id.as_deref().unwrap_or(""),
             row.recognizer_version_id.as_deref().unwrap_or(""),
@@ -105,7 +106,21 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
             row.provenance_confidence
                 .map(|confidence| confidence.to_string())
                 .unwrap_or_default(),
-            row.provenance_merged_from.as_deref().unwrap_or("")
+            row.provenance_merged_from.as_deref().unwrap_or(""),
+            row.restore_policy.as_deref().unwrap_or(""),
+            row.restore_decision.as_deref().unwrap_or(""),
+            row.restore_unknown_token_count
+                .map(|count| count.to_string())
+                .unwrap_or_default(),
+            row.restore_manifest_bypass_count
+                .map(|count| count.to_string())
+                .unwrap_or_default(),
+            row.restore_fresh_pii_count
+                .map(|count| count.to_string())
+                .unwrap_or_default(),
+            row.restore_phase_mask
+                .map(|mask| mask.to_string())
+                .unwrap_or_default()
         );
         if include_ambiguity {
             writeln!(
@@ -224,6 +239,7 @@ fn read_rows(args: &Args) -> std::result::Result<Vec<AuditLogRow>, CliError> {
         provenance_native_class: None,
         provenance_confidence: None,
         provenance_merged_from: None,
+        restore_events_only: args.restore_events_only,
     };
     SqliteLogger::query(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }
@@ -263,6 +279,7 @@ fn read_safety_net_rows(
         provenance_native_class: None,
         provenance_confidence: None,
         provenance_merged_from: None,
+        restore_events_only: false,
     };
     SqliteLogger::query_safety_net(&args.audit_db, &filter).map_err(|_| CliError::Pipeline)
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -218,6 +218,15 @@ enum Cmd {
         /// Unknown-token handling during restore.
         #[arg(long, value_enum, default_value_t = RestoreMode::Strict)]
         restore_mode: RestoreMode,
+        /// Alias for `--restore-mode` used by restore-boundary telemetry.
+        #[arg(long = "policy", value_enum)]
+        restore_policy: Option<RestoreMode>,
+        /// Emit restore telemetry in the JSON response.
+        #[arg(long)]
+        telemetry: bool,
+        /// Optional SQLite redaction-log database path for restore telemetry rows.
+        #[arg(long)]
+        audit_db: Option<PathBuf>,
         /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
         #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
         max_bytes: u64,
@@ -418,6 +427,9 @@ enum AuditCmd {
         /// Filter by collision variant identifier.
         #[arg(long)]
         collision_variant: Option<String>,
+        /// Include only restore telemetry rows.
+        #[arg(long)]
+        restore_events: bool,
     },
     /// Export filtered audit metadata rows.
     Export {
@@ -463,6 +475,9 @@ enum AuditCmd {
         /// Filter by collision variant identifier.
         #[arg(long)]
         collision_variant: Option<String>,
+        /// Include only restore telemetry rows.
+        #[arg(long)]
+        restore_events: bool,
     },
     /// Purge audit metadata rows older than an ISO 8601 UTC timestamp.
     Purge {
@@ -680,10 +695,15 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
         Cmd::Restore {
             format,
             restore_mode,
+            restore_policy,
+            telemetry,
+            audit_db,
             max_bytes,
         } => restore::run(restore::Args {
             format,
-            restore_mode,
+            restore_mode: restore_policy.unwrap_or(restore_mode),
+            telemetry,
+            audit_db,
             max_bytes,
         }),
         Cmd::Daemon {
@@ -749,6 +769,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 ambiguity_reason,
                 collision_family,
                 collision_variant,
+                restore_events,
             } => audit::query(audit::Args {
                 audit_db,
                 class: pii_class,
@@ -762,6 +783,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 ambiguity_reason,
                 collision_family,
                 collision_variant,
+                restore_events_only: restore_events,
             }),
             AuditCmd::Export {
                 audit_db,
@@ -778,6 +800,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 ambiguity_reason,
                 collision_family,
                 collision_variant,
+                restore_events,
             } => audit::export(
                 audit::Args {
                     audit_db,
@@ -792,6 +815,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                     ambiguity_reason,
                     collision_family,
                     collision_variant,
+                    restore_events_only: restore_events,
                 },
                 format,
                 output,

--- a/crates/gaze-cli/src/commands/restore.rs
+++ b/crates/gaze-cli/src/commands/restore.rs
@@ -1,12 +1,21 @@
 use crate::error::{CliError, RestoreMode};
 use crate::restore::run_restore;
+use std::path::PathBuf;
 
 pub(crate) struct Args {
     pub(crate) format: String,
     pub(crate) restore_mode: RestoreMode,
+    pub(crate) telemetry: bool,
+    pub(crate) audit_db: Option<PathBuf>,
     pub(crate) max_bytes: u64,
 }
 
 pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
-    run_restore(&args.format, args.restore_mode, args.max_bytes)
+    run_restore(
+        &args.format,
+        args.restore_mode,
+        args.telemetry,
+        args.audit_db.as_deref(),
+        args.max_bytes,
+    )
 }

--- a/crates/gaze-cli/src/error.rs
+++ b/crates/gaze-cli/src/error.rs
@@ -23,6 +23,7 @@ pub(crate) enum CliError {
     /// Pinned-artifact contract violation: a safety-net backend was requested
     /// but its required artifact (e.g. `SHA256SUMS`) is missing on disk. Exit
     /// code 2 (config-level error). Axis-1 fail-closed: never silent-disable.
+    #[allow(dead_code)]
     SafetyNetArtifactMissing {
         backend: &'static str,
         path: String,

--- a/crates/gaze-cli/src/restore/manifest.rs
+++ b/crates/gaze-cli/src/restore/manifest.rs
@@ -13,4 +13,6 @@ pub(crate) struct RestoreResponse {
     pub(crate) text: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) restore_warning: Vec<RestoreWarning>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) restore_telemetry: Option<gaze::RestoreTelemetry>,
 }

--- a/crates/gaze-cli/src/restore/mod.rs
+++ b/crates/gaze-cli/src/restore/mod.rs
@@ -1,10 +1,17 @@
 mod manifest;
 mod session;
 
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 
-use gaze::{SensitiveSnapshot, Session};
+use gaze::{
+    Action, ConflictTier, DocumentKind, PiiClass, Pipeline, RedactionEntry, RestorePolicy,
+    RestoreTelemetry, SensitiveSnapshot, Session,
+};
+use gaze_audit::SqliteLogger;
 
 use crate::error::{CliError, RestoreMode};
 use crate::io::{read_stdin_bytes, require_json_format};
@@ -14,6 +21,8 @@ use crate::restore::session::{restore_pass1, restore_pass2_validate};
 pub(crate) fn run_restore(
     format: &str,
     restore_mode: RestoreMode,
+    telemetry_enabled: bool,
+    audit_db: Option<&Path>,
     max_bytes: u64,
 ) -> std::result::Result<(), CliError> {
     require_json_format(format)?;
@@ -36,6 +45,20 @@ pub(crate) fn run_restore(
         })?;
 
     let pass1 = restore_pass1(&session, &request.text)?;
+    let restore_telemetry = if telemetry_enabled || audit_db.is_some() {
+        let pipeline = Pipeline::builder()
+            .build()
+            .map_err(|_| CliError::Pipeline)?;
+        let (_, telemetry) = pipeline
+            .restore_with_policy_telemetry(&session, &request.text, restore_policy(restore_mode))
+            .map_err(|_| CliError::Pipeline)?;
+        if let Some(path) = audit_db {
+            persist_restore_telemetry(path, &session, telemetry.clone())?;
+        }
+        telemetry_enabled.then_some(telemetry)
+    } else {
+        None
+    };
     let restore_warning = restore_pass2_validate(
         &pass1.text,
         &pass1.substitution_spans,
@@ -46,8 +69,44 @@ pub(crate) fn run_restore(
     let response = RestoreResponse {
         text: pass1.text,
         restore_warning,
+        restore_telemetry,
     };
     let json = serde_json::to_string(&response).map_err(|_| CliError::Pipeline)?;
     println!("{json}");
     Ok(())
+}
+
+fn restore_policy(mode: RestoreMode) -> RestorePolicy {
+    match mode {
+        RestoreMode::Strict => RestorePolicy::Strict,
+        RestoreMode::Tolerant => RestorePolicy::Lenient,
+    }
+}
+
+fn persist_restore_telemetry(
+    audit_db: &Path,
+    session: &Session,
+    telemetry: RestoreTelemetry,
+) -> std::result::Result<(), CliError> {
+    let logger = SqliteLogger::new(audit_db).map_err(|_| CliError::Pipeline)?;
+    let entry = RedactionEntry::new(
+        "restore",
+        PiiClass::Custom("restore.telemetry".to_string()),
+        Action::Preserve,
+        None,
+        DocumentKind::Text,
+        false,
+        ConflictTier::None,
+        current_epoch_ms(),
+        Some(session.audit_session_id().to_string()),
+    )
+    .with_restore_telemetry(telemetry);
+    logger.log(&entry).map_err(|_| CliError::Pipeline)
+}
+
+fn current_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -428,7 +428,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\n"
     ));
     assert!(stdout.contains("dictionary:audit_terms[#0]"));
     assert!(stdout.contains("custom:term"));
@@ -467,10 +467,12 @@ fn audit_sql_uses_restricted_column_set() {
         provenance_native_class: None,
         provenance_confidence: None,
         provenance_merged_from: None,
+        restore_events_only: false,
     };
     let (current_sql, values) = build_audit_query_sql(
         &filter, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true, true, true, true, true, true, true, true, true, true, true,
+        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+        true, true,
     );
     assert_eq!(
         values,
@@ -507,6 +509,12 @@ fn audit_sql_uses_restricted_column_set() {
     };
     let (legacy_sql, legacy_values) = build_audit_query_sql(
         &legacy_filter,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
         false,
         false,
         false,

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -841,6 +841,51 @@ fn t04b_tolerant_restore_reports_warning_and_preserves_text() {
 }
 
 #[test]
+fn t04d_restore_telemetry_json_and_audit_query_are_metadata_only() {
+    let (clean, blob, _) = clean_ok("Email is alice@example.invalid please.");
+    let dir = tempdir().unwrap();
+    let audit_path = dir.path().join("restore.sqlite");
+    let audit_arg = format!("--audit-db={}", audit_path.display());
+    let (code, stdout, stderr) = restore_json_with_args(
+        &["--policy=strict", "--telemetry", &audit_arg],
+        &blob,
+        &clean,
+    );
+
+    assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
+    let resp: Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(resp["text"], "Email is alice@example.invalid please.");
+    assert_eq!(resp["restore_telemetry"]["unknown_token_count"], 0);
+    assert_eq!(resp["restore_telemetry"]["manifest_bypass_count"], 0);
+    assert_eq!(resp["restore_telemetry"]["fresh_pii_detected_count"], 0);
+    assert_eq!(resp["restore_telemetry"]["restore_policy"], "strict");
+    assert_eq!(resp["restore_telemetry"]["restore_decision"], "success");
+
+    let out = Command::cargo_bin("gaze")
+        .unwrap()
+        .args([
+            "audit",
+            "query",
+            "--restore-events",
+            "--audit-db",
+            audit_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("restore_policy"));
+    assert!(stdout.contains("\tcustom:restore.telemetry\t"));
+    assert!(stdout.contains("\tstrict\tsuccess\t0\t0\t0\t"));
+    assert!(!stdout.contains("alice@example.invalid"));
+    assert!(!stdout.contains("<Email_1>"));
+}
+
+#[test]
 fn t04c_tolerant_restore_omits_empty_warning_array() {
     let (_, blob, _) = clean_ok("No PII here.");
     let (code, stdout, stderr) =
@@ -1239,7 +1284,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\n"
     ));
     assert!(
         stdout
@@ -1822,6 +1867,12 @@ fn s4_audit_query_columns_are_restricted() {
         true,
         true,
         true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
     );
     assert!(
         values.is_empty(),
@@ -1878,6 +1929,12 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
     assert!(AUDIT_RESTRICTED_COLUMNS.contains(&"source"));
     let (sql, values) = build_audit_query_sql(
         &AuditFilter::default(),
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
         true,
         true,
         true,

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -78,6 +78,91 @@ pub const RESERVED_BUNDLED_FAMILIES: &[&str] = &[
     "finnish-hetu",
 ];
 
+pub const RESTORE_PHASE_MANIFEST_LOOKUP: u32 = 1 << 0;
+pub const RESTORE_PHASE_UNKNOWN_TOKEN_SCAN: u32 = 1 << 1;
+pub const RESTORE_PHASE_MANIFEST_BYPASS_SCAN: u32 = 1 << 2;
+pub const RESTORE_PHASE_FRESH_PII_SCAN: u32 = 1 << 3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RestoredText {
+    pub text: String,
+}
+
+impl RestoredText {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RestorePolicy {
+    Strict,
+    Lenient,
+}
+
+impl RestorePolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Strict => "strict",
+            Self::Lenient => "lenient",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RestoreDecision {
+    Success,
+    Partial,
+    Failed,
+}
+
+impl RestoreDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RestoreTelemetry {
+    pub unknown_token_count: u64,
+    pub manifest_bypass_count: u64,
+    pub fresh_pii_detected_count: u64,
+    pub restore_policy: RestorePolicy,
+    pub restore_decision: RestoreDecision,
+    pub phase_execution_mask: u32,
+}
+
+impl RestoreTelemetry {
+    pub fn new(restore_policy: RestorePolicy) -> Self {
+        Self {
+            unknown_token_count: 0,
+            manifest_bypass_count: 0,
+            fresh_pii_detected_count: 0,
+            restore_policy,
+            restore_decision: RestoreDecision::Success,
+            phase_execution_mask: 0,
+        }
+    }
+
+    pub fn restore_policy_str(&self) -> &'static str {
+        self.restore_policy.as_str()
+    }
+
+    pub fn restore_decision_str(&self) -> &'static str {
+        self.restore_decision.as_str()
+    }
+}
+
 /// Collision-family membership metadata for one recognizer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1813,6 +1898,12 @@ pub struct RedactionEntry {
     pub provenance_merged_from: Option<String>,
     /// Locale-aware safety-net backend ids dropped by first-match-wins routing.
     pub backend_silently_dropped: Option<Vec<String>>,
+    pub restore_policy: Option<String>,
+    pub restore_decision: Option<String>,
+    pub restore_unknown_token_count: Option<u64>,
+    pub restore_manifest_bypass_count: Option<u64>,
+    pub restore_fresh_pii_count: Option<u64>,
+    pub restore_phase_mask: Option<u32>,
 }
 
 impl Serialize for RedactionEntry {
@@ -1848,6 +1939,19 @@ impl Serialize for RedactionEntry {
         if self.backend_silently_dropped.is_some() {
             len += 1;
         }
+        len += [self.restore_policy.as_ref(), self.restore_decision.as_ref()]
+            .into_iter()
+            .filter(|value| value.is_some())
+            .count();
+        len += [
+            self.restore_unknown_token_count.is_some(),
+            self.restore_manifest_bypass_count.is_some(),
+            self.restore_fresh_pii_count.is_some(),
+            self.restore_phase_mask.is_some(),
+        ]
+        .into_iter()
+        .filter(|value| *value)
+        .count();
         let mut state = serializer.serialize_struct("RedactionEntry", len)?;
         state.serialize_field("source", &self.source)?;
         if let Some(recognizer_id) = &self.recognizer_id {
@@ -1910,6 +2014,24 @@ impl Serialize for RedactionEntry {
         }
         if let Some(dropped) = &self.backend_silently_dropped {
             state.serialize_field("backend_silently_dropped", dropped)?;
+        }
+        if let Some(value) = &self.restore_policy {
+            state.serialize_field("restore_policy", value)?;
+        }
+        if let Some(value) = &self.restore_decision {
+            state.serialize_field("restore_decision", value)?;
+        }
+        if let Some(value) = self.restore_unknown_token_count {
+            state.serialize_field("restore_unknown_token_count", &value)?;
+        }
+        if let Some(value) = self.restore_manifest_bypass_count {
+            state.serialize_field("restore_manifest_bypass_count", &value)?;
+        }
+        if let Some(value) = self.restore_fresh_pii_count {
+            state.serialize_field("restore_fresh_pii_count", &value)?;
+        }
+        if let Some(value) = self.restore_phase_mask {
+            state.serialize_field("restore_phase_mask", &value)?;
         }
         state.end()
     }
@@ -1994,6 +2116,12 @@ impl RedactionEntry {
             provenance_confidence: None,
             provenance_merged_from: None,
             backend_silently_dropped: None,
+            restore_policy: None,
+            restore_decision: None,
+            restore_unknown_token_count: None,
+            restore_manifest_bypass_count: None,
+            restore_fresh_pii_count: None,
+            restore_phase_mask: None,
         }
     }
 
@@ -2029,6 +2157,16 @@ impl RedactionEntry {
     /// Attaches locale-aware backend ids dropped by first-match-wins routing.
     pub fn with_backend_silently_dropped(mut self, dropped: Vec<String>) -> Self {
         self.backend_silently_dropped = Some(dropped);
+        self
+    }
+
+    pub fn with_restore_telemetry(mut self, telemetry: RestoreTelemetry) -> Self {
+        self.restore_policy = Some(telemetry.restore_policy_str().to_string());
+        self.restore_decision = Some(telemetry.restore_decision_str().to_string());
+        self.restore_unknown_token_count = Some(telemetry.unknown_token_count);
+        self.restore_manifest_bypass_count = Some(telemetry.manifest_bypass_count);
+        self.restore_fresh_pii_count = Some(telemetry.fresh_pii_detected_count);
+        self.restore_phase_mask = Some(telemetry.phase_execution_mask);
         self
     }
 
@@ -2706,6 +2844,12 @@ mod redaction_logger_tests {
             provenance_confidence: None,
             provenance_merged_from: None,
             backend_silently_dropped: None,
+            restore_policy: None,
+            restore_decision: None,
+            restore_unknown_token_count: None,
+            restore_manifest_bypass_count: None,
+            restore_fresh_pii_count: None,
+            restore_phase_mask: None,
         };
 
         let trait_object: &dyn RedactionLogger = &logger;

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -33,8 +33,11 @@ pub use gaze_types::{
     CodecAuditRow, CodecCapabilitySet, CollisionMembership, DocumentExtension,
     DocumentExtensionBuilder, DocumentExtensionError, EmittedTokenSpan, ExtractionDensityPolicy,
     FallbackReason, LeakKind, LeakReport, LeakReportStats, LeakReportTelemetry, LeakSuspect,
-    Manifest, OpenAiPrivateLabel, RedactionLogError, RedactionLogger, SafetyNet, SafetyNetContext,
-    SafetyNetError, SafetyNetPiiClass, SafetyTier, TextOrigin, RESERVED_BUNDLED_FAMILIES,
+    Manifest, OpenAiPrivateLabel, RedactionLogError, RedactionLogger, RestoreDecision,
+    RestorePolicy, RestoreTelemetry, RestoredText, SafetyNet, SafetyNetContext, SafetyNetError,
+    SafetyNetPiiClass, SafetyTier, TextOrigin, RESERVED_BUNDLED_FAMILIES,
+    RESTORE_PHASE_FRESH_PII_SCAN, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
+    RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
 };
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -9,7 +9,9 @@ use gaze_recognizers::{
 use gaze_types::{
     AmbiguityReason, AmbiguityRecord, CollisionMembership, EmittedTokenSpan, FallbackReason,
     LeakKind, LeakReport, LeakReportTelemetry, LeakSuspect, Manifest, RedactionLogError,
-    RedactionLogger, SafetyNet, SafetyNetContext, SafetyNetError,
+    RedactionLogger, RestoreDecision, RestorePolicy, RestoreTelemetry, RestoredText, SafetyNet,
+    SafetyNetContext, SafetyNetError, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
+    RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
 };
 use thiserror::Error;
 
@@ -216,6 +218,37 @@ impl Pipeline {
     {
         self.safety_nets.push(Arc::new(safety_net));
         self
+    }
+
+    pub fn restore_with_telemetry(
+        &self,
+        session: &Session,
+        text: &str,
+    ) -> Result<(RestoredText, RestoreTelemetry)> {
+        self.restore_with_policy_telemetry(session, text, RestorePolicy::Strict)
+    }
+
+    pub fn restore_with_policy_telemetry(
+        &self,
+        session: &Session,
+        text: &str,
+        policy: RestorePolicy,
+    ) -> Result<(RestoredText, RestoreTelemetry)> {
+        let mut telemetry = RestoreTelemetry::new(policy);
+        telemetry.phase_execution_mask |= RESTORE_PHASE_MANIFEST_LOOKUP;
+        let restored = restore_known_tokens(session, text)?;
+        telemetry.phase_execution_mask |=
+            RESTORE_PHASE_UNKNOWN_TOKEN_SCAN | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
+        let unknown_token_count = count_unknown_restore_tokens(session, &restored);
+        telemetry.unknown_token_count = unknown_token_count;
+        telemetry.manifest_bypass_count = unknown_token_count;
+        telemetry.restore_decision = match (policy, unknown_token_count) {
+            (_, 0) => RestoreDecision::Success,
+            (RestorePolicy::Strict, _) => RestoreDecision::Failed,
+            (RestorePolicy::Lenient, _) => RestoreDecision::Partial,
+            (_, _) => RestoreDecision::Failed,
+        };
+        Ok((RestoredText::new(restored), telemetry))
     }
 
     pub fn with_pipeline_optimizations(mut self, config: PipelineOptimizationConfig) -> Pipeline {
@@ -1248,6 +1281,46 @@ fn replace_clean_span(
     clean.manifest.sort_by_key(|span| span.clean_span.start);
 }
 
+fn restore_known_tokens(session: &Session, text: &str) -> Result<String> {
+    let mut tokens = session.tokens();
+    if tokens.is_empty() {
+        return Ok(text.to_string());
+    }
+    tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    let pattern = tokens
+        .iter()
+        .map(|token| {
+            let escaped = regex::escape(token);
+            if token.starts_with('<') && token.ends_with('>') {
+                escaped
+            } else {
+                format!(r"\b(?:{escaped})\b")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("|");
+    let re = regex::Regex::new(&pattern).map_err(Error::InvalidRegex)?;
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0usize;
+    for matched in re.find_iter(text) {
+        out.push_str(&text[last..matched.start()]);
+        out.push_str(&session.restore_strict(matched.as_str())?);
+        last = matched.end();
+    }
+    out.push_str(&text[last..]);
+    Ok(out)
+}
+
+fn count_unknown_restore_tokens(session: &Session, text: &str) -> u64 {
+    crate::token_shape::pattern()
+        .find_iter(text)
+        .filter(|matched| {
+            let matched_text = matched.as_str();
+            crate::token_shape::is_trap(matched_text) || !session.contains_token(matched_text)
+        })
+        .count() as u64
+}
+
 fn adjust_emitted_span(
     existing: &EmittedTokenSpan,
     edited: &Range<usize>,
@@ -1938,6 +2011,44 @@ mod tests {
             self.entries.lock().unwrap().push(entry.clone());
             Ok(())
         }
+    }
+
+    #[test]
+    fn restore_with_telemetry_counts_unknown_tokens_deterministically() {
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+        let session =
+            Session::new(Scope::Conversation("restore-telemetry".to_string())).expect("session");
+        let clean = pipeline
+            .redact(
+                &session,
+                RawDocument::Text("Reach alice@example.invalid".to_string()),
+            )
+            .expect("redact");
+        let CleanDocument::Text(clean) = clean else {
+            panic!("expected text");
+        };
+        let input = format!("{clean} <Email_999> <Name_100>");
+
+        let (restored, telemetry) = pipeline
+            .restore_with_policy_telemetry(&session, &input, RestorePolicy::Lenient)
+            .expect("restore telemetry");
+        let (_, telemetry_again) = pipeline
+            .restore_with_policy_telemetry(&session, &input, RestorePolicy::Lenient)
+            .expect("restore telemetry");
+
+        assert!(restored.text.contains("alice@example.invalid"));
+        assert_eq!(telemetry.unknown_token_count, 2);
+        assert_eq!(telemetry.manifest_bypass_count, 2);
+        assert_eq!(telemetry.fresh_pii_detected_count, 0);
+        assert_eq!(telemetry.restore_policy, RestorePolicy::Lenient);
+        assert_eq!(telemetry.restore_decision, RestoreDecision::Partial);
+        assert_eq!(
+            telemetry.phase_execution_mask,
+            RESTORE_PHASE_MANIFEST_LOOKUP
+                | RESTORE_PHASE_UNKNOWN_TOKEN_SCAN
+                | RESTORE_PHASE_MANIFEST_BYPASS_SCAN
+        );
+        assert_eq!(telemetry_again, telemetry);
     }
 
     struct CountingSafetyNet {


### PR DESCRIPTION
## Summary

**This is manifest-integrity enforcement, not prompt-injection detection.**

Adds the v0.10 Phase D metadata-only restore telemetry foundation:
- introduces `RestoreTelemetry`, `RestorePolicy`, `RestoreDecision`, `RestoredText`, and deterministic restore phase-mask constants
- adds `Pipeline::restore_with_telemetry` plus `restore_with_policy_telemetry` for known-token restore + unknown-token/manifest-bypass counting
- extends `RedactionEntry` and the SQLite audit schema with nullable restore telemetry columns
- wires `gaze restore --policy strict --telemetry --audit-db ...` and `gaze audit query --restore-events`

## Scope guard

This is deterministic outbound DLP / manifest integrity telemetry. It does not add prompt-injection detection, AI guardrails, raw-PII restore scanning, names/NER, classifiers, LLM judgment, Phase B block mode, or Phase C rulepack work.

## Metadata-only contract

Restore telemetry rows persist only policy, decision, counters, phase mask, source/action/class/session metadata. Tests assert the audit query output does not persist the synthetic email fixture or emitted token bytes.

## Tests

- `cargo clippy --manifest-path $HOME/Workspace/EmpireTwo/gaze-phase-d-restore-telemetry/Cargo.toml -p gaze-types -p gaze-pii -p gaze-audit -p gaze-cli --all-targets -- -D warnings`
- `cargo test --manifest-path $HOME/Workspace/EmpireTwo/gaze-phase-d-restore-telemetry/Cargo.toml -p gaze-types -p gaze-pii -p gaze-audit -p gaze-cli`

## Axis check

Reliability/Reversibility/Trust: no weakening. The restore helper preserves existing manifest restore mechanics and adds auditable metadata-only counters for later enforcement decisions.