### PR TITLE
[agent] token bridge Track A registry projection primitives

### DIFF
--- a/crates/gaze-token-bridge/fixtures/policy.json
+++ b/crates/gaze-token-bridge/fixtures/policy.json
@@ -1,0 +1,74 @@
+{
+  "domains": [
+    {
+      "domain_id": "tenant_demo/customer_docs/v1",
+      "tenant_id": "tenant_demo",
+      "corpus_type": "customer_docs",
+      "purpose": "support_lookup",
+      "allowed_roles": ["support", "admin"],
+      "allowed_tools": ["support_search", "legal_search"],
+      "allowed_actions": ["search_documents"],
+      "allowed_entity_classes": ["name", "email", "custom:customer_id", "organization"],
+      "snippets_allowed": true,
+      "raw_restore_allowed": false,
+      "co_searchable_with": ["tenant_demo/legal_docs/v1"],
+      "projection_key_id": "customer-v2"
+    },
+    {
+      "domain_id": "tenant_demo/legal_docs/v1",
+      "tenant_id": "tenant_demo",
+      "corpus_type": "legal_docs",
+      "purpose": "legal_lookup",
+      "allowed_roles": ["admin"],
+      "allowed_tools": ["legal_search"],
+      "allowed_actions": ["search_documents"],
+      "allowed_entity_classes": ["name", "email", "organization"],
+      "snippets_allowed": true,
+      "raw_restore_allowed": false,
+      "co_searchable_with": ["tenant_demo/customer_docs/v1"],
+      "projection_key_id": "legal-v1"
+    }
+  ],
+  "projection_keys": [
+    {
+      "key_id": "customer-v1",
+      "material": "synthetic-customer-domain-projection-key-v1"
+    },
+    {
+      "key_id": "customer-v2",
+      "material": "synthetic-customer-domain-projection-key-v2"
+    },
+    {
+      "key_id": "legal-v1",
+      "material": "synthetic-legal-domain-projection-key"
+    }
+  ],
+  "rules": [
+    {
+      "roles": ["support"],
+      "tenant_id": "tenant_demo",
+      "workspace_id": "workspace_demo",
+      "tool_name": "support_search",
+      "action": "search_documents",
+      "purpose": "support_lookup",
+      "target_domain": "tenant_demo/customer_docs/v1",
+      "allowed_entity_classes": ["name", "email", "custom:customer_id"],
+      "max_results": 20,
+      "allow_cross_domain": false,
+      "elevated_audit_required": false
+    },
+    {
+      "roles": ["admin"],
+      "tenant_id": "tenant_demo",
+      "workspace_id": "workspace_demo",
+      "tool_name": "legal_search",
+      "action": "search_documents",
+      "purpose": "legal_lookup",
+      "target_domain": "tenant_demo/legal_docs/v1",
+      "allowed_entity_classes": ["name", "email", "organization"],
+      "max_results": 20,
+      "allow_cross_domain": false,
+      "elevated_audit_required": false
+    }
+  ]
+}

--- a/crates/gaze-token-bridge/src/keys.rs
+++ b/crates/gaze-token-bridge/src/keys.rs
@@ -1,3 +1,67 @@
 //! Track A — `KeyManager`: per-domain projection key material + rotation (retain old
 //! keys for read, addressed by `key_id`; missing key fails closed). Owner: sub-orchestrator A.
 //! Contract: `crate::traits::KeyManager`. Reference: spike `IndexDomainRegistry::projection_key`.
