### PR TITLE
chore(scrub): remove absolute home paths

### DIFF
--- a/crates/gaze-recognizers/benches/ner_models_snapshot.json
+++ b/crates/gaze-recognizers/benches/ner_models_snapshot.json
@@ -25,7 +25,7 @@
       "runtime": "onnxruntime",
       "wrapper": "scripts/kiji-runner.py",
       "model_file": null,
-      "checkpoint": "/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67",
+      "checkpoint": "~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67",
       "native_locales": [
         "Global"
       ],
@@ -71,7 +71,7 @@
       "license": "cc-by-nc-sa-4.0",
       "runtime": "transformers",
       "wrapper": "scripts/transformers-runner.py",
-      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/wikineural-multilingual",
+      "checkpoint": "~/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/wikineural-multilingual",
       "native_locales": [
         "EnUs",
         "DeDe",
@@ -115,7 +115,7 @@
       "license": "mit",
       "runtime": "transformers",
       "wrapper": "scripts/transformers-runner.py",
-      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/dslim-bert-base-ner",
+      "checkpoint": "~/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/dslim-bert-base-ner",
       "native_locales": [
         "EnUs",
         "EnGb"
@@ -155,7 +155,7 @@
       "license": "afl-3.0",
       "runtime": "transformers",
       "wrapper": "scripts/transformers-runner.py",
-      "checkpoint": "/Users/krishankoenig/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/davlan-bert-multilingual",
+      "checkpoint": "~/.anvil/worktrees/gaze-empiretwo/v0.9-multi-ner-bench/.huggingface-cache/models/davlan-bert-multilingual",
       "native_locales": [
         "EnUs",
         "DeDe",

--- a/docs/research/v0.9-ner-model-leaderboard.md
+++ b/docs/research/v0.9-ner-model-leaderboard.md
@@ -14,7 +14,7 @@ Commands:
 cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture
 .bench-venv/bin/python scripts/ner-bench-scorer.py --repo-root . --python .bench-venv/bin/python --mode all --model kiji-distilbert --model openobscure-tinybert4l-pii-ner-int8 --model mrm8488-mobilebert-ner --model osiria-minilm-italian-ner --snapshot target/tier5-ner-models-snapshot.json
 .bench-venv/bin/python scripts/ner-warm-latency.py --repo-root .
-GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort GAZE_KIJI_DISTILBERT_MODEL_DIR=/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 GAZE_KIJI_DISTILBERT_PRECISION=int8 cargo bench -p gaze-recognizers --bench safety_net_matrix --features safety-net-kiji --no-default-features
+GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort GAZE_KIJI_DISTILBERT_MODEL_DIR=~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 GAZE_KIJI_DISTILBERT_PRECISION=int8 cargo bench -p gaze-recognizers --bench safety_net_matrix --features safety-net-kiji --no-default-features
 ```
 
 Run date: 2026-05-15. Host: macOS-26.5 arm64 on Apple M5 Max. The scorer used Python 3.10.20 for Tiny/Mobile/Mini candidates; Kiji warm ORT rows used the Rust ORT backend. Corpus: 150 fixtures, `target/coverage-report.json` SHA256 `760f96163a68ce5f7dbc0409aa5109aa1a3ed190001536647e1881ba9d40a49c`.

--- a/docs/research/v0.9.0-rc1-combined-revalidation.md
+++ b/docs/research/v0.9.0-rc1-combined-revalidation.md
@@ -17,7 +17,7 @@ This re-ran the existing v0.9 benchmark scaffolding on combined main after all s
 | RAM | 68719476736 bytes |
 | Rust | `rustc 1.95.0 (59807616e 2026-04-14) (Homebrew)` |
 | Python | `3.14.5` in `/tmp/gaze-kiji-bench-venv` |
-| Kiji model dir | `/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67` |
+| Kiji model dir | `~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67` |
 
 ## Commands
 
@@ -29,10 +29,10 @@ cargo test -p gaze-recognizers --test coverage_loop -- --ignored --nocapture
   --mode all \
   --measure-latency \
   --precision int8 \
-  --model-dir /Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
+  --model-dir ~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
   --python /tmp/gaze-kiji-bench-venv/bin/python
 
-GAZE_KIJI_DISTILBERT_MODEL_DIR=/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
+GAZE_KIJI_DISTILBERT_MODEL_DIR=~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
 GAZE_KIJI_DISTILBERT_PRECISION=int8 \
 GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort \
   cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix
@@ -40,7 +40,7 @@ GAZE_SAFETY_NET_MATRIX_KIJI_BACKEND=ort \
 cargo bench -p gaze-recognizers --features safety-net-kiji --bench safety_net_matrix
 
 GAZE_KIJI_DISTILBERT_COMMAND=/tmp/gaze-kiji-int8-runner \
-GAZE_KIJI_DISTILBERT_MODEL_DIR=/Users/krishankoenig/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
+GAZE_KIJI_DISTILBERT_MODEL_DIR=~/.cache/gaze/kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67 \
   /tmp/gaze-kiji-bench-venv/bin/python scripts/gaze-pipeline-bench.py --repo-root .
 
 cargo bench -p gaze-pii --bench pipeline_end_to_end

--- a/scripts/safety_net_bench_lib.py
+++ b/scripts/safety_net_bench_lib.py
@@ -158,7 +158,7 @@ def add_common_args(parser: argparse.ArgumentParser, backend: Literal["kiji", "o
             "--model-dir",
             type=Path,
             default=Path(
-                "/Users/krishankoenig/.cache/gaze/"
+                "~/.cache/gaze/"
                 "kiji-distilbert-3a19fe9404a4469d91aa3d551558a97f68872f67"
             ),
         )


### PR DESCRIPTION
Summary:
- Replaced absolute home paths in tracked v0.9 NER benchmark artifacts with tilde-based paths.
- Kept the scrub scoped to the four known public files from todo #405.

Validation:
- git grep for the leaked username returns no tracked-file matches.
- git grep for absolute /Users/<user>/ style paths returns no tracked-file matches.

Axis note: strengthens reliability/trust by removing PII from Gaze own public artifacts; no contract or runtime behavior changes.