### PR TITLE
[agent] fix(restore+ner): byte-exact restore + token-boundary spans (P0 #923)

### DIFF
--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -324,4 +324,32 @@ mod tests {
         assert_eq!(hits[0].source, "dictionary:songs[#0]");
         assert_eq!(hits[1].source, "dictionary:songs[#2]");
     }
+
+    #[test]
+    fn dictionary_recognizer_does_not_match_inside_identifier() {
+        let ctx = TypedContext {
+            dictionaries: HashMap::from([(
+                "artist_refs".to_string(),
+                ContextDictionary {
+                    terms: vec!["Artist".to_string()],
+                    case_sensitive: true,
+                },
+            )]),
+            class_map: HashMap::new(),
+            fields: Map::new(),
+        };
+        let bundle = dictionary_bundle_from_context(&ctx);
+        let detect_context = DetectContext::new(&[LocaleTag::Global], &bundle);
+        let recognizer = DictionaryRecognizer::new(
+            "dict/artist_refs",
+            PiiClass::Custom("artist_ref".to_string()),
+            "artist_refs",
+            true,
+            "counter",
+        );
+
+        let hits = recognizer.detect("Du antwortest als Artistfy-Support.", &detect_context);
+
+        assert!(hits.is_empty(), "unexpected dictionary hits: {hits:?}");
+    }
 }

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -136,6 +136,7 @@ impl Recognizer for DictionaryRecognizer {
 
         Ok(automaton
             .find_iter(input)
+            .filter(|m| is_token_boundary_match(input, m.start(), m.end()))
             .map(|m| {
                 Candidate::new(
                     m.start()..m.end(),
@@ -164,6 +165,25 @@ impl Recognizer for DictionaryRecognizer {
     fn locales(&self) -> &[LocaleTag] {
         &self.locales
     }
+}
+
+fn is_token_boundary_match(input: &str, start: usize, end: usize) -> bool {
+    !has_identifier_char_before(input, start) && !has_identifier_char_after(input, end)
+}
+
+fn has_identifier_char_before(input: &str, start: usize) -> bool {
+    input[..start]
+        .chars()
+        .next_back()
+        .is_some_and(is_identifier_char)
+}
+
+fn has_identifier_char_after(input: &str, end: usize) -> bool {
+    input[end..].chars().next().is_some_and(is_identifier_char)
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch == '_' || ch.is_alphanumeric()
 }
 
 #[cfg(test)]

--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -368,7 +368,9 @@ mod tests {
             "counter",
         );
 
-        let hits = recognizer.detect("Du antwortest als Artistfy-Support.", &detect_context);
+        let hits = recognizer
+            .detect("Du antwortest als Artistfy-Support.", &detect_context)
+            .unwrap();
 
         assert!(hits.is_empty(), "unexpected dictionary hits: {hits:?}");
     }

--- a/crates/gaze-recognizers/src/ner/decode.rs
+++ b/crates/gaze-recognizers/src/ner/decode.rs
@@ -1,4 +1,4 @@
-use gaze_types::Detection;
+use gaze_types::{Detection, PiiClass};
 
 use super::types::{LabelMap, NerSpanResult};
 
@@ -25,6 +25,7 @@ pub(crate) fn merge_bio_span_results(
     let mut out = Vec::new();
     let (effective_labels, effective_scores) =
         bridge_joiner_tokens(source, subword_spans, subword_labels, subword_scores);
+    let enforce_source_boundaries = subword_spans.iter().all(|(_, end)| *end <= source.len());
     let mut i = 0usize;
     while i < effective_labels.len() {
         let tag = effective_labels[i].as_str();
@@ -57,14 +58,62 @@ pub(crate) fn merge_bio_span_results(
                 break;
             }
         }
-        out.push(NerSpanResult {
-            span: start..end,
-            class: class.clone(),
-            score: span_score,
-        });
+        if is_valid_entity_span(source, start, end, &class, enforce_source_boundaries) {
+            out.push(NerSpanResult {
+                span: start..end,
+                class: class.clone(),
+                score: span_score,
+            });
+        }
         i = j;
     }
     out
+}
+
+fn is_valid_entity_span(
+    source: &str,
+    start: usize,
+    end: usize,
+    class: &PiiClass,
+    enforce_source_boundaries: bool,
+) -> bool {
+    !enforce_source_boundaries
+        || (is_token_boundary_match(source, start, end)
+            && !is_suppressed_single_token_organization(source, start, end, class))
+}
+
+fn is_token_boundary_match(source: &str, start: usize, end: usize) -> bool {
+    let Some(before) = source.get(..start) else {
+        return true;
+    };
+    let Some(after) = source.get(end..) else {
+        return true;
+    };
+
+    !before
+        .chars()
+        .next_back()
+        .is_some_and(is_identifier_char)
+        && !after.chars().next().is_some_and(is_identifier_char)
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch == '_' || ch.is_alphanumeric()
+}
+
+fn is_suppressed_single_token_organization(
+    source: &str,
+    start: usize,
+    end: usize,
+    class: &PiiClass,
+) -> bool {
+    if class != &PiiClass::Organization {
+        return false;
+    }
+    let Some(text) = source.get(start..end) else {
+        return false;
+    };
+    !text.chars().any(char::is_whitespace) && text.eq_ignore_ascii_case("workspace")
 }
 
 fn bridge_joiner_tokens(
@@ -319,5 +368,25 @@ mod tests {
         let out = merge(source, &["Artist"], &["B-ORG"], &label_map);
 
         assert!(out.is_empty(), "unexpected partial identifier span: {out:?}");
+    }
+
+    #[test]
+    fn suppresses_single_token_workspace_organization() {
+        let source = "list all folders in ~/Workspace";
+        let label_map = labels(&[("ORG", PiiClass::Organization)]);
+        let out = merge(source, &["Workspace"], &["B-ORG"], &label_map);
+
+        assert!(out.is_empty(), "unexpected Workspace org span: {out:?}");
+    }
+
+    #[test]
+    fn keeps_multi_token_organization_recall() {
+        let source = "Acme Corp";
+        let label_map = labels(&[("ORG", PiiClass::Organization)]);
+        let out = merge(source, &["Acme", "Corp"], &["B-ORG", "I-ORG"], &label_map);
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].span, 0..source.len());
+        assert_eq!(out[0].class, PiiClass::Organization);
     }
 }

--- a/crates/gaze-recognizers/src/ner/decode.rs
+++ b/crates/gaze-recognizers/src/ner/decode.rs
@@ -311,4 +311,13 @@ mod tests {
         assert_eq!(out[0].span, 0..4);
         assert_eq!(out[1].span, 5..8);
     }
+
+    #[test]
+    fn drops_entity_span_inside_identifier() {
+        let source = "Artistfy";
+        let label_map = labels(&[("ORG", PiiClass::Organization)]);
+        let out = merge(source, &["Artist"], &["B-ORG"], &label_map);
+
+        assert!(out.is_empty(), "unexpected partial identifier span: {out:?}");
+    }
 }

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1915,17 +1915,36 @@ mod tests {
     #[test]
     fn restore_strict_text_preserves_path_adjacency_byte_exact() {
         let session = Session::new(Scope::Ephemeral).expect("session");
-        let token = session
+        let workspace = session
             .tokenize(&PiiClass::Organization, "Workspace")
-            .expect("token");
-        let clean = format!("list all folders in ~/{token}");
+            .expect("workspace token");
+        let artist = session
+            .tokenize(&PiiClass::Organization, "Artist")
+            .expect("artist token");
+        let email = session
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .expect("email token");
+        let cases = [
+            (
+                format!("list all folders in ~/{workspace}"),
+                "list all folders in ~/Workspace".to_string(),
+            ),
+            (format!("{workspace}*"), "Workspace*".to_string()),
+            (format!("~/{workspace}/{artist}"), "~/Workspace/Artist".to_string()),
+            (
+                format!("owner={email};path=~/{workspace}"),
+                "owner=alice@example.invalid;path=~/Workspace".to_string(),
+            ),
+        ];
 
-        let restored = session
-            .restore_strict_text(&clean)
-            .expect("restore must succeed");
+        for (clean, expected) in cases {
+            let restored = session
+                .restore_strict_text(&clean)
+                .expect("restore must succeed");
 
-        assert_eq!(restored, "list all folders in ~/Workspace");
-        assert!(!restored.contains("~/ Workspace"));
+            assert_eq!(restored, expected);
+            assert!(!restored.contains("~/ Workspace"));
+        }
     }
 
     #[test]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1913,6 +1913,22 @@ mod tests {
     }
 
     #[test]
