### PR TITLE
docs(readme): align all crate READMEs to v0.9.0 + correct release-process crate count

### DIFF
--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli
+$ cargo install gaze-cli --version 0.9.0
 ```
 
 Build from the workspace root:
@@ -99,7 +99,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --features mcp
+$ cargo install gaze-cli --version 0.9.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.7.2"
+gaze-document = "0.9.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --features document
+cargo install gaze-cli --version 0.9.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays
@@ -218,8 +218,8 @@ Both tools return a JSON object:
 
 `gaze_read_file` defaults to a 25 MiB input cap. Override it with
 `GazeReadFile::with_max_file_size(bytes)` or `GazeReadOpts`.
-`gaze mcp install` is planned as a separate `gaze-cli` flow; this crate only
-provides the opt-in tool implementations.
+`gaze-cli` provides `gaze mcp install`, `gaze mcp doctor`, and `gaze mcp serve`;
+this crate only provides the opt-in tool implementations.
 
 ## Feature flags
 
@@ -232,7 +232,7 @@ provides the opt-in tool implementations.
 | `render-image`    | no      | Reserved — future redacted-preview renderer.         |
 
 The `extract-docling` and `render-image` features are intentionally empty
-in v0.0.x so adopters can pin against the eventual flag names early.
+in v0.9.0 so adopters can pin against the eventual flag names early.
 
 ## License
 

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.7.2) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.9.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.
@@ -17,7 +17,7 @@
 
 `gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.
 
-`gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, see `gaze-proxy` (planned for v0.8 — multi-vendor reverse proxy supporting Anthropic, OpenAI, Gemini).
+`gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, use `gaze-proxy`, the v0.8+ multi-vendor reverse proxy supporting OpenAI, Anthropic, and Gemini SDK base-URL swaps.
 
 ---
 
@@ -213,9 +213,9 @@ exposing restore.
 
 - `gaze-mcp-rmcp` ships alongside this crate as the reference rmcp
   transport sink.
-- `gaze-proxy` (the user-input axis sibling, multi-vendor LLM API
-  reverse proxy) is planned for v0.8 — see the `## Scope` boundary
-  statement at the top of this README.
+- `gaze-proxy` is the user-input axis sibling: a multi-vendor LLM API
+  reverse proxy for OpenAI, Anthropic, and Gemini SDK base-URL swaps. See the
+  `## Scope` boundary statement at the top of this README.
 
 See [`docs/architecture/mcp-runtime.md`](../../docs/architecture/mcp-runtime.md)
 for the full chokepoint contract + audit-row schema + threat model.

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -8,7 +8,7 @@
 
 `gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.
 
-`gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, see `gaze-proxy` (planned for v0.8 — multi-vendor reverse proxy supporting Anthropic, OpenAI, Gemini).
+`gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, use `gaze-proxy`, the v0.8+ multi-vendor reverse proxy supporting OpenAI, Anthropic, and Gemini SDK base-URL swaps.
 
 `gaze-mcp-rmcp` is the [rmcp](https://crates.io/crates/rmcp) transport sink for [`gaze-mcp-core`]. It exposes `RmcpFrontend`, a `gaze_mcp_core::Frontend` implementation that wires rmcp `tools/list` and `tools/call` requests to a `DispatchHost`.
 
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.7"
-gaze-mcp-rmcp = "0.7"
+gaze-mcp-core = "0.9.0"
+gaze-mcp-rmcp = "0.9.0"
 ```
 
 ```rust

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -1,13 +1,24 @@
 # gaze-proxy
 
+[![Crates.io](https://img.shields.io/crates/v/gaze-proxy.svg)](https://crates.io/crates/gaze-proxy)
+[![docs.rs](https://docs.rs/gaze-proxy/badge.svg)](https://docs.rs/gaze-proxy)
+[![License](https://img.shields.io/crates/l/gaze-proxy.svg)](https://github.com/EmpireTwo/gaze#license)
+
 `gaze-proxy` is the feature-gated HTTP proxy runtime for LLM SDK base-URL swaps.
 It preserves each provider's native wire shape and uses adapters only to locate
 PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
+## Cargo
+
+```toml
+[dependencies]
+gaze-proxy = "0.9.0"
+```
+
 ## Quickstart
 
 ```bash
-cargo install gaze-cli
+cargo install gaze-cli --version 0.9.0
 gaze proxy start
 ```
 
@@ -16,6 +27,7 @@ Then point SDKs at the daemon:
 ```bash
 export OPENAI_BASE_URL=http://127.0.0.1:8787/v1
 export ANTHROPIC_BASE_URL=http://127.0.0.1:8787
+export GEMINI_BASE_URL=http://127.0.0.1:8787
 ```
 
 The default config is written to `~/.config/gaze/proxy.toml` and includes:
@@ -50,13 +62,14 @@ in that provider's native JSON. The proxy does not transcode requests.
 gaze proxy serve
 gaze proxy start
 gaze proxy status
-gaze proxy logs --follow
 gaze proxy stop
 gaze proxy restart
 ```
 
 Pidfiles live under the platform local-data directory, never `/tmp`. Stale
 pidfiles are revalidated with process liveness checks and cleaned before start.
+
+`gaze proxy logs --follow` is also available for local daemon inspection.
 
 ## Security Notes
 

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -20,6 +20,13 @@ Use `gaze-types` instead of `gaze` when building:
 
 Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
+## Cargo
+
+```toml
+[dependencies]
+gaze-types = "0.9.0"
+```
+
 ## Key types
 
 | Type | Purpose |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,7 +19,7 @@ Source: [`.github/workflows/publish-crates.yml`](../.github/workflows/publish-cr
 
 - Triggered on `v*` tag pushes (with `workflow_dispatch` dry-run available).
 - Authenticates to crates.io via OIDC trusted-publisher (`rust-lang/crates-io-auth-action`); no long-lived `CARGO_REGISTRY_TOKEN` secret.
-- Publishes all nine workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
+- Publishes all ten workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-proxy` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
 - Skips crates already at the published version (idempotent re-runs) and retries on index-propagation lag.
 - Browse crates at <https://crates.io/crates/gaze-pii> (and sibling crate pages).
 


### PR DESCRIPTION
## Summary
- Align published crate README install snippets and version mentions to v0.9.0.
- Refresh stale document, MCP, and proxy README scope text for the current v0.9.0 surfaces.
- Correct docs/release-process.md from nine to ten published crates and include gaze-proxy before gaze-cli in publish order.

## North-star axis
Strengthens Axis 4 Trust and Axis 5 Adopter ergonomics by keeping published crate pages, install commands, and release-process docs aligned with the shipped workspace.

## Verification
- git diff --check
- rg -n 'gaze[-a-z]*\s*=\s*"0\.|cargo install gaze-cli|planned for v0\.8|v0\.0\.x|0\.9\.0-rc\.1|nine workspace crates|all nine workspace crates' crates/*/README.md docs/release-process.md