### PR TITLE
[agent] Fix email unicode boundary detection

### DIFF
--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -59,13 +59,9 @@ The public surface is re-exported from [`src/lib.rs`](src/lib.rs).
 `RegexDetector` can be constructed directly:
 
 ```rust
-use gaze::PiiClass;
 use gaze_recognizers::RegexDetector;
 
-let recognizer = RegexDetector::new(
-    r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b",
-    PiiClass::Email,
-)?;
+let recognizer = RegexDetector::emails()?;
 ```
 
 Use `RegexDetector::emails()` for the built-in email recognizer. Rulepack

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -15,7 +15,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co)))(?:$|[^a-z0-9_])'''
+pattern = '''(?i)([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co)))'''
 capture_groups = [1]
 
 [recognizers.context]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -15,7 +15,8 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co))\b'''
+pattern = '''(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co)))(?:$|[^a-z0-9_])'''
+capture_groups = [1]
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -111,7 +111,7 @@ impl RegexDetector {
 
     pub fn emails() -> Result<Self> {
         let mut detector = Self::new(
-            r"(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}",
+            r"(?i)[a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,}",
             PiiClass::Email,
         )?;
         detector.ascii_email_boundary = true;
@@ -225,11 +225,11 @@ impl RegexDetector {
         let previous_ok = input[..span.start]
             .chars()
             .next_back()
-            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+            .is_none_or(|ch| !is_ascii_email_continuation(ch));
         let next_ok = input[span.end..]
             .chars()
             .next()
-            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+            .is_none_or(|ch| !is_ascii_email_continuation(ch));
 
         previous_ok && next_ok
     }
@@ -244,7 +244,7 @@ fn iban_canonicalize(input: &str) -> String {
 }
 
 fn is_ascii_email_continuation(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-')
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 #[cfg(test)]
@@ -277,6 +277,37 @@ mod tests {
         assert_eq!(detections.len(), 2);
         assert_eq!(detections[0].span, 0..17);
         assert_eq!(detections[1].span, 18..35);
+    }
+
+    #[test]
+    fn bundled_email_detector_accepts_ascii_punctuation_suffixes() {
+        let detector = RegexDetector::emails().expect("email detector");
+
+        for (input, span) in [
+            ("Contact a@example.invalid. Thanks", 8..25),
+            ("a@example.invalid- call me", 0..17),
+            ("a@example.invalid+", 0..17),
+            ("a@example.invalid%", 0..17),
+        ] {
+            let detections = Detector::detect(&detector, input);
+            assert_eq!(detections.len(), 1, "{input}");
+            assert_eq!(detections[0].span, span, "{input}");
+        }
+    }
+
+    #[test]
+    fn bundled_email_detector_keeps_leading_delimiters_out_of_span() {
+        let detector = RegexDetector::emails().expect("email detector");
+
+        for input in [
+            ".a@example.invalid",
+            "-a@example.invalid",
+            "+a@example.invalid",
+        ] {
+            let detections = Detector::detect(&detector, input);
+            assert_eq!(detections.len(), 1, "{input}");
+            assert_eq!(detections[0].span, 1..18, "{input}");
+        }
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -54,6 +54,7 @@ pub struct RegexDetector {
     exclusions: Vec<String>,
     validator_kind: Option<ValidatorKind>,
     normalizer_kind: Option<NormalizerKind>,
+    ascii_email_boundary: bool,
 }
 
 impl RegexDetector {
@@ -104,14 +105,17 @@ impl RegexDetector {
             exclusions,
             validator_kind,
             normalizer_kind,
+            ascii_email_boundary: false,
         })
     }
 
     pub fn emails() -> Result<Self> {
-        Self::new(
-            r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b",
+        let mut detector = Self::new(
+            r"(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}",
             PiiClass::Email,
-        )
+        )?;
+        detector.ascii_email_boundary = true;
+        Ok(detector)
     }
 }
 
@@ -120,6 +124,7 @@ impl Detector for RegexDetector {
         self.regex
             .captures_iter(input)
             .filter_map(|caps| self.span_from_captures(&caps))
+            .filter(|span| self.boundary_accepts(input, span))
             .map(|span| Detection::new(span, self.class.clone(), self.source.clone()))
             .collect()
     }
@@ -139,6 +144,9 @@ impl Recognizer for RegexDetector {
             .captures_iter(input)
             .filter_map(|caps| {
                 let span = self.span_from_captures(&caps)?;
+                if !self.boundary_accepts(input, &span) {
+                    return None;
+                }
                 let matched = &input[span.clone()];
                 (!self.is_excluded(matched)).then_some((span, matched))
             })
@@ -208,6 +216,23 @@ impl RegexDetector {
             caps.get(0).map(|m| m.range())
         }
     }
+
+    fn boundary_accepts(&self, input: &str, span: &std::ops::Range<usize>) -> bool {
+        if !self.ascii_email_boundary {
+            return true;
+        }
+
+        let previous_ok = input[..span.start]
+            .chars()
+            .next_back()
+            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+        let next_ok = input[span.end..]
+            .chars()
+            .next()
+            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+
+        previous_ok && next_ok
+    }
 }
 
 fn iban_canonicalize(input: &str) -> String {
@@ -218,9 +243,49 @@ fn iban_canonicalize(input: &str) -> String {
         .collect()
 }
 
+fn is_ascii_email_continuation(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bundled_email_detector_matches_before_non_ascii_letter() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalidø");
+
+        assert_eq!(detections.len(), 1);
+        assert_eq!(detections[0].span, 0..17);
+    }
+
+    #[test]
+    fn bundled_email_detector_matches_after_non_ascii_letter() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "øa@example.invalid");
+
+        assert_eq!(detections.len(), 1);
+        assert_eq!(detections[0].span, 2..19);
+    }
+
+    #[test]
+    fn bundled_email_detector_matches_comma_separated_addresses() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalid,b@example.invalid");
+
+        assert_eq!(detections.len(), 2);
+        assert_eq!(detections[0].span, 0..17);
+        assert_eq!(detections[1].span, 18..35);
+    }
+
+    #[test]
+    fn bundled_email_detector_rejects_ascii_continuation_suffix() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalid1");
+
+        assert!(detections.is_empty());
+    }
 
     #[test]
     fn email_rfc_validator_kind_populates_canonical_form() {

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -93,6 +93,8 @@ impl RegexDetector {
         normalizer_kind: Option<NormalizerKind>,
     ) -> Result<Self> {
         let regex = Regex::new(pattern).map_err(RecognizerError::InvalidRegex)?;
+        let ascii_email_boundary = class == PiiClass::Email && source == "email.global";
+
         Ok(Self {
             regex,
             class,
@@ -105,7 +107,7 @@ impl RegexDetector {
             exclusions,
             validator_kind,
             normalizer_kind,
-            ascii_email_boundary: false,
+            ascii_email_boundary,
         })
     }
 

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -925,6 +925,25 @@ fn phase2_iban_and_cards_are_universal_and_solo_classes() {
 }
 
 #[test]
+fn core_email_global_matches_non_ascii_and_punctuation_boundaries() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+
+    for input in [
+        "a@example.invalidø",
+        "a@example.invalid. Thanks",
+        "a@example.invalid- call me",
+        "a@example.invalid+",
+        ".a@example.invalid",
+    ] {
+        assert_eq!(
+            detect_recognizer(&core, "email.global", input, LocaleTag::EnUs),
+            vec!["a@example.invalid".to_string()],
+            "{input}"
+        );
+    }
+}
+
+#[test]
 fn core_and_core_extended_compose_without_counter_collision() {
     let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
     let extended = core_extended();

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -933,11 +933,32 @@ fn core_email_global_matches_non_ascii_and_punctuation_boundaries() {
         "a@example.invalid. Thanks",
         "a@example.invalid- call me",
         "a@example.invalid+",
+        "a@example.invalid%",
         ".a@example.invalid",
     ] {
         assert_eq!(
             detect_recognizer(&core, "email.global", input, LocaleTag::EnUs),
             vec!["a@example.invalid".to_string()],
+            "{input}"
+        );
+    }
+
+    assert_eq!(
+        detect_recognizer(
+            &core,
+            "email.global",
+            "a@example.invalid,b@example.invalid",
+            LocaleTag::EnUs
+        ),
+        vec![
+            "a@example.invalid".to_string(),
+            "b@example.invalid".to_string()
+        ]
+    );
+
+    for input in ["a@example.invalid1", "a@example.invalid_"] {
+        assert!(
+            detect_recognizer(&core, "email.global", input, LocaleTag::EnUs).is_empty(),
             "{input}"
         );
     }

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1189,7 +1189,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co))\b'''
+pattern = '''(?i)[a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co))'''
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1020,10 +1020,10 @@ fn structural_findings(text: &str) -> Vec<StructuralFinding> {
 }
 
 fn collect_email_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
-    for caps in email_pattern().captures_iter(text) {
-        let Some(matched) = caps.get(1) else {
+    for matched in email_pattern().find_iter(text) {
+        if !restore_email_boundary_accepts(text, &matched.range()) {
             continue;
-        };
+        }
         let raw = matched.as_str();
         if !is_basic_restore_email(raw) {
             continue;
@@ -1096,7 +1096,7 @@ fn collect_api_key_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
 fn email_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        Regex::new(r"(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,})(?:$|[^a-z0-9_])")
+        Regex::new(r"(?i)[a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,}")
             .expect("email restore DLP regex compiles")
     })
 }
@@ -1143,6 +1143,23 @@ fn is_basic_restore_email(input: &str) -> bool {
         return false;
     };
     !local.is_empty() && domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+}
+
+fn restore_email_boundary_accepts(input: &str, span: &std::ops::Range<usize>) -> bool {
+    let previous_ok = input[..span.start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_ascii_email_continuation(ch));
+    let next_ok = input[span.end..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_ascii_email_continuation(ch));
+
+    previous_ok && next_ok
+}
+
+fn is_ascii_email_continuation(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 fn ascii_digits(input: &str) -> String {
@@ -1996,6 +2013,9 @@ mod tests {
         for (input, location) in [
             ("a@example.invalidø", 0..17),
             ("a@example.invalid. Thanks", 0..17),
+            ("a@example.invalid-", 0..17),
+            ("a@example.invalid+", 0..17),
+            ("a@example.invalid%", 0..17),
             (".a@example.invalid", 1..18),
         ] {
             let findings = structural_findings(input);
@@ -2006,6 +2026,28 @@ mod tests {
 
             assert_eq!(finding.raw, "a@example.invalid", "{input}");
             assert_eq!(finding.location, location, "{input}");
+        }
+
+        let adjacent = structural_findings("a@example.invalid,b@example.invalid")
+            .into_iter()
+            .filter(|finding| finding.class == PiiClass::Email)
+            .map(|finding| (finding.raw, finding.location))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            adjacent,
+            vec![
+                ("a@example.invalid".to_string(), 0..17),
+                ("b@example.invalid".to_string(), 18..35)
+            ]
+        );
+
+        for input in ["a@example.invalid1", "a@example.invalid_"] {
+            assert!(
+                structural_findings(input)
+                    .iter()
+                    .all(|finding| finding.class != PiiClass::Email),
+                "{input}"
+            );
         }
     }
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1020,7 +1020,10 @@ fn structural_findings(text: &str) -> Vec<StructuralFinding> {
 }
 
 fn collect_email_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
-    for matched in email_pattern().find_iter(text) {
+    for caps in email_pattern().captures_iter(text) {
+        let Some(matched) = caps.get(1) else {
+            continue;
+        };
         let raw = matched.as_str();
         if !is_basic_restore_email(raw) {
             continue;
@@ -1093,7 +1096,7 @@ fn collect_api_key_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
 fn email_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
+        Regex::new(r"(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,})(?:$|[^a-z0-9_])")
             .expect("email restore DLP regex compiles")
     })
 }
@@ -1986,6 +1989,24 @@ mod tests {
         assert_ne!(events[0].raw_sha256, "alice@example.invalid");
         assert_eq!(events[1].kind, RestoreEventKind::FreshPiiDetected);
         assert_eq!(events[1].class, PiiClass::Email);
+    }
+
+    #[test]
+    fn restore_dlp_email_boundary_accepts_non_ascii_and_punctuation_delimiters() {
+        for (input, location) in [
+            ("a@example.invalidø", 0..17),
+            ("a@example.invalid. Thanks", 0..17),
+            (".a@example.invalid", 1..18),
+        ] {
+            let findings = structural_findings(input);
+            let finding = findings
+                .iter()
+                .find(|finding| finding.class == PiiClass::Email)
+                .unwrap_or_else(|| panic!("missing email finding for {input}"));
+
+            assert_eq!(finding.raw, "a@example.invalid", "{input}");
+            assert_eq!(finding.location, location, "{input}");
+        }
     }
 
     #[test]

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -206,6 +206,26 @@ fn normalization_runs_before_detection() {
 }
 
 #[test]
+fn email_tokenization_handles_non_ascii_boundary_suffix() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let pipeline = email_token_pipeline();
+
+    let text = redact_text(&pipeline, &session, "a@example.invalidø");
+
+    assert!(
+        !text.contains("a@example.invalid"),
+        "email substring leaked through clean text: {text}"
+    );
+    assert!(text.starts_with('<') && text.ends_with(":Email_1>ø"));
+
+    let token = text.trim_end_matches('ø');
+    assert_eq!(
+        session.restore_strict(token).expect("restore token"),
+        "a@example.invalid"
+    );
+}
+
+#[test]
 fn longest_span_wins_for_overlaps() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let pipeline = Pipeline::builder()


### PR DESCRIPTION
## Classification

Product bug in bundled email detector boundary semantics. The previous trailing Unicode word boundary missed synthetic ASCII emails when adjacent to non-ASCII word characters such as `a@example.invalidø`.

## Summary

- Replaced the bundled email regex word-boundary dependency with a core ASCII email match plus explicit ASCII email-continuation boundary filtering.
- Added detector regressions for non-ASCII suffix, non-ASCII prefix, comma-separated addresses, and ASCII continuation rejection.
- Added a public pipeline regression proving `Action::Tokenize` removes `a@example.invalid` from clean text while preserving restore.

## Reliability axes

This strengthens reliability and trust by closing a detector miss without weakening reversibility, agentic fit, or adopter ergonomics.

## Tests

- `cargo fmt --all`
- `cargo test -p gaze-recognizers bundled_email_detector`
- `cargo test -p gaze-pii --test contracts --features bundled-recognizers email_tokenization_handles_non_ascii_boundary_suffix`
- `cargo test -p gaze-recognizers`
- `cargo test -p gaze-pii --test contracts --features bundled-recognizers`

Plan 005 can resume after this PR merges.