### PR TITLE
feat: add restore-boundary raw PII audit events

### DIFF
--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -64,5 +64,8 @@ pub use rulepack::{
 pub use sandbox::{
     ExecPolicy, Sandbox, SandboxError, SandboxPlan, UntrustedExecRequest, ValidatedExecRequest,
 };
-pub use session::{RestoreError, Scope, SensitiveSnapshot, Session, SessionSnapshotEntry};
+pub use session::{
+    RestoreError, RestoreEvent, RestoreEventKind, Scope, SensitiveSnapshot, Session,
+    SessionSnapshotEntry,
+};
 pub use types::{CleanDocument, RawDocument, Value};

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -22,7 +22,7 @@ use crate::redaction_log::{ConflictTier, DocumentKind, RedactionEntry};
 use crate::registry::{Candidate, DetectContext, Recognizer, RecognizerRegistry};
 use crate::rule::{Action, Rule, RuleContext};
 use crate::rulepack::RulepackError;
-use crate::session::Session;
+use crate::session::{RestoreEvent, Session};
 use crate::types::{CleanDocument, RawDocument, Value};
 use crate::DictionaryBundle;
 
@@ -184,6 +184,7 @@ pub struct Pipeline {
     #[cfg(feature = "bundled-recognizers")]
     safety_net_registry: Option<Arc<LocaleAwareModelRegistry>>,
     optimization_config: PipelineOptimizationConfig,
+    restore_boundary_dlp_audit: bool,
     rules: Vec<Arc<dyn Rule>>,
 }
 
@@ -442,8 +443,13 @@ impl Pipeline {
     }
 
     pub fn restore_strict_text(&self, session: &Session, text: &str) -> Result<String> {
-        match session.restore_strict_text(text) {
-            Ok(restored) => Ok(restored),
+        match session.restore_strict_text_with_events(text) {
+            Ok((restored, events)) => {
+                if self.restore_boundary_dlp_audit {
+                    self.log_restore_events(session, &events)?;
+                }
+                Ok(restored)
+            }
             Err(Error::UnknownToken {
                 class,
                 ordinal,
@@ -1172,6 +1178,43 @@ impl Pipeline {
         Ok(())
     }
 
+    fn log_restore_events(&self, session: &Session, events: &[RestoreEvent]) -> Result<()> {
+        for event in events {
+            let entry = RedactionEntry::new(
+                event.kind.as_str(),
+                event.class.clone(),
+                Action::Preserve,
+                None,
+                DocumentKind::Text,
+                false,
+                ConflictTier::None,
+                crate::redaction_log::current_epoch_ms(),
+                Some(session.audit_session_id().to_string()),
+            )
+            .with_recognizer_metadata(Some("restore_boundary_dlp".to_string()), None)
+            .with_provenance_metadata(
+                Some("restore_boundary_dlp".to_string()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(event.kind.as_str().to_string()),
+                Some(event.class.to_canonical_str()),
+                Some(event.class.to_canonical_str()),
+                None,
+                Some(format!(
+                    "sha256:{};span:{}..{}",
+                    event.raw_sha256, event.location.start, event.location.end
+                )),
+            );
+            for logger in &self.redaction_loggers {
+                logger.log(&entry)?;
+            }
+        }
+        Ok(())
+    }
+
     fn log_vetoed_entry(
         &self,
         session: &Session,
@@ -1422,6 +1465,7 @@ pub struct PipelineBuilder {
     #[cfg(feature = "bundled-recognizers")]
     safety_net_registry: Option<Arc<LocaleAwareModelRegistry>>,
     optimization_config: PipelineOptimizationConfig,
+    restore_boundary_dlp_audit: bool,
     rules: Vec<Arc<dyn Rule>>,
 }
 
@@ -1494,6 +1538,11 @@ impl PipelineBuilder {
         self
     }
 
+    pub fn enable_restore_boundary_dlp_audit(mut self) -> Self {
+        self.restore_boundary_dlp_audit = true;
+        self
+    }
+
     pub fn enable_skip_class_gating(mut self) -> Self {
         self.optimization_config.skip_class_gating = true;
         self
@@ -1538,6 +1587,7 @@ impl PipelineBuilder {
             #[cfg(feature = "bundled-recognizers")]
             safety_net_registry: self.safety_net_registry,
             optimization_config: self.optimization_config,
+            restore_boundary_dlp_audit: self.restore_boundary_dlp_audit,
             rules: self.rules,
         })
     }
@@ -2300,6 +2350,65 @@ mod tests {
             entries[0].provenance_stage.as_deref(),
             Some("restore_strict")
         );
+    }
+
+    #[test]
+    fn restore_boundary_dlp_emits_metadata_only_audit_rows() {
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+        let pipeline = Pipeline::builder()
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .enable_restore_boundary_dlp_audit()
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .expect("token");
+
+        let restored = pipeline
+            .restore_strict_text(
+                &session,
+                &format!("{token} raw alice@example.invalid fresh bob@example.invalid"),
+            )
+            .expect("restore remains audit-only");
+
+        assert!(restored.contains("alice@example.invalid"));
+        let entries = entries.lock().unwrap();
+        let dlp_entries = entries
+            .iter()
+            .filter(|entry| entry.provenance_stage.as_deref() == Some("restore_boundary_dlp"))
+            .collect::<Vec<_>>();
+        assert_eq!(dlp_entries.len(), 2);
+        assert!(dlp_entries
+            .iter()
+            .any(|entry| entry.source == "manifest_bypass"));
+        assert!(dlp_entries
+            .iter()
+            .any(|entry| entry.source == "fresh_pii_detected"));
+        let serialized = serde_json::to_string(&dlp_entries).expect("audit json");
+        assert!(!serialized.contains("alice@example.invalid"));
+        assert!(!serialized.contains("bob@example.invalid"));
+        assert!(serialized.contains("sha256:"));
+    }
+
+    #[test]
+    fn restore_boundary_dlp_audit_is_default_off() {
+        let entries = Arc::new(Mutex::new(Vec::<RedactionEntry>::new()));
+        let pipeline = Pipeline::builder()
+            .redaction_logger(CapturingLogger {
+                entries: Arc::clone(&entries),
+            })
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        pipeline
+            .restore_strict_text(&session, "fresh bob@example.invalid")
+            .expect("restore remains audit-only");
+
+        assert!(entries.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1,5 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
+use std::ops::Range;
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -11,6 +13,7 @@ use regex::Regex;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
 
 use crate::detector::PiiClass;
 use crate::policy::{Policy, SessionScope};
@@ -25,6 +28,31 @@ const SNAPSHOT_VERSION_V4: u8 = 4;
 const SNAPSHOT_VERSION_V5: u8 = 5;
 
 pub type RestoreError = Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RestoreEventKind {
+    ManifestBypass,
+    FreshPiiDetected,
+}
+
+impl RestoreEventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ManifestBypass => "manifest_bypass",
+            Self::FreshPiiDetected => "fresh_pii_detected",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RestoreEvent {
+    pub kind: RestoreEventKind,
+    pub class: PiiClass,
+    pub raw_sha256: String,
+    pub location: Range<usize>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParsedRestoreToken {
@@ -443,6 +471,19 @@ impl Session {
         Ok(restored)
     }
 
+    pub fn restore_strict_text_with_events(
+        &self,
+        text: &str,
+    ) -> std::result::Result<(String, Vec<RestoreEvent>), RestoreError> {
+        let events = self.restore_boundary_events(text);
+        let restored = self.restore_strict_text(text)?;
+        Ok((restored, events))
+    }
+
+    pub fn restore_boundary_events(&self, text: &str) -> Vec<RestoreEvent> {
+        restore_boundary_events(text, &authorized_structural_values(self))
+    }
+
     pub fn restore(&self, token: &str) -> Option<String> {
         self.value_by_token
             .get(token)
@@ -825,6 +866,268 @@ fn scope_from_snapshot(scope: SnapshotScope) -> Scope {
             ttl: Duration::from_secs(ttl_secs),
         },
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructuralFinding {
+    class: PiiClass,
+    raw: String,
+    canonical: String,
+    location: Range<usize>,
+}
+
+fn authorized_structural_values(session: &Session) -> BTreeSet<(PiiClass, String)> {
+    let mut authorized = BTreeSet::new();
+    for entry in session.snapshot_entries() {
+        for finding in structural_findings(&entry.raw) {
+            authorized.insert((finding.class, finding.canonical));
+        }
+    }
+    authorized
+}
+
+fn restore_boundary_events(
+    text: &str,
+    authorized: &BTreeSet<(PiiClass, String)>,
+) -> Vec<RestoreEvent> {
+    structural_findings(text)
+        .into_iter()
+        .map(|finding| RestoreEvent {
+            kind: if authorized.contains(&(finding.class.clone(), finding.canonical)) {
+                RestoreEventKind::ManifestBypass
+            } else {
+                RestoreEventKind::FreshPiiDetected
+            },
+            class: finding.class,
+            raw_sha256: raw_sha256(&finding.raw),
+            location: finding.location,
+        })
+        .collect()
+}
+
+fn structural_findings(text: &str) -> Vec<StructuralFinding> {
+    let mut findings = Vec::new();
+    collect_email_findings(text, &mut findings);
+    collect_phone_findings(text, &mut findings);
+    collect_iban_findings(text, &mut findings);
+    collect_credit_card_findings(text, &mut findings);
+    collect_api_key_findings(text, &mut findings);
+    findings.sort_by(|left, right| {
+        left.location
+            .start
+            .cmp(&right.location.start)
+            .then_with(|| {
+                (right.location.end - right.location.start)
+                    .cmp(&(left.location.end - left.location.start))
+            })
+    });
+    let mut accepted = Vec::new();
+    for finding in findings {
+        if accepted.iter().any(|existing: &StructuralFinding| {
+            finding.location.start < existing.location.end
+                && existing.location.start < finding.location.end
+        }) {
+            continue;
+        }
+        accepted.push(finding);
+    }
+    accepted
+}
+
+fn collect_email_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
+    for matched in email_pattern().find_iter(text) {
+        let raw = matched.as_str();
+        if !is_basic_restore_email(raw) {
+            continue;
+        }
+        findings.push(StructuralFinding {
+            class: PiiClass::Email,
+            raw: raw.to_string(),
+            canonical: raw.to_ascii_lowercase(),
+            location: matched.range(),
+        });
+    }
+}
+
+fn collect_phone_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
+    for matched in phone_pattern().find_iter(text) {
+        let raw = matched.as_str();
+        findings.push(StructuralFinding {
+            class: PiiClass::custom("phone"),
+            raw: raw.to_string(),
+            canonical: ascii_digits(raw),
+            location: matched.range(),
+        });
+    }
+}
+
+fn collect_iban_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
+    for matched in iban_pattern().find_iter(text) {
+        let raw = matched.as_str();
+        let canonical = iban_canonicalize(raw);
+        if !iban_mod97_check(&canonical) {
+            continue;
+        }
+        findings.push(StructuralFinding {
+            class: PiiClass::custom("iban"),
+            raw: raw.to_string(),
+            canonical,
+            location: matched.range(),
+        });
+    }
+}
+
+fn collect_credit_card_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
+    for matched in card_pattern().find_iter(text) {
+        let raw = matched.as_str();
+        let canonical = ascii_digits(raw);
+        if !luhn_check(&canonical) {
+            continue;
+        }
+        findings.push(StructuralFinding {
+            class: PiiClass::custom("credit_card"),
+            raw: raw.to_string(),
+            canonical,
+            location: matched.range(),
+        });
+    }
+}
+
+fn collect_api_key_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
+    for matched in api_key_pattern().find_iter(text) {
+        let raw = matched.as_str();
+        findings.push(StructuralFinding {
+            class: PiiClass::custom("api_key"),
+            raw: raw.to_string(),
+            canonical: raw.to_string(),
+            location: matched.range(),
+        });
+    }
+}
+
+fn email_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
+            .expect("email restore DLP regex compiles")
+    })
+}
+
+fn phone_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r"(?x)(?:
+                \+?1[\s.-]+555[\s.-]*01\d{2}
+                |\+44[\s.-]*7700[\s.-]*900\d{3}
+                |\+49[\s.-]*1555[\s.-]*0112233
+            )\b",
+        )
+        .expect("phone restore DLP regex compiles")
+    })
+}
+
+fn iban_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"\b[A-Z]{2}\d{2}(?: ?[A-Z0-9]{4}){2,7} ?[A-Z0-9]{1,4}\b")
+            .expect("IBAN restore DLP regex compiles")
+    })
+}
+
+fn card_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"\b\d(?:[\s-]?\d){12,18}\b").expect("credit-card restore DLP regex compiles")
+    })
+}
+
+fn api_key_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"\b(?:sk-test-[A-Za-z0-9]{20,}|gaze_test_[A-Za-z0-9]{16,})\b")
+            .expect("API-key restore DLP regex compiles")
+    })
+}
+
+fn is_basic_restore_email(input: &str) -> bool {
+    let Some((local, domain)) = input.split_once('@') else {
+        return false;
+    };
+    !local.is_empty() && domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+}
+
+fn ascii_digits(input: &str) -> String {
+    input.chars().filter(char::is_ascii_digit).collect()
+}
+
+fn raw_sha256(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
+    hex::encode(digest)
+}
+
+fn iban_canonicalize(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace())
+        .flat_map(char::to_uppercase)
+        .collect()
+}
+
+fn iban_mod97_check(input: &str) -> bool {
+    let canonical = iban_canonicalize(input);
+    if !(15..=34).contains(&canonical.len()) {
+        return false;
+    }
+    if !canonical.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+        return false;
+    }
+
+    let mut remainder = 0u32;
+    for ch in canonical[4..].chars().chain(canonical[..4].chars()) {
+        match ch {
+            '0'..='9' => {
+                remainder = (remainder * 10 + ch.to_digit(10).expect("digit")) % 97;
+            }
+            'A'..='Z' => {
+                let value = u32::from(ch) - u32::from('A') + 10;
+                remainder = (remainder * 10 + value / 10) % 97;
+                remainder = (remainder * 10 + value % 10) % 97;
+            }
+            _ => return false,
+        }
+    }
+    remainder == 1
+}
+
+fn luhn_check(input: &str) -> bool {
+    let mut digits = Vec::new();
+    for byte in input.bytes() {
+        if !byte.is_ascii_digit() {
+            return false;
+        }
+        digits.push(byte - b'0');
+    }
+    if !(13..=19).contains(&digits.len()) {
+        return false;
+    }
+
+    let sum: u32 = digits
+        .iter()
+        .rev()
+        .enumerate()
+        .map(|(index, digit)| {
+            let mut value = u32::from(*digit);
+            if index % 2 == 1 {
+                value *= 2;
+                if value > 9 {
+                    value -= 9;
+                }
+            }
+            value
+        })
+        .sum();
+    sum.is_multiple_of(10)
 }
 
 #[derive(Debug, Clone)]
