### PR TITLE
[agent] Cache restore token regex per session

### DIFF
--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1457,24 +1457,9 @@ fn replace_clean_span(
 }
 
 fn restore_known_tokens(session: &Session, text: &str) -> Result<String> {
-    let mut tokens = session.tokens();
-    if tokens.is_empty() {
+    let Some(re) = session.restore_regex()? else {
         return Ok(text.to_string());
-    }
-    tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
-    let pattern = tokens
-        .iter()
-        .map(|token| {
-            let escaped = regex::escape(token);
-            if token.starts_with('<') && token.ends_with('>') {
-                escaped
-            } else {
-                format!(r"\b(?:{escaped})\b")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("|");
-    let re = regex::Regex::new(&pattern).map_err(Error::InvalidRegex)?;
+    };
     let mut out = String::with_capacity(text.len());
     let mut last = 0usize;
     for matched in re.find_iter(text) {

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashmap::mapref::entry::Entry;
@@ -287,6 +287,7 @@ pub struct Session {
     token_by_value: DashMap<TokenKey, String>,
     value_by_token: DashMap<String, String>,
     prefix_cache: DashMap<u64, PrefixCacheEntry>,
+    restore_regex_cache: RwLock<Option<(usize, Arc<Regex>)>>,
     signing_key: SessionKey,
 }
 
@@ -300,6 +301,7 @@ impl Session {
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
             prefix_cache: DashMap::new(),
+            restore_regex_cache: RwLock::new(None),
             signing_key: SessionKey::generate()?,
         })
     }
@@ -407,6 +409,56 @@ impl Session {
             .iter()
             .map(|entry| entry.key().clone())
             .collect()
+    }
+
+    pub(crate) fn restore_regex(&self) -> Result<Option<Arc<Regex>>> {
+        let token_count = self.value_by_token.len();
+        if token_count == 0 {
+            return Ok(None);
+        }
+
+        {
+            let cache = self.restore_regex_cache_read();
+            if let Some((cached_count, cached_regex)) = cache.as_ref() {
+                if *cached_count == token_count {
+                    return Ok(Some(Arc::clone(cached_regex)));
+                }
+            }
+        }
+
+        let mut tokens = self.tokens();
+        if tokens.is_empty() {
+            return Ok(None);
+        }
+        tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+        let pattern = tokens
+            .iter()
+            .map(|token| {
+                let escaped = regex::escape(token);
+                if token.starts_with('<') && token.ends_with('>') {
+                    escaped
+                } else {
+                    format!(r"\b(?:{escaped})\b")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        let regex = Arc::new(Regex::new(&pattern).map_err(Error::InvalidRegex)?);
+        let cached_count = tokens.len();
+        *self.restore_regex_cache_write() = Some((cached_count, Arc::clone(&regex)));
+        Ok(Some(regex))
+    }
+
+    fn restore_regex_cache_read(&self) -> RwLockReadGuard<'_, Option<(usize, Arc<Regex>)>> {
+        self.restore_regex_cache
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn restore_regex_cache_write(&self) -> RwLockWriteGuard<'_, Option<(usize, Arc<Regex>)>> {
+        self.restore_regex_cache
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     pub fn contains_token(&self, token: &str) -> bool {
@@ -707,6 +759,7 @@ impl Session {
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
             prefix_cache: DashMap::new(),
+            restore_regex_cache: RwLock::new(None),
             signing_key: SessionKey::generate()?,
         };
         for entry in payload.entries {

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -37,6 +37,36 @@ fn restore_is_lax_but_restore_strict_fails_closed() {
 }
 
 #[test]
+fn restore_regex_cache_invalidates_when_session_gains_tokens() {
+    let pipeline = Pipeline::builder().build().expect("pipeline");
+    let empty = Session::new(Scope::Ephemeral).expect("empty session");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&empty, "nothing to restore")
+        .expect("empty restore");
+    assert_eq!(restored.text, "nothing to restore");
+
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let first = session
+        .tokenize(&PiiClass::Name, "Dr. Schmidt")
+        .expect("first token");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&session, &format!("owner {first}"))
+        .expect("restore first token");
+    assert_eq!(restored.text, "owner Dr. Schmidt");
+
+    let second = session
+        .tokenize(
+            &PiiClass::Custom("tenant-note".to_string()),
+            "Grüße aus Büro A",
+        )
+        .expect("second token");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&session, &format!("{first} / {second}"))
+        .expect("restore appended token");
+    assert_eq!(restored.text, "Dr. Schmidt / Grüße aus Büro A");
+}
+
+#[test]
 fn same_session_reuses_token_for_same_raw_value() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let pipeline = Pipeline::builder()


### PR DESCRIPTION
## Summary
- cache the compiled restore-token regex on `Session`, keyed by live token count
- move the existing exact-token alternation construction out of `restore_known_tokens` into `Session::restore_regex`
- add a contract test for empty restore passthrough, cache hit, and invalidation after appending a multibyte token

## Flow
```text
Pipeline::restore_with_telemetry
  -> restore_known_tokens(session, text)
      -> session.restore_regex() [MOD]
          -> token count == 0?
              -> None; return original text
          -> cached count == live count?
              -> clone Arc<Regex>; reuse compiled regex
          -> otherwise [NEW miss path]
              -> collect current tokens
              -> sort longest-first, then lexical
              -> escape each token
              -> wrapped <...> token: literal match
              -> format-preserving token: word-boundary match
              -> Regex::new(pattern)
              -> store (token_count, Arc<Regex>)
      -> existing match loop restores each matched token strictly
```

## Verification
- `cargo build -p gaze-pii --all-features`
- `cargo test -p gaze-pii --all-features restore`
- `cargo fmt --all -- --check`
- `cargo clippy -p gaze-pii --all-features --all-targets -- -D warnings`
- `git diff --check`
- `rg -n "Regex::new" crates/gaze/src/pipeline.rs` confirms no `Regex::new` remains in `restore_known_tokens`; remaining matches are unrelated tests

## Known Test Gap / Existing Failure
- `cargo test -p gaze-pii --all-features` fails in `tests/policy_example.rs` because `policy.example.toml` on the target branch now loads `policy.detectors.len() == 0` while the test expects `2`. This change did not touch policy loading or the example policy.

## Risk
- Low. The cache is runtime-only, initialized empty for new and imported sessions, and does not alter snapshot schema. Token removal does not exist; if removal/expiry is added later, this count-keyed cache should become generation-keyed.
