### PR TITLE
ci: enforce DCO sign-off on PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,35 @@
+name: DCO
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Check DCO sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by trailers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for sha in $(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%B' "$sha" | grep -qiF "Signed-off-by: $author"; then
+              echo "::error::Commit $sha missing matching 'Signed-off-by: $author'"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "DCO check failed. Sign off your commits: 'git commit -s' (or 'git rebase --signoff <base>' to fix existing commits). See https://developercertificate.org/"
+            exit 1
+          fi
+          echo "All non-merge commits carry a matching Signed-off-by trailer."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,14 +19,19 @@ project a commons.
 
 ## Developer Certificate of Origin (DCO)
 
-Every commit must be signed off with `git commit -s`, which appends a
-`Signed-off-by:` trailer asserting that you have the right to submit the work
-under the project's licence. This is the only contribution gate; there is no
-CLA. The DCO text is the standard [developercertificate.org](https://developercertificate.org/)
-version 1.1.
+Every commit MUST carry a `Signed-off-by:` trailer matching the commit author,
+certifying the [Developer Certificate of Origin](https://developercertificate.org/).
+Add it automatically:
 
-If you forget the `-s` on a commit, amend it with
-`git commit --amend --signoff` (or for a series, `git rebase --signoff main`).
+```bash
+git commit -s
+```
+
+The `.github/workflows/dco.yml` check enforces this on every pull request: each
+non-merge commit must contain a `Signed-off-by: Name <email>` line matching its
+author identity. Fix existing commits with `git rebase --signoff <base>` (or
+`git commit --amend -s` for the latest). Enforcement is forward-looking on PRs;
+commits predating this gate are not retroactively signed.
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dco.yml`, a `pull_request` workflow with an inline bash check.
- The check walks each non-merge commit in the PR range and requires a per-commit `Signed-off-by: Name <email>` trailer matching that commit author.
- Updates `CONTRIBUTING.md` with a Sign-off (DCO) section explaining `git commit -s`, fixing existing commits, and forward-looking PR enforcement.
- No root `governance.md` exists in this checkout, so no governance doc was changed.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dco.yml'))"`
- Verified HEAD has a matching Signed-off-by trailer for the commit author.

## MANUAL STEP REQUIRED (repo admin)
After this merges, the admin (Krishan) must add the new DCO check as a REQUIRED status check in the branch ruleset for `main`. The required status check name to add is the job: **Check DCO sign-off** (workflow "DCO"). The workflow only RUNS the check; making it blocking is a ruleset toggle the agent cannot/should not perform. Do NOT confuse with or modify the existing GPG signed-commits ruleset — DCO is a separate, complementary mechanism.