@@ -1575,5 +1878,85 @@ mod tests {
                 raw,
             } if raw == "<deadbeef:Email_9>"
         ));
+    }
+
+    #[test]
+    fn restore_boundary_events_distinguish_manifest_bypass_from_fresh_pii() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .expect("token");
+
+        let (restored, events) = session
+            .restore_strict_text_with_events(&format!(
+                "{token} raw alice@example.invalid fresh bob@example.invalid"
+            ))
+            .expect("restore continues in audit-only mode");
+
+        assert!(restored.contains("alice@example.invalid"));
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, RestoreEventKind::ManifestBypass);
+        assert_eq!(events[0].class, PiiClass::Email);
+        assert_eq!(events[0].raw_sha256.len(), 64);
+        assert_ne!(events[0].raw_sha256, "alice@example.invalid");
+        assert_eq!(events[1].kind, RestoreEventKind::FreshPiiDetected);
+        assert_eq!(events[1].class, PiiClass::Email);
+    }
+
+    #[test]
+    fn restore_boundary_events_cover_structural_identifier_scope() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        session
+            .tokenize(&PiiClass::custom("phone"), "+1-555-0101")
+            .expect("phone token");
+        session
+            .tokenize(&PiiClass::custom("iban"), "DE89 3704 0044 0532 0130 00")
+            .expect("iban token");
+        session
+            .tokenize(&PiiClass::custom("credit_card"), "4111 1111 1111 1111")
+            .expect("card token");
+        session
+            .tokenize(&PiiClass::custom("api_key"), "sk-test-00000000000000000000")
+            .expect("api key token");
+
+        let events = session.restore_boundary_events(
+            "known +1-555-0101 UK +44 7700 900123 DE +49 1555 0112233 \
+             known DE89370400440532013000 fresh GB82 WEST 1234 5698 7654 32 \
+             known 4111111111111111 fresh 4012-8888-8888-1881 \
+             known sk-test-00000000000000000000 fresh gaze_test_0000000000000000",
+        );
+
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::ManifestBypass
+                && event.class == PiiClass::custom("phone")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::FreshPiiDetected
+                && event.class == PiiClass::custom("phone")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::ManifestBypass
+                && event.class == PiiClass::custom("iban")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::FreshPiiDetected
+                && event.class == PiiClass::custom("iban")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::ManifestBypass
+                && event.class == PiiClass::custom("credit_card")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::FreshPiiDetected
+                && event.class == PiiClass::custom("credit_card")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::ManifestBypass
+                && event.class == PiiClass::custom("api_key")
+        }));
+        assert!(events.iter().any(|event| {
+            event.kind == RestoreEventKind::FreshPiiDetected
+                && event.class == PiiClass::custom("api_key")
+        }));
     }
 }


