### PR TITLE
[agent] release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,37 +11,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Daemon-mode docs reframed as stdio server.** `gaze daemon` is now
-  documented as a long-lived stdio server in the LSP / MCP /
-  language-server-protocol tradition rather than a Unix daemon in the strict
-  sense. The subcommand verb is unchanged through v0.9.x; a `gaze serve`
-  canonical alias is planned for v0.10 (todo #486). External adopter feedback
-  prompted the reframe. (Axis 4 trust, Axis 5 ergonomics.)
-
-- **`gaze document clean` bundle layout splits into agent + owner paths**
-  (axis 1 enforcement). `Bundle::write` now requires distinct `AgentBundleDir`
-  and `OwnerBundleDir` newtypes; the writer rejects equal or nested paths
-  with typed `DocumentError::BundleLayoutInvalid`. The CLI gains
-  `--agent-out` + `--owner-out` and retains `--out` as a shorthand that
-  auto-creates `<PATH>/agent` + `<PATH>/owner` subdirs.
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- **Axis-1 bundle leak risk** (closes todo #489): `gaze document clean`
-  previously wrote `manifest.json` next to `clean.md` in a single caller-
-  selected `out_dir`, with no runtime enforcement of the agent / owner
-  partition. Adopters following the README who uploaded the bundle directory
-  to an LLM workspace leaked restorable manifest material. The new split-path
-  bundle layout enforces the agent / owner partition at type and path-validation
-  level. Original two-directory `manifest.bin` signed-envelope binding (the
-  v0.7.0 architectural spec in `docs/architecture/document-extension.md`)
-  remains a v0.11+ follow-up.
+### Security
+
+## [0.9.1] - 2026-05-29
+
+v0.9.1 is a reliability and adopter-trust patch. The headline is an Axis-1
+never-leak fix: NER `detect()` now fails **closed**. Previously a detector-backend
+error returned an empty detection set, silently passing the raw text through
+unredacted — a critical leak path that let PII reach an LLM outside the manifest
+contract. The backend error now propagates as a typed failure instead of an empty
+result, and inputs longer than the NER window (>512 tokens) are chunked so long
+documents can no longer slip past the model unscanned. Manifest restore semantics
+and the signed snapshot wire format are unchanged from v0.9.0.
+
+### Added
+
+- **Accessibility-aware CLI output gate** (PR #287): the CLI honours `NO_COLOR`
+  and `CLICOLOR_FORCE` and performs TTY detection; informational output is never
+  conveyed by colour alone. (Axis 5 ergonomics.)
+
+### Changed
+
+- **Daemon-mode docs reframed as stdio server.** `gaze daemon` is now documented
+  as a long-lived stdio server in the LSP / MCP / language-server-protocol
+  tradition rather than a Unix daemon in the strict sense. The subcommand verb is
+  unchanged through v0.9.x; a `gaze serve` canonical alias is planned for v0.10
+  (todo #486). External adopter feedback prompted the reframe. (Axis 4 trust,
+  Axis 5 ergonomics.)
+- **`gaze document clean` bundle layout splits into agent + owner paths** (axis 1
+  enforcement). `Bundle::write` now requires distinct `AgentBundleDir` and
+  `OwnerBundleDir` newtypes; the writer rejects equal or nested paths with typed
+  `DocumentError::BundleLayoutInvalid`. The CLI gains `--agent-out` + `--owner-out`
+  and retains `--out` as a shorthand that auto-creates `<PATH>/agent` +
+  `<PATH>/owner` subdirs.
+- **CI: DCO sign-off is now enforced on pull requests** (PR #288), and the Rust
+  toolchain is pinned to 1.96.0 for reproducible trybuild output (PR #289).
+  Contributor-facing; no adopter API change. (Axis 4 trust.)
+
+### Fixed
+
+- **Axis-1 bundle leak risk** (closes todo #489): `gaze document clean` previously
+  wrote `manifest.json` next to `clean.md` in a single caller-selected `out_dir`,
+  with no runtime enforcement of the agent / owner partition. Adopters following
+  the README who uploaded the bundle directory to an LLM workspace leaked
+  restorable manifest material. The new split-path bundle layout enforces the
+  agent / owner partition at type and path-validation level. Original two-directory
+  `manifest.bin` signed-envelope binding (the v0.7.0 architectural spec in
+  `docs/architecture/document-extension.md`) remains a v0.11+ follow-up.
 
 ### Security
+
+- **NER fail-closed never-leak fix** (PR #290): a recognizer/NER-backend error no
+  longer returns an empty detection set that passes raw text through unredacted;
+  the error now propagates and inputs exceeding the NER window (>512 tokens) are
+  chunked. Any byte of PII reaching an LLM outside the manifest contract is a
+  critical defect — this closes a detector-error bypass of the redaction pipeline.
+  (Axis 1 reliability.)
 
 ## [0.9.0] - 2026-05-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.9.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.9.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.9.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.9.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.9.1" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.9.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ The CLI is a process boundary around the Rust runtime; you can link the runtime 
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.0"
-gaze-assembly = "0.9.0"
+gaze-pii = "0.9.1"
+gaze-assembly = "0.9.1"
 ```
 
 The crate is published as `gaze-pii` because the bare `gaze` name is in transfer on crates.io; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved.

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0" }
+gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.0"
-gaze-assembly = "0.9.0"
-gaze-recognizers = "0.9.0"
+gaze-pii = "0.9.1"
+gaze-assembly = "0.9.1"
+gaze-recognizers = "0.9.1"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.0"
-gaze-audit = "0.9.0"
+gaze-pii = "0.9.1"
+gaze-audit = "0.9.1"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -44,14 +44,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.9.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.0" }
+gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.9.0", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.9.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.1", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -66,7 +66,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.9.0
+$ cargo install gaze-cli --version 0.9.1
 ```
 
 Build from the workspace root:
@@ -109,7 +109,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.9.0 --features mcp
+$ cargo install gaze-cli --version 0.9.1 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0" }
+gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.1" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.9.0"
+gaze-document = "0.9.1"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.9.0 --features document
+cargo install gaze-cli --version 0.9.1 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays
@@ -243,7 +243,7 @@ this crate only provides the opt-in tool implementations.
 | `render-image`    | no      | Reserved — future redacted-preview renderer.         |
 
 The `extract-docling` and `render-image` features are intentionally empty
-in v0.9.0 so adopters can pin against the eventual flag names early.
+in v0.9.1 so adopters can pin against the eventual flag names early.
 
 ## License
 

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.9.0) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.9.1) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.9.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.9.1" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.9.0"
-gaze-mcp-rmcp = "0.9.0"
+gaze-mcp-core = "0.9.1"
+gaze-mcp-rmcp = "0.9.1"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.9.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.0" }
+gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.9.0"
+gaze-proxy = "0.9.1"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.9.0
+cargo install gaze-cli --version 0.9.1
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.0"
-gaze-recognizers = "0.9.0"
+gaze-pii = "0.9.1"
+gaze-recognizers = "0.9.1"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.9.0", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.9.1", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.9.0"
+gaze-types = "0.9.1"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.0"
-gaze-assembly = "0.9.0"
-gaze-recognizers = "0.9.0"
+gaze-pii = "0.9.1"
+gaze-assembly = "0.9.1"
+gaze-recognizers = "0.9.1"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).


### PR DESCRIPTION
v0.9.1 is a reliability and adopter-trust patch release. The headline is the Axis-1 NER fail-closed fix: detector-backend errors now propagate instead of silently returning an empty detection set, and long inputs are chunked so documents over the NER window do not slip past unscanned.

Also included:
- Accessibility-aware CLI output handling for `NO_COLOR`, `CLICOLOR_FORCE`, TTY detection, and non-color-only status output.
- CI trust updates: DCO enforcement on PRs and the Rust 1.96.0 toolchain pin for reproducible trybuild output.
- Preserved curated `[Unreleased]` entries for the daemon-docs reframe and document bundle layout split in the v0.9.1 changelog.

Release prep notes:
- Bumped workspace/package/internal dependency/README pins from 0.9.0 to 0.9.1.
- Promoted the v0.9.1 changelog block and reset `[Unreleased]`.
- Re-blessed the `tool_ctx_seal` trybuild stderr fixture for the pinned Rust 1.96 diagnostic wording.

Gates run with rustup Cargo/Rust 1.96.0 from `rust-toolchain.toml`:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo run -p xtask -- readme-version-check`
- `cargo test --workspace --all-features`

Manual human steps after review:
1. Review + merge this PR to `main` (bypass branch protection if the agent SSH signature is not recognized as Verified).
2. On the merge commit: `git tag -s v0.9.1 -m "v0.9.1"` then `git push origin v0.9.1`. This fires `.github/workflows/release.yml` for GitHub Release artifacts and `.github/workflows/publish-crates.yml` for crates.io OIDC publishing in topological order. No manual crates.io step.
3. Homebrew is artifact-only/repo-local, so no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
