### PR TITLE
[agent] docs+test: clarify Session = pseudonym namespace (closes #275)

### DIFF
--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -61,13 +61,21 @@ pub(crate) struct ParsedRestoreToken {
     pub raw: String,
 }
 
-/// Lifetime scope of a [`Session`]'s token manifest.
+/// Persistence scope of a [`Session`]'s token manifest.
+///
+/// `Scope` chooses *persistence*, not *isolation*. A [`Session`] instance is the
+/// pseudonym namespace boundary; two Sessions never share counters or value-keyed
+/// lookups, regardless of which `Scope` variant they use.
 ///
 /// | Variant | Use case | `export()` allowed |
 /// |---------|----------|--------------------|
-/// | `Ephemeral` | Single-pass sanitization, no restore needed | No |
-/// | `Conversation(id)` | Multi-turn LLM sessions | Yes |
+/// | `Ephemeral` | Process-bound one-off redaction; namespace lives until the Session is dropped | No |
+/// | `Conversation(id)` | Keyed multi-turn LLM sessions that can be re-opened across process restarts, storage backend-dependent | Yes |
 /// | `Persistent { ttl: Duration }` | Long-lived sessions across restarts | Yes |
+///
+/// Do not share one `Scope::Ephemeral` Session across logical conversations if
+/// each conversation should start with independent `Email_1` / `Person_1`
+/// counters. Use one [`Session`] per logical isolation boundary.
 ///
 /// `Persistent`'s `ttl` is a [`std::time::Duration`]. `SensitiveSnapshot`s exported from a
 /// persistent session carry the TTL; [`Session::import`] returns `Error::BlobExpired { .. }` once
@@ -168,10 +176,32 @@ struct PrefixCacheEntry {
     manifest: Vec<gaze_types::EmittedTokenSpan>,
 }
 
-/// Owns the token manifest for one conversation or request.
+/// Owns the token manifest for one pseudonym namespace.
 ///
 /// A `Session` holds the bidirectional map between PII values and their pseudonymous tokens.
 /// Create one per conversation and thread it through every [`Pipeline::redact`] call.
+///
+/// A `Session` is the boundary of a pseudonym namespace. Each new `Session`
+/// starts with fresh per-class counters (`Person_1`, `Email_1`, etc.) and a
+/// fresh `session_hex` prefix. Two Sessions never share `next_by_class`,
+/// `token_by_value`, or `value_by_token`, regardless of `Scope` variant.
+///
+/// The [`Scope`] variant chooses *persistence*, not *isolation*:
+///
+/// - `Scope::Ephemeral` is process-bound. Its namespace lives until the
+///   Session is dropped. Use it for ad-hoc one-off redaction. Do not share one
+///   `Ephemeral` Session across logical conversations if those conversations
+///   should have independent counters and value-to-token mappings.
+/// - `Scope::Conversation(String)` is a keyed namespace that can be re-opened
+///   across process restarts when the adopter stores and imports the session
+///   snapshot. Use it for per-conversation chat or per-thread agents.
+/// - `Scope::Persistent { .. }` is a long-lived namespace with a TTL encoded in
+///   exported snapshots.
+///
+/// Picking the wrong variant does not break single-call redaction correctness,
+/// but it can produce cross-call linkability: identical raw values fed into one
+/// Session always map to the same pseudonym, so downstream consumers can link
+/// mentions across contexts that the adopter intended to keep independent.
 ///
 /// # Restore workflow
 ///

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -66,6 +66,55 @@ fn same_session_reuses_token_for_same_raw_value() {
 }
 
 #[test]
+fn distinct_conversation_sessions_produce_distinct_pseudonyms_for_identical_raw_values() {
+    let pipeline = email_token_pipeline();
+    let a = Session::new(Scope::Conversation("a".to_string())).expect("session a");
+    let b = Session::new(Scope::Conversation("b".to_string())).expect("session b");
+
+    let clean_a = redact_text(&pipeline, &a, "x@y.invalid");
+    let clean_b = redact_text(&pipeline, &b, "x@y.invalid");
+
+    assert_ne!(
+        clean_a, clean_b,
+        "two Sessions must never produce the same pseudonym for identical input"
+    );
+}
+
+#[test]
+fn two_ephemeral_sessions_are_independent_namespaces() {
+    let pipeline = email_token_pipeline();
+    let a = Session::new(Scope::Ephemeral).expect("session a");
+    let b = Session::new(Scope::Ephemeral).expect("session b");
+
+    let clean_a = redact_text(&pipeline, &a, "x@y.invalid");
+    let clean_b = redact_text(&pipeline, &b, "x@y.invalid");
+
+    assert_ne!(
+        clean_a, clean_b,
+        "two Ephemeral Sessions must not share counters or value-keyed lookups"
+    );
+}
+
+fn email_token_pipeline() -> Pipeline {
+    Pipeline::builder()
+        .detector(RegexDetector::emails().expect("email detector"))
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .expect("pipeline")
+}
+
+fn redact_text(pipeline: &Pipeline, session: &Session, text: &str) -> String {
+    let clean = pipeline
+        .redact(session, RawDocument::Text(text.to_string()))
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+    text
+}
+
+#[test]
 fn raw_document_is_not_serializable() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/raw_document_serialize.rs");

--- a/docs/architecture/daemon-mode.md
+++ b/docs/architecture/daemon-mode.md
@@ -41,6 +41,30 @@ creates a new session from the policy. Reuse of the same `session_id` reuses the
 same manifest and token map. Distinct `session_id` values never share a
 manifest.
 
+## Common Pitfalls
+
+### Single Shared Session Across Conversations
+
+**Symptom:** the same email or person name in two adapter-side conversations
+produces the same pseudonym. Per-class counters (`Email_N`, `Person_N`) grow
+monotonically across the entire app lifetime. Internal value-to-token maps grow
+unboundedly.
+
+**Cause:** one `Session::new(Scope::Ephemeral)` shared across all calls. The
+`Scope` variant controls *persistence* (whether the namespace survives process
+restart), not *isolation* (whether two logical conversations share a namespace).
+
+**Fix:** use one `Session` per logical isolation boundary. For chat or agent
+threads, `Scope::Conversation(conv_id)` re-opens the same namespace on a key,
+which is useful across restarts. For ad-hoc one-shot redaction with no reuse,
+`Scope::Ephemeral` is fine.
+
+**Why this matters (axis 1):** cross-context linkability through pseudonym reuse
+is the failure mode that GDPR Art. 4(5) pseudonymization is meant to prevent. If
+two contexts that should be independent share a `Session`, the pseudonym becomes
+a stable identifier across them, which is exactly the property an attacker
+correlating two logs would exploit.
+
 ## Session Lifecycle
 
 The registry defaults to 1000 live sessions. When it exceeds `--session-cap`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pipeline = core.pipeline();
 
     // One Session per conversation -- it owns the token map.
+    // Share a Session only within the same logical isolation boundary.
     let session = Session::new(Scope::Conversation("conv-abc".into()))?;
 
     let cleaned = pipeline.redact(


### PR DESCRIPTION
## Summary

Closes #275.

External adopter (EmpireTwo/harness) hit a cross-conversation pseudonym linkability incident: one shared `Session::new(Scope::Ephemeral)` across all conversations produced identical pseudonyms for identical raw values across logically-independent conversations. This is a KDD-7 violation in the harness and, more broadly, the exact failure mode that GDPR Art. 4(5) pseudonymization is meant to prevent.

The runtime contract was always correct (per-Session namespace isolation works as designed); the misuse was invisible until cross-conversation testing was added. This PR closes the documentation + test gap that let the misuse slip through review.

## Changes

- `crates/gaze/src/session.rs` — rustdoc on `Session` and `Scope` makes explicit:
  - `Session` is the pseudonym namespace boundary.
  - `Scope` variants choose *persistence*, not *isolation*.
  - Sharing one `Ephemeral` Session across logical conversations pools their pseudonym counters.
- `docs/architecture/daemon-mode.md` — new "Common Pitfalls" section anonymizing the adopter incident.
- `crates/gaze/tests/contracts.rs` — two integration tests asserting distinct Sessions produce distinct pseudonyms for identical raw input (both `Scope::Conversation` and `Scope::Ephemeral`).
- `docs/getting-started.md` — one-line callout to share a Session only within the same logical isolation boundary.

## North-star check

- Reliability (axis 1): cross-context pseudonym linkability through shared `Session` is a leak in the GDPR pseudonymization sense. Test now locks the contract going forward.
- Reversibility (axis 2): unchanged.
- Agentic-first (axis 3): improves the multi-turn / multi-conversation agent path explicitly.
- Trust (axis 4): documented contract is honest about what `Scope` does and does not do.
- Adopter ergonomics (axis 5): docs match the mental model adopters arrive with; tests fail loudly if they get it wrong.

## Test plan

- [x] `cargo test --workspace --all-features` green.
- [x] `cargo doc --workspace --no-deps` completed; no warnings from new `Session` rustdoc. Existing unrelated broken intra-doc link warnings remain in `gaze-mcp-core` and `gaze-cli`.
- [x] Both new integration tests pass.
- [x] Dogfood: ran `gaze clean` on new prose, zero suspects / no unexpected PII tokenization.