### PR TITLE
docs(skills): add release orchestration skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: release
-description: Use when orchestrating a Gaze release end to end, including trigger phrases like "cut release", "ship vX.Y.Z", "tag vX.Y.Z", "publish vX.Y.Z", or "release vX.Y.Z". Covers pre-flight gates, explicit tag authorization, GitHub/crates.io workflow expectations, post-tag verification, and escalation rules. Counter-pattern: do not just push a tag and hope.
+description: "Use when orchestrating an EmpireTwo/gaze release end to end, especially when the user says cut release, ship vX.Y.Z, tag vX.Y.Z, publish vX.Y.Z, or release vX.Y.Z. Covers pre-flight gates, explicit tag authorization, GitHub and crates.io workflow expectations, post-tag verification, escalation rules, and the counter-pattern to avoid: do not just push a tag and hope."
 ---
 
 # Release Orchestration
 
-This skill governs release execution for `EmpireTwo/gaze`. It complements the
-`release-notes` skill, which controls release-note voice only.
+Use this skill for Gaze release execution. It complements the `release-notes`
+skill, which controls release-note voice only.
 
 Do not cut a release, push a tag, or trigger publish workflows until the
-checklist below is green and the user gives an explicit lock signal such as
-"Do it yourself", "Tag + push", or an equivalent direct instruction.
+pre-flight checklist is green and the user gives an explicit lock signal such
+as "Do it yourself", "Tag + push", or an equivalent direct instruction.
 
-## Pre-Flight
+## Pre-Flight Gates
 
 Run from `main` after all release-blocker PRs are merged.
 
@@ -75,8 +75,8 @@ After the workflows finish:
 
 - Do not push tags without an explicit user lock signal.
 - Do not publish to crates.io manually.
-- Do not amend, delete, or force-push a tag after it has been pushed.
-  If a released tag is wrong, make a new patch release.
+- Do not amend, delete, or force-push a tag after it has been pushed. If a
+  released tag is wrong, make a new patch release.
 - Do not put local absolute paths in release notes, PR bodies, or commit
   messages. Use `~/` or `$HOME`.
 - If release notes need prose changes, use the `release-notes` skill before

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: release
+description: Use when orchestrating a Gaze release end to end, including trigger phrases like "cut release", "ship vX.Y.Z", "tag vX.Y.Z", "publish vX.Y.Z", or "release vX.Y.Z". Covers pre-flight gates, explicit tag authorization, GitHub/crates.io workflow expectations, post-tag verification, and escalation rules. Counter-pattern: do not just push a tag and hope.
+---
+
+# Release Orchestration
+
+This skill governs release execution for `EmpireTwo/gaze`. It complements the
+`release-notes` skill, which controls release-note voice only.
+
+Do not cut a release, push a tag, or trigger publish workflows until the
+checklist below is green and the user gives an explicit lock signal such as
+"Do it yourself", "Tag + push", or an equivalent direct instruction.
+
+## Pre-Flight
+
+Run from `main` after all release-blocker PRs are merged.
+
+1. Confirm the working tree is clean and `main` is at the intended merge commit.
+2. Confirm all open PRs marked as `v0.X.0-final` blockers are merged.
+3. Confirm the workspace version pin matches the about-to-tag version in the
+   root `Cargo.toml` and all per-crate `Cargo.toml` files.
+4. Run `cargo run -p xtask -- ci-feature-matrix` and require green.
+5. Run `cargo run -p xtask -- readme-version-check` and require green.
+6. Run `git grep krishankoenig` and require zero tracked-file matches.
+7. Run `git grep -E '/Users/[a-z]+'` and require zero tracked-file matches.
+   Path-leak output is release-blocking until scrubbed to `~/` or `$HOME`.
+8. Dogfood Gaze on its own release text: pipe `dist/release-notes/vX.Y.Z.md`
+   plus the modified `CHANGELOG.md` section through `gaze clean` and verify
+   zero detections. This preserves the `feedback-dogfood-gaze-on-own-output`
+   memory.
+9. Verify benchmark claims in release notes link to the script and hardware
+   specification that produced them. This preserves the
+   `feedback-bench-claims-reproducible` memory.
+
+If any step fails, stop and fix the release branch. Do not tag around a red
+checklist.
+
+## Tag Procedure
+
+Only after explicit user lock signal:
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z" <merge-sha>
+git push origin vX.Y.Z
+```
+
+Use an annotated tag on the merge commit. Do not tag a local-only commit, an
+unmerged branch head, or a dirty working tree.
+
+The tag push auto-fires two workflows:
+
+- `release.yml`: builds binaries and creates the GitHub Release.
+- `publish-crates.yml`: publishes the 10 crates via OIDC trusted publishing.
+
+Do not publish to crates.io manually. The workflow owns publication order and
+idempotent retries.
+
+## Post-Tag Verification
+
+After the workflows finish:
+
+1. Confirm `gh release view vX.Y.Z` returns the release.
+2. Confirm both workflow runs succeeded: `release.yml` and `publish-crates.yml`.
+3. Confirm all 10 crates are published by checking
+   `https://crates.io/api/v1/crates/<name>` and expecting
+   `max_version == X.Y.Z` for:
+   `gaze-types`, `gaze-audit`, `gaze-recognizers`, `gaze-pii`,
+   `gaze-assembly`, `gaze-mcp-core`, `gaze-mcp-rmcp`, `gaze-document`,
+   `gaze-proxy`, and `gaze-cli`.
+4. Update the orchestrator scratchpad with released URLs:
+   GitHub Release URL plus the 10 crates.io URLs.
+
+## Escalation Rules
+
+- Do not push tags without an explicit user lock signal.
+- Do not publish to crates.io manually.
+- Do not amend, delete, or force-push a tag after it has been pushed.
+  If a released tag is wrong, make a new patch release.
+- Do not put local absolute paths in release notes, PR bodies, or commit
+  messages. Use `~/` or `$HOME`.
+- If release notes need prose changes, use the `release-notes` skill before
+  publishing the GitHub Release body.
+
+## Counter-Pattern
+
+Do not just push a tag and hope. A Gaze release is complete only when the
+pre-flight gates are green, the tag was explicitly authorized, both workflows
+succeeded, all 10 crates report the expected version, and the orchestrator
+scratchpad records the shipped URLs.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,14 +22,13 @@ Run from `main` after all release-blocker PRs are merged.
    root `Cargo.toml` and all per-crate `Cargo.toml` files.
 4. Run `cargo run -p xtask -- ci-feature-matrix` and require green.
 5. Run `cargo run -p xtask -- readme-version-check` and require green.
