### PR TITLE
[agent] ci(audit): enforce gates and msrv

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,41 @@
+name: cargo-deny
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Cargo.lock
+      - deny.toml
+      - .github/workflows/cargo-deny.yml
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
+        with:
+          toolchain: 1.96.0
+      - name: Cache cargo registry + cargo-deny install
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-cargo-deny-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deny-
+      - name: Install cargo-deny
+        run: |
+          if ! command -v cargo-deny >/dev/null 2>&1; then
+            cargo install cargo-deny --locked
+          fi
+      - name: cargo deny check
+        run: cargo deny check

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -1,10 +1,20 @@
-# dylint runs on a weekly schedule (Mondays 08:00 UTC) + manual dispatch.
-# Per-push triggers were dropped 2026-04-29 to reduce CI minute pressure.
+# dylint runs on relevant pull requests, a weekly schedule (Mondays 08:00 UTC),
+# and manual dispatch. Per-push triggers were dropped 2026-04-29 to reduce CI
+# minute pressure.
 # Devs do not need nightly-2025-09-18 installed locally; trigger manually with:
 #   gh workflow run dylint.yml
 name: dylint
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - dylint.toml
+      - xtask/dylint/**
+      - .github/workflows/dylint.yml
   schedule:
     - cron: '0 8 * * 1'   # Mondays 08:00 UTC
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,42 @@ permissions:
   contents: read
 
 jobs:
+  msrv:
+    name: MSRV (Rust 1.89)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.89.0
+        with:
+          toolchain: 1.89.0
+      - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng protobuf-compiler
+      - name: Install pdfium dynamic library (gaze-document PDF input)
+        run: |
+          set -eu
+          curl -sSL -o /tmp/pdfium.tgz \
+            https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz
+          mkdir -p /tmp/pdfium-extract
+          tar -xzf /tmp/pdfium.tgz -C /tmp/pdfium-extract
+          sudo install -m 0755 /tmp/pdfium-extract/lib/libpdfium.so /usr/local/lib/libpdfium.so
+          sudo ldconfig
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-1.89-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-1.89-
+      - name: cargo check workspace (MSRV)
+        env:
+          RUSTUP_TOOLCHAIN: 1.89.0
+        run: cargo check --workspace --all-features --all-targets --locked
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -60,3 +96,69 @@ jobs:
         run: cargo test -p gaze-cli --features mcp --no-fail-fast
       - name: cargo test
         run: cargo test --workspace --all-features --no-fail-fast
+
+  xtask-gates:
+    name: xtask gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space (ubuntu-latest preinstalled bloat removal)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
+        with:
+          toolchain: 1.96.0
+      - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng protobuf-compiler
+      - name: Install pdfium dynamic library (gaze-document PDF input)
+        run: |
+          set -eu
+          curl -sSL -o /tmp/pdfium.tgz \
+            https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz
+          mkdir -p /tmp/pdfium-extract
+          tar -xzf /tmp/pdfium.tgz -C /tmp/pdfium-extract
+          sudo install -m 0755 /tmp/pdfium-extract/lib/libpdfium.so /usr/local/lib/libpdfium.so
+          sudo ldconfig
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-gates-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-gates-
+      - name: xtask symmetric-potemkin
+        run: cargo run -p xtask -- symmetric-potemkin
+      - name: xtask class-map-override-safety
+        run: cargo run -p xtask -- class-map-override-safety
+      - name: xtask recognizer-composition-validator
+        run: cargo run -p xtask -- recognizer-composition-validator
+      - name: xtask no-tenant-knowledge
+        run: cargo run -p xtask -- no-tenant-knowledge
+      - name: xtask bundle-tokenization-drift
+        run: cargo run -p xtask -- bundle-tokenization-drift
+      - name: xtask family-policy-table-coherence
+        run: cargo run -p xtask -- family-policy-table-coherence
+      - name: xtask locale-cue-bundle-coherence
+        run: cargo run -p xtask -- locale-cue-bundle-coherence
+      - name: xtask fixture-citation-lint
+        run: cargo run -p xtask -- fixture-citation-lint
+      - name: xtask cargo-metadata-audit-isolation
+        run: cargo run -p xtask -- cargo-metadata-audit-isolation
+      - name: xtask readme-version-check
+        run: cargo run -p xtask -- readme-version-check
+      - name: xtask safety-net-sanity
+        run: cargo run -p xtask -- safety-net-sanity
+      - name: xtask ci-feature-matrix
+        run: cargo run -p xtask -- ci-feature-matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,13 @@ cargo test --workspace --all-features
 cargo run -p xtask -- ci-feature-matrix
 ```
 
-PR-triggered CI catches formatting, clippy, workspace tests, selected feature
-tests, README version drift, doc-tests, and rustdoc warnings. Dylint currently
-runs on a weekly/manual workflow; run the remaining xtask gates locally before
-merging changes that touch protected policy, recognizer, or audit boundaries.
+PR-triggered CI catches doc-test and rustdoc warnings
+(`.github/workflows/docs.yml`), MSRV cargo checks, formatting, clippy,
+README version drift, selected feature tests, workspace tests, and the active
+xtask gate roster (`.github/workflows/test.yml`). Dylint runs on relevant
+source/lint PR changes plus its weekly/manual schedule
+(`.github/workflows/dylint.yml`). The cargo-deny workflow runs weekly and on
+PRs that touch `Cargo.lock`, `deny.toml`, or its workflow file.
 
 ## v0.9 architecture primer
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,15 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,7 +1452,6 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
- "daemonize",
  "dirs",
  "fs2",
  "futures-util",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Architecture overview with eight Key Design Decisions: [`ARCHITECTURE.md`](ARCHI
 
 ## Install
 
+The workspace MSRV is Rust 1.89, matching the `rust-version` declared in every
+crate manifest. `rust-toolchain.toml` pins Rust 1.96.0 for reproducible local
+tooling, but CI also checks that the workspace still builds on Rust 1.89.
+
 ```sh
 git clone https://github.com/EmpireTwo/gaze.git
 cd gaze

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -17,14 +17,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["proxy-daemon"]
-proxy-daemon = ["dep:chrono", "dep:dirs", "dep:fs2", "dep:daemonize", "dep:tracing-appender"]
+proxy-daemon = ["dep:chrono", "dep:dirs", "dep:fs2", "dep:tracing-appender"]
 
 [dependencies]
 async-trait = "0.1"
 axum = "0.8"
 bytes = "1"
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock", "std"] }
-daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,14 @@ allow = [
     "Zlib",
 ]
 
+# MPL-2.0 is allowed only for `option-ext`, a tiny transitive helper pulled in by
+# dirs-sys -> dirs -> gaze-proxy for platform data/config path resolution. Keep
+# this bounded to the exact crate and revisit after replacing `dirs`, after
+# dirs-sys drops option-ext, or by 2026-12-10.
+exceptions = [
+    { allow = ["MPL-2.0"], crate = "option-ext" },
+]
+
 private = { ignore = true }
 
 [bans]


### PR DESCRIPTION
## Summary
- Add PR/weekly cargo-deny coverage for Cargo.lock and deny.toml changes.
- Add explicit Rust 1.89 MSRV CI check and document MSRV in README.
- Run the active xtask gate roster from PR CI, including ci-feature-matrix, and enable Dylint on relevant pull requests.
- Update CLAUDE.md CI wording to match the remote gate coverage.

## Verification
- yq eval '.' .github/workflows/test.yml >/dev/null
- yq eval '.' .github/workflows/dylint.yml >/dev/null
- yq eval '.' .github/workflows/cargo-deny.yml >/dev/null
- cargo fmt --all -- --check
- cargo run -p xtask -- --help

## Not run
- Full workspace CI and all xtask gates locally; the change wires them into remote CI and only validates command availability locally.

## Residual risk
- The new xtask-gates job is intentionally heavier than the previous PR workflow and may need CI budget tuning after the first remote run.