### PR TITLE
[agent] release: v0.10.0 (NER fail-closed + byte-exact restore + scrub gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [0.10.0] - 2026-06-01
 
 ### Changed
 
@@ -41,10 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   design contract in
   [`docs/architecture/p0-908-ner-failclosed.md`](docs/architecture/p0-908-ner-failclosed.md).
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - **Byte-exact restore for adjacent and path-like tokens** (P0 #923, PR #295).
@@ -74,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   knob; spans are remapped to original byte offsets before de-duplication.
   Contract:
   [`docs/architecture/p0-908-ner-failclosed.md`](docs/architecture/p0-908-ner-failclosed.md).
+- **Release pre-flight now scrubs public text for local path/PII leaks** (PR #294).
+  The new `scrub-public-text` gate scans release-facing docs and notes before
+  publication, making accidental workspace-path or fixture leaks a release
+  blocker rather than a post-release cleanup. (Axis 1 never-leak, Axis 4 trust.)
 
 ## [0.9.1] - 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.9.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.9.1" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.9.1" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.10.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.10.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.10.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ The CLI is a process boundary around the Rust runtime; you can link the runtime 
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.1"
-gaze-assembly = "0.9.1"
+gaze-pii = "0.10.0"
+gaze-assembly = "0.10.0"
 ```
 
 The crate is published as `gaze-pii` because the bare `gaze` name is in transfer on crates.io; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved.

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
+gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.1"
-gaze-assembly = "0.9.1"
-gaze-recognizers = "0.9.1"
+gaze-pii = "0.10.0"
+gaze-assembly = "0.10.0"
+gaze-recognizers = "0.10.0"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.1"
-gaze-audit = "0.9.1"
+gaze-pii = "0.10.0"
+gaze-audit = "0.10.0"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -44,14 +44,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
+gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.9.1", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.1", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.10.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -66,7 +66,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.9.1
+$ cargo install gaze-cli --version 0.10.0
 ```
 
 Build from the workspace root:
@@ -109,7 +109,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.9.1 --features mcp
+$ cargo install gaze-cli --version 0.10.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
+gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.9.1" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.9.1"
+gaze-document = "0.10.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.9.1 --features document
+cargo install gaze-cli --version 0.10.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays
@@ -243,7 +243,7 @@ this crate only provides the opt-in tool implementations.
 | `render-image`    | no      | Reserved — future redacted-preview renderer.         |
 
 The `extract-docling` and `render-image` features are intentionally empty
-in v0.9.1 so adopters can pin against the eventual flag names early.
+in v0.10.0 so adopters can pin against the eventual flag names early.
 
 ## License
 

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.9.1) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.10.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.9.1" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.9.1" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.10.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.9.1"
-gaze-mcp-rmcp = "0.9.1"
+gaze-mcp-core = "0.10.0"
+gaze-mcp-rmcp = "0.10.0"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.9.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.9.1" }
+gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.9.1"
+gaze-proxy = "0.10.0"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.9.1
+cargo install gaze-cli --version 0.10.0
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.1"
-gaze-recognizers = "0.9.1"
+gaze-pii = "0.10.0"
+gaze-recognizers = "0.10.0"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.9.1", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.10.0", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -495,7 +495,7 @@ mod tests {
             },
         };
         let dense_prefix = "x".repeat(NER_CHUNK_TOKEN_BUDGET + NER_CHUNK_TOKEN_OVERLAP + 80);
-        let input = format!("{dense_prefix}/Users/krishan/Workspace/Artistfy Dr. Schmidt");
+        let input = format!("{dense_prefix}~/Workspace/Artistfy Dr. Schmidt");
         let entity_start = input.find("Dr. Schmidt").expect("fixture entity");
         let dictionaries = DictionaryBundle::default();
         let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.9.1"
+gaze-types = "0.10.0"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.9.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.9.1"
-gaze-assembly = "0.9.1"
-gaze-recognizers = "0.9.1"
+gaze-pii = "0.10.0"
+gaze-assembly = "0.10.0"
+gaze-recognizers = "0.10.0"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).

--- a/crates/xtask/fixtures/scrub_public_text/dirty.md
+++ b/crates/xtask/fixtures/scrub_public_text/dirty.md
@@ -1,3 +1,3 @@
 # Release Notes
 
-Do not publish contact alice@example.invalid, token <Email_1>, or local path /Users/alice/project.
+Do not publish contact alice@example.invalid, token <Email_1>, or local path /home/alice/project.

--- a/crates/xtask/tests/scrub_public_text.rs
+++ b/crates/xtask/tests/scrub_public_text.rs
@@ -54,7 +54,7 @@ fn scrub_public_text_fails_token_and_user_path_fixture() {
         "gate must report already-tokenized public text; {text}"
     );
     assert!(
-        text.contains("OS user path `/Users/<name>/`"),
+        text.contains("OS user path `/home/<name>/`"),
         "gate must report OS user path patterns without echoing the username; {text}"
     );
 }