+    fn restore_strict_text_preserves_path_adjacency_byte_exact() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::Organization, "Workspace")
+            .expect("token");
+        let clean = format!("list all folders in ~/{token}");
+
+        let restored = session
+            .restore_strict_text(&clean)
+            .expect("restore must succeed");
+
+        assert_eq!(restored, "list all folders in ~/Workspace");
+        assert!(!restored.contains("~/ Workspace"));
+    }
+
+    #[test]
     fn restore_boundary_events_distinguish_manifest_bypass_from_fresh_pii() {
         let session = Session::new(Scope::Ephemeral).expect("session");
         let token = session


### PR DESCRIPTION
Summary:\n- Pin byte-exact restore for path-like and adjacent token text so path-token adjacency restores without inserted whitespace.\n- Prevent dictionary and NER span emission from matching entity text inside larger identifiers such as Artistfy.\n- Suppress the narrow NER false positive where single-token Workspace is labeled as Organization, while preserving multi-token organization recall.\n- Refresh a trybuild stderr fixture for current Rust diagnostic wording.\n\nRepro / Diagnosis:\n- Wrote design/p0-923 Solo scratchpad with findings.\n- Dictionary repro: Artist previously matched inside Artistfy.\n- NER decode repro: a B-ORG subword span for Artist inside Artistfy previously emitted a partial entity.\n- Core restore adjacency already restored byte-exactly; coverage now pins the contract for path-like adjacency.\n\nTest Plan:\n- cargo test --workspace --all-features\n\nFollow-ups:\n- Created Solo todo 927 for argv/path pseudonymization policy at harness/chokepoint level.