### PR TITLE
feat(cli): accessibility output gate + tests (NLnet submit-gap business#31)

### DIFF
--- a/crates/gaze-cli/src/commands/mcp/doctor.rs
+++ b/crates/gaze-cli/src/commands/mcp/doctor.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::error::CliError;
+use crate::style;
 
 use super::install::{targets, ClientTarget};
 use super::serve::default_manifest_dir;
@@ -33,11 +34,12 @@ pub(crate) fn run(args: DoctorArgs) -> Result<(), CliError> {
                 .map_err(|err| CliError::McpDetail(format!("doctor JSON failed: {err}")))?
         );
     } else {
+        let ansi_enabled = style::ansi_enabled(&std::io::stdout());
         println!("{:<5}\t{:<28}\tevidence", "state", "check");
         for check in &checks {
             println!(
-                "{:<5}\t{:<28}\t{}",
-                check.state.as_str(),
+                "{}\t{:<28}\t{}",
+                check.state.styled(ansi_enabled),
                 check.name,
                 check.evidence
             );
@@ -75,6 +77,14 @@ impl CheckState {
             Self::Pass => "pass",
             Self::Warn => "warn",
             Self::Fail => "fail",
+        }
+    }
+
+    fn styled(self, ansi_enabled: bool) -> String {
+        match self {
+            Self::Pass => style::paint(self.as_str(), style::GREEN, ansi_enabled),
+            Self::Warn => style::paint(self.as_str(), style::YELLOW, ansi_enabled),
+            Self::Fail => style::paint(self.as_str(), style::RED, ansi_enabled),
         }
     }
 }

--- a/crates/gaze-cli/src/main.rs
+++ b/crates/gaze-cli/src/main.rs
@@ -13,6 +13,7 @@ mod io;
 mod logger;
 mod pipeline;
 mod restore;
+mod style;
 
 use clap::Parser;
 

