### PR TITLE
feat: enforce strict manifest-bound restore

### DIFF
--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -61,24 +61,13 @@ impl Tool for RestoreStrictTool {
             .get("text")
             .and_then(|value| value.as_str())
             .ok_or_else(|| ToolError::InvalidArgs("missing required field `text`".into()))?;
-        let restored = restore_strict_text(ctx.resources().session(), text)?;
+        let restored = ctx
+            .resources()
+            .pipeline()
+            .restore_strict_text(ctx.resources().session(), text)
+            .map_err(|err| ToolError::NotFound(err.to_string()))?;
         Ok(ToolResponse::json(json!({ "text": restored })))
     }
-}
-
-fn restore_strict_text(session: &gaze::Session, text: &str) -> Result<String, ToolError> {
-    let mut restored = String::with_capacity(text.len());
-    let mut cursor = 0usize;
-    for token in gaze::token_shape::pattern().find_iter(text) {
-        restored.push_str(&text[cursor..token.start()]);
-        let raw = session.restore(token.as_str()).ok_or_else(|| {
-            ToolError::NotFound(format!("token {} not in session", token.as_str()))
-        })?;
-        restored.push_str(&raw);
-        cursor = token.end();
-    }
-    restored.push_str(&text[cursor..]);
-    Ok(restored)
 }
 
 #[cfg(test)]

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -64,5 +64,5 @@ pub use rulepack::{
 pub use sandbox::{
     ExecPolicy, Sandbox, SandboxError, SandboxPlan, UntrustedExecRequest, ValidatedExecRequest,
 };
-pub use session::{Scope, SensitiveSnapshot, Session, SessionSnapshotEntry};
+pub use session::{RestoreError, Scope, SensitiveSnapshot, Session, SessionSnapshotEntry};
 pub use types::{CleanDocument, RawDocument, Value};

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -33,8 +33,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[error("invalid regex: {0}")]
     InvalidRegex(#[source] regex::Error),
-    #[error("unknown token: {0}")]
-    UnknownToken(String),
+    #[error("unknown token: [REDACTED]")]
+    UnknownToken {
+        class: PiiClass,
+        ordinal: u32,
+        raw: String,
+    },
     #[error("ephemeral sessions cannot be exported")]
     ExportForbidden,
     #[error("document extension integrity fields cannot be empty")]
@@ -435,6 +439,25 @@ impl Pipeline {
             walk_value_for_safety_net_scan(self, session, value, key, locale_chain, &mut report)?;
         }
         Ok(SafetyNetResult { nets_run, report })
+    }
+
+    pub fn restore_strict_text(&self, session: &Session, text: &str) -> Result<String> {
+        match session.restore_strict_text(text) {
+            Ok(restored) => Ok(restored),
+            Err(Error::UnknownToken {
+                class,
+                ordinal,
+                raw,
+            }) => {
+                self.log_restore_strict_rejection(session, class.clone(), ordinal)?;
+                Err(Error::UnknownToken {
+                    class,
+                    ordinal,
+                    raw,
+                })
+            }
+            Err(err) => Err(err),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1108,6 +1131,43 @@ impl Pipeline {
             for logger in &self.redaction_loggers {
                 logger.log(&entry)?;
             }
+        }
+        Ok(())
+    }
+
+    fn log_restore_strict_rejection(
+        &self,
+        session: &Session,
+        class: PiiClass,
+        ordinal: u32,
+    ) -> Result<()> {
+        let entry = RedactionEntry::new(
+            "restore_strict",
+            class.clone(),
+            Action::Preserve,
+            None,
+            DocumentKind::Text,
+            true,
+            ConflictTier::None,
+            crate::redaction_log::current_epoch_ms(),
+            Some(session.audit_session_id().to_string()),
+        )
+        .with_recognizer_metadata(Some("restore_strict".to_string()), None)
+        .with_provenance_metadata(
+            Some("restore_strict".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(class.to_canonical_str()),
+            Some(class.to_canonical_str()),
+            None,
+            Some(format!("ordinal:{ordinal}")),
+        );
+        for logger in &self.redaction_loggers {
+            logger.log(&entry)?;
         }
         Ok(())
     }
@@ -2206,6 +2266,40 @@ mod tests {
             entry.source == "prefix_cache"
                 && entry.provenance_stage.as_deref() == Some("prefix_cache")
         }));
+    }
+
+    #[test]
+    fn restore_strict_rejection_emits_audit_provenance() {
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+        let pipeline = Pipeline::builder()
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        let err = pipeline
+            .restore_strict_text(&session, "Reply to <deadbeef:Email_1>.")
+            .expect_err("unknown token must fail closed");
+
+        assert!(matches!(
+            err,
+            Error::UnknownToken {
+                class: PiiClass::Email,
+                ordinal: 1,
+                raw,
+            } if raw == "<deadbeef:Email_1>"
+        ));
+        let entries = entries.lock().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source, "restore_strict");
+        assert_eq!(entries[0].class, PiiClass::Email);
+        assert_eq!(entries[0].action, Action::Preserve);
+        assert_eq!(
+            entries[0].provenance_stage.as_deref(),
+            Some("restore_strict")
+        );
     }
 
     #[test]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1,11 +1,13 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use rand::RngCore;
