### PR TITLE
fix(gaze-recognizers): NER detect() fail-closed + >512-token chunking (P0 never-leak)

### DIFF
--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -229,7 +229,9 @@ mod tests {
         );
 
         let registry = RecognizerRegistry::builder().register(recognizer).build();
-        let hits = registry.detect_all("Listening to bohemian rhapsody", &detect_context);
+        let hits = registry
+            .detect_all("Listening to bohemian rhapsody", &detect_context)
+            .expect("detect all");
         assert!(hits.is_empty());
     }
 

--- a/crates/gaze-recognizers/src/ner/backend/test_support.rs
+++ b/crates/gaze-recognizers/src/ner/backend/test_support.rs
@@ -11,6 +11,8 @@ use crate::ner::types::{NerBackendKind, NerOptions, NerSpanResult};
 
 struct TestSupportBackend;
 
+struct ErrorBackend;
+
 impl NerBackend for TestSupportBackend {
     fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
         Ok(input
@@ -30,13 +32,23 @@ impl NerBackend for TestSupportBackend {
     }
 }
 
+impl NerBackend for ErrorBackend {
+    fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+        Err(NerRuntimeError::Inference(
+            "forced test-support backend failure".to_string(),
+        ))
+    }
+}
+
 pub(crate) fn load_test_support_recognizer(
     model_dir: &Path,
     options: &NerOptions,
 ) -> Option<NerRecognizer> {
-    if model_dir.file_name().and_then(|name| name.to_str()) != Some("__gaze_test_fixed_ner") {
-        return None;
-    }
+    let backend: Arc<dyn NerBackend> = match model_dir.file_name().and_then(|name| name.to_str()) {
+        Some("__gaze_test_fixed_ner") => Arc::new(TestSupportBackend),
+        Some("__gaze_test_error_ner") => Arc::new(ErrorBackend),
+        _ => return None,
+    };
 
     Some(NerRecognizer {
         detector: NerDetector {
@@ -45,7 +57,7 @@ pub(crate) fn load_test_support_recognizer(
             recognizer_version_id: "ner.test-support.v1".to_string(),
             locale: options.locale.clone(),
             threshold: options.threshold,
-            backend: Arc::new(TestSupportBackend),
+            backend,
         },
     })
 }

--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use gaze_types::{Detection, Detector};
+use gaze_types::{Detection, Detector, RecognizerRuntimeError};
 
 use super::backend::{load_backend, NerBackend};
 use super::decode;
@@ -88,6 +88,22 @@ impl NerDetector {
         &self.recognizer_version_id
     }
 
+    pub(crate) fn detect_span_results(
+        &self,
+        input: &str,
+    ) -> Result<Vec<NerSpanResult>, super::error::NerRuntimeError> {
+        let mut spans = Vec::new();
+        for chunk in input_chunks(input) {
+            spans.extend(self.backend.detect(&input[chunk.clone()])?.into_iter().map(
+                |mut span| {
+                    span.span = span.span.start + chunk.start..span.span.end + chunk.start;
+                    span
+                },
+            ));
+        }
+        Ok(merge_overlapping_spans(spans))
+    }
+
     /// Label/offset reconstruction helper. Public for testing the BIO merge.
     /// `subword_spans` are byte ranges against the tokenizer input string,
     /// `subword_labels` are CoNLL-style labels per subword (e.g. `O`, `B-PER`,
@@ -121,21 +137,87 @@ impl NerDetector {
 
 impl Detector for NerDetector {
     fn detect(&self, input: &str) -> Vec<Detection> {
-        match self.backend.detect(input) {
-            Ok(detections) => detections
-                .into_iter()
-                .map(|span| {
-                    Detection::new(
-                        span.span,
-                        span.class,
-                        format!("ner/{}", self.backend_kind.as_str()),
-                    )
-                })
-                .collect(),
-            Err(err) => {
+        self.try_detect(input)
+            .expect("ner detector backend failure is fail-closed")
+    }
+
+    fn try_detect(&self, input: &str) -> Result<Vec<Detection>, RecognizerRuntimeError> {
+        self.detect_span_results(input)
+            .map(|detections| {
+                detections
+                    .into_iter()
+                    .map(|span| {
+                        Detection::new(
+                            span.span,
+                            span.class,
+                            format!("ner/{}", self.backend_kind.as_str()),
+                        )
+                    })
+                    .collect()
+            })
+            .map_err(|err| {
                 tracing::warn!(backend = self.backend_kind.as_str(), error = %err, "ner: backend detect failed");
-                Vec::new()
+                RecognizerRuntimeError::new("ner", err.to_string())
+            })
+    }
+}
+
+const NER_CHUNK_TOKEN_WINDOW: usize = 512;
+const NER_CHUNK_TOKEN_OVERLAP: usize = 32;
+
+fn input_chunks(input: &str) -> Vec<std::ops::Range<usize>> {
+    let mut tokens = Vec::new();
+    let mut token_start = None;
+    for (idx, ch) in input.char_indices() {
+        if ch.is_whitespace() {
+            if let Some(start) = token_start.take() {
+                tokens.push(start..idx);
             }
+        } else if token_start.is_none() {
+            token_start = Some(idx);
         }
     }
+    if let Some(start) = token_start {
+        tokens.push(start..input.len());
+    }
+
+    if tokens.len() <= NER_CHUNK_TOKEN_WINDOW {
+        return std::iter::once(0..input.len()).collect();
+    }
+
+    let stride = NER_CHUNK_TOKEN_WINDOW - NER_CHUNK_TOKEN_OVERLAP;
+    let mut chunks = Vec::new();
+    let mut token_start = 0;
+    while token_start < tokens.len() {
+        let token_end = (token_start + NER_CHUNK_TOKEN_WINDOW).min(tokens.len());
+        chunks.push(tokens[token_start].start..tokens[token_end - 1].end);
+        if token_end == tokens.len() {
+            break;
+        }
+        token_start += stride;
+    }
+    chunks
+}
+
+fn merge_overlapping_spans(mut spans: Vec<NerSpanResult>) -> Vec<NerSpanResult> {
+    spans.sort_by(|left, right| {
+        left.span
+            .start
+            .cmp(&right.span.start)
+            .then(left.span.end.cmp(&right.span.end))
+            .then(left.class.cmp(&right.class))
+    });
+
+    let mut merged: Vec<NerSpanResult> = Vec::new();
+    for span in spans {
+        if let Some(last) = merged.last_mut() {
+            if last.class == span.class && last.span.end >= span.span.start {
+                last.span.end = last.span.end.max(span.span.end);
+                last.score = last.score.max(span.score);
+                continue;
+            }
+        }
+        merged.push(span);
+    }
+    merged
 }

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -433,4 +433,81 @@ mod tests {
         assert_eq!(default_candidates[0].score, 0.40);
         assert!(stricter_candidates.is_empty());
     }
+
+    #[test]
+    fn ner_backend_error_fails_closed() {
+        struct ErrorBackend;
+
+        impl NerBackend for ErrorBackend {
+            fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+                Err(NerRuntimeError::Inference(
+                    "forced backend failure".to_string(),
+                ))
+            }
+        }
+
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(ErrorBackend),
+            },
+        };
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let err = recognizer
+            .try_detect("Alice Example", &ctx)
+            .expect_err("backend runtime failures must surface");
+
+        assert_eq!(err.recognizer_id, "ner");
+        assert!(err.message.contains("forced backend failure"));
+    }
+
+    #[test]
+    fn ner_long_input_chunked_detects() {
+        struct FixedAliceBackend;
+
+        impl NerBackend for FixedAliceBackend {
+            fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+                Ok(input
+                    .find("Alice Example")
+                    .map(|start| NerSpanResult {
+                        span: start..start + "Alice Example".len(),
+                        class: PiiClass::Name,
+                        score: 0.40,
+                    })
+                    .into_iter()
+                    .collect())
+            }
+        }
+
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.3,
+                backend: Arc::new(FixedAliceBackend),
+            },
+        };
+        let prefix = (0..540)
+            .map(|idx| format!("word{idx}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let input = format!("{prefix} Alice Example met the team.");
+        let start = input.find("Alice Example").expect("name span start");
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let candidates = recognizer.try_detect(&input, &ctx).expect("detect");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].span, start..start + "Alice Example".len());
+        assert_eq!(&input[candidates[0].span.clone()], "Alice Example");
+    }
 }