--- a/crates/gaze-cli/src/style.rs
+++ b/crates/gaze-cli/src/style.rs
@@ -1,0 +1,29 @@
+use std::io::IsTerminal;
+
+const RESET: &str = "\x1b[0m";
+
+pub(crate) const GREEN: &str = "\x1b[32m";
+pub(crate) const YELLOW: &str = "\x1b[33m";
+pub(crate) const RED: &str = "\x1b[31m";
+
+pub(crate) fn ansi_enabled(stream: &impl IsTerminal) -> bool {
+    if env_non_empty("NO_COLOR") {
+        return false;
+    }
+    if env_non_empty("CLICOLOR_FORCE") {
+        return true;
+    }
+    stream.is_terminal()
+}
+
+pub(crate) fn paint(text: &'static str, color: &str, enabled: bool) -> String {
+    if enabled {
+        format!("{color}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+fn env_non_empty(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}

--- a/crates/gaze-cli/tests/mcp_doctor_color.rs
+++ b/crates/gaze-cli/tests/mcp_doctor_color.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "mcp")]
+
+use std::ffi::OsString;
+
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+fn doctor_output(envs: &[(&str, &str)]) -> String {
+    let temp = tempdir().expect("tempdir");
+    let exe = assert_cmd::cargo::cargo_bin("gaze");
+    let exe_dir = exe.parent().expect("gaze bin parent");
+    let agents_dir = temp.path().join("agents-dir");
+    std::fs::create_dir(&agents_dir).expect("agents dir");
+
+    let mut path = OsString::from(exe_dir);
+    if let Some(existing_path) = std::env::var_os("PATH") {
+        path.push(":");
+        path.push(existing_path);
+    }
+
+    let mut command = Command::new(exe);
+    command
+        .current_dir(temp.path())
+        .args([
+            "mcp",
+            "doctor",
+            "--agents-md",
+            agents_dir.to_str().expect("agents path"),
+        ])
+        .env("PATH", path)
+        .env(
+            "GAZE_MCP_CLAUDE_DESKTOP_CONFIG",
+            temp.path().join("missing-claude-desktop.json"),
+        )
+        .env_remove("NO_COLOR")
+        .env_remove("CLICOLOR_FORCE");
+
+    for (name, value) in envs {
+        command.env(name, value);
+    }
+
+    let output = command.output().expect("doctor output");
+    assert_eq!(
+        output.status.code(),
+        Some(6),
+        "doctor should fail only because the test passes a directory as AGENTS.md; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("doctor stdout utf8")
+}
+
+fn assert_state_words(output: &str) {
+    assert!(output.contains("pass"), "missing pass state: {output}");
+    assert!(output.contains("warn"), "missing warn state: {output}");
+    assert!(output.contains("fail"), "missing fail state: {output}");
+}
+
+#[test]
+fn mcp_doctor_human_output_colors_state_when_forced() {
+    let output = doctor_output(&[("CLICOLOR_FORCE", "1")]);
+
+    assert!(
+        output.contains("\x1b["),
+        "forced-color doctor output should contain ANSI escapes: {output}"
+    );
+    assert_state_words(&output);
+}
+
+#[test]
+fn mcp_doctor_human_output_suppresses_color_when_no_color_is_set() {
+    let output = doctor_output(&[("CLICOLOR_FORCE", "1"), ("NO_COLOR", "1")]);
+
+    assert!(
+        !output.contains("\x1b["),
+        "NO_COLOR must suppress ANSI escapes even with CLICOLOR_FORCE: {output}"
+    );
+    assert_state_words(&output);
+}
+
+#[test]
+fn mcp_doctor_human_output_suppresses_color_when_stdout_is_not_tty() {
+    let output = doctor_output(&[]);
+
+    assert!(
+        !output.contains("\x1b["),
+        "piped doctor output must not contain ANSI escapes: {output}"
+    );
+    assert_state_words(&output);
+}
+
+#[test]
+fn mcp_doctor_json_output_is_never_colored() {
+    let temp = tempdir().expect("tempdir");
+    let output = Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .current_dir(temp.path())
+        .args(["mcp", "doctor", "--json"])
+        .env("CLICOLOR_FORCE", "1")
+        .output()
+        .expect("doctor json output");
+
+    assert!(
+        output.status.success(),
+        "doctor --json should succeed without injected fail; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("doctor stdout utf8");
+    assert!(
+        !stdout.contains("\x1b["),
+        "doctor JSON output must not contain ANSI escapes: {stdout}"
+    );
+    assert!(stdout.contains("\"state\""));
+}

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -8,7 +8,7 @@ The `gaze` binary is the primary user-facing surface. It operates over stdin/std
 
 - Never encode information through color alone. ANSI styling, when used in diagnostics, always carries the same information in the text itself (e.g. `[error]` prefixes, not just red text).
 - Keep error messages self-describing — the reader does not need visual context (such as a TUI panel position) to understand what went wrong.
-- Respect `NO_COLOR` and non-TTY environments by suppressing ANSI escapes.
+- Respect `NO_COLOR` and non-TTY environments by suppressing ANSI escapes. Human-facing CLI styling is behind one std `IsTerminal` gate: non-empty `NO_COLOR` disables ANSI, non-empty `CLICOLOR_FORCE` enables ANSI only when `NO_COLOR` is absent, and otherwise styling is emitted only for terminal streams. The `gaze mcp doctor` human table uses this gate for decorative state-column color while still printing the literal `pass`, `warn`, and `fail` words; `--json` output is never colored. Regression tests cover forced color, `NO_COLOR`, non-TTY stdout, text-only state words, and JSON output.
 
 ## Documentation
 


### PR DESCRIPTION
Implements the accessibility guarantee docs/accessibility.md promised: centralized NO_COLOR + TTY (is_terminal) gate for CLI output (with CLICOLOR_FORCE override), info always carried in text, with tests asserting zero ANSI under NO_COLOR=1 and non-TTY. Doc aligned to the implemented mechanism. Addresses EmpireTwo/business#31.