### PR TITLE
[agent] fix(ner): surface backend errors so NER detection fails closed (P0 #908)

### DIFF
--- a/crates/gaze-recognizers/src/anchored_match.rs
+++ b/crates/gaze-recognizers/src/anchored_match.rs
@@ -109,9 +109,13 @@ impl Recognizer for AnchoredMatchRecognizer {
         &PiiClass::Name
     }
 
-    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+    fn detect(
+        &self,
+        input: &str,
+        _ctx: &DetectContext<'_>,
+    ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
         if !matches!(self.name_shape, NameShape::PersonName) {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let mut candidates = Vec::new();
@@ -143,7 +147,7 @@ impl Recognizer for AnchoredMatchRecognizer {
         }
         candidates.sort_by_key(|candidate| candidate.span.start);
         candidates.dedup_by(|a, b| a.span == b.span);
-        candidates
+        Ok(candidates)
     }
 
     fn token_family(&self) -> &str {
@@ -402,7 +406,9 @@ mod tests {
             CuePosition::Before,
             "from",
         );
-        let hits = recognizer.detect("Hello from Alice Example, please reply.", &ctx());
+        let hits = recognizer
+            .detect("Hello from Alice Example, please reply.", &ctx())
+            .unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].span, 11..24);
@@ -420,7 +426,10 @@ mod tests {
             "from",
         );
         assert_eq!(
-            line_end.detect("Forwarded from Alice Example\nBody", &ctx())[0].span,
+            line_end
+                .detect("Forwarded from Alice Example\nBody", &ctx())
+                .unwrap()[0]
+                .span,
             15..28
         );
 
@@ -432,7 +441,10 @@ mod tests {
             "agent_recipient",
         );
         assert_eq!(
-            whitespace.detect("Please reply to Alice Example today", &ctx())[0].span,
+            whitespace
+                .detect("Please reply to Alice Example today", &ctx())
+                .unwrap()[0]
+                .span,
             16..29
         );
     }
@@ -447,7 +459,10 @@ mod tests {
             "footer",
         );
         assert_eq!(
-            recognizer.detect("Alice Example sent this", &ctx())[0].span,
+            recognizer
+                .detect("Alice Example sent this", &ctx())
+                .unwrap()[0]
+                .span,
             0..13
         );
 
@@ -463,7 +478,10 @@ mod tests {
             0.9,
             10,
         );
-        assert!(short.detect("from Alice Example.", &ctx()).is_empty());
+        assert!(short
+            .detect("from Alice Example.", &ctx())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -481,7 +499,10 @@ mod tests {
             10,
         );
         assert_eq!(
-            one_component_non_forward.detect("from Alice:", &ctx())[0].span,
+            one_component_non_forward
+                .detect("from Alice:", &ctx())
+                .unwrap()[0]
+                .span,
             5..10
         );
 
@@ -499,6 +520,7 @@ mod tests {
         );
         assert!(two_component_forward
             .detect("from Alice:", &ctx())
+            .unwrap()
             .is_empty());
     }
 
@@ -511,7 +533,9 @@ mod tests {
             CuePosition::Before,
             "forward_marker",
         );