-6. Run `git grep krishankoenig` and require zero tracked-file matches.
-7. Run `git grep -E '/Users/[a-z]+'` and require zero tracked-file matches.
+6. Run `git grep -E '/Users/[a-z]+'` and require zero tracked-file matches.
    Path-leak output is release-blocking until scrubbed to `~/` or `$HOME`.
-8. Dogfood Gaze on its own release text: pipe `dist/release-notes/vX.Y.Z.md`
+7. Dogfood Gaze on its own release text: pipe `dist/release-notes/vX.Y.Z.md`
    plus the modified `CHANGELOG.md` section through `gaze clean` and verify
    zero detections. This preserves the `feedback-dogfood-gaze-on-own-output`
    memory.
-9. Verify benchmark claims in release notes link to the script and hardware
+8. Verify benchmark claims in release notes link to the script and hardware
    specification that produced them. This preserves the
    `feedback-bench-claims-reproducible` memory.
 


### PR DESCRIPTION
## Summary
- Add `.claude/skills/release/SKILL.md` for full Gaze release orchestration.
- Cover pre-flight gates, path-leak checks, dogfood/reproducible-benchmark checks, explicit tag authorization, workflow expectations, post-tag verification, and escalation rules.
- Keep release-note voice delegated to the existing release-notes skill.

## Stack note
PR #269 was auto-closed after its stack base was deleted. This replacement PR targets `main` directly and carries the reviewed release skill changes plus the gate-6 self-trap fix.

## North star
Gaze = reversible PII pseudonymization for agentic workflows. Zero PII leaks.
Axes: Reliability, Reversibility, Agentic-first, Trust, Adopter ergonomics.
v0.10 restore-boundary work = outbound DLP / manifest integrity. NOT prompt-injection.

## North-star axis
Strengthens Axis 4 Trust and Axis 5 Adopter ergonomics by turning release execution into an explicit, repeatable checklist with clear stop conditions.
No axis is weakened.

## Verification
- `python3 ~/.scribe/skills/skill-creator/scripts/quick_validate.py .claude/skills/release` -> `Skill is valid!`
- `git grep krishankoenig .claude/skills/release/SKILL.md` -> zero matches
- `python3 -c "import yaml; print(yaml.__version__)"` -> `6.0.3`
- `scribe list 2>&1 | grep -i skill-creator` returns non-empty