--- a/crates/gaze-recognizers/src/ner/recognizer.rs
+++ b/crates/gaze-recognizers/src/ner/recognizer.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use gaze_types::{Candidate, ConflictTier, DetectContext, PiiClass, Recognizer};
+use gaze_types::{
+    Candidate, ConflictTier, DetectContext, PiiClass, Recognizer, RecognizerRuntimeError,
+};
 
 #[cfg(feature = "test-support")]
 use super::backend::test_support::load_test_support_recognizer;
@@ -35,31 +37,42 @@ impl Recognizer for NerRecognizer {
     }
 
     fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-        match self.detector.backend.detect(input) {
-            Ok(spans) => spans
-                .into_iter()
-                .filter(|span| span.score >= self.detector.threshold)
-                .map(|span| {
-                    Candidate::new(
-                        span.span,
-                        span.class,
-                        self.id(),
-                        span.score,
-                        0,
-                        None,
-                        self.token_family(),
-                        format!("ner/{}", self.detector.backend_kind.as_str()),
-                        ConflictTier::None,
-                        Vec::new(),
-                    )
-                    .with_recognizer_version_id(self.detector.recognizer_version_id())
-                })
-                .collect(),
-            Err(err) => {
+        self.try_detect(input, _ctx)
+            .expect("ner recognizer backend failure is fail-closed")
+    }
+
+    fn try_detect(
+        &self,
+        input: &str,
+        _ctx: &DetectContext<'_>,
+    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
+        self.detector
+            .detect_span_results(input)
+            .map(|spans| {
+                spans
+                    .into_iter()
+                    .filter(|span| span.score >= self.detector.threshold)
+                    .map(|span| {
+                        Candidate::new(
+                            span.span,
+                            span.class,
+                            self.id(),
+                            span.score,
+                            0,
+                            None,
+                            self.token_family(),
+                            format!("ner/{}", self.detector.backend_kind.as_str()),
+                            ConflictTier::None,
+                            Vec::new(),
+                        )
+                        .with_recognizer_version_id(self.detector.recognizer_version_id())
+                    })
+                    .collect()
+            })
+            .map_err(|err| {
                 tracing::warn!(backend = self.detector.backend_kind.as_str(), error = %err, "ner: backend detect failed");
-                Vec::new()
-            }
-        }
+                RecognizerRuntimeError::new(self.id(), err.to_string())
+            })
     }
 
     fn token_family(&self) -> &str {

--- a/crates/gaze-recognizers/tests/ner_fail_closed.rs
+++ b/crates/gaze-recognizers/tests/ner_fail_closed.rs
@@ -1,0 +1,91 @@
+#![cfg(feature = "test-support")]
+
+use std::path::Path;
+
+use gaze::{
+    CleanDocument, DictionaryBundle, DictionaryEntry, DictionarySource, Error, LocaleTag, PiiClass,
+    Pipeline, RawDocument, Scope, Session,
+};
+use gaze_recognizers::{DictionaryRecognizer, NerOptions, NerRecognizer};
+use gaze_types::{DetectContext, Recognizer};
+
+#[test]
+fn ner_backend_error_fails_closed_pipeline() {
+    let recognizer =
+        NerRecognizer::load_with_options(Path::new("__gaze_test_error_ner"), NerOptions::default())
+            .expect("test support recognizer");
+    let pipeline = Pipeline::builder()
+        .recognizer(recognizer)
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let result = pipeline.redact(
+        &session,
+        RawDocument::Text("Alice Example visited Berlin".to_string()),
+    );
+
+    let err = result.expect_err("backend error must fail closed before clean output");
+    match err {
+        Error::DetectionBackendFailed {
+            recognizer_id,
+            message,
+        } => {
+            assert_eq!(recognizer_id, "ner");
+            assert!(message.contains("forced test-support backend failure"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn recognizer_infallible_try_detect_ok() {
+    let recognizer = DictionaryRecognizer::new(
+        "dict.artist",
+        PiiClass::Custom("artist".to_string()),
+        "artists",
+        true,
+        "counter",
+    );
+    let entry = DictionaryEntry::new(
+        "artists",
+        vec!["Synthetic Artist".to_string()],
+        true,
+        DictionarySource::Cli,
+    )
+    .expect("dictionary entry");
+    let dictionaries = DictionaryBundle::from_entries([("artists".to_string(), entry)]);
+    let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+    let candidates = recognizer
+        .try_detect("Play Synthetic Artist", &ctx)
+        .expect("infallible recognizer should use default Ok path");
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        &"Play Synthetic Artist"[candidates[0].span.clone()],
+        "Synthetic Artist"
+    );
+}
+
+#[test]
+fn ner_pipeline_does_not_emit_unredacted_output_on_backend_error() {
+    let recognizer =
+        NerRecognizer::load_with_options(Path::new("__gaze_test_error_ner"), NerOptions::default())
+            .expect("test support recognizer");
+    let pipeline = Pipeline::builder()
+        .recognizer(recognizer)
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Alice Example";
+
+    let result = pipeline.redact(&session, RawDocument::Text(input.to_string()));
+
+    if let Ok(CleanDocument::Text(clean)) = result {
+        assert!(
+            !clean.contains(input),
+            "pipeline must not return unredacted NER-only PII on backend error"
+        );
+    }
+}

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -13,7 +13,41 @@ use thiserror::Error;
 pub trait Detector: Send + Sync {
     /// Detect PII spans in the supplied input string.
     fn detect(&self, input: &str) -> Vec<Detection>;
+
+    /// Fallible detection entrypoint for detectors backed by runtime systems.
+    fn try_detect(&self, input: &str) -> Result<Vec<Detection>, RecognizerRuntimeError> {
+        Ok(self.detect(input))
+    }
 }
+
+/// Runtime failure raised by a recognizer or detector backend during detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RecognizerRuntimeError {
+    pub recognizer_id: String,
+    pub message: String,
+}
+
+impl RecognizerRuntimeError {
+    pub fn new(recognizer_id: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            recognizer_id: recognizer_id.into(),
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for RecognizerRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "recognizer '{}' backend failed: {}",
+            self.recognizer_id, self.message
+        )
+    }
+}
+
+impl std::error::Error for RecognizerRuntimeError {}
 
 /// The category of a detected PII span.
 ///
@@ -3111,6 +3145,14 @@ pub trait Recognizer: Send + Sync {
     fn supported_class(&self) -> &PiiClass;
     /// Detects PII candidates in the supplied input and context.
     fn detect(&self, input: &str, ctx: &DetectContext<'_>) -> Vec<Candidate>;
+    /// Fallible detection entrypoint for recognizers backed by runtime systems.
+    fn try_detect(
+        &self,
+        input: &str,
+        ctx: &DetectContext<'_>,
+    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
+        Ok(self.detect(input, ctx))
+    }
     /// Token family used for candidate token emission.
     fn token_family(&self) -> &str;
     /// Optional validator kind used by pre-resolver validator-veto.

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -8,9 +8,9 @@ use gaze_recognizers::{
 };
 use gaze_types::{
     AmbiguityReason, AmbiguityRecord, CollisionMembership, EmittedTokenSpan, FallbackReason,
-    LeakKind, LeakReport, LeakReportTelemetry, LeakSuspect, Manifest, RedactionLogError,
-    RedactionLogger, RestoreDecision, RestorePolicy, RestoreTelemetry, RestoredText, SafetyNet,
-    SafetyNetContext, SafetyNetError, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
+    LeakKind, LeakReport, LeakReportTelemetry, LeakSuspect, Manifest, RecognizerRuntimeError,
+    RedactionLogError, RedactionLogger, RestoreDecision, RestorePolicy, RestoreTelemetry,
+    RestoredText, SafetyNet, SafetyNetContext, SafetyNetError, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
     RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
 };
 use thiserror::Error;
@@ -63,6 +63,11 @@ pub enum Error {
     SafetyNet(#[from] SafetyNetError),
     #[error("redaction log error: {0}")]
     RedactionLog(#[from] RedactionLogError),
+    #[error("detection backend failed for recognizer '{recognizer_id}': {message}")]
+    DetectionBackendFailed {
+        recognizer_id: String,
+        message: String,
+    },
     #[error("safety net fallback failed closed: {0:?}")]
     SafetyNetFallback(FallbackReason),
     #[error("capitals heuristic gate is unsupported for locale {locale}")]
@@ -73,6 +78,15 @@ pub enum Error {
     UnsupportedValueVariant,
     #[error("unsupported policy action variant")]
     UnsupportedActionVariant,
+}
+
+impl From<RecognizerRuntimeError> for Error {
+    fn from(err: RecognizerRuntimeError) -> Self {
+        Self::DetectionBackendFailed {
+            recognizer_id: err.recognizer_id,
+            message: err.message,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -566,7 +580,7 @@ impl Pipeline {
         let normalized = normalize(text);
         let spans = &normalized.spans;
         let ctx = DetectContext::new(locale_chain, dictionaries);
-        let (resolved, vetoed) = self.registry.detect_all_resolved(&normalized.text, &ctx);
+        let (resolved, vetoed) = self.registry.detect_all_resolved(&normalized.text, &ctx)?;
         let vetoed = vetoed
             .into_iter()
             .filter_map(|vetoed| translate_vetoed_candidate(vetoed, spans))
@@ -2055,6 +2069,33 @@ where
                 )
             })
             .collect()
+    }
+
+    fn try_detect(
+        &self,
+        input: &str,
+        _ctx: &DetectContext<'_>,
+    ) -> std::result::Result<Vec<Candidate>, RecognizerRuntimeError> {
+        Ok(self
+            .detector
+            .try_detect(input)?
+            .into_iter()
+            .map(|detection| {
+                let source = detection.source;
+                Candidate::new(
+                    detection.span,
+                    detection.class,
+                    source.clone(),
+                    1.0,
+                    0,
+                    None,
+                    "counter",
+                    source,
+                    ConflictTier::None,
+                    Vec::new(),
+                )
+            })
+            .collect())
     }
 
     fn token_family(&self) -> &str {

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::anchor_resolver::AnchorResolver;
 use crate::resolver::resolve_candidates_with_policy_and_anchors;
 pub use gaze_types::{Candidate, DetectContext, Recognizer};
-use gaze_types::{CollisionMembership, LocaleChain, LocaleTag, PiiClass};
+use gaze_types::{CollisionMembership, LocaleChain, LocaleTag, PiiClass, RecognizerRuntimeError};
 
 pub trait Validator: Send + Sync {
     fn id(&self) -> &str;
@@ -187,12 +187,14 @@ mod tests {
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
 
-        let candidates = registry.detect_all("input", &ctx);
+        let candidates = registry.detect_all("input", &ctx).expect("detect all");
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].class, PiiClass::Email);
         assert_eq!(candidates[0].token_family, "counter");
 
-        let (candidates, vetoed) = registry.detect_all_resolved("input", &ctx);
+        let (candidates, vetoed) = registry
+            .detect_all_resolved("input", &ctx)
+            .expect("detect all resolved");
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].class, PiiClass::Email);
         assert!(vetoed.is_empty());
@@ -254,7 +256,10 @@ mod tests {
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::EnUs, LocaleTag::Global], &dictionaries);
 
-        assert!(registry.detect_all("input", &ctx).is_empty());
+        assert!(registry
+            .detect_all("input", &ctx)
+            .expect("detect all")
+            .is_empty());
     }
 
     #[test]
@@ -312,21 +317,26 @@ impl RecognizerRegistry {
         RecognizerRegistryBuilder::default()
     }
 
-    pub fn detect_all(&self, input: &str, ctx: &DetectContext<'_>) -> Vec<Candidate> {
-        self.entries
-            .iter()
-            .filter(|recognizer| {
-                LocaleChain::from(ctx.locale_chain).intersects(recognizer.locales())
-            })
-            .flat_map(|recognizer| recognizer.detect(input, ctx))
-            .collect()
+    pub fn detect_all(
+        &self,
+        input: &str,
+        ctx: &DetectContext<'_>,
+    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
+        let mut candidates = Vec::new();
+        for recognizer in self.entries.iter().filter(|recognizer| {
+            LocaleChain::from(ctx.locale_chain).intersects(recognizer.locales())
+        }) {
+            candidates.extend(recognizer.try_detect(input, ctx)?);
+        }
+        Ok(candidates)
     }
 
     pub fn detect_all_resolved(
         &self,
         input: &str,
         ctx: &DetectContext<'_>,
-    ) -> (Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>) {
+    ) -> Result<(Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>), RecognizerRuntimeError>
+    {
         let classes = self
             .entries
             .iter()
@@ -338,16 +348,22 @@ impl RecognizerRegistry {
             for locale in ctx.locale_chain {
                 let locale_ctx = DetectContext::new(std::slice::from_ref(locale), ctx.dictionaries);
                 locale_ctx.degraded.set(ctx.degraded.get());
-                let class_candidates = self
+                let mut class_candidates = Vec::new();
+                for recognizer in self
                     .entries
                     .iter()
                     .filter(|recognizer| recognizer.supported_class() == &class)
                     .filter(|recognizer| {
                         LocaleChain::from(locale_ctx.locale_chain).intersects(recognizer.locales())
                     })
-                    .flat_map(|recognizer| recognizer.detect(input, &locale_ctx))
-                    .filter(|candidate| candidate.score >= min_score(&class))
-                    .collect::<Vec<_>>();
+                {
+                    class_candidates.extend(
+                        recognizer
+                            .try_detect(input, &locale_ctx)?
+                            .into_iter()
+                            .filter(|candidate| candidate.score >= min_score(&class)),
+                    );
+                }
                 if !class_candidates.is_empty() {
                     candidates.extend(class_candidates);
                     break;
@@ -356,7 +372,7 @@ impl RecognizerRegistry {
         }
 
         let (candidates, vetoed) = crate::validator_veto::apply(candidates, self, input);
-        (
+        Ok((
             resolve_candidates_with_policy_and_anchors(
                 candidates,
                 self.family_policy(),
@@ -365,7 +381,7 @@ impl RecognizerRegistry {
                 ctx.locale_chain,
             ),
             vetoed,
-        )
+        ))
     }
 
     pub fn recognizer(&self, id: &str) -> Option<&Arc<dyn Recognizer>> {


### PR DESCRIPTION
## Root cause

`NerRecognizer::detect()` caught NER backend runtime failures, logged `ner: backend detect failed`, and returned `Vec::new()`. `RecognizerRegistry` then used `flat_map()` over recognizer results, so a backend failure was indistinguishable from a true no-entity result. The pipeline could continue with clean output that still contained NER-only PII.

## Fix

P0 axis-1 never-leak

- Added `RecognizerRuntimeError` in `gaze-types` and default fallible `try_detect()` methods on both `Recognizer` and `Detector`.
- Changed `NerRecognizer::try_detect()` to propagate backend runtime failures instead of swallowing them.
- Changed `RecognizerRegistry::{detect_all, detect_all_resolved}` to call `try_detect()` and return errors.
- Added `pipeline::Error::DetectionBackendFailed { recognizer_id, message }` and propagated registry errors with `?`, so the pipeline fails closed and emits no clean output on backend failure.
- Updated the legacy `DetectorRecognizer` adapter to call `Detector::try_detect()`, so the `PipelineBuilder::detector(NerDetector)` path also fails closed instead of converting backend failures into empty detections.

## >512-token chunking

- Added chunked NER backend dispatch in `NerDetector::detect_span_results()`.
- Inputs are split into <=512 whitespace-token windows with a 32-token overlap.
- Chunk-local spans are remapped to original input byte offsets.
- Overlapping same-class detections are merged/deduped after chunking.
- No truncation: long inputs are scanned across all chunks.

## Caller ripple

`gaze-types::Recognizer` / `Detector` -> `gaze-recognizers::NerRecognizer` / `NerDetector` -> `gaze::RecognizerRegistry` -> `gaze::Pipeline`.

Infallible recognizers keep the default `try_detect()` implementation, so regex/dictionary-style recognizers continue to work unchanged.

## Tests

Added/updated tests:

- `ner_backend_error_fails_closed`
- `ner_long_input_chunked_detects`
- `ner_backend_error_fails_closed_pipeline`
- `ner_pipeline_does_not_emit_unredacted_output_on_backend_error`
- `recognizer_infallible_try_detect_ok`

Local gate passed:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`

## CI caveat

The prompt noted a pre-existing unrelated required `test` CI failure in `gaze-mcp-core` trybuild/billing. I did not touch that area or attempt to work around CI. Local all-feature clippy and test gates pass for this branch.