--- a/dist/release-notes/v0.10.0.md
+++ b/dist/release-notes/v0.10.0.md
@@ -1,0 +1,65 @@
+# gaze v0.10.0 - NER fail-closed and byte-exact restore
+
+## TL;DR
+
+v0.10.0 tightened the never-leak core: NER backend failures now stop the
+pipeline instead of looking like "no findings," and long NER inputs are chunked
+across the model window. It also fixed byte-exact restore for adjacent and
+path-like tokens, preserving Gaze's reversibility contract while improving
+precision around token boundaries.
+
+## Highlights
+
+1. **NER detection failed closed** (#290, #293). Custom recognizers and NER
+   backends now report `DetectError` instead of silently returning an empty
+   candidate list on failure. The pipeline surfaces that as
+   `Error::RecognizerDetect`, making backend failure a hard stop before any
+   outbound text can leak. Long inputs were also chunked into overlapping
+   WordPiece windows so documents beyond the 512-token model ceiling are still
+   scanned. This is the Axis 1 never-leak release.
+2. **Restore became byte-exact in adjacent-token cases** (#295). Gaze no longer
+   inserts stray whitespace when restoring adjacent or path-like spans. That
+   keeps manifest restore reversible byte-for-byte, which is the Axis 2 moat.
+3. **Token-boundary precision improved** (#295). Recognizers now avoid matching
+   inside larger tokens, and the common-word `Workspace` no longer promotes to
+   an organization span by itself. The result is less surrounding-context churn
+   without relaxing the fail-closed posture.
+4. **Public release text now has a scrub gate** (#294). Release-facing docs and
+   notes can be checked with `scrub-public-text`, turning accidental local path
+   or fixture leaks into a release blocker.
+
+## Known Limitations
+
+- NER entities that are longer than the chunk overlap can still split across a
+  chunk boundary. The overlap is intentionally treated as a security invariant;
+  increasing it should be justified against the longest entity class being
+  protected.
+- Trybuild snapshots remain sensitive to the Rust compiler version. The v0.10.0
+  pre-flight was run under rustc 1.96.0, matching the pinned CI toolchain.
+
+## Adopter Notes / Migration
+
+This release is breaking for custom recognizer authors. Implementations of
+`Recognizer::detect` must now return
+`Result<Vec<Candidate>, gaze_types::DetectError>` instead of `Vec<Candidate>`.
+Infallible recognizers should wrap their existing result in `Ok(...)`; fallible
+backends should map runtime failures to `DetectError::backend(...)`.
+
+Pipeline consumers can detect NER backend failure through
+`Error::RecognizerDetect(DetectError::Backend { .. })`. Treat that as a hard
+fail-closed event, not as a recoverable "no PII found" result.
+
+## Download
+
+After the maintainer creates the `v0.10.0` tag, the release workflow should
+publish:
+
+- `gaze-v0.10.0-aarch64-apple-darwin.tar.gz`
+- `gaze-v0.10.0-x86_64-unknown-linux-gnu.tar.gz`
+- `SHA256SUMS`
+
+Both binaries should be built with `--features proxy --features document`.
+
+## Changelog
+
+Full PR-by-PR detail: [CHANGELOG.md](https://github.com/EmpireTwo/gaze/blob/main/CHANGELOG.md#0100---2026-06-01).


### PR DESCRIPTION
## Summary

- prepared v0.10.0 release metadata and crate versions across all 10 published crates
- scrubbed the release-blocking `/Users/...` fixture path in NER chunking coverage and the xtask dirty fixture
- promoted CHANGELOG `[0.10.0] - 2026-06-01` and added curated notes at `dist/release-notes/v0.10.0.md`

## BREAKING / Migration

Custom `Recognizer` implementations must now return `Result<Vec<Candidate>, gaze_types::DetectError>` from `Recognizer::detect`. Infallible recognizers can wrap existing output in `Ok(...)`; fallible NER/backend implementations should return `DetectError::backend(...)`. Pipeline consumers should treat `Error::RecognizerDetect(DetectError::Backend { .. })` as fail-closed, not as "no PII found".

## Pre-flight Gates (rustc 1.96.0)

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run -p xtask -- ci-feature-matrix`
- [x] `cargo run -p xtask -- readme-version-check`
- [x] `git grep -nE '/Users/[a-z]+' -- ':!*.lock'` returned empty
- [x] `cargo run -p xtask -- scrub-public-text dist/release-notes/v0.10.0.md /tmp/gaze-changelog-v0.10.0.md`

## Release Notes

`dist/release-notes/v0.10.0.md` covers NER fail-closed/chunking (#290/#293), byte-exact restore and token-boundary precision (#295), and the scrub-public-text gate (#294), with known limitations and adopter migration notes.

No tag created. Tagging remains blocked on maintainer go/no-go.
