### PR TITLE
[agent] fix(safety-net): fail closed on unknown opf labels

### DIFF
--- a/crates/gaze-recognizers/src/safety_net/openai_filter/class_map.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/class_map.rs
@@ -41,8 +41,10 @@ pub fn map_openai_label(label: &str) -> Result<OpenAiPrivateLabel, SafetyNetErro
 }
 
 /// Maps an official OPF label into the closed safety-net PII vocabulary.
-pub fn openai_label_to_safety_net_class(label: OpenAiPrivateLabel) -> SafetyNetPiiClass {
-    match label {
+pub fn openai_label_to_safety_net_class(
+    label: OpenAiPrivateLabel,
+) -> Result<SafetyNetPiiClass, SafetyNetError> {
+    Ok(match label {
         OpenAiPrivateLabel::PrivatePerson => SafetyNetPiiClass::Name,
         OpenAiPrivateLabel::PrivateAddress => SafetyNetPiiClass::Location,
         OpenAiPrivateLabel::PrivateEmail => SafetyNetPiiClass::Email,
@@ -51,8 +53,12 @@ pub fn openai_label_to_safety_net_class(label: OpenAiPrivateLabel) -> SafetyNetP
         OpenAiPrivateLabel::PrivateDate => SafetyNetPiiClass::Date,
         OpenAiPrivateLabel::AccountNumber => SafetyNetPiiClass::AccountNumber,
         OpenAiPrivateLabel::Secret => SafetyNetPiiClass::Secret,
-        _ => panic!("unknown OpenAI private label - update class_map.rs"),
-    }
+        _ => {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "opf returned unsupported label".to_string(),
+            })
+        }
+    })
 }
 
 fn invalid_label() -> SafetyNetError {
@@ -84,7 +90,9 @@ mod tests {
             let private_label = map_openai_label(label).expect("official label");
             assert_eq!(private_label.as_str(), label);
             assert_eq!(
-                openai_label_to_safety_net_class(private_label).to_pii_class(),
+                openai_label_to_safety_net_class(private_label)
+                    .expect("official label maps to safety-net class")
+                    .to_pii_class(),
                 expected
             );
         }
@@ -92,11 +100,18 @@ mod tests {
 
     #[test]
     fn unknown_and_invalid_labels_fail_closed() {
-        assert!(map_openai_label("organization").is_err());
-        assert!(map_openai_label("private-email").is_err());
-        assert!(map_openai_label("PRIVATE_EMAIL").is_err());
-        assert!(map_openai_label("private_email_123").is_err());
-        assert!(map_openai_label("").is_err());
-        assert!(map_openai_label("abcdefghijklmnopqrstuvwxyzabcdefg").is_err());
+        for label in [
+            "organization",
+            "private-email",
+            "PRIVATE_EMAIL",
+            "private_email_123",
+            "",
+            "abcdefghijklmnopqrstuvwxyzabcdefg",
+        ] {
+            assert!(matches!(
+                map_openai_label(label),
+                Err(SafetyNetError::InvalidOutput { .. })
+            ));
+        }
     }
 }

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs
@@ -144,7 +144,9 @@ fn raw_span_to_model_span(
 
     let private_label = map_openai_label(&raw.label)
         .map_err(|error| ModelError::InferenceFailed(error.to_string()))?;
-    let class = openai_label_to_safety_net_class(private_label).to_pii_class();
+    let class = openai_label_to_safety_net_class(private_label)
+        .map_err(|error| ModelError::InferenceFailed(error.to_string()))?
+        .to_pii_class();
     let byte_range = raw.start..raw.end;
     let text = input[byte_range.clone()].to_string();
 
@@ -163,7 +165,7 @@ fn raw_span_to_suspect(
     context: SafetyNetContext<'_>,
 ) -> Result<Option<LeakSuspect>, SafetyNetError> {
     let private_label = map_openai_label(&raw.label)?;
-    let class = openai_label_to_safety_net_class(private_label).to_pii_class();
+    let class = openai_label_to_safety_net_class(private_label)?.to_pii_class();
     let span = raw.start..raw.end;
     let Some(kind) = context.manifest.diff_against(&span, &class) else {
         return Ok(None);

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -70,7 +70,9 @@ fn all_official_labels_map_exactly_to_gaze_classes() {
     for (raw, expected) in cases {
         let label = map_openai_label(raw).unwrap();
         assert_eq!(
-            openai_label_to_safety_net_class(label).to_pii_class(),
+            openai_label_to_safety_net_class(label)
+                .expect("official label maps to safety-net class")
+                .to_pii_class(),
             expected
         );
     }


### PR DESCRIPTION
## Summary
- Clean replacement for #304, rebuilt from origin/agent/context-json-docs.
- Convert OPF private-label class mapping from unreachable panic to typed SafetyNetError::InvalidOutput fallback.
- Propagate the fallible mapping through safety-net and locale-aware model call sites.
- Update OPF class-map and subprocess tests for the new Result signature and typed fail-closed behavior.

## Diff scope
- crates/gaze-recognizers/src/safety_net/openai_filter/class_map.rs
- crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs
- crates/gaze-recognizers/tests/openai_filter_subprocess.rs

## Tests
- cargo fmt --manifest-path /Users/krishankoenig/Workspace/EmpireTwo/gaze-audit-wave-c-opf-panic-clean/Cargo.toml --all -- --check
- cargo test --manifest-path /Users/krishankoenig/Workspace/EmpireTwo/gaze-audit-wave-c-opf-panic-clean/Cargo.toml -p gaze-recognizers openai_filter --no-fail-fast (0 tests matched; OPF is feature-gated)
- cargo test --manifest-path /Users/krishankoenig/Workspace/EmpireTwo/gaze-audit-wave-c-opf-panic-clean/Cargo.toml -p gaze-recognizers --features safety-net-openai openai_filter --no-fail-fast
- cargo test --manifest-path /Users/krishankoenig/Workspace/EmpireTwo/gaze-audit-wave-c-opf-panic-clean/Cargo.toml -p gaze-recognizers --features safety-net-openai --test openai_filter_subprocess --no-fail-fast

## Risk
Low. Supported OPF labels preserve their existing class mappings; unsupported or future private labels now fail closed through typed errors instead of panicking.