### PR DESCRIPTION
## Summary

**This is manifest-integrity enforcement, not prompt-injection detection.**

Implements v0.10 Phase B unauthorized raw-PII detection at restore in audit-only mode:
- adds typed `RestoreEventKind::{ManifestBypass, FreshPiiDetected}` and metadata-only `RestoreEvent` values
- scans pre-restore text for deterministic structural identifiers only: email, synthetic phone shapes, IBAN, credit-card, and API-key-like strings
- distinguishes manifest-known raw values from fresh structural PII by comparing canonicalized findings against the active session manifest
- adds default-off `PipelineBuilder::enable_restore_boundary_dlp_audit()` to emit audit rows without blocking restore
- persists no raw detected values; audit metadata carries class, event kind, byte span, and SHA-256 hash only

## Notes

Phase B builds directly on Phase A strict restore (`Session::restore_strict_text`). The scan runs before token replacement, so manifest-authorized restore output does not self-trigger raw-PII findings. Restore continues on findings; unknown-token failures from Phase A still fail closed.

Phase B documentation is owned by PR #260. This PR only implements the code and audit-only event surface in `crates/gaze/src/lib.rs`, `crates/gaze/src/pipeline.rs`, and `crates/gaze/src/session.rs`.

Phase D PR #261 has broader restore telemetry/schema work. This PR intentionally avoids duplicating that schema migration and logs Phase B rows through the existing metadata-only audit fields; #261 can map these typed events into its additive telemetry columns when integrated.

## Non-goals

No prompt-injection defense, semantic intent detection, names/entities/NER restore detection, LLM-as-judge, classifiers, block mode, or Phase C restore-risk rulepack.

## Tests

- `git diff --check`
- targeted path/framing grep on PR body and diff
- dogfooded this PR body through `gaze clean` using `cargo run -q -p gaze-cli -- clean`
- `cargo test -p gaze-pii restore_boundary --lib`
- `cargo test -p gaze-pii restore_strict --lib`

---

_Rebased onto main after PR #260 + #262 merge; original PR #264 auto-closed when Phase A base branch was deleted. Same head commit (rebased)._