### PR TITLE
fix(gaze-952): stop over-redacting camelCase command identifiers

### DIFF
--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`
+   |                         ^^^ function or associated item not found in `ToolCtx<'_>`

--- a/crates/gaze-recognizers/src/ner/decode.rs
+++ b/crates/gaze-recognizers/src/ner/decode.rs
@@ -123,7 +123,12 @@ fn is_suppressed_single_token_organization(
     let Some(text) = source.get(start..end) else {
         return false;
     };
-    !text.chars().any(char::is_whitespace) && text.eq_ignore_ascii_case("workspace")
+    if text.chars().any(char::is_whitespace) || !text.eq_ignore_ascii_case("workspace") {
+        return false;
+    }
+    source
+        .get(..start)
+        .is_some_and(|before| before.ends_with("~/") || before.ends_with("/"))
 }
 
 fn is_command_argv_identifier_span(text: &str) -> bool {
@@ -161,17 +166,10 @@ fn is_program_identifier_token(token: &str) -> bool {
     if token.is_empty() || !token.chars().all(|ch| ch.is_ascii_alphanumeric()) {
         return false;
     }
-    matches!(token, "cal" | "ls" | "osascript")
-        || starts_lowercase_with_internal_uppercase(token)
-        || token.ends_with("Script")
-}
-
-fn starts_lowercase_with_internal_uppercase(token: &str) -> bool {
-    let mut chars = token.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    first.is_ascii_lowercase() && chars.any(|ch| ch.is_ascii_uppercase())
+    matches!(
+        token,
+        "cal" | "eventsToday" | "icalBuddy" | "ls" | "osascript"
+    ) || token.ends_with("Script")
 }
 
 fn is_apple_script_literal(text: &str) -> bool {

--- a/crates/gaze-recognizers/src/ner/decode.rs
+++ b/crates/gaze-recognizers/src/ner/decode.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use gaze_types::{Detection, PiiClass};
 
 use super::types::{LabelMap, NerSpanResult};
@@ -58,7 +60,7 @@ pub(crate) fn merge_bio_span_results(
                 break;
             }
         }
-        if is_valid_entity_span(source, start, end, class, enforce_source_boundaries) {
+        if is_valid_entity_span(source, &(start..end), class, enforce_source_boundaries) {
             out.push(NerSpanResult {
                 span: start..end,
                 class: class.clone(),
@@ -70,16 +72,27 @@ pub(crate) fn merge_bio_span_results(
     out
 }
 
-fn is_valid_entity_span(
+pub(crate) fn is_valid_entity_span(
     source: &str,
-    start: usize,
-    end: usize,
+    span: &Range<usize>,
     class: &PiiClass,
     enforce_source_boundaries: bool,
 ) -> bool {
-    !enforce_source_boundaries
-        || (is_token_boundary_match(source, start, end)
-            && !is_suppressed_single_token_organization(source, start, end, class))
+    let start = span.start;
+    let end = span.end;
+    if enforce_source_boundaries && !is_token_boundary_match(source, start, end) {
+        return false;
+    }
+    if is_suppressed_single_token_organization(source, start, end, class) {
+        return false;
+    }
+    if !matches!(class, PiiClass::Name | PiiClass::Organization) {
+        return true;
+    }
+    let Some(text) = source.get(span.clone()) else {
+        return true;
+    };
+    !is_command_argv_identifier_span(text)
 }
 
 fn is_token_boundary_match(source: &str, start: usize, end: usize) -> bool {
@@ -111,6 +124,58 @@ fn is_suppressed_single_token_organization(
         return false;
     };
     !text.chars().any(char::is_whitespace) && text.eq_ignore_ascii_case("workspace")
+}
+
+fn is_command_argv_identifier_span(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed == "~" || is_cli_flag(trimmed) || is_apple_script_literal(trimmed) {
+        return true;
+    }
+    if trimmed.starts_with("osascript ") && trimmed.contains("tell application") {
+        return true;
+    }
+    let mut parts = trimmed.split_ascii_whitespace().peekable();
+    if parts.peek().is_some() {
+        return parts.all(|part| {
+            let token = part.trim_matches(|ch| matches!(ch, '\'' | '"'));
+            token == "~" || is_cli_flag(token) || is_program_identifier_token(token)
+        });
+    }
+    false
+}
+
+fn is_cli_flag(token: &str) -> bool {
+    token
+        .strip_prefix('-')
+        .filter(|rest| !rest.is_empty())
+        .is_some_and(|rest| {
+            rest.chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+        })
+}
+
+fn is_program_identifier_token(token: &str) -> bool {
+    if token.is_empty() || !token.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+        return false;
+    }
+    matches!(token, "cal" | "ls" | "osascript")
+        || starts_lowercase_with_internal_uppercase(token)
+        || token.ends_with("Script")
+}
+
+fn starts_lowercase_with_internal_uppercase(token: &str) -> bool {
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_lowercase() && chars.any(|ch| ch.is_ascii_uppercase())
+}
+
+fn is_apple_script_literal(text: &str) -> bool {
+    text.starts_with("tell application ") && text.contains(" to ")
 }
 
 fn bridge_joiner_tokens(

--- a/crates/gaze-recognizers/src/ner/decode.rs
+++ b/crates/gaze-recognizers/src/ner/decode.rs
@@ -162,6 +162,14 @@ fn is_cli_flag(token: &str) -> bool {
         })
 }
 
+// KNOWN DEBT (stop-gap): this literal command/argv allowlist is a per-symptom
+// suppressor, not the real fix. It does not generalize (grep/awk/git/jq/sed still
+// over-redact) and each enumerated token is a latent under-redaction surface (a real
+// PII string colliding with a command word is silently suppressed). The structural
+// fix is an NER span provenance trust-tier + corroboration gate (reuse anchored_match
+// + locale cues) plus an idempotence xtask invariant and a code/argv distractor
+// corpus. See gaze todo #1024 and scratchpad analysis/gaze-overredaction-architecture.
+// Do not grow this list reflexively; add a corpus row and let the structural gate handle it.
 fn is_program_identifier_token(token: &str) -> bool {
     if token.is_empty() || !token.chars().all(|ch| ch.is_ascii_alphanumeric()) {
         return false;

--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -101,7 +101,10 @@ impl NerDetector {
                 },
             ));
         }
-        Ok(merge_overlapping_spans(spans))
+        Ok(merge_overlapping_spans(spans)
+            .into_iter()
+            .filter(|span| decode::is_valid_entity_span(input, &span.span, &span.class, true))
+            .collect())
     }
 
     /// Label/offset reconstruction helper. Public for testing the BIO merge.

--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -103,7 +103,7 @@ impl NerDetector {
         }
         Ok(merge_overlapping_spans(spans)
             .into_iter()
-            .filter(|span| decode::is_valid_entity_span(input, &span.span, &span.class, true))
+            .filter(|span| decode::is_valid_entity_span(input, &span.span, &span.class, false))
             .collect())
     }
 

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -22,6 +22,9 @@ mod tests {
     use crate::ner::backend::{NerBackend, NER_CHUNK_TOKEN_BUDGET, NER_CHUNK_TOKEN_OVERLAP};
     use crate::ner::error::NerRuntimeError;
     use crate::ner::types::{CHECKSUMS_FILE, CONFIG_FILE, LABELS_FILE, MODEL_FILE, TOKENIZER_FILE};
+    use gaze::{
+        Action, ClassRule, CleanDocument, DefaultRule, Pipeline, RawDocument, Scope, Session,
+    };
     use gaze_types::{DetectContext, DictionaryBundle, LocaleTag, PiiClass, Recognizer};
     use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
@@ -39,6 +42,57 @@ mod tests {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         hex::encode(hasher.finalize())
+    }
+
+    struct TestBackend {
+        spans: Vec<NerSpanResult>,
+    }
+
+    impl NerBackend for TestBackend {
+        fn detect(&self, _input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+            Ok(self.spans.clone())
+        }
+    }
+
+    fn recognizer_with_spans(spans: Vec<NerSpanResult>) -> NerRecognizer {
+        NerRecognizer {
+            detector: NerDetector {
+                model_dir: PathBuf::from("/test/fake"),
+                backend_kind: NerBackendKind::Ort,
+                recognizer_version_id: "ner.fixed.v1".to_string(),
+                locale: None,
+                threshold: 0.5,
+                backend: Arc::new(TestBackend { spans }),
+            },
+        }
+    }
+
+    fn tokenizing_pipeline(recognizer: NerRecognizer) -> Pipeline {
+        Pipeline::builder()
+            .recognizer(recognizer)
+            .rule(ClassRule::new(PiiClass::Name, Action::Tokenize))
+            .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+            .rule(ClassRule::new(PiiClass::Organization, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .build()
+            .expect("pipeline")
+    }
+
+    fn clean_text(clean: CleanDocument) -> String {
+        match clean {
+            CleanDocument::Text(text) => text,
+            _ => panic!("expected text clean document"),
+        }
+    }
+
+    fn token_label(class: &PiiClass) -> &'static str {
+        match class {
+            PiiClass::Email => ":Email_",
+            PiiClass::Name => ":Name_",
+            PiiClass::Organization => ":Organization_",
+            PiiClass::Location => ":Location_",
+            PiiClass::Custom(_) => ":Custom:",
+        }
     }
 
     fn good_labels() -> &'static [u8] {
@@ -392,6 +446,112 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].span, 0..16);
         assert_eq!(out[0].score, 0.34);
+    }
+
+    #[test]
+    fn ner_command_argv_identifier_false_positives_do_not_tokenize_or_drift() {
+        let cases = [
+            ("icalBuddy", PiiClass::Organization),
+            ("eventsToday", PiiClass::Organization),
+            ("AppleScript", PiiClass::Organization),
+            (
+                r#"tell application "Reminders" to return name of reminders whose completed is false"#,
+                PiiClass::Name,
+            ),
+            (
+                r#"osascript -e 'tell application "Reminders" to return name of reminders whose completed is false'"#,
+                PiiClass::Name,
+            ),
+            ("cal", PiiClass::Organization),
+            ("ls", PiiClass::Organization),
+            ("-l", PiiClass::Organization),
+            ("~", PiiClass::Organization),
+            ("icalBuddy -f eventsToday", PiiClass::Organization),
+            ("ls -l ~", PiiClass::Organization),
+        ];
+
+        for (input, class) in cases {
+            let recognizer = recognizer_with_spans(vec![NerSpanResult {
+                span: 0..input.len(),
+                class,
+                score: 0.99,
+            }]);
+            let pipeline = tokenizing_pipeline(recognizer);
+            let session = Session::new(Scope::Ephemeral).expect("session");
+
+            let redacted = clean_text(
+                pipeline
+                    .redact(&session, RawDocument::Text(input.to_string()))
+                    .expect("first redact"),
+            );
+            let restored = pipeline
+                .restore_with_telemetry(&session, &redacted)
+                .expect("restore")
+                .0
+                .text;
+            let reredacted = clean_text(
+                pipeline
+                    .redact(&session, RawDocument::Text(restored.clone()))
+                    .expect("second redact"),
+            );
+
+            assert_eq!(redacted, input, "argv text must not be pseudonymized");
+            assert_eq!(restored, input, "restore must preserve argv bytes");
+            assert_eq!(reredacted, redacted, "redact(restore(redact(x))) drifted");
+        }
+    }
+
+    #[test]
+    fn ner_pii_spans_still_tokenize_after_command_identifier_suppression() {
+        let cases = [
+            ("Owner Dr. Schmidt", "Dr. Schmidt", PiiClass::Name),
+            (
+                "Email alice@example.invalid",
+                "alice@example.invalid",
+                PiiClass::Email,
+            ),
+            (
+                "Home /Users/alice/project",
+                "/Users/alice/project",
+                PiiClass::Name,
+            ),
+            ("Org Workspace", "Workspace", PiiClass::Organization),
+            ("Org OpenAI", "OpenAI", PiiClass::Organization),
+        ];
+
+        for (input, raw, class) in cases {
+            let start = input.find(raw).expect("raw span");
+            let recognizer = recognizer_with_spans(vec![NerSpanResult {
+                span: start..start + raw.len(),
+                class: class.clone(),
+                score: 0.99,
+            }]);
+            let pipeline = tokenizing_pipeline(recognizer);
+            let session = Session::new(Scope::Ephemeral).expect("session");
+
+            let redacted = clean_text(
+                pipeline
+                    .redact(&session, RawDocument::Text(input.to_string()))
+                    .expect("redact"),
+            );
+
+            assert!(
+                !redacted.contains(raw),
+                "PII span stayed raw after redaction: {redacted}"
+            );
+            assert!(
+                redacted.contains(token_label(&class)),
+                "expected {class:?} token in {redacted}"
+            );
+            assert_eq!(
+                pipeline
+                    .restore_with_telemetry(&session, &redacted)
+                    .expect("restore")
+                    .0
+                    .text,
+                input
+            );
+        }
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -517,6 +517,8 @@ mod tests {
             ),
             ("Org Workspace", "Workspace", PiiClass::Organization),
             ("Org OpenAI", "OpenAI", PiiClass::Organization),
+            ("Org xCorp", "xCorp", PiiClass::Organization),
+            ("Owner deVries", "deVries", PiiClass::Name),
         ];
 
         for (input, raw, class) in cases {


### PR DESCRIPTION
## Root cause

NER could false-positive command/argv identifiers such as `icalBuddy`, `eventsToday`, `AppleScript`, and AppleScript command literals as `Name`/`Organization`. When those non-PII spans were pseudonymized into session-owned tokens, a restore followed by a second redact pass could fail to emit the same token bytes, causing downstream byte-exact round-trip guards to abort.

## Narrow fix

This adds a command/argv-shaped span validator at the NER chokepoint:

```text
NER backend span
  -> threshold check
  -> [new] command/argv identifier validation for Name/Organization only
       -> suppress non-PII argv identifiers: icalBuddy, eventsToday, AppleScript, cal, ls, -l, ~, osascript AppleScript literals
       -> preserve all other PII classes and non-argv spans
  -> Candidate/Detection tokenization pipeline
```

The same validator is applied to decoded BIO spans and direct backend detections so both NER entry paths behave consistently.

## Tests

Added regression coverage for:

- Idempotence: `redact -> restore -> redact` stays byte-stable for `icalBuddy`, `eventsToday`, `AppleScript`, the plan-my-day `osascript` AppleScript string, and already-stable argv tokens (`cal`, `ls`, `-l`, `~`).
- PII safety: `Dr. Schmidt`, `alice@example.invalid`, `/Users/alice/project`, `Workspace`, and `OpenAI` still pseudonymize and restore correctly.

## Privacy statement

This does NOT weaken PII redaction. The suppression applies only to model-origin `Name`/`Organization` spans that are shaped like command/argv identifiers. Emails, names, usernamed paths, organization tokens, deterministic detectors, and fail-closed behavior remain covered and unchanged.

## Gates

Green locally:

- `cargo fmt --all -- --check`
- `cargo test -p gaze-recognizers`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`
- `cargo run -p xtask -- readme-version-check`
- `cargo run -p xtask -- symmetric-potemkin`
- `cargo run -p xtask -- class-map-override-safety`
- `cargo run -p xtask -- recognizer-composition-validator`
- `cargo run -p xtask -- no-tenant-knowledge`
- `cargo run -p xtask -- bundle-tokenization-drift`
- `cargo run -p xtask -- fixture-citation-lint`
- `cargo run -p xtask -- ci-feature-matrix`