+
+use std::collections::HashMap;
+
+use crate::error::BridgeError;
+use crate::traits::KeyManager;
+
+/// Projection keys retained by stable `key_id`.
+///
+/// Rotation is read-compatible by construction: loading a new active key for a
+/// domain does not remove old key material from this store.
+#[derive(Debug, Clone, Default)]
+pub struct ProjectionKeyStore {
+    keys: HashMap<String, Vec<u8>>,
+}
+
+impl ProjectionKeyStore {
+    pub fn from_pairs<I>(pairs: I) -> Result<Self, BridgeError>
+    where
+        I: IntoIterator<Item = (String, Vec<u8>)>,
+    {
+        let mut store = Self::default();
+        for (key_id, material) in pairs {
+            store.insert(key_id, material)?;
+        }
+        Ok(store)
+    }
+
+    pub fn insert(&mut self, key_id: String, material: Vec<u8>) -> Result<(), BridgeError> {
+        if key_id.is_empty() {
+            return Err(BridgeError::Policy(
+                "projection key id must not be empty".to_string(),
+            ));
+        }
+        if material.is_empty() {
+            return Err(BridgeError::Policy(format!(
+                "projection key {key_id} material must not be empty"
+            )));
+        }
+        if self.keys.insert(key_id.clone(), material).is_some() {
+            return Err(BridgeError::Policy(format!(
+                "duplicate projection key {key_id}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn contains_key(&self, key_id: &str) -> bool {
+        self.keys.contains_key(key_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+impl KeyManager for ProjectionKeyStore {
+    fn key(&self, key_id: &str) -> Option<&[u8]> {
+        self.keys.get(key_id).map(Vec::as_slice)
+    }
+}

--- a/crates/gaze-token-bridge/src/model.rs
+++ b/crates/gaze-token-bridge/src/model.rs
@@ -12,6 +12,7 @@
 use gaze::PiiClass;
 use serde::{Deserialize, Serialize};
 
+use crate::error::DenyReason;
 use crate::util::collapse_ascii_whitespace;
 
 /// `tenant/corpus/version` identifier, e.g. `tenant_demo/customer_docs/v1`.
@@ -277,6 +278,34 @@ pub enum BridgeDecision {
     },
     Deny {
         reason: crate::error::DenyReason,
+    },
+}
+
+/// Authorization grant emitted by Track A policy evaluation. Track C turns this into
+/// a short-lived capability; Track A does not mint handles.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthGrant {
+    pub entity_ref: IndexedEntityRef,
+    pub entity_class: PiiClass,
+    pub effective_purpose: String,
+    pub max_results: usize,
+    pub allowed_filters: Vec<String>,
+    pub elevated_audit: bool,
+    pub raw_sha256: String,
+}
+
+/// Policy outcome: either enough owner-side authorization data for Track C to issue
+/// a capability, or a typed fail-closed deny.
+// Transient decision value matched immediately by bridge runtime; keep it direct to
+// mirror BridgeDecision and avoid allocation in the hot path.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyOutcome {
+    Grant(AuthGrant),
+    Deny {
+        reason: DenyReason,
+        entity_class: Option<PiiClass>,
+        raw_sha256: Option<String>,
     },
 }
 

--- a/crates/gaze-token-bridge/src/projection.rs
+++ b/crates/gaze-token-bridge/src/projection.rs
@@ -2,3 +2,53 @@
 //! `HMAC((tenant,domain) key, canonical_value)` → `IndexedEntityRef`. NEVER salt with
 //! principal. Owner: sub-orchestrator A.
 //! Contract: `crate::traits::DomainProjector`. Reference: spike `DomainProjection`.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::error::BridgeError;
+use crate::model::{CanonicalEntity, IndexDomain, IndexedEntityRef};
+use crate::traits::{DomainProjector, KeyManager};
+use crate::util::hex;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// HMAC-SHA256 projector keyed by the target domain's `projection_key_id`.
+#[derive(Debug)]
+pub struct HmacDomainProjector<'a, K: KeyManager + ?Sized> {
+    keys: &'a K,
+}
+
+impl<'a, K: KeyManager + ?Sized> HmacDomainProjector<'a, K> {
+    pub fn new(keys: &'a K) -> Self {
+        Self { keys }
+    }
+}
+
+impl<K: KeyManager + ?Sized> DomainProjector for HmacDomainProjector<'_, K> {
+    fn project(
+        &self,
+        domain: &IndexDomain,
+        entity: &CanonicalEntity,
+    ) -> Result<IndexedEntityRef, BridgeError> {
+        let key = self.keys.key(&domain.projection_key_id).ok_or_else(|| {
+            BridgeError::Policy(format!(
+                "missing projection key {} for domain {}",
+                domain.projection_key_id, domain.domain_id
+            ))
+        })?;
+
+        let mut mac = HmacSha256::new_from_slice(key)
+            .map_err(|err| BridgeError::Policy(format!("invalid hmac key: {err:?}")))?;
+        mac.update(entity.canonical_value.as_bytes());
+
+        Ok(IndexedEntityRef {
+            domain_id: domain.domain_id.clone(),
+            key_id: domain.projection_key_id.clone(),
+            entity_class: entity.class.clone(),
+            fingerprint_hex: hex(mac.finalize().into_bytes().as_slice()),
+        })
+    }
+}
+
+pub type DomainProjection<'a> = HmacDomainProjector<'a, crate::registry::IndexDomainRegistry>;

--- a/crates/gaze-token-bridge/src/registry.rs
+++ b/crates/gaze-token-bridge/src/registry.rs
@@ -1,3 +1,174 @@
 //! Track A — `IndexDomainRegistry`: load `IndexDomain`s + `PolicyRule`s from a policy
 //! file, expose domain/rule/key lookup. Owner: sub-orchestrator A.
 //! Contract: `crate::model::{IndexDomain, PolicyRule}`. Reference: spike `IndexDomainRegistry`.
+
+use std::collections::HashMap;
+
+use gaze::PiiClass;
+use serde::Deserialize;
+
+use crate::error::BridgeError;
+use crate::keys::ProjectionKeyStore;
+use crate::model::{DomainId, IndexDomain, PolicyRule};
+use crate::traits::KeyManager;
+
+/// Registry of index domains, allow rules, and all projection keys retained for
+/// active and historical reads.
+#[derive(Debug, Clone)]
+pub struct IndexDomainRegistry {
+    domains: HashMap<DomainId, IndexDomain>,
+    rules: Vec<PolicyRule>,
+    projection_keys: ProjectionKeyStore,
+}
+
+impl IndexDomainRegistry {
+    pub fn from_json(input: &str) -> Result<Self, BridgeError> {
+        let raw: RawPolicyFile =
+            serde_json::from_str(input).map_err(|err| BridgeError::Policy(err.to_string()))?;
+
+        let mut domains = HashMap::with_capacity(raw.domains.len());
+        for raw_domain in raw.domains {
+            let domain = IndexDomain {
+                domain_id: raw_domain.domain_id,
+                tenant_id: raw_domain.tenant_id,
+                corpus_type: raw_domain.corpus_type,
+                purpose: raw_domain.purpose,
+                allowed_roles: raw_domain.allowed_roles,
+                allowed_tools: raw_domain.allowed_tools,
+                allowed_actions: raw_domain.allowed_actions,
+                allowed_entity_classes: parse_classes(&raw_domain.allowed_entity_classes)?,
+                snippets_allowed: raw_domain.snippets_allowed,
+                raw_restore_allowed: raw_domain.raw_restore_allowed,
+                co_searchable_with: raw_domain.co_searchable_with,
+                projection_key_id: raw_domain.projection_key_id,
+            };
+            if domains
+                .insert(domain.domain_id.clone(), domain.clone())
+                .is_some()
+            {
+                return Err(BridgeError::Policy(format!(
+                    "duplicate index domain {}",
+                    domain.domain_id
+                )));
+            }
+        }
+
+        let projection_keys = ProjectionKeyStore::from_pairs(
+            raw.projection_keys
+                .into_iter()
+                .map(|key| (key.key_id, key.material.into_bytes())),
+        )?;
+
+        let mut rules = Vec::with_capacity(raw.rules.len());
+        for raw_rule in raw.rules {
+            rules.push(PolicyRule {
+                roles: raw_rule.roles,
+                tenant_id: raw_rule.tenant_id,
+                workspace_id: raw_rule.workspace_id,
+                tool_name: raw_rule.tool_name,
+                action: raw_rule.action,
+                purpose: raw_rule.purpose,
+                target_domain: raw_rule.target_domain,
+                allowed_entity_classes: parse_classes(&raw_rule.allowed_entity_classes)?,
+                max_results: raw_rule.max_results,
+                allow_cross_domain: raw_rule.allow_cross_domain,
+                elevated_audit_required: raw_rule.elevated_audit_required,
+            });
+        }
+
+        Ok(Self {
+            domains,
+            rules,
+            projection_keys,
+        })
+    }
+
+    pub fn domain(&self, domain_id: &str) -> Option<&IndexDomain> {
+        self.domains.get(domain_id)
+    }
+
+    pub fn domains(&self) -> impl Iterator<Item = &IndexDomain> {
+        self.domains.values()
+    }
+
+    pub fn rules(&self) -> &[PolicyRule] {
+        &self.rules
+    }
+
+    pub fn rules_for_domain<'a>(
+        &'a self,
+        domain_id: &'a str,
+    ) -> impl Iterator<Item = &'a PolicyRule> + 'a {
+        self.rules
+            .iter()
+            .filter(move |rule| rule.target_domain == domain_id)
+    }
+
+    pub fn projection_key(&self, key_id: &str) -> Option<&[u8]> {
+        self.projection_keys.key(key_id)
+    }
+
+    pub fn projection_keys(&self) -> &ProjectionKeyStore {
+        &self.projection_keys
+    }
+}
+
+impl KeyManager for IndexDomainRegistry {
+    fn key(&self, key_id: &str) -> Option<&[u8]> {
+        self.projection_key(key_id)
+    }
+}
+
+fn parse_classes(values: &[String]) -> Result<Vec<PiiClass>, BridgeError> {
+    values
+        .iter()
+        .map(|value| {
+            PiiClass::from_canonical_str(value)
+                .ok_or_else(|| BridgeError::Policy(format!("unknown pii class {value}")))
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPolicyFile {
+    domains: Vec<RawIndexDomain>,
+    projection_keys: Vec<RawProjectionKey>,
+    rules: Vec<RawPolicyRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawIndexDomain {
+    domain_id: DomainId,
+    tenant_id: String,
+    corpus_type: String,
+    purpose: String,
+    allowed_roles: Vec<String>,
+    allowed_tools: Vec<String>,
+    allowed_actions: Vec<String>,
+    allowed_entity_classes: Vec<String>,
+    snippets_allowed: bool,
+    raw_restore_allowed: bool,
+    co_searchable_with: Vec<DomainId>,
+    projection_key_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProjectionKey {
+    key_id: String,
+    material: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPolicyRule {
+    roles: Vec<String>,
+    tenant_id: String,
+    workspace_id: String,
+    tool_name: String,
+    action: String,
+    purpose: String,
+    target_domain: DomainId,
+    allowed_entity_classes: Vec<String>,
+    max_results: usize,
+    allow_cross_domain: bool,
+    elevated_audit_required: bool,
+}

--- a/crates/gaze-token-bridge/src/traits.rs
+++ b/crates/gaze-token-bridge/src/traits.rs
@@ -6,8 +6,8 @@
 
 use crate::error::{BridgeError, DenyReason};
 use crate::model::{
-    AgentSearchHit, AuditEvent, BridgeDecision, BridgeRequest, CanonicalEntity, IndexDomain,
-    IndexSearchHit, IndexedEntityRef, SearchHandle, ValidatedSearchRequest,
+    AgentSearchHit, AuditEvent, BridgeRequest, CanonicalEntity, IndexDomain, IndexSearchHit,
+    IndexedEntityRef, PolicyOutcome, SearchHandle, ValidatedSearchRequest,
 };
 use crate::session::RedactionSession;
 
@@ -25,7 +25,7 @@ pub trait DomainProjector {
 /// Track A — owner-side authorization. Default-deny; resolves an owner-bound purpose
 /// from policy config (ignoring any request-supplied purpose); emits a typed decision.
 pub trait PolicyGate {
-    fn evaluate(&mut self, session: &RedactionSession, request: &BridgeRequest) -> BridgeDecision;
+    fn evaluate(&mut self, session: &RedactionSession, request: &BridgeRequest) -> PolicyOutcome;
 }
 
 /// Track A — projection key material, addressed by `key_id`. Supports rotation by

--- a/crates/gaze-token-bridge/tests/track_a_projection.rs
+++ b/crates/gaze-token-bridge/tests/track_a_projection.rs
@@ -1,0 +1,117 @@
+use gaze::PiiClass;
+use gaze_token_bridge::registry::IndexDomainRegistry;
+use gaze_token_bridge::traits::{DomainProjector, KeyManager};
+use gaze_token_bridge::{AuthGrant, BridgeError, CanonicalEntity, IndexedEntityRef, PolicyOutcome};
+
+const POLICY_JSON: &str = include_str!("../fixtures/policy.json");
+const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
+const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+
+fn registry() -> IndexDomainRegistry {
+    IndexDomainRegistry::from_json(POLICY_JSON).expect("fixture policy loads")
+}
+
+#[test]
+fn projection_is_deterministic_and_domain_key_scoped() {
+    let registry = registry();
+    let projector = gaze_token_bridge::projection::HmacDomainProjector::new(&registry);
+    let entity = CanonicalEntity::from_raw(PiiClass::Email, "alice@example.invalid");
+    let customer_domain = registry.domain(CUSTOMER_DOMAIN).unwrap();
+    let legal_domain = registry.domain(LEGAL_DOMAIN).unwrap();
+
+    let first = projector.project(customer_domain, &entity).unwrap();
+    let second = projector.project(customer_domain, &entity).unwrap();
+    let legal = projector.project(legal_domain, &entity).unwrap();
+
+    let mut old_key_customer_domain = customer_domain.clone();
+    old_key_customer_domain.projection_key_id = "customer-v1".to_string();
+    let old_key = projector
+        .project(&old_key_customer_domain, &entity)
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first.domain_id, CUSTOMER_DOMAIN);
+    assert_eq!(first.key_id, "customer-v2");
+    assert_ne!(first.fingerprint_hex, legal.fingerprint_hex);
+    assert_ne!(first.fingerprint_hex, old_key.fingerprint_hex);
+    assert_eq!(old_key.key_id, "customer-v1");
+}
+
+#[test]
+fn key_rotation_retains_old_key_material_for_reads() {
+    let registry = registry();
+    let active_domain = registry.domain(CUSTOMER_DOMAIN).unwrap();
+
+    assert_eq!(active_domain.projection_key_id, "customer-v2");
+    assert!(KeyManager::key(&registry, "customer-v1").is_some());
+    assert!(KeyManager::key(&registry, "customer-v2").is_some());
+    assert!(registry
+        .domains()
+        .all(|domain| domain.projection_key_id != "customer-v1"));
+}
+
+#[test]
+fn missing_projection_key_fails_closed() {
+    let registry = registry();
+    let projector = gaze_token_bridge::projection::HmacDomainProjector::new(&registry);
+    let mut domain = registry.domain(CUSTOMER_DOMAIN).unwrap().clone();
+    domain.projection_key_id = "missing-key".to_string();
+    let entity = CanonicalEntity::from_raw(PiiClass::Name, "Dr. Schmidt");
+
+    let err = projector.project(&domain, &entity).unwrap_err();
+
+    assert!(
+        matches!(err, BridgeError::Policy(message) if message.contains("missing projection key"))
+    );
+    assert!(KeyManager::key(&registry, "missing-key").is_none());
+}
+
+#[test]
+fn unknown_pii_class_in_policy_fails_closed() {
+    let bad_policy = POLICY_JSON.replace("\"name\"", "\"not_a_real_class\"");
+
+    let err = IndexDomainRegistry::from_json(&bad_policy).unwrap_err();
+
+    assert!(matches!(err, BridgeError::Policy(message) if message.contains("unknown pii class")));
+}
+
+#[test]
+fn registry_exposes_domain_rules_and_keys() {
+    let registry = registry();
+
+    assert!(registry.domain(CUSTOMER_DOMAIN).is_some());
+    assert_eq!(registry.rules().len(), 2);
+    assert_eq!(registry.rules_for_domain(CUSTOMER_DOMAIN).count(), 1);
+    assert!(registry.projection_key("legal-v1").is_some());
+    assert_eq!(registry.projection_keys().len(), 3);
+}
+
+#[test]
+fn r1_policy_outcome_grant_is_constructible() {
+    let entity_ref = IndexedEntityRef {
+        domain_id: CUSTOMER_DOMAIN.to_string(),
+        key_id: "customer-v2".to_string(),
+        entity_class: PiiClass::Email,
+        fingerprint_hex: "ab".repeat(32),
+    };
+
+    let outcome = PolicyOutcome::Grant(AuthGrant {
+        entity_ref: entity_ref.clone(),
+        entity_class: PiiClass::Email,
+        effective_purpose: "support_lookup".to_string(),
+        max_results: 20,
+        allowed_filters: vec!["customer_status".to_string()],
+        elevated_audit: false,
+        raw_sha256: "cd".repeat(32),
+    });
+
+    match outcome {
+        PolicyOutcome::Grant(grant) => {
+            assert_eq!(grant.entity_ref, entity_ref);
+            assert_eq!(grant.effective_purpose, "support_lookup");
+            assert_eq!(grant.max_results, 20);
+            assert!(!grant.elevated_audit);
+        }
+        PolicyOutcome::Deny { .. } => panic!("expected grant"),
+    }
+}


### PR DESCRIPTION
Summary:
- Add R1 AuthGrant/PolicyOutcome and switch PolicyGate::evaluate to PolicyOutcome.
- Add JSON-backed IndexDomainRegistry, key store, and HMAC domain projector with key-rotation read support.
- Add Track A fixture and focused projection/registry/R1 tests.

Test plan:
- cargo fmt --all -- --check
- cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings
- cargo test -p gaze-token-bridge
- cargo build --workspace

Resolves solo todo #1522