-        let hits = recognizer.detect("Forwarded message from Łukasz Müller:", &ctx());
+        let hits = recognizer
+            .detect("Forwarded message from Łukasz Müller:", &ctx())
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(
             &"Forwarded message from Łukasz Müller:"[hits[0].span.clone()],
@@ -520,6 +544,7 @@ mod tests {
 
         assert!(recognizer
             .detect("Forwarded message from mailgun:", &ctx())
+            .unwrap()
             .is_empty());
     }
 
@@ -555,7 +580,7 @@ mod tests {
                 CuePosition::Before,
                 short_label,
             );
-            let hits = recognizer.detect(input, &ctx());
+            let hits = recognizer.detect(input, &ctx()).unwrap();
 
             assert_eq!(
                 hits.first().map(|hit| hit.source.as_str()),

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -124,13 +124,17 @@ impl Recognizer for DictionaryRecognizer {
         &self.class
     }
 
-    fn detect(&self, input: &str, ctx: &DetectContext<'_>) -> Vec<Candidate> {
+    fn detect(
+        &self,
+        input: &str,
+        ctx: &DetectContext<'_>,
+    ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
         let Some(entry) = ctx.dictionaries.get(&self.dictionary_name) else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
         let automaton = self.automaton_for(entry);
 
-        automaton
+        Ok(automaton
             .find_iter(input)
             .map(|m| {
                 Candidate::new(
@@ -150,7 +154,7 @@ impl Recognizer for DictionaryRecognizer {
                     Vec::new(),
                 )
             })
-            .collect()
+            .collect())
     }
 
     fn token_family(&self) -> &str {
@@ -196,7 +200,9 @@ mod tests {
             "counter",
         );
 
-        let hits = recognizer.detect("Customer bought AAA-12345", &detect_context);
+        let hits = recognizer
+            .detect("Customer bought AAA-12345", &detect_context)
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].span, 16..25);
         assert_eq!(hits[0].class, PiiClass::Custom("class_alpha".to_string()));
@@ -262,10 +268,12 @@ mod tests {
             "counter",
         );
 
-        let hits = recognizer.detect(
-            "first alpha-one, second bravo-two, third charlie-three",
-            &detect_context,
-        );
+        let hits = recognizer
+            .detect(
+                "first alpha-one, second bravo-two, third charlie-three",
+                &detect_context,
+            )
+            .unwrap();
 
         assert_eq!(hits.len(), 3);
         let source_shape = regex::Regex::new(r"^dictionary:[a-z_]+\[#\d+\]$").unwrap();
@@ -308,7 +316,9 @@ mod tests {
             "counter",
         );
 
-        let hits = recognizer.detect("same-song then other-song", &detect_context);
+        let hits = recognizer
+            .detect("same-song then other-song", &detect_context)
+            .unwrap();
 
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].source, "dictionary:songs[#0]");

--- a/crates/gaze-recognizers/src/ner/backend/mod.rs
+++ b/crates/gaze-recognizers/src/ner/backend/mod.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use std::sync::Arc;
 
 use super::error::{NerLoadError, NerRuntimeError};
@@ -7,11 +8,18 @@ mod ort;
 #[cfg(feature = "test-support")]
 pub(crate) mod test_support;
 
+pub(crate) const NER_CHUNK_TOKEN_BUDGET: usize = 480;
+pub(crate) const NER_CHUNK_TOKEN_OVERLAP: usize = 30;
+
 /// Driver contract: produce byte-offset detections against a pre-normalized
 /// input string. Each backend owns its own model-specific state (label map,
 /// id2label for BERT, entity-type list for GLiNER, etc.) — the trait stays
 /// shape-agnostic so new backends plug in without changing `NerDetector`.
 pub(crate) trait NerBackend: Send + Sync {
+    fn chunk_ranges(&self, input: &str) -> Result<Vec<Range<usize>>, NerRuntimeError> {
+        Ok(std::iter::once(0..input.len()).collect())
+    }
+
     fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError>;
 }
 

--- a/crates/gaze-recognizers/src/ner/backend/ort.rs
+++ b/crates/gaze-recognizers/src/ner/backend/ort.rs
@@ -1,7 +1,8 @@
+use std::ops::Range;
 use std::path::Path;
 use std::sync::Mutex;
 
-use super::NerBackend;
+use super::{NerBackend, NER_CHUNK_TOKEN_BUDGET, NER_CHUNK_TOKEN_OVERLAP};
 use crate::ner::decode::softmax_confidence;
 use crate::ner::detector::NerDetector;
 use crate::ner::error::{NerLoadError, NerRuntimeError};
@@ -41,6 +42,10 @@ impl OrtBackend {
 }
 
 impl NerBackend for OrtBackend {
+    fn chunk_ranges(&self, input: &str) -> Result<Vec<Range<usize>>, NerRuntimeError> {
+        tokenized_chunk_ranges(&self.tokenizer, input)
+    }
+
     fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
         let labels = &self.labels;
         let id2label: &[String] = &self.id2label;
@@ -127,4 +132,51 @@ impl NerBackend for OrtBackend {
         .filter(|span| span.span.end <= input.len())
         .collect())
     }
+}
+
+fn tokenized_chunk_ranges(
+    tokenizer: &tokenizers::Tokenizer,
+    input: &str,
+) -> Result<Vec<Range<usize>>, NerRuntimeError> {
+    let mut tokenizer = tokenizer.clone();
+    tokenizer
+        .with_truncation(None)
+        .map_err(|err| NerRuntimeError::Tokenizer(err.to_string()))?;
+    let encoded = tokenizer
+        .encode(input, true)
+        .map_err(|err| NerRuntimeError::Tokenizer(err.to_string()))?;
+    let tokens: Vec<Range<usize>> = encoded
+        .get_offsets()
+        .iter()
+        .filter_map(|&(start, end)| {
+            if start < end
+                && end <= input.len()
+                && input.is_char_boundary(start)
+                && input.is_char_boundary(end)
+            {
+                Some(start..end)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if tokens.len() <= NER_CHUNK_TOKEN_BUDGET {
+        return Ok(std::iter::once(0..input.len()).collect());
+    }
+
+    debug_assert!(NER_CHUNK_TOKEN_OVERLAP < NER_CHUNK_TOKEN_BUDGET);
+    let stride = NER_CHUNK_TOKEN_BUDGET - NER_CHUNK_TOKEN_OVERLAP;
+    let mut chunks = Vec::new();
+    let mut token_start = 0;
+    while token_start < tokens.len() {
+        let token_end = (token_start + NER_CHUNK_TOKEN_BUDGET).min(tokens.len());
+        chunks.push(tokens[token_start].start..tokens[token_end - 1].end);
+        if token_end == tokens.len() {
+            break;
+        }
+        token_start += stride;
+    }
+
+    Ok(chunks)
 }

--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -93,7 +93,7 @@ impl NerDetector {
         input: &str,
     ) -> Result<Vec<NerSpanResult>, super::error::NerRuntimeError> {
         let mut spans = Vec::new();
-        for chunk in input_chunks(input) {
+        for chunk in self.backend.chunk_ranges(input)? {
             spans.extend(self.backend.detect(&input[chunk.clone()])?.into_iter().map(
                 |mut span| {
                     span.span = span.span.start + chunk.start..span.span.end + chunk.start;
@@ -160,43 +160,6 @@ impl Detector for NerDetector {
                 RecognizerRuntimeError::new("ner", err.to_string())
             })
     }
-}
-
-const NER_CHUNK_TOKEN_WINDOW: usize = 512;
-const NER_CHUNK_TOKEN_OVERLAP: usize = 32;
-
-fn input_chunks(input: &str) -> Vec<std::ops::Range<usize>> {
-    let mut tokens = Vec::new();
-    let mut token_start = None;
-    for (idx, ch) in input.char_indices() {
-        if ch.is_whitespace() {
-            if let Some(start) = token_start.take() {
-                tokens.push(start..idx);
-            }
-        } else if token_start.is_none() {
-            token_start = Some(idx);
-        }
-    }
-    if let Some(start) = token_start {
-        tokens.push(start..input.len());
-    }
-
-    if tokens.len() <= NER_CHUNK_TOKEN_WINDOW {
-        return std::iter::once(0..input.len()).collect();
-    }
-
-    let stride = NER_CHUNK_TOKEN_WINDOW - NER_CHUNK_TOKEN_OVERLAP;
-    let mut chunks = Vec::new();
-    let mut token_start = 0;
-    while token_start < tokens.len() {
-        let token_end = (token_start + NER_CHUNK_TOKEN_WINDOW).min(tokens.len());
-        chunks.push(tokens[token_start].start..tokens[token_end - 1].end);
-        if token_end == tokens.len() {
-            break;
-        }
-        token_start += stride;
-    }
-    chunks
 }
 
 fn merge_overlapping_spans(mut spans: Vec<NerSpanResult>) -> Vec<NerSpanResult> {

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -19,13 +19,14 @@ pub(crate) use types::NerSpanResult;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ner::backend::NerBackend;
+    use crate::ner::backend::{NerBackend, NER_CHUNK_TOKEN_BUDGET, NER_CHUNK_TOKEN_OVERLAP};
     use crate::ner::error::NerRuntimeError;
     use crate::ner::types::{CHECKSUMS_FILE, CONFIG_FILE, LABELS_FILE, MODEL_FILE, TOKENIZER_FILE};
     use gaze_types::{DetectContext, DictionaryBundle, LocaleTag, PiiClass, Recognizer};
     use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
     use std::fs;
+    use std::ops::Range;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -74,6 +75,69 @@ mod tests {
         );
         write(&path.join(CHECKSUMS_FILE), sums.as_bytes());
         dir
+    }
+
+    struct WordPieceFixtureBackend {
+        entity: &'static str,
+        fail_on_oversized_window: bool,
+    }
+
+    fn fake_wordpiece_ranges(input: &str) -> Vec<Range<usize>> {
+        input
+            .char_indices()
+            .filter_map(|(start, ch)| {
+                if ch.is_whitespace() {
+                    None
+                } else {
+                    Some(start..start + ch.len_utf8())
+                }
+            })
+            .collect()
+    }
+
+    fn fake_wordpiece_chunks(input: &str) -> Vec<Range<usize>> {
+        let tokens = fake_wordpiece_ranges(input);
+        if tokens.len() <= NER_CHUNK_TOKEN_BUDGET {
+            return std::iter::once(0..input.len()).collect();
+        }
+
+        let stride = NER_CHUNK_TOKEN_BUDGET - NER_CHUNK_TOKEN_OVERLAP;
+        let mut chunks = Vec::new();
+        let mut token_start = 0;
+        while token_start < tokens.len() {
+            let token_end = (token_start + NER_CHUNK_TOKEN_BUDGET).min(tokens.len());
+            chunks.push(tokens[token_start].start..tokens[token_end - 1].end);
+            if token_end == tokens.len() {
+                break;
+            }
+            token_start += stride;
+        }
+        chunks
+    }
+
+    impl NerBackend for WordPieceFixtureBackend {
+        fn chunk_ranges(&self, input: &str) -> Result<Vec<Range<usize>>, NerRuntimeError> {
+            Ok(fake_wordpiece_chunks(input))
+        }
+
+        fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+            if self.fail_on_oversized_window
+                && fake_wordpiece_ranges(input).len() > NER_CHUNK_TOKEN_BUDGET
+            {
+                return Err(NerRuntimeError::Inference(
+                    "window exceeded model limit".to_string(),
+                ));
+            }
+            Ok(input
+                .find(self.entity)
+                .map(|start| NerSpanResult {
+                    span: start..start + self.entity.len(),
+                    class: PiiClass::Name,
+                    score: 0.91,
+                })
+                .into_iter()
+                .collect())
+        }
     }
 
     #[test]
@@ -417,27 +481,6 @@ mod tests {
 
     #[test]
     fn ner_recognizer_chunks_long_input_and_offsets_spans() {
-        struct WindowBackend;
-
-        impl NerBackend for WindowBackend {
-            fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
-                if input.split_whitespace().count() > 512 {
-                    return Err(NerRuntimeError::Inference(
-                        "window exceeded model limit".to_string(),
-                    ));
-                }
-                Ok(input
-                    .find("Dr. Schmidt")
-                    .map(|start| NerSpanResult {
-                        span: start..start + "Dr. Schmidt".len(),
-                        class: PiiClass::Name,
-                        score: 0.91,
-                    })
-                    .into_iter()
-                    .collect())
-            }
-        }
-
         let recognizer = NerRecognizer {
             detector: NerDetector {
                 model_dir: PathBuf::from("/test/fake"),
@@ -445,10 +488,14 @@ mod tests {
                 recognizer_version_id: "ner.fixed.v1".to_string(),
                 locale: None,
                 threshold: 0.5,
-                backend: Arc::new(WindowBackend),
+                backend: Arc::new(WordPieceFixtureBackend {
+                    entity: "Dr. Schmidt",
+                    fail_on_oversized_window: true,
+                }),
             },
         };
-        let input = format!("{} Dr. Schmidt", vec!["word"; 520].join(" "));
+        let dense_prefix = "x".repeat(NER_CHUNK_TOKEN_BUDGET + NER_CHUNK_TOKEN_OVERLAP + 80);
+        let input = format!("{dense_prefix}/Users/krishan/Workspace/Artistfy Dr. Schmidt");
         let entity_start = input.find("Dr. Schmidt").expect("fixture entity");
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
@@ -461,6 +508,68 @@ mod tests {
             entity_start..entity_start + "Dr. Schmidt".len()
         );
         assert_eq!(candidates[0].class, PiiClass::Name);
+    }
+
+    #[test]
+    fn ner_overlap_merges_duplicate_spans_once() {
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(WordPieceFixtureBackend {
+                    entity: "Alice Example",
+                    fail_on_oversized_window: false,
+                }),
+            },
+        };
+        let prefix = "x".repeat(NER_CHUNK_TOKEN_BUDGET - NER_CHUNK_TOKEN_OVERLAP + 5);
+        let input = format!("{prefix} Alice Example met the team.");
+        let entity_start = input.find("Alice Example").expect("fixture entity");
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let candidates = Recognizer::detect(&recognizer, &input, &ctx).unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].span,
+            entity_start..entity_start + "Alice Example".len()
+        );
+    }
+
+    #[test]
+    fn ner_boundary_straddling_entity_inside_overlap_detects_once() {
+        assert!("AliceExample".len() <= NER_CHUNK_TOKEN_OVERLAP);
+
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(WordPieceFixtureBackend {
+                    entity: "Alice Example",
+                    fail_on_oversized_window: false,
+                }),
+            },
+        };
+        let prefix = "x".repeat(NER_CHUNK_TOKEN_BUDGET - "Alice".len());
+        let input = format!("{prefix}Alice Example met the team.");
+        let entity_start = input.find("Alice Example").expect("fixture entity");
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let candidates = Recognizer::detect(&recognizer, &input, &ctx).unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].span,
+            entity_start..entity_start + "Alice Example".len()
+        );
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -368,7 +368,7 @@ mod tests {
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
 
-        let candidates = Recognizer::detect(&recognizer, "alpha bravo", &ctx);
+        let candidates = Recognizer::detect(&recognizer, "alpha bravo", &ctx).unwrap();
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].span, 6..11);
@@ -377,6 +377,90 @@ mod tests {
             candidates[0].recognizer_version_id.as_deref(),
             Some("ner.fixed.v1")
         );
