### PR TITLE
[agent] feat(xtask): scrub-public-text pre-release gate (#407)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,6 +27,37 @@ jobs:
       - name: README version check
         run: cargo run -p xtask -- readme-version-check
 
+      - name: Scrub public release text
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "scrub-public-text skipped: workflow_dispatch has no tag-scoped release notes"
+            exit 0
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          changelog_section="$(mktemp)"
+          awk -v version="$version" '
+            index($0, "## [" version "]") == 1 { in_section=1; print; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > "$changelog_section"
+
+          if [ ! -s "$changelog_section" ]; then
+            echo "scrub-public-text failed: CHANGELOG.md has no section for ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          release_notes="dist/release-notes/${GITHUB_REF_NAME}.md"
+          if [ ! -f "$release_notes" ]; then
+            echo "scrub-public-text failed: missing release notes file ${release_notes}" >&2
+            exit 1
+          fi
+
+          cargo run -p xtask -- scrub-public-text "$changelog_section" "$release_notes"
+
       - name: Authenticate to crates.io via OIDC
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: cargo-auth

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,13 +27,13 @@ jobs:
       - name: README version check
         run: cargo run -p xtask -- readme-version-check
 
-      - name: Scrub public release text
+      - name: Scrub public changelog text
         shell: bash
         run: |
           set -euo pipefail
 
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "scrub-public-text skipped: workflow_dispatch has no tag-scoped release notes"
+            echo "scrub-public-text skipped: workflow_dispatch has no tag-scoped changelog section"
             exit 0
           fi
 
@@ -50,13 +50,7 @@ jobs:
             exit 1
           fi
 
-          release_notes="dist/release-notes/${GITHUB_REF_NAME}.md"
-          if [ ! -f "$release_notes" ]; then
-            echo "scrub-public-text failed: missing release notes file ${release_notes}" >&2
-            exit 1
-          fi
-
-          cargo run -p xtask -- scrub-public-text "$changelog_section" "$release_notes"
+          cargo run -p xtask -- scrub-public-text "$changelog_section"
 
       - name: Authenticate to crates.io via OIDC
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Scrub public release text
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          changelog_section="$(mktemp)"
+          awk -v version="$version" '
+            index($0, "## [" version "]") == 1 { in_section=1; print; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > "$changelog_section"
+
+          if [ ! -s "$changelog_section" ]; then
+            echo "scrub-public-text failed: CHANGELOG.md has no section for ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          release_notes="dist/release-notes/${GITHUB_REF_NAME}.md"
+          if [ ! -f "$release_notes" ]; then
+            echo "scrub-public-text failed: missing release notes file ${release_notes}" >&2
+            exit 1
+          fi
+
+          cargo run -p xtask -- scrub-public-text "$changelog_section" "$release_notes"
       - uses: actions/download-artifact@v8
         with:
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,22 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to scrub, with or without leading v"
+        required: true
+        type: string
+      release_notes:
+        description: "Release notes path; defaults to dist/release-notes/v<version>.md"
+        required: false
+        type: string
+        default: ""
+      pr_number:
+        description: "Optional release PR number whose body should be scrubbed"
+        required: false
+        type: string
+        default: ""
   push:
     tags:
       - 'v*'
@@ -9,7 +25,64 @@ permissions:
   contents: write
 
 jobs:
+  scrub-public-text-preflight:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Scrub public release text before tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+          RELEASE_PR_NUMBER: ${{ inputs.pr_number }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_VERSION#v}"
+          if [ -z "$version" ]; then
+            echo "scrub-public-text failed: release preflight requires a version" >&2
+            exit 1
+          fi
+
+          changelog_section="$(mktemp)"
+          awk -v version="$version" '
+            index($0, "## [" version "]") == 1 { in_section=1; print; next }
+            in_section && /^## \[/ { exit }
+            in_section { print }
+          ' CHANGELOG.md > "$changelog_section"
+
+          if [ ! -s "$changelog_section" ]; then
+            echo "scrub-public-text failed: CHANGELOG.md has no section for v${version}" >&2
+            exit 1
+          fi
+
+          release_notes="$RELEASE_NOTES"
+          if [ -z "$release_notes" ]; then
+            release_notes="dist/release-notes/v${version}.md"
+          fi
+          if [ ! -f "$release_notes" ]; then
+            echo "scrub-public-text failed: missing release notes file ${release_notes}" >&2
+            exit 1
+          fi
+
+          files=("$changelog_section" "$release_notes")
+
+          if [ -n "$RELEASE_PR_NUMBER" ]; then
+            pr_body="$(mktemp)"
+            gh pr view "$RELEASE_PR_NUMBER" --json body --jq .body > "$pr_body"
+            files+=("$pr_body")
+          fi
+
+          cargo run -p xtask -- scrub-public-text "${files[@]}"
+
   build:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -120,12 +193,17 @@ jobs:
           status_out="$("$bin" proxy status)"; grep -q 'not running' <<< "$status_out"
 
   release:
+    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - name: Scrub public release text
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Scrub public release text before publication
         shell: bash
         run: |
           set -euo pipefail
@@ -150,10 +228,6 @@ jobs:
           fi
 
           cargo run -p xtask -- scrub-public-text "$changelog_section" "$release_notes"
-      - uses: actions/download-artifact@v8
-        with:
-          path: dist
-          merge-multiple: true
       - name: Generate NER checksums
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ dependencies = [
  "gaze-recognizers",
  "phonenumber",
  "rand 0.8.6",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -12,6 +12,7 @@ gaze = { path = "../gaze", package = "gaze-pii" }
 gaze-recognizers = { path = "../gaze-recognizers" }
 phonenumber = { version = "0.3.9", default-features = false }
 rand = "0.8"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/xtask/fixtures/scrub_public_text/clean.md
+++ b/crates/xtask/fixtures/scrub_public_text/clean.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+This release improves the restore workflow and tightens release automation.

--- a/crates/xtask/fixtures/scrub_public_text/dirty.md
+++ b/crates/xtask/fixtures/scrub_public_text/dirty.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+Do not publish contact alice@example.invalid, token <Email_1>, or local path /Users/alice/project.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -16,6 +16,7 @@ mod mcp_tier_isolation;
 mod no_tenant_knowledge;
 mod readme_version_check;
 mod safety_net_sanity;
+mod scrub_public_text;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -41,6 +42,7 @@ enum Command {
     SafetyNetSanity,
     McpTierIsolation,
     ReadmeVersionCheck,
+    ScrubPublicText(scrub_public_text::Args),
 }
 
 fn main() -> Result<()> {
@@ -61,6 +63,7 @@ fn main() -> Result<()> {
         Command::SafetyNetSanity => safety_net_sanity::run(),
         Command::McpTierIsolation => mcp_tier_isolation::run(),
         Command::ReadmeVersionCheck => readme_version_check::run(),
+        Command::ScrubPublicText(args) => scrub_public_text::run(args),
     }
 }
 

--- a/crates/xtask/src/scrub_public_text.rs
+++ b/crates/xtask/src/scrub_public_text.rs
@@ -1,0 +1,180 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+use clap::Args as ClapArgs;
+use regex::Regex;
+use serde::Deserialize;
+
+#[derive(Debug, ClapArgs)]
+pub(crate) struct Args {
+    /// Public text files to check before release publication.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+struct Finding {
+    file: PathBuf,
+    line: usize,
+    column: usize,
+    detail: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CleanResponse {
+    #[serde(default)]
+    entries: Vec<CleanEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CleanEntry {
+    class: String,
+    token: String,
+}
+
+pub(crate) fn run(args: Args) -> Result<()> {
+    let mut findings = Vec::new();
+
+    for file in &args.files {
+        let text = fs::read_to_string(file)
+            .with_context(|| format!("failed to read {}", file.display()))?;
+        findings.extend(scan_user_paths(file, &text)?);
+        findings.extend(scan_existing_tokens(file, &text)?);
+        findings.extend(scan_with_gaze_clean(file, &text)?);
+    }
+
+    if findings.is_empty() {
+        println!(
+            "scrub-public-text: passed ({} file{})",
+            args.files.len(),
+            if args.files.len() == 1 { "" } else { "s" }
+        );
+        return Ok(());
+    }
+
+    eprintln!("scrub-public-text: public text contains PII-shaped content");
+    for finding in &findings {
+        eprintln!(
+            "  {}:{}:{}: {}",
+            finding.file.display(),
+            finding.line,
+            finding.column,
+            finding.detail
+        );
+    }
+    bail!("scrub-public-text failed; scrub or pseudonymize the reported text before release")
+}
+
+fn scan_user_paths(file: &Path, text: &str) -> Result<Vec<Finding>> {
+    let patterns = [
+        (
+            Regex::new(r"/Users/[^/\s]+/")?,
+            "OS user path `/Users/<name>/`",
+        ),
+        (
+            Regex::new(r"/home/[^/\s]+/")?,
+            "OS user path `/home/<name>/`",
+        ),
+        (
+            Regex::new(r"C:\\Users\\[^\\\s]+\\")?,
+            "OS user path `C:\\Users\\<name>\\`",
+        ),
+    ];
+    let mut findings = Vec::new();
+    for (regex, label) in patterns {
+        for hit in regex.find_iter(text) {
+            let (line, column) = line_column(text, hit.start());
+            findings.push(Finding {
+                file: file.to_path_buf(),
+                line,
+                column,
+                detail: label.to_string(),
+            });
+        }
+    }
+    Ok(findings)
+}
+
+fn scan_existing_tokens(file: &Path, text: &str) -> Result<Vec<Finding>> {
+    let token = Regex::new(r"<(?:[0-9a-f]{8}:)?[A-Za-z][A-Za-z0-9:_-]*_\d+>")?;
+    Ok(token
+        .find_iter(text)
+        .map(|hit| {
+            let (line, column) = line_column(text, hit.start());
+            Finding {
+                file: file.to_path_buf(),
+                line,
+                column,
+                detail: format!("existing gaze token {}", hit.as_str()),
+            }
+        })
+        .collect())
+}
+
+fn scan_with_gaze_clean(file: &Path, text: &str) -> Result<Vec<Finding>> {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut child = Command::new(cargo)
+        .args(["run", "-q", "-p", "gaze-cli", "--", "clean"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start gaze clean for {}", file.display()))?;
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin piped")
+        .write_all(text.as_bytes())
+        .with_context(|| format!("failed to send {} to gaze clean", file.display()))?;
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("failed to wait for gaze clean on {}", file.display()))?;
+    if !output.status.success() {
+        bail!(
+            "gaze clean failed for {}: {}",
+            file.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let response: CleanResponse = serde_json::from_slice(&output.stdout).with_context(|| {
+        format!(
+            "failed to parse gaze clean JSON for {}: {}",
+            file.display(),
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })?;
+
+    Ok(response
+        .entries
+        .into_iter()
+        .map(|entry| Finding {
+            file: file.to_path_buf(),
+            line: 1,
+            column: 1,
+            detail: format!("gaze clean emitted {} token {}", entry.class, entry.token),
+        })
+        .collect())
+}
+
+fn line_column(text: &str, byte_offset: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut column = 1;
+    for (idx, ch) in text.char_indices() {
+        if idx >= byte_offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    (line, column)
+}

--- a/crates/xtask/tests/scrub_public_text.rs
+++ b/crates/xtask/tests/scrub_public_text.rs
@@ -1,0 +1,60 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn run_gate(root: &Path, fixture: &str) -> Output {
+    Command::new("cargo")
+        .args(["run", "-p", "xtask", "--", "scrub-public-text"])
+        .arg(format!("crates/xtask/fixtures/scrub_public_text/{fixture}"))
+        .current_dir(root)
+        .output()
+        .expect("run scrub-public-text gate")
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn scrub_public_text_passes_clean_fixture() {
+    let output = run_gate(&workspace_root(), "clean.md");
+    assert!(
+        output.status.success(),
+        "clean public text must pass; {}",
+        output_text(&output)
+    );
+}
+
+#[test]
+fn scrub_public_text_fails_token_and_user_path_fixture() {
+    let output = run_gate(&workspace_root(), "dirty.md");
+    let text = output_text(&output);
+    assert!(
+        !output.status.success(),
+        "dirty public text must fail; {text}"
+    );
+    assert!(
+        text.contains("gaze clean emitted Email token"),
+        "gate must report tokens emitted by gaze clean; {text}"
+    );
+    assert!(
+        text.contains("existing gaze token <Email_1>"),
+        "gate must report already-tokenized public text; {text}"
+    );
+    assert!(
+        text.contains("OS user path `/Users/<name>/`"),
+        "gate must report OS user path patterns without echoing the username; {text}"
+    );
+}


### PR DESCRIPTION
Summary:
- Add xtask scrub-public-text to run public text through gaze clean and fail on emitted tokens.
- Add best-effort linting for existing gaze token shapes and OS user-path patterns without echoing usernames.
- Wire the scrub gate into release and crates publish tag workflows for the tagged CHANGELOG section and release-notes file.

Test plan:
- cargo test -p xtask --test scrub_public_text -- --nocapture
- cargo run -p xtask -- scrub-public-text crates/xtask/fixtures/scrub_public_text/clean.md
- cargo run -p xtask -- scrub-public-text crates/xtask/fixtures/scrub_public_text/dirty.md (expected failure)
- cargo run -p xtask -- scrub-public-text <v0.9.0 CHANGELOG temp section> dist/release-notes/v0.9.0.md
- cargo fmt --all -- --check
- cargo test --workspace --all-features
- cargo run -p xtask -- ci-feature-matrix