+use regex::Regex;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
@@ -21,6 +23,15 @@ const SNAPSHOT_VERSION_V2: u8 = 2;
 const SNAPSHOT_VERSION_V3: u8 = 3;
 const SNAPSHOT_VERSION_V4: u8 = 4;
 const SNAPSHOT_VERSION_V5: u8 = 5;
+
+pub type RestoreError = Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedRestoreToken {
+    pub class: PiiClass,
+    pub ordinal: u32,
+    pub raw: String,
+}
 
 /// Lifetime scope of a [`Session`]'s token manifest.
 ///
@@ -406,7 +417,30 @@ impl Session {
         self.value_by_token
             .get(token)
             .map(|value| value.value().clone())
-            .ok_or_else(|| Error::UnknownToken(token.to_string()))
+            .ok_or_else(|| unknown_token_error(token))
+    }
+
+    pub fn restore_strict_text(&self, text: &str) -> std::result::Result<String, RestoreError> {
+        let tokens = strict_restore_tokens(text)?;
+        for token in &tokens {
+            if !self.value_by_token.contains_key(token.parsed.raw.as_str()) {
+                return Err(unknown_token_error(token.parsed.raw.as_str()));
+            }
+        }
+
+        let mut restored = String::with_capacity(text.len());
+        let mut cursor = 0usize;
+        for token in tokens {
+            restored.push_str(&text[cursor..token.start]);
+            let raw = self
+                .value_by_token
+                .get(token.parsed.raw.as_str())
+                .expect("validated manifest token must remain present");
+            restored.push_str(raw.value());
+            cursor = token.end;
+        }
+        restored.push_str(&text[cursor..]);
+        Ok(restored)
     }
 
     pub fn restore(&self, token: &str) -> Option<String> {
@@ -791,6 +825,93 @@ fn scope_from_snapshot(scope: SnapshotScope) -> Scope {
             ttl: Duration::from_secs(ttl_secs),
         },
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StrictRestoreToken {
+    pub start: usize,
+    pub end: usize,
+    pub parsed: ParsedRestoreToken,
+}
+
+pub(crate) fn strict_restore_tokens(text: &str) -> Result<Vec<StrictRestoreToken>> {
+    let mut tokens = Vec::new();
+    for matched in crate::token_shape::pattern().find_iter(text) {
+        tokens.push(StrictRestoreToken {
+            start: matched.start(),
+            end: matched.end(),
+            parsed: parsed_restore_token(matched.as_str()),
+        });
+    }
+
+    for matched in malformed_restore_token_pattern().find_iter(text) {
+        if tokens
+            .iter()
+            .any(|token| matched.start() < token.end && token.start < matched.end())
+        {
+            continue;
+        }
+        return Err(unknown_token_error(matched.as_str()));
+    }
+
+    tokens.sort_by_key(|token| token.start);
+    Ok(tokens)
+}
+
+pub(crate) fn unknown_token_error(raw: &str) -> Error {
+    let parsed = parsed_restore_token(raw);
+    Error::UnknownToken {
+        class: parsed.class,
+        ordinal: parsed.ordinal,
+        raw: parsed.raw,
+    }
+}
+
+pub(crate) fn parsed_restore_token(raw: &str) -> ParsedRestoreToken {
+    let (class, ordinal) = parse_restore_token_parts(raw)
+        .unwrap_or_else(|| (PiiClass::Custom("unknown".to_string()), 0));
+    ParsedRestoreToken {
+        class,
+        ordinal,
+        raw: raw.to_string(),
+    }
+}
+
+fn parse_restore_token_parts(raw: &str) -> Option<(PiiClass, u32)> {
+    if let Some(rest) = raw.strip_prefix("email") {
+        let (ordinal, tail) = rest.split_once('.')?;
+        if tail.ends_with("@gaze-fake.invalid") || tail.ends_with("@example.test") {
+            return Some((PiiClass::Email, ordinal.parse().ok()?));
+        }
+    }
+
+    let mut body = raw.strip_prefix('<').unwrap_or(raw);
+    body = body.strip_suffix('>').unwrap_or(body);
+    if body.len() > 9 && body.as_bytes().get(8) == Some(&b':') && is_session_hex(&body[..8]) {
+        body = &body[9..];
+    }
+
+    if let Some(rest) = body.strip_prefix("Custom:") {
+        let (name, ordinal) = rest.rsplit_once('_')?;
+        return Some((PiiClass::Custom(name.to_string()), ordinal.parse().ok()?));
+    }
+    if let Some(rest) = body.strip_prefix("custom:") {
+        let (name, ordinal) = rest.rsplit_once('_')?;
+        return Some((PiiClass::Custom(name.to_string()), ordinal.parse().ok()?));
+    }
+
+    let (class, ordinal) = body.rsplit_once('_')?;
+    let ordinal = ordinal.parse().ok()?;
+    let class = PiiClass::from_canonical_str(class).unwrap_or_else(|| PiiClass::custom(class));
+    Some((class, ordinal))
+}
+
+fn malformed_restore_token_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"<(?:[0-9a-f]{8}:)?(?:Email|Name|Location|Organization|email|name|location|organization|Custom:[a-z0-9_]*|custom:[a-z0-9_]*)_?>")
+            .expect("malformed restore token regex must compile")
+    })
 }
 
 fn random_session_hex() -> [u8; 4] {
@@ -1377,5 +1498,82 @@ mod tests {
                 .expect("beta stable"),
             beta
         );
+    }
+
+    #[test]
+    fn restore_strict_text_rejects_unknown_token() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let err = session
+            .restore_strict_text("Reply to <deadbeef:Email_999>.")
+            .expect_err("unknown token must fail closed");
+
+        assert!(matches!(
+            err,
+            Error::UnknownToken {
+                class: PiiClass::Email,
+                ordinal: 999,
+                raw,
+            } if raw == "<deadbeef:Email_999>"
+        ));
+    }
+
+    #[test]
+    fn restore_strict_text_rejects_malformed_token() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let err = session
+            .restore_strict_text("Reply to <Email_>.")
+            .expect_err("malformed token must fail closed");
+
+        assert!(matches!(
+            err,
+            Error::UnknownToken {
+                class: PiiClass::Custom(name),
+                ordinal: 0,
+                raw,
+            } if name == "unknown" && raw == "<Email_>"
+        ));
+    }
+
+    #[test]
+    fn restore_strict_text_rejects_cross_session_token_as_unknown() {
+        let source = Session::new(Scope::Ephemeral).expect("source session");
+        let token = source
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .expect("token");
+        let target = Session::new(Scope::Ephemeral).expect("target session");
+
+        let err = target
+            .restore_strict_text(&format!("Reply to {token}."))
+            .expect_err("wrong-session token must fail closed");
+
+        assert!(matches!(
+            err,
+            Error::UnknownToken {
+                class: PiiClass::Email,
+                ordinal: 1,
+                raw,
+            } if raw == token
+        ));
+    }
+
+    #[test]
+    fn restore_strict_text_is_atomic_on_failure() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::Name, "Dr. Schmidt")
+            .expect("token");
+
+        let err = session
+            .restore_strict_text(&format!("{token} then <deadbeef:Email_9>"))
+            .expect_err("unknown token must prevent partial restore output");
+
+        assert!(matches!(
+            err,
+            Error::UnknownToken {
+                class: PiiClass::Email,
+                ordinal: 9,
+                raw,
+            } if raw == "<deadbeef:Email_9>"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

**This is manifest-integrity enforcement, not prompt-injection detection.**

Implements v0.10 Phase A strict manifest-bound restore:
- adds `Session::restore_strict_text(&str) -> Result<String, RestoreError>` with two-pass validation before emitting restored output
- changes unknown token failures to typed `Error::UnknownToken { class, ordinal, raw }`
- routes MCP `restore_strict` through the core strict restore path
- adds audit rows for strict restore rejections through the existing `Pipeline` logger path with `provenance_stage = "restore_strict"`

## Notes

The audit event is implemented on `Pipeline::restore_strict_text`, not directly inside `Session::restore_strict_text`, because the current audit architecture keeps `RedactionLogger` ownership on `Pipeline`. Moving loggers into `Session` would blur the existing crate/runtime boundary. Session-level restore remains deterministic and logger-free; audit-capable callers should use the Pipeline wrapper.

Cross-session and wrong-session tokens intentionally fail through the same `UnknownToken` path. Malformed token-like spans also fail closed through `UnknownToken` with `class = custom:unknown`, `ordinal = 0` when the grammar cannot parse class/ordinal.

`docs/architecture/restore-boundary.md` is not present on current `origin/main`; this code PR does not link to it and should be paired with the Phase #397 docs PR when that lands.

## Non-goals

No heuristics, classifiers, LLM judgment, semantic maliciousness checks, names/NER detection, generic prompt-injection detection, or Phase C work.

## Tests

- `cargo test -p gaze-pii restore_strict_text --lib`
- `cargo test -p gaze-pii restore_strict_rejection --lib`
- `cargo test -p gaze-mcp-core --lib`
- `cargo test -p gaze-pii --lib`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