+    }
+
+    #[test]
+    fn ner_recognizer_surfaces_backend_failure() {
+        struct FailingBackend;
+
+        impl NerBackend for FailingBackend {
+            fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+                Err(NerRuntimeError::Inference("synthetic failure".to_string()))
+            }
+        }
+
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(FailingBackend),
+            },
+        };
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let err = Recognizer::detect(&recognizer, "Dr. Schmidt", &ctx)
+            .expect_err("backend failure must be caller-visible");
+
+        assert!(matches!(
+            err,
+            gaze_types::DetectError::Backend {
+                recognizer_id,
+                message,
+                ..
+            } if recognizer_id == "ner" && message.contains("synthetic failure")
+        ));
+    }
+
+    #[test]
+    fn ner_recognizer_chunks_long_input_and_offsets_spans() {
+        struct WindowBackend;
+
+        impl NerBackend for WindowBackend {
+            fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+                if input.split_whitespace().count() > 512 {
+                    return Err(NerRuntimeError::Inference(
+                        "window exceeded model limit".to_string(),
+                    ));
+                }
+                Ok(input
+                    .find("Dr. Schmidt")
+                    .map(|start| NerSpanResult {
+                        span: start..start + "Dr. Schmidt".len(),
+                        class: PiiClass::Name,
+                        score: 0.91,
+                    })
+                    .into_iter()
+                    .collect())
+            }
+        }
+
+        let recognizer = NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(WindowBackend),
+            },
+        };
+        let input = format!("{} Dr. Schmidt", vec!["word"; 520].join(" "));
+        let entity_start = input.find("Dr. Schmidt").expect("fixture entity");
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let candidates = Recognizer::detect(&recognizer, &input, &ctx).unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].span,
+            entity_start..entity_start + "Dr. Schmidt".len()
+        );
+        assert_eq!(candidates[0].class, PiiClass::Name);
     }
 
     #[test]
