### PR TITLE
[agent] feat(gaze-document): enforce agent/owner bundle partition at type + path level (closes #489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canonical alias is planned for v0.10 (todo #486). External adopter feedback
   prompted the reframe. (Axis 4 trust, Axis 5 ergonomics.)
 
+- **`gaze document clean` bundle layout splits into agent + owner paths**
+  (axis 1 enforcement). `Bundle::write` now requires distinct `AgentBundleDir`
+  and `OwnerBundleDir` newtypes; the writer rejects equal or nested paths
+  with typed `DocumentError::BundleLayoutInvalid`. The CLI gains
+  `--agent-out` + `--owner-out` and retains `--out` as a shorthand that
+  auto-creates `<PATH>/agent` + `<PATH>/owner` subdirs.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- **Axis-1 bundle leak risk** (closes todo #489): `gaze document clean`
+  previously wrote `manifest.json` next to `clean.md` in a single caller-
+  selected `out_dir`, with no runtime enforcement of the agent / owner
+  partition. Adopters following the README who uploaded the bundle directory
+  to an LLM workspace leaked restorable manifest material. The new split-path
+  bundle layout enforces the agent / owner partition at type and path-validation
+  level. Original two-directory `manifest.bin` signed-envelope binding (the
+  v0.7.0 architectural spec in `docs/architecture/document-extension.md`)
+  remains a v0.11+ follow-up.
 
 ### Security
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,6 +33,41 @@ exists today.)
 
 ---
 
+## v0.9.x → v0.10.0
+
+Status: **unreleased.**
+
+### TL;DR
+
+1. **Document bundles now split agent and owner outputs.** `gaze document clean`
+   requires either `--agent-out` + `--owner-out` or the `--out` shorthand that
+   creates `<PATH>/agent` + `<PATH>/owner`.
+
+### gaze document clean — bundle layout split (axis 1)
+
+Previous behavior: `gaze document clean --out <PATH>` wrote `clean.md`,
+`manifest.json`, and `report.json` into a single directory. Uploading
+that directory to an LLM workspace leaked restorable manifest material —
+an axis-1 violation that depended on caller discipline rather than
+runtime enforcement.
+
+New behavior: `gaze document clean` requires `--agent-out` + `--owner-out`
+or the `--out` shorthand that auto-creates `<PATH>/agent` + `<PATH>/owner`
+subdirs. `clean.md` and `report.json` land in the agent path; `manifest.json`
+lands in the owner path. The writer rejects equal or nested agent/owner
+paths with a typed `DocumentError::BundleLayoutInvalid`.
+
+Migration:
+
+- If you used `--out <PATH>` and you intend `<PATH>` to remain agent-shippable,
+  switch to `--agent-out <PATH> --owner-out <SOMEWHERE_ELSE>`.
+- If you can accept the agent/ + owner/ subdir split, keep `--out <PATH>` —
+  the shorthand now creates both subdirs for you.
+- Downstream tooling that read files from `<PATH>` must move manifest reads
+  to `<PATH>/owner/manifest.json` (or the explicit owner path).
+
+---
+
 ## v0.7.x → v0.8.0
 
 Status: **shipped.** v0.8.0 is published to crates.io; the workspace

--- a/crates/gaze-cli/src/commands/document.rs
+++ b/crates/gaze-cli/src/commands/document.rs
@@ -9,17 +9,27 @@ use crate::error::CliError;
 #[derive(Debug)]
 pub(crate) struct CleanArgs {
     pub input: PathBuf,
-    pub out: PathBuf,
+    pub out: Option<PathBuf>,
+    pub agent_out: Option<PathBuf>,
+    pub owner_out: Option<PathBuf>,
 }
 
 pub(crate) fn run_clean(args: CleanArgs) -> Result<(), CliError> {
-    let bundle = gaze_document::clean(&args.input, &args.out)
-        .map_err(|err| CliError::DocumentDetail(err.to_string()))?;
+    let (agent_out, owner_out) = resolve_output_dirs(args.out, args.agent_out, args.owner_out)?;
+    let bundle = gaze_document::clean(
+        &args.input,
+        gaze_document::AgentBundleDir::new(agent_out)
+            .map_err(|err| CliError::DocumentDetail(err.to_string()))?,
+        gaze_document::OwnerBundleDir::new(owner_out)
+            .map_err(|err| CliError::DocumentDetail(err.to_string()))?,
+    )
+    .map_err(|err| CliError::DocumentDetail(err.to_string()))?;
 
     let summary = serde_json::json!({
         "ok": true,
         "input": bundle.source_path.display().to_string(),
-        "out_dir": bundle.out_dir.display().to_string(),
+        "agent_out_dir": bundle.agent_out_dir.display().to_string(),
+        "owner_out_dir": bundle.owner_out_dir.display().to_string(),
         "bundle_version": bundle.report.bundle_version,
         "clean_char_count": bundle.report.clean_char_count,
         "pii_token_count": bundle.report.pii_token_count,
@@ -34,4 +44,27 @@ pub(crate) fn run_clean(args: CleanArgs) -> Result<(), CliError> {
     });
     println!("{}", serde_json::to_string(&summary).expect("json summary"));
     Ok(())
+}
+
+fn resolve_output_dirs(
+    out: Option<PathBuf>,
+    agent_out: Option<PathBuf>,
+    owner_out: Option<PathBuf>,
+) -> Result<(PathBuf, PathBuf), CliError> {
+    match (out, agent_out, owner_out) {
+        (Some(out), None, None) => {
+            let agent = out.join("agent");
+            let owner = out.join("owner");
+            tracing::info!(
+                agent_out = %agent.display(),
+                owner_out = %owner.display(),
+                "`--out` shorthand inferred split document bundle paths"
+            );
+            Ok((agent, owner))
+        }
+        (None, Some(agent), Some(owner)) => Ok((agent, owner)),
+        _ => Err(CliError::DocumentDetail(
+            "gaze document clean requires either `--out PATH` or both `--agent-out PATH --owner-out PATH`".to_string(),
+        )),
+    }
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -236,7 +236,7 @@ enum Cmd {
         #[command(subcommand)]
         command: AuditCmd,
     },
-    /// Ingest a document (PNG/JPG/PDF) into a SafeBundle (clean.md + manifest + report).
+    /// Ingest a document (PNG/JPG/PDF) into a split SafeBundle.
     ///
     /// Requires the binary to be built with `--features document`.
     #[cfg(feature = "document")]
@@ -265,14 +265,24 @@ enum Cmd {
 #[cfg(feature = "document")]
 #[derive(Subcommand, Debug)]
 enum DocumentCmd {
-    /// Run OCR + Gaze redact on `<input>`, write `clean.md`, `manifest.json`,
-    /// and `report.json` to `--out`.
+    /// Run OCR + Gaze redact on `<input>` and split agent-safe files from owner restore material.
+    #[command(group(
+        clap::ArgGroup::new("document_output")
+            .required(true)
+            .args(["out", "agent_out"])
+    ))]
     Clean {
         /// Source file. Must be `.png`, `.jpg`, `.jpeg`, or `.pdf` (single-page).
         input: PathBuf,
-        /// Output directory. Created if missing.
-        #[arg(long)]
-        out: PathBuf,
+        /// Convenience output root. Creates `<PATH>/agent` and `<PATH>/owner`.
+        #[arg(long, conflicts_with_all = ["agent_out", "owner_out"])]
+        out: Option<PathBuf>,
+        /// Agent-visible output directory for `clean.md` and `report.json`.
+        #[arg(long, requires = "owner_out")]
+        agent_out: Option<PathBuf>,
+        /// Owner-only output directory for `manifest.json`.
+        #[arg(long, requires = "agent_out")]
+        owner_out: Option<PathBuf>,
     },
 }
 
@@ -851,9 +861,17 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
         },
         #[cfg(feature = "document")]
         Cmd::Document { command } => match command {
-            DocumentCmd::Clean { input, out } => {
-                document::run_clean(document::CleanArgs { input, out })
-            }
+            DocumentCmd::Clean {
+                input,
+                out,
+                agent_out,
+                owner_out,
+            } => document::run_clean(document::CleanArgs {
+                input,
+                out,
+                agent_out,
+                owner_out,
+            }),
         },
         #[cfg(feature = "mcp")]
         Cmd::Mcp { command } => match command {

--- a/crates/gaze-cli/tests/document_clean.rs
+++ b/crates/gaze-cli/tests/document_clean.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "document")]
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn fixture_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace crates dir")
+        .join("gaze-document")
+        .join("testdata")
+        .join("synthetic_image.png")
+}
+
+fn run_document_clean(args: &[String]) -> Option<Value> {
+    let output = Command::cargo_bin("gaze")
+        .expect("gaze binary")
+        .arg("document")
+        .arg("clean")
+        .args(args)
+        .output()
+        .expect("run gaze document clean");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("tesseract binary not found") {
+            eprintln!("SKIP: tesseract not installed: {stderr}");
+            return None;
+        }
+        panic!(
+            "gaze document clean failed: status={:?} stderr={stderr}",
+            output.status
+        );
+    }
+
+    Some(serde_json::from_slice(&output.stdout).expect("stdout is JSON"))
+}
+
+#[test]
+fn cli_document_clean_split_out_writes_files_to_correct_dirs() {
+    let tmp = tempdir().expect("tempdir");
+    let input = fixture_path();
+    let agent = tmp.path().join("agent-bundle");
+    let owner = tmp.path().join("owner-vault");
+    let args = vec![
+        input.display().to_string(),
+        "--agent-out".to_string(),
+        agent.display().to_string(),
+        "--owner-out".to_string(),
+        owner.display().to_string(),
+    ];
+
+    let Some(summary) = run_document_clean(&args) else {
+        return;
+    };
+
+    assert_eq!(summary["ok"], true);
+    assert!(agent.join("clean.md").exists());
+    assert!(agent.join("report.json").exists());
+    assert!(!agent.join("manifest.json").exists());
+    assert!(owner.join("manifest.json").exists());
+    assert_eq!(dir_entry_names(&owner), vec!["manifest.json".to_string()]);
+}
+
+#[test]
+fn cli_document_clean_out_shorthand_creates_subdirs() {
+    let tmp = tempdir().expect("tempdir");
+    let input = fixture_path();
+    let out = tmp.path().join("safe-bundle");
+    let args = vec![
+        input.display().to_string(),
+        "--out".to_string(),
+        out.display().to_string(),
+    ];
+
+    let Some(summary) = run_document_clean(&args) else {
+        return;
+    };
+
+    assert_eq!(summary["ok"], true);
+    assert!(out.join("agent").join("clean.md").exists());
+    assert!(out.join("agent").join("report.json").exists());
+    assert!(!out.join("agent").join("manifest.json").exists());
+    assert!(out.join("owner").join("manifest.json").exists());
+    assert_eq!(
+        dir_entry_names(&out.join("owner")),
+        vec!["manifest.json".to_string()]
+    );
+}
+
+fn dir_entry_names(path: &std::path::Path) -> Vec<String> {
+    let mut names = std::fs::read_dir(path)
+        .expect("read dir")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -73,7 +73,8 @@ use std::path::Path;
 
 let bundle = gaze_document::clean(
     Path::new("invoice.pdf"),
-    Path::new("./safe-out"),
+    gaze_document::AgentBundleDir::new("./agent-bundle")?,
+    gaze_document::OwnerBundleDir::new("./owner-vault")?,
 )?;
 
 // Tokenized Markdown safe to hand to an LLM.
@@ -94,28 +95,38 @@ println!(
 ## Quickstart (CLI)
 
 ```bash
+# Convenience shorthand: --out creates agent/ + owner/ subdirs
 gaze document clean ./invoice.pdf --out ./safe/
+
+# Explicit: caller controls both paths
+gaze document clean ./invoice.pdf --agent-out ./agent-bundle/ --owner-out ./owner-vault/
 ```
 
 Writes:
 
 ```
-safe/
+agent/
   clean.md        # OCR text with PII replaced by reversible tokens
-  manifest.json   # gaze::Manifest — restorable, canonical
   report.json     # BundleReport — OCR + PII counts + provenance
+owner/
+  manifest.json   # gaze::Manifest — restorable, canonical
 ```
 
 Stdout carries a one-line JSON summary so callers can pipe it.
 
+`manifest.json` carries restorable PII mapping material. It belongs in an
+owner-only path; uploading it alongside `clean.md` to an LLM workspace defeats
+pseudonymization. The split layout makes that axis-1 boundary a runtime
+contract instead of caller discipline.
+
 ## Bundle on-disk shapes
 
-* **`clean.md`** — Markdown with a short header (`# gaze-document safe
+* **`agent/clean.md`** — Markdown with a short header (`# gaze-document safe
   bundle`) plus the OCR text after token substitution.
-* **`manifest.json`** — serialized `gaze::Manifest` (re-exported from
+* **`owner/manifest.json`** — serialized `gaze::Manifest` (re-exported from
   `gaze-types`). Compatible with `gaze restore` and the rest of the
   `gaze` runtime.
-* **`report.json`** — `BundleReport`. Schema versioned via
+* **`agent/report.json`** — `BundleReport`. Schema versioned via
   `bundle_version: u32 = 2`; field set is `#[non_exhaustive]` so additive
   fields are SemVer-safe. Includes per-page extraction source
   (`vector_pdf` or `ocr`), OCR backend, normalized confidence,

--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -3,20 +3,22 @@
 //! The top-level [`clean`] function is the public adopter entry point. It
 //! routes any supported input (PNG / JPG / single-page PDF) through OCR,
 //! pipes the extracted text through a [`gaze::Pipeline`], and persists the
-//! result as three files in a target directory:
+//! result as three files split across agent and owner target directories:
 //!
 //! ```text
-//! out/
+//! agent_out/
 //!   clean.md        # OCR text with PII replaced by reversible tokens
-//!   manifest.json   # gaze::Manifest — restorable, canonical
 //!   report.json     # BundleReport — OCR + PII counts + provenance
+//!
+//! owner_out/
+//!   manifest.json   # gaze::Manifest — restorable, canonical
 //! ```
 //!
 //! The manifest contract is the same one the rest of the gaze runtime
-//! uses (`gaze::Manifest`). Adopters can pair `clean.md` with `manifest.json`
-//! and restore via the standard gaze session APIs.
+//! uses (`gaze::Manifest`). Because it carries restore material, it is written
+//! only to the owner output directory.
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 use gaze::Manifest;
 use serde::{Deserialize, Serialize};
@@ -29,8 +31,6 @@ use crate::ocr::{
 use std::collections::BTreeMap;
 #[cfg(feature = "ocr-tesseract")]
 use std::fs;
-#[cfg(feature = "ocr-tesseract")]
-use std::path::Path;
 
 #[cfg(any(feature = "ocr-tesseract", feature = "mcp"))]
 use gaze::{
@@ -47,18 +47,62 @@ use gaze_types::{EmittedTokenSpan, PiiClass};
 #[cfg(feature = "ocr-tesseract")]
 use crate::extract::InputKind;
 #[cfg(feature = "ocr-tesseract")]
-use crate::DocumentError;
+use crate::{BundleLayoutInvalidReason, DocumentError};
 
 /// Versioned `report.json` schema tag (bump on breaking shape changes).
 pub const BUNDLE_VERSION: u32 = 2;
 const DEFAULT_LOW_CONFIDENCE_THRESHOLD: f32 = 0.65;
 
-/// Bundle filename written into `--out` for tokenized Markdown.
+/// Bundle filename written into the agent output directory for tokenized Markdown.
 pub const CLEAN_MARKDOWN_FILE: &str = "clean.md";
-/// Bundle filename written into `--out` for the restorable manifest.
+/// Bundle filename written into the owner output directory for the restorable manifest.
 pub const MANIFEST_FILE: &str = "manifest.json";
-/// Bundle filename written into `--out` for the OCR + PII provenance report.
+/// Bundle filename written into the agent output directory for the OCR + PII provenance report.
 pub const REPORT_FILE: &str = "report.json";
+
+/// Agent-visible SafeBundle output directory.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentBundleDir(PathBuf);
+
+impl AgentBundleDir {
+    /// Build an agent output directory wrapper.
+    ///
+    /// The directory is created later, after the paired owner directory has
+    /// been validated so equal and nested layouts fail before any bundle write.
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self, DocumentError> {
+        let path = path.into();
+        validate_non_empty_path(&path)?;
+        Ok(Self(path))
+    }
+
+    /// Return the wrapped filesystem path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+/// Owner-only SafeBundle output directory.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnerBundleDir(PathBuf);
+
+impl OwnerBundleDir {
+    /// Build an owner output directory wrapper.
+    ///
+    /// The directory is created later, after the paired agent directory has
+    /// been validated so equal and nested layouts fail before any bundle write.
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self, DocumentError> {
+        let path = path.into();
+        validate_non_empty_path(&path)?;
+        Ok(Self(path))
+    }
+
+    /// Return the wrapped filesystem path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
 
 /// Post-ingestion artifact paired with a Gaze [`Manifest`].
 #[non_exhaustive]
@@ -76,12 +120,15 @@ pub struct SafeBundle {
     pub report: BundleReport,
     /// Absolute path of the input that produced this bundle.
     pub source_path: PathBuf,
-    /// Absolute path of the output directory that received this bundle.
-    pub out_dir: PathBuf,
+    /// Absolute path of the agent-visible output directory.
+    pub agent_out_dir: PathBuf,
+    /// Absolute path of the owner-only output directory.
+    pub owner_out_dir: PathBuf,
 }
 
 impl SafeBundle {
     /// Build a [`SafeBundle`] from its component parts.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         clean_markdown: String,
         manifest: Manifest,
@@ -89,7 +136,8 @@ impl SafeBundle {
         preview_png: Option<Vec<u8>>,
         report: BundleReport,
         source_path: PathBuf,
-        out_dir: PathBuf,
+        agent_out_dir: PathBuf,
+        owner_out_dir: PathBuf,
     ) -> Self {
         Self {
             clean_markdown,
@@ -98,7 +146,8 @@ impl SafeBundle {
             preview_png,
             report,
             source_path,
-            out_dir,
+            agent_out_dir,
+            owner_out_dir,
         }
     }
 }
@@ -289,10 +338,11 @@ impl Pipeline {
     pub fn clean_with_ocr_backend(
         &self,
         input: &Path,
-        out_dir: &Path,
+        agent_out: AgentBundleDir,
+        owner_out: OwnerBundleDir,
         ocr_backend: &dyn OcrBackend,
     ) -> Result<SafeBundle, DocumentError> {
-        clean_with_options(input, out_dir, ocr_backend, *self)
+        clean_with_options(input, agent_out, owner_out, ocr_backend, *self)
     }
 }
 
@@ -328,8 +378,8 @@ impl LayoutSummary {
 /// Top-level entry point: ingest one document, write a [`SafeBundle`] to disk.
 ///
 /// `input` must be a regular file with extension `.png`, `.jpg`, `.jpeg`, or
-/// `.pdf`. `out_dir` is created if missing and populated with three files
-/// (see module docs).
+/// `.pdf`. `agent_out` and `owner_out` are created if missing and populated
+/// with the split artifact layout described in the module docs.
 ///
 /// # Errors
 ///
@@ -338,9 +388,13 @@ impl LayoutSummary {
 /// diagnose without inspecting partial bundle state.
 #[cfg(feature = "ocr-tesseract")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
-pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> {
+pub fn clean(
+    input: &Path,
+    agent_out: AgentBundleDir,
+    owner_out: OwnerBundleDir,
+) -> Result<SafeBundle, DocumentError> {
     let backend = crate::ocr::TesseractBackend::new();
-    Pipeline::new().clean_with_ocr_backend(input, out_dir, &backend)
+    Pipeline::new().clean_with_ocr_backend(input, agent_out, owner_out, &backend)
 }
 
 /// Top-level entry point with an adopter-supplied OCR backend.
@@ -357,25 +411,24 @@ pub fn clean(input: &Path, out_dir: &Path) -> Result<SafeBundle, DocumentError> 
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub fn clean_with_ocr_backend(
     input: &Path,
-    out_dir: &Path,
+    agent_out: AgentBundleDir,
+    owner_out: OwnerBundleDir,
     ocr_backend: &dyn OcrBackend,
 ) -> Result<SafeBundle, DocumentError> {
-    Pipeline::new().clean_with_ocr_backend(input, out_dir, ocr_backend)
+    Pipeline::new().clean_with_ocr_backend(input, agent_out, owner_out, ocr_backend)
 }
 
 #[cfg(feature = "ocr-tesseract")]
 fn clean_with_options(
     input: &Path,
-    out_dir: &Path,
+    agent_out: AgentBundleDir,
+    owner_out: OwnerBundleDir,
     ocr_backend: &dyn OcrBackend,
     options: Pipeline,
 ) -> Result<SafeBundle, DocumentError> {
     let kind = InputKind::detect(input)?;
     let absolute_input = absolutize(input);
-    let absolute_out = absolutize(out_dir);
-
-    fs::create_dir_all(out_dir)
-        .map_err(|err| DocumentError::OutputDir(absolute_out.clone(), err))?;
+    let (absolute_agent_out, absolute_owner_out) = prepare_bundle_dirs(&agent_out, &owner_out)?;
 
     let extraction = run_document_extraction(input, kind, ocr_backend, options)?;
     // Repair known narrow OCR artifacts (e.g. spurious whitespace around
@@ -418,7 +471,7 @@ fn clean_with_options(
     );
 
     let clean_markdown = format_clean_markdown(&clean_text, kind);
-    write_bundle(out_dir, &clean_markdown, &manifest, &report)?;
+    write_bundle(&agent_out, &owner_out, &clean_markdown, &manifest, &report)?;
 
     Ok(SafeBundle::new(
         clean_markdown,
@@ -427,7 +480,8 @@ fn clean_with_options(
         None,
         report,
         absolute_input,
-        absolute_out,
+        absolute_agent_out,
+        absolute_owner_out,
     ))
 }
 
@@ -687,17 +741,86 @@ fn count_pii_by_class(spans: &[EmittedTokenSpan]) -> Vec<ClassCount> {
 
 #[cfg(feature = "ocr-tesseract")]
 fn write_bundle(
-    out_dir: &Path,
+    agent_out: &AgentBundleDir,
+    owner_out: &OwnerBundleDir,
     clean_markdown: &str,
     manifest: &Manifest,
     report: &BundleReport,
 ) -> Result<(), DocumentError> {
-    fs::write(out_dir.join(CLEAN_MARKDOWN_FILE), clean_markdown)?;
+    fs::write(
+        agent_out.as_path().join(CLEAN_MARKDOWN_FILE),
+        clean_markdown,
+    )?;
     let manifest_json = serde_json::to_vec_pretty(manifest)?;
-    fs::write(out_dir.join(MANIFEST_FILE), manifest_json)?;
+    fs::write(owner_out.as_path().join(MANIFEST_FILE), manifest_json)?;
     let report_json = serde_json::to_vec_pretty(report)?;
-    fs::write(out_dir.join(REPORT_FILE), report_json)?;
+    fs::write(agent_out.as_path().join(REPORT_FILE), report_json)?;
     Ok(())
+}
+
+#[cfg(feature = "ocr-tesseract")]
+fn prepare_bundle_dirs(
+    agent_out: &AgentBundleDir,
+    owner_out: &OwnerBundleDir,
+) -> Result<(PathBuf, PathBuf), DocumentError> {
+    let agent = normalize_for_layout(agent_out.as_path());
+    let owner = normalize_for_layout(owner_out.as_path());
+    validate_bundle_layout(&agent, &owner)?;
+
+    fs::create_dir_all(agent_out.as_path())
+        .map_err(|err| DocumentError::OutputDir(agent.clone(), err))?;
+    fs::create_dir_all(owner_out.as_path())
+        .map_err(|err| DocumentError::OutputDir(owner.clone(), err))?;
+
+    let agent = fs::canonicalize(agent_out.as_path()).unwrap_or(agent);
+    let owner = fs::canonicalize(owner_out.as_path()).unwrap_or(owner);
+    validate_bundle_layout(&agent, &owner)?;
+    Ok((agent, owner))
+}
+
+fn validate_non_empty_path(path: &Path) -> Result<(), DocumentError> {
+    if path.as_os_str().is_empty() {
+        return Err(DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::EmptyPath,
+        });
+    }
+    Ok(())
+}
+
+fn validate_bundle_layout(agent: &Path, owner: &Path) -> Result<(), DocumentError> {
+    if agent == owner {
+        return Err(DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::AgentEqualsOwner,
+        });
+    }
+    if agent.starts_with(owner) {
+        return Err(DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::AgentNestedInOwner,
+        });
+    }
+    if owner.starts_with(agent) {
+        return Err(DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::OwnerNestedInAgent,
+        });
+    }
+    Ok(())
+}
+
+fn normalize_for_layout(path: &Path) -> PathBuf {
+    let absolute = absolutize(path);
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
 }
 
 #[cfg(feature = "ocr-tesseract")]
@@ -722,7 +845,6 @@ pub(crate) fn kind_label(kind: InputKind) -> &'static str {
     }
 }
 
-#[cfg(feature = "ocr-tesseract")]
 fn absolutize(path: &Path) -> PathBuf {
     if path.is_absolute() {
         path.to_path_buf()
@@ -768,6 +890,13 @@ mod tests {
             bbox: BBox { x, y, w: 90, h: 16 },
             confidence: Some(confidence),
         }
+    }
+
+    fn bundle_dirs(tmp: &tempfile::TempDir) -> (AgentBundleDir, OwnerBundleDir) {
+        (
+            AgentBundleDir::new(tmp.path().join("agent")).expect("agent dir"),
+            OwnerBundleDir::new(tmp.path().join("owner")).expect("owner dir"),
+        )
     }
 
     #[test]
@@ -859,10 +988,11 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
         fs::write(&input, b"\x89PNG\r\n\x1A\nnot-real-image").expect("write input");
+        let (agent_out, owner_out) = bundle_dirs(&tmp);
 
         let bundle = Pipeline::new()
             .with_low_confidence_threshold(0.65)
-            .clean_with_ocr_backend(&input, tmp.path(), &backend)
+            .clean_with_ocr_backend(&input, agent_out, owner_out, &backend)
             .expect("clean succeeds");
 
         assert_eq!(bundle.report.bundle_version, 2);
@@ -899,9 +1029,10 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
         fs::write(&input, b"\x89PNG\r\n\x1A\nnot-real-image").expect("write input");
+        let (agent_out, owner_out) = bundle_dirs(&tmp);
 
         let bundle = Pipeline::new()
-            .clean_with_ocr_backend(&input, tmp.path(), &backend)
+            .clean_with_ocr_backend(&input, agent_out, owner_out, &backend)
             .expect("clean succeeds");
 
         assert_eq!(bundle.report.pages[0].column_count, 1);
@@ -966,9 +1097,10 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
         fs::write(&input, bytes).expect("write input");
+        let (agent_out, owner_out) = bundle_dirs(&tmp);
 
         let bundle = Pipeline::new()
-            .clean_with_ocr_backend(&input, tmp.path(), &OrientationSensitiveBackend)
+            .clean_with_ocr_backend(&input, agent_out, owner_out, &OrientationSensitiveBackend)
             .expect("clean succeeds");
 
         assert!(
@@ -1068,9 +1200,10 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let input = tmp.path().join("input.png");
         fs::write(&input, bytes).expect("write input");
+        let (agent_out, owner_out) = bundle_dirs(&tmp);
 
         let bundle = Pipeline::new()
-            .clean_with_ocr_backend(&input, tmp.path(), &backend)
+            .clean_with_ocr_backend(&input, agent_out, owner_out, &backend)
             .expect("clean succeeds");
 
         assert!(

--- a/crates/gaze-document/src/lib.rs
+++ b/crates/gaze-document/src/lib.rs
@@ -2,9 +2,10 @@
 //!
 //! `gaze-document` turns a single image (PNG / JPG) or PDF into a
 //! [`SafeBundle`]: tokenized Markdown, a restorable [`gaze::Manifest`], and a
-//! structured OCR + PII [`BundleReport`]. PII detection flows through the
-//! standard [`gaze::Pipeline`] so the manifest stays canonical and reversible
-//! (Axis 2 reversibility).
+//! structured OCR + PII [`BundleReport`]. Agent-safe files and owner-only
+//! restore material are written to separate output directories. PII detection
+//! flows through the standard [`gaze::Pipeline`] so the manifest stays
+//! canonical and reversible (Axis 2 reversibility).
 //!
 //! # Quickstart
 //!
@@ -13,7 +14,8 @@
 //!
 //! let bundle = gaze_document::clean(
 //!     Path::new("invoice.pdf"),
-//!     Path::new("./safe-out"),
+//!     gaze_document::AgentBundleDir::new("./agent-out")?,
+//!     gaze_document::OwnerBundleDir::new("./owner-out")?,
 //! )?;
 //! assert!(!bundle.clean_markdown.is_empty());
 //! # Ok::<(), gaze_document::DocumentError>(())
@@ -54,8 +56,8 @@ pub mod render;
 #[cfg_attr(docsrs, doc(cfg(feature = "ocr-tesseract")))]
 pub use bundle::{clean, clean_with_ocr_backend};
 pub use bundle::{
-    BundleReport, ClassCount, LayoutSummary, OcrSource, PageReport, Pipeline, SafeBundle,
-    BUNDLE_VERSION,
+    AgentBundleDir, BundleReport, ClassCount, LayoutSummary, OcrSource, OwnerBundleDir, PageReport,
+    Pipeline, SafeBundle, BUNDLE_VERSION,
 };
 pub use layout::ReadingOrder;
 #[cfg(feature = "ocr-tesseract")]
@@ -102,6 +104,12 @@ pub enum DocumentError {
     Io(std::io::Error),
     /// The bundle output directory could not be prepared.
     OutputDir(std::path::PathBuf, std::io::Error),
+    /// The requested agent/owner bundle directory pair violates the runtime
+    /// partition contract.
+    BundleLayoutInvalid {
+        /// Machine-readable reason for the layout rejection.
+        reason: BundleLayoutInvalidReason,
+    },
     /// `gaze::Pipeline` construction or invocation failed.
     Pipeline(String),
     /// `serde_json` serialization of the bundle report or manifest failed.
@@ -110,6 +118,20 @@ pub enum DocumentError {
     /// implementation yet. Returned by reserved stubs (Renderer trait,
     /// ReadingOrder) until follow-up PRs land.
     NotImplemented(&'static str),
+}
+
+/// Closed reason set for invalid SafeBundle agent/owner output layouts.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleLayoutInvalidReason {
+    /// Agent and owner outputs resolve to the same directory.
+    AgentEqualsOwner,
+    /// The agent output directory is nested inside the owner output directory.
+    AgentNestedInOwner,
+    /// The owner output directory is nested inside the agent output directory.
+    OwnerNestedInAgent,
+    /// One output path was empty and cannot name a directory.
+    EmptyPath,
 }
 
 impl core::fmt::Display for DocumentError {
@@ -140,11 +162,35 @@ impl core::fmt::Display for DocumentError {
                 "gaze-document: cannot prepare output dir `{}`: {err}",
                 path.display()
             ),
+            Self::BundleLayoutInvalid { reason } => {
+                write!(f, "gaze-document: invalid bundle layout: {reason}")
+            }
             Self::Pipeline(detail) => write!(f, "gaze-document: pipeline error: {detail}"),
             Self::Serde(err) => write!(f, "gaze-document: serialize error: {err}"),
             Self::NotImplemented(what) => {
                 write!(f, "gaze-document: {what} is not yet implemented")
             }
+        }
+    }
+}
+
+impl core::fmt::Display for BundleLayoutInvalidReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AgentEqualsOwner => write!(f, "agent and owner output directories are equal"),
+            Self::AgentNestedInOwner => {
+                write!(
+                    f,
+                    "agent output directory is nested inside owner output directory"
+                )
+            }
+            Self::OwnerNestedInAgent => {
+                write!(
+                    f,
+                    "owner output directory is nested inside agent output directory"
+                )
+            }
+            Self::EmptyPath => write!(f, "bundle output directory path is empty"),
         }
     }
 }

--- a/crates/gaze-document/tests/e2e.rs
+++ b/crates/gaze-document/tests/e2e.rs
@@ -6,7 +6,8 @@
 //!
 //! * `clean.md` exists, contains the canonical tokenized substrings, and
 //!   carries **none** of the original PII literals.
-//! * `manifest.json` deserializes back into a `gaze::Manifest` and contains
+//! * `manifest.json` in the owner directory deserializes back into a
+//!   `gaze::Manifest` and contains
 //!   at least one `Email` + one `Custom("phone")` span.
 //! * `report.json` deserializes into a `BundleReport` shape with
 //!   `bundle_version = 2`, per-page provenance, and non-zero PII counts.
@@ -23,7 +24,10 @@
 use std::path::{Path, PathBuf};
 
 use gaze::Manifest;
-use gaze_document::{BundleReport, DocumentError, OcrSource, BUNDLE_VERSION};
+use gaze_document::{
+    AgentBundleDir, BundleLayoutInvalidReason, BundleReport, DocumentError, OcrSource,
+    OwnerBundleDir, BUNDLE_VERSION,
+};
 use gaze_types::PiiClass;
 
 const ORIGINAL_EMAIL: &str = "jane.doe@example.invalid";
@@ -46,7 +50,13 @@ fn skip_reason(err: &DocumentError) -> Option<&'static str> {
 
 fn assert_clean_bundle(input: &Path, expect_pdf_fields: bool) {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let bundle = match gaze_document::clean(input, tmp.path()) {
+    let agent_dir = tmp.path().join("agent");
+    let owner_dir = tmp.path().join("owner");
+    let bundle = match gaze_document::clean(
+        input,
+        AgentBundleDir::new(&agent_dir).expect("agent dir"),
+        OwnerBundleDir::new(&owner_dir).expect("owner dir"),
+    ) {
         Ok(b) => b,
         Err(err) => {
             if let Some(why) = skip_reason(&err) {
@@ -57,12 +67,16 @@ fn assert_clean_bundle(input: &Path, expect_pdf_fields: bool) {
         }
     };
 
-    let clean_md_path = tmp.path().join("clean.md");
-    let manifest_path = tmp.path().join("manifest.json");
-    let report_path = tmp.path().join("report.json");
+    let clean_md_path = agent_dir.join("clean.md");
+    let manifest_path = owner_dir.join("manifest.json");
+    let report_path = agent_dir.join("report.json");
     assert!(clean_md_path.exists(), "clean.md missing");
     assert!(manifest_path.exists(), "manifest.json missing");
     assert!(report_path.exists(), "report.json missing");
+    assert!(
+        !agent_dir.join("manifest.json").exists(),
+        "agent dir must not contain restorable manifest material"
+    );
 
     let clean_text = std::fs::read_to_string(&clean_md_path).expect("clean.md readable");
     // Belt-and-braces negative substring checks. Each one independently
@@ -159,6 +173,14 @@ fn assert_clean_bundle(input: &Path, expect_pdf_fields: bool) {
     // Sanity: the in-memory bundle matches the written report.
     assert_eq!(bundle.report.bundle_version, BUNDLE_VERSION);
     assert_eq!(bundle.report.pii_token_count, report.pii_token_count);
+    assert_eq!(
+        bundle.agent_out_dir,
+        std::fs::canonicalize(&agent_dir).unwrap()
+    );
+    assert_eq!(
+        bundle.owner_out_dir,
+        std::fs::canonicalize(&owner_dir).unwrap()
+    );
 }
 
 #[test]
@@ -174,4 +196,117 @@ fn synthetic_doc_pdf_clean_emits_safe_bundle() {
     let input = testdata_dir().join("synthetic_doc.pdf");
     assert!(input.exists(), "missing fixture: {}", input.display());
     assert_clean_bundle(&input, true);
+}
+
+#[test]
+fn bundle_writer_rejects_equal_agent_and_owner_paths() {
+    let input = testdata_dir().join("synthetic_image.png");
+    assert!(input.exists(), "missing fixture: {}", input.display());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let err = gaze_document::clean(
+        &input,
+        AgentBundleDir::new(tmp.path()).expect("agent dir"),
+        OwnerBundleDir::new(tmp.path()).expect("owner dir"),
+    )
+    .expect_err("equal bundle paths must be rejected");
+
+    assert!(matches!(
+        err,
+        DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::AgentEqualsOwner
+        }
+    ));
+}
+
+#[test]
+fn bundle_writer_rejects_nested_paths() {
+    let input = testdata_dir().join("synthetic_image.png");
+    assert!(input.exists(), "missing fixture: {}", input.display());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let err = gaze_document::clean(
+        &input,
+        AgentBundleDir::new(tmp.path().join("agent")).expect("agent dir"),
+        OwnerBundleDir::new(tmp.path().join("agent").join("owner")).expect("owner dir"),
+    )
+    .expect_err("nested bundle paths must be rejected");
+
+    assert!(matches!(
+        err,
+        DocumentError::BundleLayoutInvalid {
+            reason: BundleLayoutInvalidReason::OwnerNestedInAgent
+        }
+    ));
+}
+
+#[test]
+fn agent_dir_contains_no_manifest_material() {
+    let input = testdata_dir().join("synthetic_image.png");
+    assert!(input.exists(), "missing fixture: {}", input.display());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agent_dir = tmp.path().join("agent");
+    let owner_dir = tmp.path().join("owner");
+    match gaze_document::clean(
+        &input,
+        AgentBundleDir::new(&agent_dir).expect("agent dir"),
+        OwnerBundleDir::new(&owner_dir).expect("owner dir"),
+    ) {
+        Ok(_) => {}
+        Err(err) => {
+            if let Some(why) = skip_reason(&err) {
+                eprintln!("SKIP: {why}: {err}");
+                return;
+            }
+            panic!("gaze_document::clean failed: {err}");
+        }
+    }
+
+    let names = dir_entry_names(&agent_dir);
+    assert_eq!(
+        names,
+        vec!["clean.md".to_string(), "report.json".to_string()]
+    );
+    assert!(!names.iter().any(|name| name == "manifest.json"));
+}
+
+#[test]
+fn owner_dir_contains_only_manifest() {
+    let input = testdata_dir().join("synthetic_image.png");
+    assert!(input.exists(), "missing fixture: {}", input.display());
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agent_dir = tmp.path().join("agent");
+    let owner_dir = tmp.path().join("owner");
+    match gaze_document::clean(
+        &input,
+        AgentBundleDir::new(&agent_dir).expect("agent dir"),
+        OwnerBundleDir::new(&owner_dir).expect("owner dir"),
+    ) {
+        Ok(_) => {}
+        Err(err) => {
+            if let Some(why) = skip_reason(&err) {
+                eprintln!("SKIP: {why}: {err}");
+                return;
+            }
+            panic!("gaze_document::clean failed: {err}");
+        }
+    }
+
+    assert_eq!(
+        dir_entry_names(&owner_dir),
+        vec!["manifest.json".to_string()]
+    );
+}
+
+fn dir_entry_names(path: &Path) -> Vec<String> {
+    let mut names = std::fs::read_dir(path)
+        .expect("read dir")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    names
 }

--- a/docs/architecture/document-extension.md
+++ b/docs/architecture/document-extension.md
@@ -10,18 +10,19 @@ Only the owner-side snapshot envelope may contain reversible PII. Agent-facing
 files must be safe to upload to an LLM workspace as a unit.
 
 ```text
-<base>-agent/
+agent_out/
   clean.md
-  layout.json
-  preview-redacted.png
   report.json
 
-<base>-owner/
-  manifest.bin
+owner_out/
+  manifest.json
 ```
 
-`<base>-agent/` is the agent-shippable directory. `<base>-owner/manifest.bin` is
-owner-only restore material produced by `Session::export_with_extension`.
+`agent_out` is the agent-shippable directory. `owner_out/manifest.json` is
+owner-only restore material. The original `manifest.bin` signed-envelope binding
+remains a v0.11+ Design B follow-up; v0.10 Design A keeps the shipped JSON
+manifest and enforces the partition with `AgentBundleDir` / `OwnerBundleDir`
+newtypes plus path validation.
 
 ## File Shapes
 
@@ -31,11 +32,12 @@ owner-only restore material produced by `Session::export_with_extension`.
 frontmatter, comments, or duplicated metadata. Byte spans are relative to this
 normalized file.
 
-### manifest.bin
+### manifest.json
 
-`manifest.bin` is the existing signed snapshot envelope with an optional
-`DocumentExtension` field inside the payload. It is the only v0.7.0 bundle file
-that can carry reversible PII, so it stays in `<base>-owner/`.
+`manifest.json` is the shipped `gaze::Manifest` restore mapping. It is the only
+v0.10 bundle file that can carry reversible PII, so it stays in `owner_out`.
+Moving the owner restore material to the signed snapshot envelope
+(`Session::export_with_extension` -> `manifest.bin`) is deferred to v0.11+.
 
 ### layout.json
 
@@ -83,6 +85,8 @@ continues to restore both plain v3 and document-extended v4 snapshots.
 
 ## Shipped in v0.7.1
 
-`gaze-document` now ships the OSS document-ingestion path on top of this hook:
-PNG/JPG/PDF input, Tesseract OCR, optional PDF rasterization, `write_bundle`
-runtime separation, and a versioned `BundleReport` with `bundle_version = 1`.
+`gaze-document` now ships the OSS document-ingestion path with PNG/JPG/PDF
+input, Tesseract OCR, optional PDF rasterization, `write_bundle` runtime
+separation, and a versioned `BundleReport` with `bundle_version = 2`. The
+signed `DocumentExtension` envelope shown above is still the intended Design B
+integrity upgrade, not the v0.10 on-disk owner manifest.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ Every verb below is defined by the clap `Subcommand` enum in
 | [`gaze audit export`](../crates/gaze-cli/README.md#audit-export) | Export filtered redaction-log metadata rows as JSONL for downstream processing. | always |
 | `gaze audit purge` | Manually delete redaction-log metadata rows older than an ISO 8601 UTC timestamp. See [guide](#gaze-audit-purge). | always |
 | [`gaze audit safety-net query`](../crates/gaze-cli/README.md#audit-safety-net-query) | Print filtered `safety_net_log` rows as TSV. See [guide](#gaze-audit-safety-net-query). | always |
-| `gaze document clean` | OCR a PNG/JPG/PDF into a `SafeBundle` (`clean.md` + `manifest.json` + `report.json`). See [guide](#gaze-document-clean) and [crate README](../crates/gaze-document/README.md). | `document` |
+| `gaze document clean` | OCR a PNG/JPG/PDF into a split `SafeBundle` (`agent/clean.md`, `agent/report.json`, `owner/manifest.json`). See [guide](#gaze-document-clean) and [crate README](../crates/gaze-document/README.md). | `document` |
 | `gaze mcp install` | Install `gaze mcp serve` into a supported MCP client config. See [guide](#gaze-mcp-install--doctor--serve) and [crate README](../crates/gaze-cli/README.md#mcp-installation). | `mcp` |
 | `gaze mcp doctor` | Diagnose MCP runtime dependencies, client config, and AGENTS.md guidance. See [guide](#gaze-mcp-install--doctor--serve) and [crate README](../crates/gaze-cli/README.md#mcp-installation). | `mcp` |
 | `gaze mcp serve` | Run the stdio MCP server exposing agent-tier document tools. See [guide](#gaze-mcp-install--doctor--serve) and [crate README](../crates/gaze-cli/README.md#mcp-installation). | `mcp` |
@@ -259,18 +259,33 @@ input:
 
 `gaze document clean` is the OSS document ingestion verb. It OCRs the input
 through Tesseract, redacts the recognized text through the standard Gaze
-pipeline, and writes a `SafeBundle` to `--out`: `clean.md` (tokenized text),
-`manifest.json` (restore mapping), and `report.json` (per-detection metadata).
+pipeline, and writes a split `SafeBundle`: `clean.md` and `report.json` go to
+the agent-visible output, while `manifest.json` goes to the owner-only output.
 Requires the binary to be built with `--features document`, and the host must
 have `tesseract` on PATH plus the pdfium runtime for PDF input.
 
 ```sh
 cargo install gaze-cli --features document
+
+# Convenience shorthand: creates ./safe-bundle/agent and ./safe-bundle/owner.
 gaze document clean ./invoice.pdf --out ./safe-bundle/
+
+# Explicit: caller controls both sides of the partition.
+gaze document clean ./invoice.pdf --agent-out ./agent-bundle/ --owner-out ./owner-vault/
 ```
 
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--out <PATH>` | Either this or both explicit flags | Convenience shorthand that creates `<PATH>/agent` and `<PATH>/owner`. |
+| `--agent-out <PATH>` | With `--owner-out` | Agent-visible directory for `clean.md` and `report.json`. |
+| `--owner-out <PATH>` | With `--agent-out` | Owner-only directory for `manifest.json`. |
+
+Do not upload `owner/manifest.json` to an LLM workspace. It carries restorable
+PII mapping material; placing it beside `clean.md` defeats pseudonymization.
+The split output layout makes that axis-1 boundary a runtime contract.
+
 The supported inputs are `.png`, `.jpg`, `.jpeg`, and single-page `.pdf`. The
-`BundleReport` schema is versioned via `bundle_version = 1`. See the
+`BundleReport` schema is versioned via `bundle_version = 2`. See the
 `gaze-document` crate for the full bundle contract.
 
 ### Legacy audit databases

--- a/docs/getting-started/document-workflow.md
+++ b/docs/getting-started/document-workflow.md
@@ -13,16 +13,24 @@ bundle that is safe to hand to an agent workspace:
 source document -> OCR / PDF text extraction -> Gaze redact -> SafeBundle
 ```
 
-The output directory contains:
+The bundle is split across two output directories:
 
 ```text
-clean.md
-manifest.json
-report.json
+agent/
+  clean.md
+  report.json
+
+owner/
+  manifest.json
 ```
 
-`clean.md` is the tokenized Markdown. `manifest.json` is the restorable
-`gaze::Manifest`. `report.json` carries OCR, layout, and PII-count provenance.
+`clean.md` is the tokenized Markdown. `report.json` carries OCR, layout, and
+PII-count provenance. `manifest.json` is the restorable `gaze::Manifest`.
+
+Keep `owner/manifest.json` out of LLM workspaces. It carries the restore mapping
+for the original PII, so uploading it with `clean.md` defeats the
+pseudonymization boundary. The split layout exists so the agent-visible path can
+be shared without owner-only restore material riding along.
 
 ## Prerequisites
 
@@ -51,33 +59,39 @@ with your platform's dynamic-library path.
 Run OCR plus Gaze redaction:
 
 ```sh
+# Convenience shorthand: --out creates agent/ + owner/ subdirs.
 gaze document clean ./invoice.pdf --out ./safe-bundle/
+
+# Explicit: caller controls both paths.
+gaze document clean ./invoice.pdf --agent-out ./agent-bundle/ --owner-out ./owner-vault/
 ```
 
 The source document can be a synthetic fixture such as an invoice PDF containing
-`alice@example.invalid`. The output directory is created if it does not exist.
+`alice@example.invalid`. Output directories are created if they do not exist.
 
 Successful stdout is a one-line JSON summary; the bundle files are written to
-`--out`.
+the resolved agent and owner outputs.
 
 ```text
 safe-bundle/
-  clean.md
-  manifest.json
-  report.json
+  agent/
+    clean.md
+    report.json
+  owner/
+    manifest.json
 ```
 
 ## SafeBundle Anatomy
 
-`clean.md` contains Markdown with PII replaced by reversible Gaze tokens. It is
-the file to provide to the agent or model-facing workflow.
+`agent/clean.md` contains Markdown with PII replaced by reversible Gaze tokens.
+It is the file to provide to the agent or model-facing workflow.
 
-`manifest.json` contains the `gaze::Manifest` needed for restore. Keep it on the
-owner side with the same controls used for other restore material.
-
-`report.json` serializes `BundleReport`. New emissions use
+`agent/report.json` serializes `BundleReport`. New emissions use
 `bundle_version = 2`; older v1 reports still deserialize, but v2 is the current
 layout-report shape.
+
+`owner/manifest.json` contains the `gaze::Manifest` needed for restore. Keep it
+on the owner side with the same controls used for other restore material.
 
 Important per-page fields:
 
@@ -134,15 +148,16 @@ the restore contract in
 ## Five-Axis Pitch
 
 - Reliability: OCR output is normalized before redaction, and low-confidence
-  pages are surfaced for downstream routing.
-- Reversibility: `manifest.json` carries the same restore contract as the rest
-  of Gaze.
-- Agentic-first: `clean.md` is safe Markdown for agent workspaces; the owner
-  keeps restore material.
+  pages are surfaced for downstream routing. The agent and owner output
+  directories are separated by runtime path validation.
+- Reversibility: `owner/manifest.json` carries the same restore contract as the
+  rest of Gaze.
+- Agentic-first: `agent/clean.md` and `agent/report.json` are safe for agent
+  workspaces; the owner keeps restore material.
 - Trust: `report.json` records OCR source, backend, confidence, layout, and PII
   counts without raw PII.
-- Adopter ergonomics: one CLI verb turns PNG, JPG, or PDF input into a
-  three-file SafeBundle.
+- Adopter ergonomics: one CLI verb turns PNG, JPG, or PDF input into a split
+  SafeBundle, with `--out` preserving the one-flag workflow.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Closes todo #489. Axis-1 enforcement for the gaze-document SafeBundle: separates agent-safe artifacts from owner-only manifest material at type and path-validation level. Caller cannot accidentally write `manifest.json` next to `clean.md` anymore.

External adopter scenario the previous layout failed: an adopter follows the README, runs `gaze document clean ./input.pdf --out ./safe-bundle/`, uploads `./safe-bundle/` to an LLM workspace. With the previous flat layout, `manifest.json` rides along — leaking restorable PII the workspace agent can use to undo pseudonymization. Investigation evidence: scratchpad 686.

Design A (this PR): flat per-directory layout, caller controls agent and owner paths via newtypes. Design B (`manifest.bin` signed-envelope binding from the v0.7.0 architectural spec) is deferred to v0.11+ as a follow-up.

## Changes (summary)

- New types in `gaze-document`: `AgentBundleDir`, `OwnerBundleDir`, `BundleLayoutInvalidReason`.
- `Bundle::write` (and adjacent writer fns) now require both newtypes. Path validation rejects equal or nested agent/owner paths with typed `DocumentError::BundleLayoutInvalid`.
- CLI: `gaze document clean` gains `--agent-out PATH` + `--owner-out PATH`. `--out PATH` retained as a shorthand that auto-creates `PATH/agent` + `PATH/owner` subdirs. `--out` is mutually exclusive with the explicit flags.
- Tests: regression tests assert agent dir contains no manifest material, owner dir contains only manifest, equal + nested paths rejected.
- Docs: `crates/gaze-document/README.md`, `docs/cli.md`, `docs/getting-started/document-workflow.md`, and `docs/architecture/document-extension.md` updated for the new layout + axis-1 callout. `UPGRADE.md` carries the v0.10 migration entry. `CHANGELOG.md` has the entry in `[Unreleased]`.

## North-star check

- Reliability (axis 1): closes the leak risk. Runtime enforcement, not caller discipline.
- Reversibility (axis 2): unchanged. JSON manifest remains. Design B (signed-envelope binding) deferred to v0.11+.
- Agentic-first (axis 3): unchanged.
- Trust (axis 4): typed error, type-level guard, no silent acceptance of misconfigured paths.
- Adopter ergonomics (axis 5): `--out` shorthand preserves the one-flag workflow for adopters who don't need explicit control. UPGRADE.md spells out the migration cost.

## Test plan

CI checks not run — gh actions has a billing issue, gates were run locally on `8d8cc8c`.

- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`.
- [x] `cargo test --workspace --all-features` green.
- [x] `cargo run -p xtask -- ci-feature-matrix` green.
- [x] `cargo doc --workspace --no-deps` completed; observed pre-existing rustdoc warnings in `gaze-mcp-core` and CLI `[ner]` option docs, no new bundle-doc warnings.
- [x] New regression tests pass.
- [x] Dogfood: ran `gaze clean` on all new prose, no stderr stats emitted.
- [x] Manual smoke: built the binary, ran `gaze document clean` with both `--out` and explicit flags, verified resulting layout.
- [x] Manual smoke: verified equal and nested agent/owner paths are rejected with the typed document layout error.
