### PR TITLE
ci/fix: restore green `test` (gaze-mcp-core tool_ctx_seal trybuild)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
           docker-images: true
           swap-storage: false
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
+        with:
+          toolchain: 1.96.0
       - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
         run: |
           sudo apt-get update

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ function or associated item not found in `ToolCtx<'_>`
+   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Diagnosis

The required `test` workflow was red because the repo and CI were using floating stable Rust. Stable moved to rustc 1.96.0 (2026-05-25), and that compiler reworded the E0599 diagnostic emitted by the `gaze-mcp-core` `tool_ctx_seal` trybuild fixture.

## Fix

- Pinned `rust-toolchain.toml` to Rust 1.96.0.
- Made the pinned `dtolnay/rust-toolchain` CI action install toolchain 1.96.0 explicitly while keeping the action SHA pin.
- Re-blessed the drifted `tool_ctx_no_external_constructor.stderr` snapshot under rustc 1.96.0.

## Why this is not masking a regression

The compile-fail fixture still rejects external construction: both E0624 (`SessionHandle::new` is private) and E0599 (`ToolCtx::new` is unavailable) still fire. The ToolCtx seal still holds; only the E0599 diagnostic prose changed.

## Tradeoff

Pinning to 1.96.0 means contributors on older rustc versions must update to match the checked-in trybuild snapshots.

## Verification

- `rustc --version` => `rustc 1.96.0 (ac68faa20 2026-05-25)`
- `TRYBUILD=overwrite cargo test -p gaze-mcp-core --test tool_ctx_seal`
- `TRYBUILD=overwrite cargo test -p gaze-pii --test contracts raw_document_is_not_serializable`
- `cargo test -p gaze-mcp-core --test tool_ctx_seal` => `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`

🤖 Generated with [Claude Code]