@@ -424,8 +508,8 @@ mod tests {
             },
         };
 
-        let default_candidates = Recognizer::detect(&default_threshold, input, &ctx);
-        let stricter_candidates = Recognizer::detect(&stricter_threshold, input, &ctx);
+        let default_candidates = Recognizer::detect(&default_threshold, input, &ctx).unwrap();
+        let stricter_candidates = Recognizer::detect(&stricter_threshold, input, &ctx).unwrap();
 
         assert_eq!(default_candidates.len(), 1);
         assert_eq!(default_candidates[0].span, name_start..name_end);

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -544,11 +544,17 @@ mod tests {
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
 
         let err = recognizer
-            .try_detect("Alice Example", &ctx)
+            .detect("Alice Example", &ctx)
             .expect_err("backend runtime failures must surface");
 
-        assert_eq!(err.recognizer_id, "ner");
-        assert!(err.message.contains("forced backend failure"));
+        assert!(matches!(
+            err,
+            gaze_types::DetectError::Backend {
+                recognizer_id,
+                message,
+                ..
+            } if recognizer_id == "ner" && message.contains("forced backend failure")
+        ));
     }
 
     #[test]
@@ -588,7 +594,7 @@ mod tests {
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
 
-        let candidates = recognizer.try_detect(&input, &ctx).expect("detect");
+        let candidates = recognizer.detect(&input, &ctx).expect("detect");
 
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].span, start..start + "Alice Example".len());

--- a/crates/gaze-recognizers/src/ner/recognizer.rs
+++ b/crates/gaze-recognizers/src/ner/recognizer.rs
@@ -1,8 +1,6 @@
 use std::path::Path;
 
-use gaze_types::{
-    Candidate, ConflictTier, DetectContext, PiiClass, Recognizer, RecognizerRuntimeError,
-};
+use gaze_types::{Candidate, ConflictTier, DetectContext, DetectError, PiiClass, Recognizer};
 
 #[cfg(feature = "test-support")]
 use super::backend::test_support::load_test_support_recognizer;
@@ -36,18 +34,13 @@ impl Recognizer for NerRecognizer {
         &PiiClass::Name
     }
 
-    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-        self.try_detect(input, _ctx)
-            .expect("ner recognizer backend failure is fail-closed")
-    }
-
-    fn try_detect(
-        &self,
-        input: &str,
-        _ctx: &DetectContext<'_>,
-    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
+    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Result<Vec<Candidate>, DetectError> {
         self.detector
             .detect_span_results(input)
+            .map_err(|err| {
+                tracing::error!(backend = self.detector.backend_kind.as_str(), error = %err, "ner: backend detect failed closed");
+                DetectError::backend(self.id(), err.to_string())
+            })
             .map(|spans| {
                 spans
                     .into_iter()
@@ -68,10 +61,6 @@ impl Recognizer for NerRecognizer {
                         .with_recognizer_version_id(self.detector.recognizer_version_id())
                     })
                     .collect()
-            })
-            .map_err(|err| {
-                tracing::warn!(backend = self.detector.backend_kind.as_str(), error = %err, "ner: backend detect failed");
-                RecognizerRuntimeError::new(self.id(), err.to_string())
             })
     }
 

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -134,8 +134,13 @@ impl Recognizer for RegexDetector {
         &self.class
     }
 
