### PR TITLE
[agent] chore(release): gaze v0.10.1 (gaze-952 fix #302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-04
+
+### Fixed
+
+- **fix(gaze-952): stop over-redacting camelCase command/argv identifiers + narrow lowerCamel suppression** (PR #302). This patch keeps command and argv-shaped identifiers from being treated as PII while preserving the tighter lowerCamel safety-net suppression.
+
 ## [0.10.0] - 2026-06-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.10.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.10.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.10.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.10.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.10.1" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.10.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ The CLI is a process boundary around the Rust runtime; you can link the runtime 
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.0"
-gaze-assembly = "0.10.0"
+gaze-pii = "0.10.1"
+gaze-assembly = "0.10.1"
 ```
 
 The crate is published as `gaze-pii` because the bare `gaze` name is in transfer on crates.io; the import path stays `use gaze::...` because `[lib].name = "gaze"` is preserved.

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
+gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.0"
-gaze-assembly = "0.10.0"
-gaze-recognizers = "0.10.0"
+gaze-pii = "0.10.1"
+gaze-assembly = "0.10.1"
+gaze-recognizers = "0.10.1"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.0"
-gaze-audit = "0.10.0"
+gaze-pii = "0.10.1"
+gaze-audit = "0.10.1"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -44,14 +44,14 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
+gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.10.0", optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.10.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.1", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -66,7 +66,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.10.0
+$ cargo install gaze-cli --version 0.10.1
 ```
 
 Build from the workspace root:
@@ -109,7 +109,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.10.0 --features mcp
+$ cargo install gaze-cli --version 0.10.1 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
+gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.1" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.10.0"
+gaze-document = "0.10.1"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.10.0 --features document
+cargo install gaze-cli --version 0.10.1 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.10.0) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.10.1) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.10.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.10.1" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.10.0"
-gaze-mcp-rmcp = "0.10.0"
+gaze-mcp-core = "0.10.1"
+gaze-mcp-rmcp = "0.10.1"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.10.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.0" }
+gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.10.0"
+gaze-proxy = "0.10.1"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.10.0
+cargo install gaze-cli --version 0.10.1
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.0"
-gaze-recognizers = "0.10.0"
+gaze-pii = "0.10.1"
+gaze-recognizers = "0.10.1"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.10.0", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.10.1", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.10.0"
+gaze-types = "0.10.1"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.0"
-gaze-assembly = "0.10.0"
-gaze-recognizers = "0.10.0"
+gaze-pii = "0.10.1"
+gaze-assembly = "0.10.1"
+gaze-recognizers = "0.10.1"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).


### PR DESCRIPTION
## Summary
- Bump all published workspace crate/package pins and README install/dependency examples from 0.10.0 to 0.10.1.
- Add CHANGELOG.md entry for v0.10.1 shipping fix(gaze-952): stop over-redacting camelCase command/argv identifiers + narrow lowerCamel suppression (#302).
- Refresh Cargo.lock package versions for v0.10.1.

## Gates
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --workspace --all-features --no-fail-fast
- cargo run -p xtask -- readme-version-check
- cargo run -p xtask -- symmetric-potemkin
- cargo run -p xtask -- class-map-override-safety
- cargo run -p xtask -- recognizer-composition-validator
- cargo run -p xtask -- no-tenant-knowledge
- cargo run -p xtask -- bundle-tokenization-drift
- cargo run -p xtask -- fixture-citation-lint
- cargo run -p xtask -- ci-feature-matrix

Tag is intentionally not created here; orchestrator will cut the signed v0.10.1 tag after merge. DCO sign-off is expected to be handled by the orchestrator merge flow.