### PR TITLE
[agent] chore(gaze-mcp-core): refresh trybuild snapshot for current stable rustc diagnostic wording

### DIFF
--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`
+   |                         ^^^ function or associated item not found in `ToolCtx<'_>`


### PR DESCRIPTION
Summary:\n- Refresh the gaze-mcp-core trybuild stderr snapshot for current stable rustc diagnostic wording.\n- rustc now reports 'no function or associated item named new' instead of 'no associated function or constant named new' for the sealed ToolCtx constructor case.\n- This is diagnostic wording churn only; the compile-fail contract remains unchanged.\n\nWhy:\n- Unblocks PRs #293 and #295 from carrying this unrelated snapshot refresh.\n\nTest Plan:\n- TRYBUILD=overwrite cargo test -p gaze-mcp-core --all-features\n- cargo test -p gaze-mcp-core --all-features