-    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-        self.regex
+    fn detect(
+        &self,
+        input: &str,
+        _ctx: &DetectContext<'_>,
+    ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
+        Ok(self
+            .regex
             .captures_iter(input)
             .filter_map(|caps| {
                 let span = self.span_from_captures(&caps)?;
@@ -157,7 +162,7 @@ impl Recognizer for RegexDetector {
                     Vec::new(),
                 )
             })
-            .collect()
+            .collect())
     }
 
     fn token_family(&self) -> &str {
@@ -240,7 +245,8 @@ mod tests {
         .expect("regex detector");
         let dictionaries = gaze_types::DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
-        let detections = Recognizer::detect(&detector, "Email Alice@Example.invalid", &ctx);
+        let detections =
+            Recognizer::detect(&detector, "Email Alice@Example.invalid", &ctx).unwrap();
 
         assert_eq!(
             detections[0].canonical_form.as_deref(),
@@ -307,7 +313,7 @@ mod tests {
         let input =
             "From: Dana Weber <user@example.invalid>\nFrom: \"Prof. Weber\" <other@example.invalid>";
 
-        let candidates = Recognizer::detect(&detector, input, &ctx);
+        let candidates = Recognizer::detect(&detector, input, &ctx).unwrap();
         let matched = candidates
             .iter()
             .map(|candidate| &input[candidate.span.clone()])

--- a/crates/gaze-recognizers/tests/anchored_match_fp_budget.rs
+++ b/crates/gaze-recognizers/tests/anchored_match_fp_budget.rs
@@ -96,9 +96,13 @@ fn name_count(input: &str) -> usize {
     let ctx = ctx();
     let anchored = anchored_recognizers()
         .iter()
-        .flat_map(|recognizer| recognizer.detect(input, &ctx))
+        .flat_map(|recognizer| recognizer.detect(input, &ctx).unwrap())
         .count();
-    anchored + paren_header_name_recognizer().detect(input, &ctx).len()
+    anchored
+        + paren_header_name_recognizer()
+            .detect(input, &ctx)
+            .unwrap()
+            .len()
 }
 
 #[test]

--- a/crates/gaze-recognizers/tests/context_sensitivity_v0_6.rs
+++ b/crates/gaze-recognizers/tests/context_sensitivity_v0_6.rs
@@ -111,7 +111,7 @@ fn anchored_name_count(input: &str) -> usize {
     let ctx = ctx();
     anchored_recognizers()
         .iter()
-        .flat_map(|recognizer| recognizer.detect(input, &ctx))
+        .flat_map(|recognizer| recognizer.detect(input, &ctx).unwrap())
         .count()
 }
 
@@ -133,7 +133,7 @@ fn p6_context_sensitivity_matrix_locks_expected_verdicts() {
     )
     .expect("test-support NER recognizer");
     let row1 = "Hallo, hier ist Alice. Wie geht's?";
-    assert_eq!(ner.detect(row1, &ctx).len(), 1);
+    assert_eq!(ner.detect(row1, &ctx).unwrap().len(), 1);
     assert_eq!(anchored_name_count(row1), 0);
 
     // Synthesis matrix row 2 / R2-Patch-18: no Subject/Re anchor in v0.6.
@@ -144,16 +144,19 @@ fn p6_context_sensitivity_matrix_locks_expected_verdicts() {
 
     // Synthesis matrix row 3 / R2-Patch-8: auto-footer cue catches the sender
     // while single-component and organization-shaped suffixes stay out.
-    let row3 = anchored_recognizers()[2].detect(
-        "Sent by Alice Example via Mailgun on behalf of Acme Corp",
-        &ctx,
-    );
+    let row3 = anchored_recognizers()[2]
+        .detect(
+            "Sent by Alice Example via Mailgun on behalf of Acme Corp",
+            &ctx,
+        )
+        .unwrap();
     assert_eq!(row3.len(), 1);
     assert_eq!(row3[0].source, "structural.footer");
 
     // Synthesis matrix row 4 / R2-Patch-11: GH#24 headline prompt preamble.
     let row4 = anchored_recognizers()[1]
-        .detect("Du antwortest als Artistfy-Support an Alice Example.", &ctx);
+        .detect("Du antwortest als Artistfy-Support an Alice Example.", &ctx)
+        .unwrap();
     assert_eq!(row4.len(), 1);
     assert_eq!(row4[0].source, "structural.agent_recipient");
 
@@ -163,6 +166,7 @@ fn p6_context_sensitivity_matrix_locks_expected_verdicts() {
     assert_eq!(
         paren
             .detect("From: alice@example.invalid (Alice Example)", &ctx)
+            .unwrap()
             .len(),
         1
     );
@@ -172,21 +176,24 @@ fn p6_context_sensitivity_matrix_locks_expected_verdicts() {
                 "From: bob@example.invalid (Bob B), alice@example.invalid (Alice A)",
                 &ctx
             )
+            .unwrap()
             .len(),
         2
     );
 
     // Synthesis matrix row 6 / R2-Patch-13: single forward-marker path.
-    let row6 = anchored_recognizers()[0].detect("Forwarded message from Alice Example:", &ctx);
+    let row6 = anchored_recognizers()[0]
+        .detect("Forwarded message from Alice Example:", &ctx)
+        .unwrap();
     assert_eq!(row6.len(), 1);
     assert_eq!(row6[0].source, "structural.forward_marker");
 
     // Synthesis matrix row 7 / R2-Patch-18: local-parts are not fabricated
     // into Name candidates; only Email candidates are present.
     let row7 = "Cc: bob@example.invalid, alice@example.invalid";
-    assert_eq!(paren.detect(row7, &ctx).len(), 0);
+    assert_eq!(paren.detect(row7, &ctx).unwrap().len(), 0);
     assert_eq!(anchored_name_count(row7), 0);
-    assert_eq!(email_recognizer().detect(row7, &ctx).len(), 2);
+    assert_eq!(email_recognizer().detect(row7, &ctx).unwrap().len(), 2);
 
     // Synthesis matrix row 8 / R2-Patch-18: no structural cue in v0.6.
     assert_eq!(

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -72,6 +72,7 @@ fn detect_recognizer(
     let validator_kind = detector.validator_kind();
 
     Recognizer::detect(&detector, input, &ctx)
+        .unwrap()
         .into_iter()
         .filter(|candidate| {
             validator_kind.is_none_or(|kind| {
@@ -104,6 +105,7 @@ fn detect_recognizer_canonical_forms(
     let validator_kind = detector.validator_kind();
 
     Recognizer::detect(&detector, input, &ctx)
+        .unwrap()
         .into_iter()
         .filter(|candidate| {
             validator_kind.is_none_or(|kind| {

--- a/crates/gaze-recognizers/tests/ner_fail_closed.rs
+++ b/crates/gaze-recognizers/tests/ner_fail_closed.rs
@@ -27,10 +27,11 @@ fn ner_backend_error_fails_closed_pipeline() {
 
     let err = result.expect_err("backend error must fail closed before clean output");
     match err {
-        Error::DetectionBackendFailed {
+        Error::RecognizerDetect(gaze_types::DetectError::Backend {
             recognizer_id,
             message,
-        } => {
+            ..
+        }) => {
             assert_eq!(recognizer_id, "ner");
             assert!(message.contains("forced test-support backend failure"));
         }
@@ -39,7 +40,7 @@ fn ner_backend_error_fails_closed_pipeline() {
 }
 
 #[test]
-fn recognizer_infallible_try_detect_ok() {
+fn recognizer_infallible_detect_ok() {
     let recognizer = DictionaryRecognizer::new(
         "dict.artist",
         PiiClass::Custom("artist".to_string()),
@@ -58,7 +59,7 @@ fn recognizer_infallible_try_detect_ok() {
     let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
 
     let candidates = recognizer
-        .try_detect("Play Synthetic Artist", &ctx)
+        .detect("Play Synthetic Artist", &ctx)
         .expect("infallible recognizer should use default Ok path");
 
     assert_eq!(candidates.len(), 1);

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -3144,15 +3144,11 @@ pub trait Recognizer: Send + Sync {
     /// PII class supported by this recognizer.
     fn supported_class(&self) -> &PiiClass;
     /// Detects PII candidates in the supplied input and context.
-    fn detect(&self, input: &str, ctx: &DetectContext<'_>) -> Vec<Candidate>;
-    /// Fallible detection entrypoint for recognizers backed by runtime systems.
-    fn try_detect(
+    fn detect(
         &self,
         input: &str,
         ctx: &DetectContext<'_>,
-    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
-        Ok(self.detect(input, ctx))
-    }
+    ) -> std::result::Result<Vec<Candidate>, DetectError>;
     /// Token family used for candidate token emission.
     fn token_family(&self) -> &str;
     /// Optional validator kind used by pre-resolver validator-veto.
@@ -3162,6 +3158,30 @@ pub trait Recognizer: Send + Sync {
     /// Locales where this recognizer is active.
     fn locales(&self) -> &[LocaleTag] {
         &[LocaleTag::Global]
+    }
+}
+
+/// Caller-visible recognizer detection failure.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum DetectError {
+    /// A recognizer backend failed while scanning the input.
+    #[error("recognizer {recognizer_id} backend failed: {message}")]
+    Backend {
+        /// Stable recognizer identifier.
+        recognizer_id: String,
+        /// Sanitized backend error message.
+        message: String,
+    },
+}
+
+impl DetectError {
+    /// Build a backend failure without requiring recognizer crates in `gaze-types`.
+    pub fn backend(recognizer_id: impl Into<String>, source: impl Into<String>) -> Self {
+        Self::Backend {
+            recognizer_id: recognizer_id.into(),
+            message: source.into(),
+        }
     }
 }
 

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -61,6 +61,8 @@ pub enum Error {
     Rulepack(#[from] RulepackError),
     #[error("safety net error: {0}")]
     SafetyNet(#[from] SafetyNetError),
+    #[error("recognizer detection failed: {0}")]
+    RecognizerDetect(#[from] gaze_types::DetectError),
     #[error("redaction log error: {0}")]
     RedactionLog(#[from] RedactionLogError),
     #[error("detection backend failed for recognizer '{recognizer_id}': {message}")]
@@ -2049,36 +2051,15 @@ where
         &self.class
     }
 
-    fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-        self.detector
-            .detect(input)
-            .into_iter()
-            .map(|detection| {
-                let source = detection.source;
-                Candidate::new(
-                    detection.span,
-                    detection.class,
-                    source.clone(),
-                    1.0,
-                    0,
-                    None,
-                    "counter",
-                    source,
-                    ConflictTier::None,
-                    Vec::new(),
-                )
-            })
-            .collect()
-    }
-
-    fn try_detect(
+    fn detect(
         &self,
         input: &str,
         _ctx: &DetectContext<'_>,
-    ) -> std::result::Result<Vec<Candidate>, RecognizerRuntimeError> {
+    ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
         Ok(self
             .detector
-            .try_detect(input)?
+            .try_detect(input)
+            .map_err(|err| gaze_types::DetectError::backend(err.recognizer_id, err.message))?
             .into_iter()
             .map(|detection| {
                 let source = detection.source;
@@ -2145,6 +2126,33 @@ mod tests {
         }
     }
 
+    struct FailingRecognizer;
+
+    impl Recognizer for FailingRecognizer {
+        fn id(&self) -> &str {
+            "ner"
+        }
+
+        fn supported_class(&self) -> &PiiClass {
+            &PiiClass::Name
+        }
+
+        fn detect(
+            &self,
+            _input: &str,
+            _ctx: &DetectContext<'_>,
+        ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
+            Err(gaze_types::DetectError::backend(
+                self.id(),
+                "synthetic backend failure",
+            ))
+        }
+
+        fn token_family(&self) -> &str {
+            "counter"
+        }
+    }
+
     fn detector_with_detections(source: &str, detections: Vec<Detection>) -> FixedDetector {
         FixedDetector {
             detections: detections
@@ -2155,6 +2163,28 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    #[test]
+    fn recognizer_backend_failure_fails_closed_before_output() {
+        let pipeline = Pipeline::builder()
+            .recognizer(FailingRecognizer)
+            .build()
+            .expect("pipeline");
+        let session =
+            Session::new(Scope::Conversation("detect-failclosed".to_string())).expect("session");
+
+        let err = pipeline
+            .redact(&session, RawDocument::Text("Hello Dr. Schmidt".to_string()))
+            .expect_err("recognizer backend failure must abort redaction");
+
+        assert!(matches!(
+            err,
+            Error::RecognizerDetect(gaze_types::DetectError::Backend {
+                recognizer_id,
+                ..
+            }) if recognizer_id == "ner"
+        ));
     }
 
     impl RedactionLogger for CapturingLogger {
@@ -2307,8 +2337,12 @@ mod tests {
             fn supported_class(&self) -> &PiiClass {
                 &PiiClass::Name
             }
-            fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-                input
+            fn detect(
+                &self,
+                input: &str,
+                _ctx: &DetectContext<'_>,
+            ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
+                Ok(input
                     .find("Dr. Schmidt")
                     .map(|start| {
                         Candidate::new(
@@ -2325,7 +2359,7 @@ mod tests {
                         )
                     })
                     .into_iter()
-                    .collect()
+                    .collect())
             }
             fn token_family(&self) -> &str {
                 "counter"
@@ -2553,12 +2587,16 @@ mod tests {
                 &PiiClass::Name
             }
 
-            fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+            fn detect(
+                &self,
+                input: &str,
+                _ctx: &DetectContext<'_>,
+            ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
                 let Some(start) = input.find("Dr. Schmidt") else {
-                    return Vec::new();
+                    return Ok(Vec::new());
                 };
                 let end = start + "Dr. Schmidt".len();
-                vec![Candidate::new(
+                Ok(vec![Candidate::new(
                     start..end,
                     PiiClass::Name,
                     self.id(),
@@ -2570,7 +2608,7 @@ mod tests {
                     ConflictTier::None,
                     Vec::new(),
                 )
-                .with_recognizer_version_id("name.semantic.v2")]
+                .with_recognizer_version_id("name.semantic.v2")])
             }
 
             fn token_family(&self) -> &str {
@@ -2719,12 +2757,16 @@ mod tests {
                 &PiiClass::Name
             }
 
-            fn detect(&self, input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
+            fn detect(
+                &self,
+                input: &str,
+                _ctx: &DetectContext<'_>,
+            ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
                 let Some(start) = input.find("Dr. Schmidt") else {
-                    return Vec::new();
+                    return Ok(Vec::new());
                 };
                 let end = start + "Dr. Schmidt".len();
-                vec![Candidate::new(
+                Ok(vec![Candidate::new(
                     start..end,
                     PiiClass::Name,
                     self.id(),
@@ -2735,7 +2777,7 @@ mod tests {
                     self.id(),
                     ConflictTier::None,
                     Vec::new(),
-                )]
+                )])
             }
 
             fn token_family(&self) -> &str {

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use crate::anchor_resolver::AnchorResolver;
 use crate::resolver::resolve_candidates_with_policy_and_anchors;
-pub use gaze_types::{Candidate, DetectContext, Recognizer};
-use gaze_types::{CollisionMembership, LocaleChain, LocaleTag, PiiClass, RecognizerRuntimeError};
+pub use gaze_types::{Candidate, DetectContext, DetectError, Recognizer};
+use gaze_types::{CollisionMembership, LocaleChain, LocaleTag, PiiClass};
 
 pub trait Validator: Send + Sync {
     fn id(&self) -> &str;
@@ -157,8 +157,12 @@ mod tests {
             &self.class
         }
 
-        fn detect(&self, _input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-            vec![Candidate::new(
+        fn detect(
+            &self,
+            _input: &str,
+            _ctx: &DetectContext<'_>,
+        ) -> Result<Vec<Candidate>, DetectError> {
+            Ok(vec![Candidate::new(
                 0..5,
                 self.class.clone(),
                 self.id(),
@@ -169,7 +173,7 @@ mod tests {
                 "test",
                 ConflictTier::None,
                 Vec::new(),
-            )]
+            )])
         }
 
         fn token_family(&self) -> &str {
@@ -224,8 +228,12 @@ mod tests {
                 &PiiClass::Email
             }
 
-            fn detect(&self, _input: &str, _ctx: &DetectContext<'_>) -> Vec<Candidate> {
-                vec![Candidate::new(
+            fn detect(
+                &self,
+                _input: &str,
+                _ctx: &DetectContext<'_>,
+            ) -> Result<Vec<Candidate>, DetectError> {
+                Ok(vec![Candidate::new(
                     0..5,
                     PiiClass::Email,
                     self.id(),
@@ -236,7 +244,7 @@ mod tests {
                     self.id(),
                     ConflictTier::None,
                     Vec::new(),
-                )]
+                )])
             }
 
             fn token_family(&self) -> &str {
@@ -321,12 +329,12 @@ impl RecognizerRegistry {
         &self,
         input: &str,
         ctx: &DetectContext<'_>,
-    ) -> Result<Vec<Candidate>, RecognizerRuntimeError> {
+    ) -> Result<Vec<Candidate>, DetectError> {
         let mut candidates = Vec::new();
         for recognizer in self.entries.iter().filter(|recognizer| {
             LocaleChain::from(ctx.locale_chain).intersects(recognizer.locales())
         }) {
-            candidates.extend(recognizer.try_detect(input, ctx)?);
+            candidates.extend(recognizer.detect(input, ctx)?);
         }
         Ok(candidates)
     }
@@ -335,8 +343,7 @@ impl RecognizerRegistry {
         &self,
         input: &str,
         ctx: &DetectContext<'_>,
-    ) -> Result<(Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>), RecognizerRuntimeError>
-    {
+    ) -> Result<(Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>), DetectError> {
         let classes = self
             .entries
             .iter()
@@ -359,7 +366,7 @@ impl RecognizerRegistry {
                 {
                     class_candidates.extend(
                         recognizer
-                            .try_detect(input, &locale_ctx)?
+                            .detect(input, &locale_ctx)?
                             .into_iter()
                             .filter(|candidate| candidate.score >= min_score(&class)),
                     );

--- a/docs/architecture/p0-908-ner-failclosed.md
+++ b/docs/architecture/p0-908-ner-failclosed.md
@@ -32,3 +32,29 @@ from leaving the pipeline.
 
 Long NER input is scanned through bounded overlapping chunks before backend
 execution; chunk failures are propagated as recognizer errors.
+
+## Long-Input Chunking Invariant
+
+NER chunk windows are measured in the model tokenizer's real WordPiece token
+offsets, not whitespace words. The ORT backend uses a 480-token payload budget,
+leaving room for `[CLS]` and `[SEP]` under the 512-token model ceiling, and a
+30-token overlap between adjacent windows.
+
+The overlap is a security invariant, not a throughput knob:
+
+```text
+overlap_tokens >= longest detectable entity + margin
+stride = budget - overlap
+```
+
+Current NER PII entities are assumed to be short in WordPiece space: personal
+names are typically 2-4 tokens, and common location/organization spans are
+well below the 30-token overlap. The margin protects entities that land on a
+window edge and prevents a surname/given-name split from becoming a leak
+surface. Spans are remapped to original byte offsets before overlap
+de-duplication, so an entity detected in both windows emits one manifest span.
+
+Residual risk remains for an entity longer than the overlap, especially long
+organization names or pathological fragmented input. Pass-3 SafetyNet should
+rescan the reassembled clean output as defense in depth for any boundary miss
+that tokenizer-window overlap cannot catch.

--- a/docs/architecture/p0-908-ner-failclosed.md
+++ b/docs/architecture/p0-908-ner-failclosed.md
@@ -1,0 +1,34 @@
+# P0-908 NER Fail-Closed Design
+
+## Decision
+
+Use a fallible recognizer contract end to end:
+
+```rust
+Recognizer::detect(...) -> Result<Vec<Candidate>, DetectError>
+```
+
+The shared `DetectError` type lives in `gaze-types`. NER backend runtime
+failures map to `DetectError::Backend`, registry aggregation returns `Result`,
+and the pipeline aborts outbound redaction on recognizer failure.
+
+## Blast Radius
+
+- `gaze-types`: `Recognizer::detect` becomes fallible and exposes `DetectError`.
+- `gaze`: `RecognizerRegistry::detect_all` and `detect_all_resolved` propagate
+  errors; `pipeline::Error` gains a recognizer-detection variant.
+- `gaze-recognizers`: regex, dictionary, anchored, and NER recognizers implement
+  the fallible contract. NER no longer maps backend failure to an empty result.
+- `gaze-cli`, `gaze-assembly`, and `gaze-mcp-core`: consume the existing core
+  pipeline `Result`, so recognizer failures surface as core pipeline errors.
+
+## Fail-Closed Proof
+
+Backend failure is no longer representable as an empty candidate list at the
+recognizer boundary. Registry detection short-circuits on `Err`, and pipeline
+redaction uses that `Result` before translating spans, logging, or emitting
+clean text. A NER backend failure therefore prevents partially cleaned output
+from leaving the pipeline.
+
+Long NER input is scanned through bounded overlapping chunks before backend
+execution; chunk failures are propagated as recognizer errors.


### PR DESCRIPTION
## Summary
- Adds `gaze_types::DetectError` and changes `Recognizer::detect` to return `Result<Vec<Candidate>, DetectError>`.
- Propagates recognizer detection errors through `RecognizerRegistry::detect_all(_resolved)` into `gaze::pipeline::Error::RecognizerDetect`, aborting redaction before clean output is emitted.
- Routes NER backend failures to `DetectError::Backend` instead of warning and returning an empty candidate list.
- Chunks long NER input with overlap before backend calls and remaps chunk spans back to original byte offsets.

## Design shape
Chose shape A: fallible recognizer detection end-to-end. This makes the previous fail-open representation (`Err` -> empty `Vec`) unrepresentable at the recognizer boundary. Registry aggregation short-circuits on `Err`, and pipeline redaction uses `?` before translating spans or emitting output.

## New error surface for harness
- Trait surface: `gaze_types::Recognizer::detect(&self, input, ctx) -> Result<Vec<Candidate>, gaze_types::DetectError>`.
- Backend failure variant: `gaze_types::DetectError::Backend { recognizer_id, message, .. }`.
- Pipeline surface: `gaze::pipeline::Error::RecognizerDetect(gaze_types::DetectError)`.
- Consumer detection: treat `Error::RecognizerDetect(DetectError::Backend { recognizer_id: "ner", .. })` as a NER backend failure. No clean document is returned.

## Tests
- `cargo test --workspace --all-features`
- Added forced backend-error regression coverage for NER recognizer and pipeline fail-closed behavior.
- Added long-input chunking coverage with an entity after the 512-token boundary.

## Axis note
Reliability is strengthened: NER backend failure can no longer silently degrade to “no entities found.” No axis tradeoff weakens reliability, reversibility, agentic fit, trust, or adopter ergonomics.
