### PR TITLE
[agent] Fail closed on safety-net redaction spans

### DIFF
--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -65,6 +65,12 @@ pub enum Error {
     RedactionLog(#[from] RedactionLogError),
     #[error("safety net fallback failed closed: {0:?}")]
     SafetyNetFallback(FallbackReason),
+    #[error("safety net span invalid: start={start}, end={end}, text_len={text_len}")]
+    SafetyNetSpanInvalid {
+        start: usize,
+        end: usize,
+        text_len: usize,
+    },
     #[error("capitals heuristic gate is unsupported for locale {locale}")]
     UnsupportedCapitalHeuristicLocale { locale: String },
     #[error("unsupported raw document variant")]
@@ -960,9 +966,20 @@ impl Pipeline {
         log_entries: bool,
     ) -> Result<()> {
         for suspect in redaction_suspects(report).into_iter().rev() {
-            let span = suspect_action_span(suspect);
-            if !is_char_boundary_range(&clean.text, &span) {
-                continue;
+            let span =
+                round_span_outward_to_char_boundaries(&clean.text, suspect_action_span(suspect))?;
+            let span = expand_span_to_overlapping_manifest_entries(clean, span);
+            for existing in clean
+                .manifest
+                .iter()
+                .filter(|existing| ranges_overlap(&existing.clean_span, &span))
+            {
+                tracing::warn!(
+                    class = ?existing.class,
+                    clean_span_start = existing.clean_span.start,
+                    clean_span_end = existing.clean_span.end,
+                    "safety net redaction dropping overlapping manifest entry"
+                );
             }
             if log_entries {
                 self.log_safety_net_entry(
@@ -1311,6 +1328,61 @@ fn is_char_boundary_range(text: &str, span: &Range<usize>) -> bool {
         && span.end <= text.len()
         && text.is_char_boundary(span.start)
         && text.is_char_boundary(span.end)
+}
+
+fn round_span_outward_to_char_boundaries(text: &str, span: Range<usize>) -> Result<Range<usize>> {
+    if span.start > span.end || span.end > text.len() {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: text.len(),
+        });
+    }
+
+    let mut start = span.start;
+    while start > 0 && !text.is_char_boundary(start) {
+        start -= 1;
+    }
+
+    let mut end = span.end;
+    while end < text.len() && !text.is_char_boundary(end) {
+        end += 1;
+    }
+
+    if !is_char_boundary_range(text, &(start..end)) {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: text.len(),
+        });
+    }
+
+    Ok(start..end)
+}
+
+fn expand_span_to_overlapping_manifest_entries(
+    clean: &CleanText,
+    span: Range<usize>,
+) -> Range<usize> {
+    let mut expanded = span;
+    loop {
+        let mut changed = false;
+        for existing in &clean.manifest {
+            if ranges_overlap(&existing.clean_span, &expanded) {
+                let start = expanded.start.min(existing.clean_span.start);
+                let end = expanded.end.max(existing.clean_span.end);
+                changed |= start != expanded.start || end != expanded.end;
+                expanded = start..end;
+            }
+        }
+        if !changed {
+            return expanded;
+        }
+    }
+}
+
+fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
 }
 
 fn validate_capitals_gate_locales(locale_chain: &[crate::LocaleTag]) -> Result<()> {

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -37,6 +37,13 @@ struct MockNet {
     seen: Arc<Mutex<Vec<SeenCheck>>>,
 }
 
+#[derive(Clone)]
+struct InvalidSpanNet {
+    locales: Vec<gaze::LocaleTag>,
+    span: Range<usize>,
+    class: PiiClass,
+}
+
 #[derive(Debug, Clone)]
 struct SeenCheck {
     clean_text: String,
@@ -142,6 +149,9 @@ impl SafetyNet for MockNet {
         let Some(span) = self.span.clone() else {
             return Ok(Vec::new());
         };
+        if span.start > span.end || span.end > clean_text.len() {
+            return Ok(Vec::new());
+        }
         let Some(kind) = context.manifest.diff_against(&span, &self.class) else {
             return Ok(Vec::new());
         };
@@ -153,6 +163,32 @@ impl SafetyNet for MockNet {
             Some(0.99),
             kind,
             self.raw_label,
+            context.field_path.map(str::to_string),
+        )])
+    }
+}
+
+impl SafetyNet for InvalidSpanNet {
+    fn id(&self) -> &str {
+        "invalid-span"
+    }
+
+    fn supported_locales(&self) -> &[gaze::LocaleTag] {
+        &self.locales
+    }
+
+    fn check(
+        &self,
+        _clean_text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        Ok(vec![LeakSuspect::new(
+            self.span.clone(),
+            self.class.clone(),
+            self.id(),
+            Some(0.99),
+            LeakKind::Uncovered,
+            "private_email",
             context.field_path.map(str::to_string),
         )])
     }
@@ -265,6 +301,138 @@ fn safety_net_redact_mode_strips_suspect_without_manifest_entry() {
         .expect("redact");
 
     assert_eq!(text(clean), "Reach ");
+    assert!(manifest.is_empty());
+    assert_eq!(report.stats.uncovered_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_rounds_misaligned_multibyte_suspect_outward() {
+    let raw = "Grüße von Dr. Schmidt".to_string();
+    let multibyte = raw.find('ü').expect("multibyte char");
+    let net = MockNet::new(Some(multibyte + 1..multibyte + "ü".len()), PiiClass::Name);
+    let pipeline = pipeline_with_net(Some(net));
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("misaligned redact rounds outward");
+    let clean_text = text(clean);
+
+    assert_eq!(clean_text, "Grße von Dr. Schmidt");
+    assert!(!clean_text.contains("Grüße"));
+    assert!(manifest.is_empty());
+    assert_eq!(report.stats.uncovered_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_expands_overlap_to_entire_emitted_token() {
+    let session = session();
+    let raw = RawDocument::Text("alice@example.invalid ok".to_string());
+    let baseline = text(
+        tokenizing_pipeline()
+            .redact(&session, raw.clone())
+            .expect("baseline"),
+    );
+    let token_len = baseline.find(" ok").expect("token suffix");
+    let net = MockNet::new(Some(2..token_len - 2), PiiClass::Name);
+
+    let (clean, manifest, report) = tokenizing_pipeline_with_net(net)
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            raw,
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("overlap redact expands to emitted token");
+    let clean_text = text(clean);
+
+    assert_eq!(clean_text, " ok");
+    assert!(!clean_text.contains('<'));
+    assert!(!clean_text.contains("Email"));
+    assert!(manifest.is_empty());
+    assert_eq!(
+        session.restore_strict_text(&clean_text).expect("restore"),
+        " ok"
+    );
+    assert_eq!(report.stats.class_mismatch_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_out_of_range_suspect_fails_closed_without_raw_text() {
+    let raw = "Reach alice@example.invalid".to_string();
+    let net = InvalidSpanNet {
+        locales: vec![gaze::LocaleTag::Global],
+        span: 6..raw.len() + 1,
+        class: PiiClass::Email,
+    };
+    let pipeline = Pipeline::builder()
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(net)
+        .build()
+        .expect("pipeline");
+    let session = session();
+
+    let err = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw.clone()),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect_err("out-of-range safety net span fails closed");
+
+    assert!(matches!(
+        err,
+        gaze::Error::SafetyNetSpanInvalid {
+            start: 6,
+            end: _,
+            text_len: _
+        }
+    ));
+    assert!(!err.to_string().contains("alice@example.invalid"));
+    assert!(session.tokens().is_empty());
+}
+
+#[test]
+fn safety_net_redact_mode_keeps_aligned_span_redaction_behavior() {
+    let raw = "Hello Dr. Schmidt".to_string();
+    let suspect = "Dr. Schmidt";
+    let start = raw.find(suspect).expect("suspect");
+    let net = MockNet::new(Some(start..start + suspect.len()), PiiClass::Name);
+    let pipeline = pipeline_with_net(Some(net));
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("aligned redact");
+
+    assert_eq!(text(clean), "Hello ");
     assert!(manifest.is_empty());
     assert_eq!(report.stats.uncovered_count, 1);
 }


### PR DESCRIPTION
Summary
- Clean replacement for #310, branched from current origin/agent/context-json-docs.
- Make safety-net redact/fallback span handling fail closed: invalid spans return a sanitized typed error instead of silently skipping.
- Round misaligned UTF-8 spans outward to char boundaries before redaction.
- Expand redaction spans to cover overlapping emitted-token manifest spans and warn with class/span metadata only.
- Add regression coverage in crates/gaze/tests/safety_net.rs for misaligned multibyte spans, emitted-token overlap, out-of-range typed error, and aligned redaction behavior.

Scope verification
- PASS: git diff --name-only origin/agent/context-json-docs...HEAD shows only:
  - crates/gaze/src/pipeline.rs
  - crates/gaze/tests/safety_net.rs

Flow review

after safety net report
        |
        v
redact_safety_net_suspects
        |
        v
for each suspect from right to left
        |
        v
[NEW] round span outward to UTF-8 char boundaries
        |                         |
        | invalid/out of range     | valid
        v                         v
Error::SafetyNetSpanInvalid   [NEW] expand span across overlapping manifest entries
(no raw text)                      |
                                  v
                         warn dropped manifest entries
                         (class + clean_span only)
                                  |
                                  v
                         existing audit log entry
                                  |
                                  v
                         replace_clean_span drops fully-overlapped entries

Verification on final base 11af355
- PASS: cargo test -p gaze-pii --all-features safety_net
- BLOCKED/BASELINE: cargo test -p gaze-pii --all-features fails in crates/gaze/tests/policy_example.rs:16 with policy.detectors.len() left=0 right=2. Confirmed the same failure on detached origin/agent/context-json-docs with cargo test -p gaze-pii --all-features --test policy_example. This branch does not touch policy.example.toml or policy_example.rs.
- PASS: cargo run -p xtask -- safety-net-sanity
- PASS: cargo clippy --workspace --all-features --all-targets -- -D warnings
- PASS: cargo fmt --all -- --check

Notes
- No PII fixtures added; tests use synthetic .invalid email and Dr. Schmidt fixture text.
- Supersedes #310, which had a broad conflicting branch diff.