### PR TITLE
Fix empty locale fallback for resolved detection

### DIFF
--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -327,6 +327,7 @@ impl RecognizerRegistry {
         input: &str,
         ctx: &DetectContext<'_>,
     ) -> (Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>) {
+        let locale_chain = LocaleChain::from(ctx.locale_chain);
         let classes = self
             .entries
             .iter()
@@ -335,7 +336,7 @@ impl RecognizerRegistry {
         let mut candidates = Vec::new();
 
         for class in classes {
-            for locale in ctx.locale_chain {
+            for locale in locale_chain.as_slice() {
                 let locale_ctx = DetectContext::new(std::slice::from_ref(locale), ctx.dictionaries);
                 locale_ctx.degraded.set(ctx.degraded.get());
                 let class_candidates = self
@@ -362,7 +363,7 @@ impl RecognizerRegistry {
                 self.family_policy(),
                 &self.anchor_resolver,
                 input,
-                ctx.locale_chain,
+                locale_chain.as_slice(),
             ),
             vetoed,
         )

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -81,6 +81,37 @@ fn distinct_conversation_sessions_produce_distinct_pseudonyms_for_identical_raw_
 }
 
 #[test]
+fn clean_with_safety_net_tokenizes_minimal_email() {
+    let pipeline = Pipeline::builder()
+        .detector(RegexDetector::emails().expect("email detector"))
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let (clean, _manifest, _report) = pipeline
+        .clean_with_safety_net(
+            &session,
+            RawDocument::Text("a@example.invalid".to_string()),
+            &[],
+        )
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+
+    assert!(
+        !text.contains("a@example.invalid"),
+        "minimal email leaked through clean text: {text:?}"
+    );
+    assert!(text.starts_with('<') && text.ends_with(":Email_1>"));
+    assert_eq!(
+        session.restore_strict(&text).expect("restore"),
+        "a@example.invalid"
+    );
+}
+
+#[test]
 fn two_ephemeral_sessions_are_independent_namespaces() {
     let pipeline = email_token_pipeline();
     let a = Session::new(Scope::Ephemeral).expect("session a");


### PR DESCRIPTION
## Summary
- Treat an empty detect context locale chain as `global` inside `RecognizerRegistry::detect_all_resolved`.
- Add a regression test for `clean_with_safety_net(..., &[])` tokenizing the minimized synthetic email `a@example.invalid`.

## Classification
Product bug. The public safety-net clean path passed an empty locale chain through resolved detection, so no recognizer ran and the raw synthetic email survived clean text.

## North star / axes
Strengthens reliability by failing back to global recognizers when callers pass an empty locale chain. No reversibility tradeoff: the regression asserts strict restore back to the original synthetic value.

## Verification
- `cargo test -p gaze-pii --all-features clean_with_safety_net_tokenizes_minimal_email -- --exact --nocapture`
- `cargo test -p gaze-pii --all-features --test contracts`
- `cargo fmt --all && cargo test -p gaze-pii --all-features` (fails only at pre-existing `root_policy_example_loads_under_current_policy_loader`: expected 2 detectors, loaded 0 from current `policy.example.toml`)
- `cargo test -p gaze-pii --all-features --test safety_net && cargo test -p gaze-pii --all-features --test canary_e2e`

Plan 005 can resume after this PR merges.
## Review disclosure
- LocaleChain::from(ctx.locale_chain) normalizes any chain missing Global, not only the empty chain. This aligns resolved detection with canonical locale-chain semantics and the existing safety-net normalization while fixing the empty-chain leak.