### PR TITLE
[agent] feat(token-bridge): Track C bridge runtime + R2 CapabilityIssuer

### DIFF
--- a/crates/gaze-token-bridge/src/audit.rs
+++ b/crates/gaze-token-bridge/src/audit.rs
@@ -2,3 +2,31 @@
 //! decision, raw values only as sha256. Follow the `gaze-audit` restricted-column +
 //! Dylint-isolation pattern when persisting durably. Owner: sub-orchestrator C.
 //! Contract: `crate::traits::BridgeAuditSink`, `crate::model::AuditEvent`. Reference: spike `BridgeAudit`.
+
+use crate::model::AuditEvent;
+use crate::traits::BridgeAuditSink;
+
+/// In-memory append-only audit sink. One [`AuditEvent`] per bridge decision; raw values
+/// are already reduced to `raw_sha256` by the time they reach here (enforced by the
+/// `AuditEvent` shape). A durable, restricted-column SQLite sink (the `gaze-audit`
+/// Dylint-isolation pattern) is the follow-up for production persistence.
+#[derive(Debug, Default)]
+pub struct VecAuditSink {
+    events: Vec<AuditEvent>,
+}
+
+impl VecAuditSink {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl BridgeAuditSink for VecAuditSink {
+    fn record(&mut self, event: AuditEvent) {
+        self.events.push(event);
+    }
+
+    fn events(&self) -> &[AuditEvent] {
+        &self.events
+    }
+}

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -2,3 +2,402 @@
 //! project (A) → policy (A) → mint capability (C) → adapter (B) → translate (C) → audit (C).
 //! Also the chokepoint integration (ToolResources sealed handle, `search_documents` tool).
 //! Owner: sub-orchestrator C. Reference: spike `TokenBridge`.
+//!
+//! # Ownership note
+//! [`crate::policy::RegistryPolicyGate`] borrows its registry, while [`TokenBridge::demo`]
+//! must return an owned value. A struct that owns the registry *and* a gate borrowing it
+//! would be self-referential, so the bridge owns the registry and constructs a fresh gate
+//! per authorization. Consequence: the gate's per-principal rate-limit buckets do not
+//! persist across calls. Tracked as a follow-up (the bundled fixture limit is never hit).
+
+use std::collections::HashMap;
+use std::ops::Range;
+
+use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, PiiClass, Pipeline};
+
+use crate::adapter::InMemorySearchAdapter;
+use crate::audit::VecAuditSink;
+use crate::capability::CapabilityRuntime;
+use crate::error::{BridgeError, DenyReason};
+use crate::ingest::CorpusIngestor;
+use crate::model::{
+    AdapterFilterClause, AuditDecision, AuditEvent, BridgeDecision, BridgeRequest,
+    BridgeSearchOutcome, BridgeSearchResponse, DomainId, IndexSearchHit, PolicyOutcome,
+    SearchHandle, SearchRequest,
+};
+use crate::policy::RegistryPolicyGate;
+use crate::projection::HmacDomainProjector;
+use crate::registry::IndexDomainRegistry;
+use crate::session::RedactionSession;
+use crate::traits::{
+    BridgeAuditSink, CapabilityIssuer, PolicyGate, ResponseTranslator, SearchAdapter,
+};
+use crate::translate::SessionResponseTranslator;
+use crate::util::sha256_hex;
+
+/// Bundled demo policy (two domains, support + admin rules). Owner-side fixture.
+const DEMO_POLICY_JSON: &str = include_str!("../fixtures/policy.json");
+const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
+const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+
+/// Owner-side bridge runtime. Composes the registry-backed policy gate (A), the corpus
+/// search adapter (B), the capability runtime (C), and an append-only audit sink (C).
+#[derive(Debug)]
+pub struct TokenBridge {
+    registry: IndexDomainRegistry,
+    adapter: InMemorySearchAdapter,
+    capability: CapabilityRuntime,
+    audit: VecAuditSink,
+    /// Owner-side copy of ingested hits, keyed by domain, for test introspection
+    /// (`primary_alias` / `primary_fingerprint`). Never `Serialize`, never agent-visible.
+    corpus: HashMap<DomainId, Vec<IndexSearchHit>>,
+    /// The projected filters last handed to the adapter (proves raw filter values are
+    /// projected owner-side before the adapter sees them).
+    last_adapter_filters: Vec<AdapterFilterClause>,
+}
+
+impl TokenBridge {
+    /// Build the bundled demo bridge: load the demo policy, ingest the synthetic corpus
+    /// into both domains via the Track B redact-before-index ingestor, and compose.
+    pub fn demo() -> Result<Self, BridgeError> {
+        Self::from_policy_json(DEMO_POLICY_JSON)
+    }
+
+    /// Build a bridge from an explicit policy JSON document, ingesting the synthetic
+    /// corpus into both demo domains. Used by tests that need an augmented policy (e.g.
+    /// an elevated cross-domain rule) without mutating the bundled fixture.
+    pub fn from_policy_json(policy_json: &str) -> Result<Self, BridgeError> {
+        let registry = IndexDomainRegistry::from_json(policy_json)?;
+        let mut adapter = InMemorySearchAdapter::new();
+        let mut corpus: HashMap<DomainId, Vec<IndexSearchHit>> = HashMap::new();
+        let docs = synthetic_docs();
+
+        for domain_id in [CUSTOMER_DOMAIN, LEGAL_DOMAIN] {
+            let domain = registry
+                .domain(domain_id)
+                .ok_or_else(|| BridgeError::Policy(format!("missing demo domain {domain_id}")))?
+                .clone();
+            let pipeline = build_demo_pipeline(&docs)?;
+            let projector = HmacDomainProjector::new(&registry);
+            let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector);
+
+            for doc in &docs {
+                let raw_text = doc.raw_text(domain_id);
+                let hit =
+                    ingestor.ingest_text_into_store(adapter.store_mut(), doc.id, &raw_text)?;
+                corpus.entry(domain_id.to_string()).or_default().push(hit);
+            }
+        }
+
+        Ok(Self {
+            registry,
+            adapter,
+            capability: CapabilityRuntime::new(),
+            audit: VecAuditSink::new(),
+            corpus,
+            last_adapter_filters: Vec::new(),
+        })
+    }
+
+    /// Authorize a request and, on success, mint a single-use capability. Records exactly
+    /// one audit event per call (the authorization decision). The owner-side policy gate
+    /// does all authz internally; the bridge trusts the resulting grant.
+    pub fn authorize(
+        &mut self,
+        session: &RedactionSession,
+        request: &BridgeRequest,
+    ) -> BridgeDecision {
+        // Scope the gate's borrow of `self.registry` to this block so the subsequent
+        // mutable borrows of `self.capability` / `self.audit` are legal.
+        let outcome = {
+            let mut gate = RegistryPolicyGate::new(&self.registry);
+            gate.evaluate(session, request)
+        };
+
+        match outcome {
+            PolicyOutcome::Grant(grant) => {
+                let handle = self.capability.issue(&grant, request);
+                self.audit.record(AuditEvent {
+                    audit_id: handle.audit_id.clone(),
+                    decision: AuditDecision::Allow,
+                    deny_reason: None,
+                    principal_id: request.principal.id.clone(),
+                    target_domain: request.target_domain.clone(),
+                    action: request.action.clone(),
+                    purpose: grant.effective_purpose.clone(),
+                    entity_class: Some(grant.entity_class.clone()),
+                    source_token_hash: handle.source_token_hash.clone(),
+                    raw_sha256: Some(grant.raw_sha256.clone()),
+                    elevated_audit: grant.elevated_audit,
+                });
+                BridgeDecision::Allow {
+                    handle,
+                    elevated_audit: grant.elevated_audit,
+                }
+            }
+            PolicyOutcome::Deny {
+                reason,
+                entity_class,
+                raw_sha256,
+            } => {
+                let audit_id = self.capability.next_audit_id();
+                self.audit.record(AuditEvent {
+                    audit_id,
+                    decision: AuditDecision::Deny,
+                    deny_reason: Some(reason.clone()),
+                    principal_id: request.principal.id.clone(),
+                    target_domain: request.target_domain.clone(),
+                    action: request.action.clone(),
+                    // No grant ⇒ no owner-bound purpose; record the request-stated one.
+                    purpose: request.purpose.clone(),
+                    entity_class,
+                    source_token_hash: sha256_hex(&request.source_token),
+                    raw_sha256,
+                    elevated_audit: false,
+                });
+                BridgeDecision::Deny { reason }
+            }
+        }
+    }
+
+    /// Execute a previously issued handle over exactly its bound entity (no extra filters).
+    pub fn execute_handle(
+        &mut self,
+        session: &RedactionSession,
+        handle: &SearchHandle,
+    ) -> Result<BridgeSearchResponse, DenyReason> {
+        self.execute_search_request(session, handle, SearchRequest::from_handle(handle))
+    }
+
+    /// Execute a handle against an explicit search request: validate the handle, project
+    /// raw filter values owner-side, search the adapter, then translate hits into the
+    /// active session namespace. Every failure path fails closed to a typed [`DenyReason`].
+    pub fn execute_search_request(
+        &mut self,
+        session: &RedactionSession,
+        handle: &SearchHandle,
+        request: SearchRequest,
+    ) -> Result<BridgeSearchResponse, DenyReason> {
+        self.capability
+            .validate_handle(handle, &request.requested_entity_ref)?;
+        let validated = self
+            .capability
+            .project_request(&self.registry, handle, request)?;
+        self.last_adapter_filters = validated.filters.clone();
+
+        let now = self.capability.now();
+        let hits = self.adapter.search(handle, validated, now)?;
+        let results = SessionResponseTranslator::translate(session, hits)?;
+
+        Ok(BridgeSearchResponse {
+            target_domain: handle.target_domain.clone(),
+            audit_id: handle.audit_id.clone(),
+            results,
+        })
+    }
+
+    /// End-to-end search: authorize (audited) → execute → translate. Any deny — at the
+    /// policy gate or during execution — surfaces as a typed [`BridgeSearchOutcome::Denied`].
+    pub fn search(
+        &mut self,
+        session: &RedactionSession,
+        request: &BridgeRequest,
+    ) -> BridgeSearchOutcome {
+        match self.authorize(session, request) {
+            BridgeDecision::Allow { handle, .. } => match self.execute_handle(session, &handle) {
+                Ok(response) => BridgeSearchOutcome::Allowed(response),
+                Err(reason) => BridgeSearchOutcome::Denied(reason),
+            },
+            BridgeDecision::Deny { reason } => BridgeSearchOutcome::Denied(reason),
+        }
+    }
+
+    /// Advance the logical clock (controls handle expiry in tests / batch runs).
+    pub fn advance_clock(&mut self, ticks: u64) {
+        self.capability.advance_clock(ticks);
+    }
+
+    /// Append-only audit trail of bridge decisions.
+    pub fn audit(&self) -> &[AuditEvent] {
+        self.audit.events()
+    }
+
+    /// Projected filters last handed to the adapter (owner-side test introspection).
+    pub fn last_adapter_filters(&self) -> &[AdapterFilterClause] {
+        &self.last_adapter_filters
+    }
+
+    /// Owner-side: the stable domain alias of the first `class` entity in a known doc.
+    pub fn primary_alias(&self, domain_id: &str, doc_id: &str, class: &PiiClass) -> Option<String> {
+        self.entity(domain_id, doc_id, class)
+            .map(|entity| entity.domain_alias.clone())
+    }
+
+    /// Owner-side: the projection fingerprint of the first `class` entity in a known doc.
+    pub fn primary_fingerprint(
+        &self,
+        domain_id: &str,
+        doc_id: &str,
+        class: &PiiClass,
+    ) -> Option<String> {
+        self.entity(domain_id, doc_id, class)
+            .map(|entity| entity.index_ref.fingerprint_hex.clone())
+    }
+
+    fn entity(
+        &self,
+        domain_id: &str,
+        doc_id: &str,
+        class: &PiiClass,
+    ) -> Option<&crate::model::IndexEntity> {
+        self.corpus
+            .get(domain_id)?
+            .iter()
+            .find(|hit| hit.doc_id == doc_id)?
+            .entities
+            .iter()
+            .find(|entity| &entity.class == class)
+    }
+}
+
+/// A structured synthetic record. Mirrors the spike fixture set; reused by the PR3 example.
+#[derive(Debug, Clone)]
+pub struct SyntheticDoc {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub email: &'static str,
+    pub customer_id: &'static str,
+    pub organization: &'static str,
+}
+
+impl SyntheticDoc {
+    /// Render this record as raw corpus text for a domain. The text is fed through the
+    /// Track B redact-before-index ingestor, so the raw values below never enter the
+    /// index in cleartext — only their projected aliases and owner-side raw fields do.
+    fn raw_text(&self, domain_id: &str) -> String {
+        if domain_id == CUSTOMER_DOMAIN {
+            format!(
+                "Customer profile {} / {} / {} is linked to {}.",
+                self.name, self.email, self.customer_id, self.organization
+            )
+        } else {
+            format!(
+                "Legal matter references {} at {}; contact route {}.",
+                self.name, self.organization, self.email
+            )
+        }
+    }
+}
+
+/// The bundled synthetic corpus (mirrors the spike). Reused by the PR3 example.
+pub fn synthetic_docs() -> Vec<SyntheticDoc> {
+    vec![
+        SyntheticDoc {
+            id: "cust-001",
+            name: "Markus Gottschaue",
+            email: "markus@example.invalid",
+            customer_id: "91A",
+            organization: "Globex GmbH",
+        },
+        SyntheticDoc {
+            id: "cust-002",
+            name: "Dr. Schmidt",
+            email: "schmidt@example.invalid",
+            customer_id: "72B",
+            organization: "Initech AG",
+        },
+        SyntheticDoc {
+            id: "cust-003",
+            name: "Lena Torres",
+            email: "lena@example.invalid",
+            customer_id: "48C",
+            organization: "Umbrella LLC",
+        },
+        SyntheticDoc {
+            id: "cust-004",
+            name: "Prof. Weber",
+            email: "weber@example.invalid",
+            customer_id: "54D",
+            organization: "Soylent GmbH",
+        },
+        SyntheticDoc {
+            id: "cust-005",
+            name: "Ana Rossi",
+            email: "ana@example.invalid",
+            customer_id: "33E",
+            organization: "Vehement Capital Partners",
+        },
+    ]
+}
+
+/// Build the gaze pipeline that redacts the synthetic corpus before indexing. The
+/// synthetic values are known fixtures, so a deterministic literal detector keeps the
+/// demo reproducible (the bridge's job here is the runtime, not detector quality).
+fn build_demo_pipeline(docs: &[SyntheticDoc]) -> Result<Pipeline, BridgeError> {
+    Pipeline::builder()
+        .detector(SyntheticCorpusDetector::from_docs(docs))
+        .rule(ClassRule::new(PiiClass::Name, Action::Tokenize))
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(PiiClass::Organization, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::custom("customer_id"),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .map_err(|err| BridgeError::Policy(format!("failed to build demo pipeline: {err:?}")))
+}
+
+/// Deterministic literal detector over the known synthetic values. Emits a non-overlapping
+/// detection for every known `(value, class)` pair present in the input (longest first).
+#[derive(Debug)]
+struct SyntheticCorpusDetector {
+    entries: Vec<(String, PiiClass)>,
+}
+
+impl SyntheticCorpusDetector {
+    fn from_docs(docs: &[SyntheticDoc]) -> Self {
+        let mut entries = Vec::with_capacity(docs.len() * 4);
+        for doc in docs {
+            entries.push((doc.name.to_string(), PiiClass::Name));
+            entries.push((doc.email.to_string(), PiiClass::Email));
+            entries.push((doc.organization.to_string(), PiiClass::Organization));
+            entries.push((doc.customer_id.to_string(), PiiClass::custom("customer_id")));
+        }
+        // Longest values first so a longer value claims its span before any shorter
+        // value that might be a substring of it.
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
+        entries.dedup();
+        Self { entries }
+    }
+}
+
+impl Detector for SyntheticCorpusDetector {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        let mut detections = Vec::new();
+        let mut claimed: Vec<Range<usize>> = Vec::new();
+        for (value, class) in &self.entries {
+            if value.is_empty() {
+                continue;
+            }
+            let mut cursor = 0;
+            while let Some(offset) = input[cursor..].find(value.as_str()) {
+                let start = cursor + offset;
+                let end = start + value.len();
+                let overlaps = claimed
+                    .iter()
+                    .any(|range| start < range.end && range.start < end);
+                if !overlaps {
+                    detections.push(Detection::new(
+                        start..end,
+                        class.clone(),
+                        "synthetic.corpus",
+                    ));
+                    claimed.push(start..end);
+                }
+                cursor = end;
+            }
+        }
+        detections
+    }
+}

--- a/crates/gaze-token-bridge/src/capability.rs
+++ b/crates/gaze-token-bridge/src/capability.rs
@@ -3,3 +3,166 @@
 //! unused), project raw filter values before they reach the adapter. Owner: sub-orchestrator C.
 //! Contract: `crate::model::{SearchHandle, SearchRequest, ValidatedSearchRequest}`.
 //! Reference: spike `TokenBridge::{issue_handle, project_search_request}`.
+
+use std::collections::HashSet;
+
+use crate::error::DenyReason;
+use crate::model::{
+    AdapterFilterClause, AuthGrant, BridgeRequest, CanonicalEntity, IndexedEntityRef, SearchHandle,
+    SearchRequest, ValidatedSearchRequest,
+};
+use crate::projection::HmacDomainProjector;
+use crate::registry::IndexDomainRegistry;
+use crate::traits::{CapabilityIssuer, DomainProjector};
+use crate::util::sha256_hex;
+
+/// Logical lifespan, in clock ticks, of a freshly issued [`SearchHandle`].
+const HANDLE_TTL_TICKS: u64 = 2;
+
+/// Monotonic logical clock. Tests advance it explicitly; nothing wall-clock-derived
+/// leaks into handle expiry (keeps the contract deterministic — north-star axis 4).
+#[derive(Debug, Default)]
+pub struct LogicalClock {
+    tick: u64,
+}
+
+impl LogicalClock {
+    pub fn now(&self) -> u64 {
+        self.tick
+    }
+
+    pub fn advance(&mut self, ticks: u64) {
+        self.tick = self.tick.saturating_add(ticks);
+    }
+}
+
+/// Owner-side capability runtime: issues entity-bound handles, validates them on use
+/// (entity_ref / expiry / single-use nonce), and projects raw filter values into the
+/// domain keyspace before they reach the adapter. Single-use nonce state lives here.
+#[derive(Debug, Default)]
+pub struct CapabilityRuntime {
+    clock: LogicalClock,
+    next_nonce: u64,
+    next_audit: u64,
+    consumed_nonces: HashSet<String>,
+}
+
+impl CapabilityRuntime {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Current logical tick.
+    pub fn now(&self) -> u64 {
+        self.clock.now()
+    }
+
+    /// Advance the logical clock (test/runtime control over handle expiry).
+    pub fn advance_clock(&mut self, ticks: u64) {
+        self.clock.advance(ticks);
+    }
+
+    /// Next monotonic audit id. Shared by allow (carried in the handle) and deny rows
+    /// so every bridge decision gets a unique, ordered id.
+    pub fn next_audit_id(&mut self) -> String {
+        self.next_audit += 1;
+        format!("bridge-audit-{}", self.next_audit)
+    }
+
+    fn next_nonce_value(&mut self) -> String {
+        self.next_nonce += 1;
+        format!("nonce-{}", self.next_nonce)
+    }
+
+    /// Validate a handle against the entity_ref it is being used for. Fails closed on
+    /// confused-deputy (entity_ref mismatch), domain mismatch, expiry, and replay.
+    /// Consuming the nonce is the authoritative single-use gate; the adapter repeats
+    /// these checks defensively (defense in depth — north-star axis 1).
+    pub fn validate_handle(
+        &mut self,
+        handle: &SearchHandle,
+        requested_entity_ref: &IndexedEntityRef,
+    ) -> Result<(), DenyReason> {
+        if requested_entity_ref != &handle.entity_ref {
+            return Err(DenyReason::EntityRefMismatch);
+        }
+        if handle.entity_ref.domain_id != handle.target_domain {
+            return Err(DenyReason::HandleDomainMismatch);
+        }
+        if self.clock.now() > handle.expires_at_tick {
+            return Err(DenyReason::ExpiredHandle);
+        }
+        if !self.consumed_nonces.insert(handle.nonce.clone()) {
+            return Err(DenyReason::ReplayedHandle);
+        }
+        Ok(())
+    }
+
+    /// Validate filter fields against the handle allowlist and project each raw filter
+    /// value into `projected:<key_id>:<fingerprint>` so the adapter never sees raw PII.
+    /// A filter field outside the handle allowlist fails closed (default-deny).
+    pub fn project_request(
+        &self,
+        registry: &IndexDomainRegistry,
+        handle: &SearchHandle,
+        request: SearchRequest,
+    ) -> Result<ValidatedSearchRequest, DenyReason> {
+        let domain = registry
+            .domain(&handle.target_domain)
+            .ok_or(DenyReason::DomainNotFound)?;
+        let projector = HmacDomainProjector::new(registry);
+
+        let mut filters = Vec::with_capacity(request.filters.len());
+        for filter in request.filters {
+            if !handle
+                .allowed_filters
+                .iter()
+                .any(|allowed| allowed == &filter.field)
+            {
+                return Err(DenyReason::NoMatchingAllowRule);
+            }
+            let entity = CanonicalEntity::from_raw(filter.class, &filter.value);
+            let projected = projector
+                .project(domain, &entity)
+                .map_err(|_| DenyReason::NoMatchingAllowRule)?;
+            filters.push(AdapterFilterClause {
+                field: filter.field,
+                value: format!(
+                    "projected:{}:{}",
+                    projected.key_id, projected.fingerprint_hex
+                ),
+            });
+        }
+
+        Ok(ValidatedSearchRequest {
+            requested_entity_ref: request.requested_entity_ref,
+            filters,
+        })
+    }
+}
+
+impl CapabilityIssuer for CapabilityRuntime {
+    fn issue(&mut self, grant: &AuthGrant, request: &BridgeRequest) -> SearchHandle {
+        let audit_id = self.next_audit_id();
+        let nonce = self.next_nonce_value();
+        SearchHandle {
+            principal_id: request.principal.id.clone(),
+            tenant_id: request.tenant_id.clone(),
+            workspace_id: request.workspace_id.clone(),
+            agent_run_id: request.agent_run_id.clone(),
+            conversation_session_id: request.conversation_session_id.clone(),
+            source_token_hash: sha256_hex(&request.source_token),
+            target_domain: request.target_domain.clone(),
+            action: request.action.clone(),
+            // Owner-bound purpose comes from the grant, never from the request.
+            purpose: grant.effective_purpose.clone(),
+            entity_class: grant.entity_class.clone(),
+            entity_ref: grant.entity_ref.clone(),
+            allowed_filters: grant.allowed_filters.clone(),
+            max_results: grant.max_results,
+            expires_at_tick: self.clock.now() + HANDLE_TTL_TICKS,
+            nonce,
+            audit_id,
+        }
+    }
+}

--- a/crates/gaze-token-bridge/src/traits.rs
+++ b/crates/gaze-token-bridge/src/traits.rs
@@ -6,8 +6,8 @@
 
 use crate::error::{BridgeError, DenyReason};
 use crate::model::{
-    AgentSearchHit, AuditEvent, BridgeRequest, CanonicalEntity, IndexDomain, IndexSearchHit,
-    IndexedEntityRef, PolicyOutcome, SearchHandle, ValidatedSearchRequest,
+    AgentSearchHit, AuditEvent, AuthGrant, BridgeRequest, CanonicalEntity, IndexDomain,
+    IndexSearchHit, IndexedEntityRef, PolicyOutcome, SearchHandle, ValidatedSearchRequest,
 };
 use crate::session::RedactionSession;
 
@@ -61,4 +61,12 @@ pub trait ResponseTranslator {
 pub trait BridgeAuditSink {
     fn record(&mut self, event: AuditEvent);
     fn events(&self) -> &[AuditEvent];
+}
+
+/// Track C (R2, master-authorized) — mint a short-lived, entity-bound capability from a
+/// policy grant. The issuer copies trusted request context + the grant's owner-side
+/// authorization into a single-use [`SearchHandle`]; it never re-authorizes (the grant
+/// already encodes the owner-side decision) and never decides scope itself.
+pub trait CapabilityIssuer {
+    fn issue(&mut self, grant: &AuthGrant, request: &BridgeRequest) -> SearchHandle;
 }

--- a/crates/gaze-token-bridge/src/translate.rs
+++ b/crates/gaze-token-bridge/src/translate.rs
@@ -3,3 +3,54 @@
 //! fail closed if any domain alias or raw value would remain. Owner: sub-orchestrator C.
 //! Contract: `crate::traits::ResponseTranslator`, `crate::util::contains_domain_alias`.
 //! Reference: spike `ResponseTranslator`.
+
+use crate::error::DenyReason;
+use crate::model::{AgentSearchHit, IndexSearchHit};
+use crate::session::RedactionSession;
+use crate::traits::ResponseTranslator;
+use crate::util::contains_domain_alias;
+
+/// Translates owner-side hits into the active session namespace. Every domain alias is
+/// replaced by a session token minted for the same `(class, raw_value)`; previously
+/// seen entities reuse the existing session token, newly-discovered ones get a fresh
+/// one. Fails closed if any index alias or raw value would survive into agent output.
+pub struct SessionResponseTranslator;
+
+impl ResponseTranslator for SessionResponseTranslator {
+    fn translate(
+        session: &RedactionSession,
+        hits: Vec<IndexSearchHit>,
+    ) -> Result<Vec<AgentSearchHit>, DenyReason> {
+        let mut translated = Vec::with_capacity(hits.len());
+        for hit in hits {
+            let mut snippet = hit.snippet;
+            for entity in &hit.entities {
+                if snippet.contains(&entity.domain_alias) {
+                    let token = session
+                        .tokenize(&entity.class, &entity.raw_value)
+                        .map_err(|_| DenyReason::TranslatorFailed)?;
+                    snippet = snippet.replace(&entity.domain_alias, &token);
+                }
+            }
+
+            // Fail closed: no index-domain alias may remain (translator leak guard) ...
+            if contains_domain_alias(&snippet) {
+                return Err(DenyReason::TranslatorFailed);
+            }
+            // ... and no entity raw value may survive into agent-visible output.
+            if hit
+                .entities
+                .iter()
+                .any(|entity| snippet.contains(&entity.raw_value))
+            {
+                return Err(DenyReason::TranslatorFailed);
+            }
+
+            translated.push(AgentSearchHit {
+                doc_id: hit.doc_id,
+                snippet,
+            });
+        }
+        Ok(translated)
+    }
+}

--- a/crates/gaze-token-bridge/tests/track_c_bridge.rs
+++ b/crates/gaze-token-bridge/tests/track_c_bridge.rs
@@ -1,0 +1,531 @@
+//! Track C — end-to-end bridge runtime acceptance tests.
+//!
+//! Ports the throwaway spike's 22 tests (`crates/spike-token-bridge`) onto the REAL
+//! `TokenBridge::demo()`, which integrates the real Track A policy/projection, Track B
+//! redact-before-index ingest + search adapter, and the Track C capability/translate/audit
+//! runtime. Call sites are adapted to the frozen contract API (e.g. `ephemeral_for(&str)`,
+//! `&BridgeRequest`, `audit()` slice). One extra test covers the filter-field allowlist
+//! hardening the bridge adds over the spike.
+
+use gaze::PiiClass;
+use gaze_token_bridge::bridge::TokenBridge;
+use gaze_token_bridge::{
+    AuditDecision, BridgeDecision, BridgeRequest, BridgeSearchResponse, DenyReason, FilterClause,
+    Principal, RedactionSession, RequestedScope, SearchHandle, SearchRequest,
+};
+
+const POLICY_JSON: &str = include_str!("../fixtures/policy.json");
+const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
+const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+
+fn support_principal() -> Principal {
+    Principal {
+        id: "principal_support_1".to_string(),
+        roles: vec!["support".to_string()],
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+    }
+}
+
+fn admin_principal() -> Principal {
+    Principal {
+        id: "principal_admin_1".to_string(),
+        roles: vec!["admin".to_string()],
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+    }
+}
+
+/// A demo bridge plus a support-bound session that has already minted a Name token for
+/// "Markus Gottschaue" (the canonical happy-path entity).
+fn bridge_and_session() -> (TokenBridge, RedactionSession, String) {
+    bridge_and_session_for(&support_principal())
+}
+
+fn bridge_and_session_for(principal: &Principal) -> (TokenBridge, RedactionSession, String) {
+    let bridge = TokenBridge::demo().unwrap();
+    let session = RedactionSession::ephemeral_for(&principal.id).unwrap();
+    let token = session
+        .tokenize(&PiiClass::Name, "Markus Gottschaue")
+        .unwrap();
+    (bridge, session, token)
+}
+
+/// A demo bridge whose policy is augmented with an elevated cross-domain admin rule
+/// (mirrors the Track A `registry_with_elevated_cross_domain_rule` helper). The bundled
+/// fixture deliberately ships without this rule; augmenting JSON keeps the fixture frozen.
+fn cross_domain_bridge_and_session() -> (TokenBridge, RedactionSession, String) {
+    let mut policy: serde_json::Value =
+        serde_json::from_str(POLICY_JSON).expect("fixture policy parses as json");
+    let rules = policy
+        .get_mut("rules")
+        .and_then(serde_json::Value::as_array_mut)
+        .expect("fixture policy has rule array");
+    rules.push(serde_json::json!({
+        "roles": ["admin"],
+        "tenant_id": "tenant_demo",
+        "workspace_id": "workspace_demo",
+        "tool_name": "legal_search",
+        "action": "search_documents",
+        "purpose": "legal_lookup",
+        "target_domain": LEGAL_DOMAIN,
+        "allowed_entity_classes": ["name", "email", "organization"],
+        "max_results": 20,
+        "max_entities_per_window": 1000,
+        "allow_cross_domain": true,
+        "elevated_audit_required": true
+    }));
+    let policy = serde_json::to_string(&policy).expect("augmented policy serializes");
+
+    let bridge = TokenBridge::from_policy_json(&policy).unwrap();
+    let session = RedactionSession::ephemeral_for(&admin_principal().id).unwrap();
+    let token = session
+        .tokenize(&PiiClass::Name, "Markus Gottschaue")
+        .unwrap();
+    (bridge, session, token)
+}
+
+fn support_customer_request(source_token: &str) -> BridgeRequest {
+    BridgeRequest {
+        principal: support_principal(),
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+        agent_run_id: "agent-run-1".to_string(),
+        conversation_session_id: "conversation-1".to_string(),
+        tool_name: "support_search".to_string(),
+        action: "search_documents".to_string(),
+        purpose: "support_lookup".to_string(),
+        source_token: source_token.to_string(),
+        target_domain: CUSTOMER_DOMAIN.to_string(),
+        requested_scope: RequestedScope::SameDomain,
+    }
+}
+
+fn support_legal_request(source_token: &str) -> BridgeRequest {
+    BridgeRequest {
+        principal: support_principal(),
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+        agent_run_id: "agent-run-1".to_string(),
+        conversation_session_id: "conversation-1".to_string(),
+        tool_name: "legal_search".to_string(),
+        action: "search_documents".to_string(),
+        purpose: "legal_lookup".to_string(),
+        source_token: source_token.to_string(),
+        target_domain: LEGAL_DOMAIN.to_string(),
+        requested_scope: RequestedScope::SameDomain,
+    }
+}
+
+fn admin_legal_request(source_token: &str) -> BridgeRequest {
+    BridgeRequest {
+        principal: admin_principal(),
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+        agent_run_id: "agent-run-2".to_string(),
+        conversation_session_id: "conversation-1".to_string(),
+        tool_name: "legal_search".to_string(),
+        action: "search_documents".to_string(),
+        purpose: "legal_lookup".to_string(),
+        source_token: source_token.to_string(),
+        target_domain: LEGAL_DOMAIN.to_string(),
+        requested_scope: RequestedScope::SameDomain,
+    }
+}
+
+fn authorize_handle(
+    bridge: &mut TokenBridge,
+    session: &RedactionSession,
+    request: &BridgeRequest,
+) -> SearchHandle {
+    match bridge.authorize(session, request) {
+        BridgeDecision::Allow { handle, .. } => handle,
+        BridgeDecision::Deny { reason } => panic!("unexpected deny: {reason:?}"),
+    }
+}
+
+fn response_json(response: &BridgeSearchResponse) -> String {
+    serde_json::to_string(response).unwrap()
+}
+
+fn assert_no_raw_fixture_values(value: &str) {
+    for raw in [
+        "Markus Gottschaue",
+        "markus@example.invalid",
+        "91A",
+        "Globex GmbH",
+        "Dr. Schmidt",
+        "schmidt@example.invalid",
+        "72B",
+        "Initech AG",
+        "Lena Torres",
+        "lena@example.invalid",
+        "48C",
+        "Umbrella LLC",
+        "Prof. Weber",
+        "weber@example.invalid",
+        "54D",
+        "Soylent GmbH",
+        "Ana Rossi",
+        "ana@example.invalid",
+        "33E",
+        "Vehement Capital Partners",
+    ] {
+        assert!(
+            !value.contains(raw),
+            "agent-visible output leaked raw fixture value {raw}"
+        );
+    }
+}
+
+#[test]
+fn support_search_name_in_customer_docs_allows_and_returns_translated_snippets() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+    let json = response_json(&response);
+
+    assert_eq!(response.target_domain, CUSTOMER_DOMAIN);
+    assert!(!response.results.is_empty());
+    assert!(json.contains(&token));
+    assert_no_raw_fixture_values(&json);
+}
+
+#[test]
+fn support_search_in_legal_docs_denies() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let reason = bridge
+        .search(&session, &support_legal_request(&token))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::PrincipalNotAllowed);
+}
+
+#[test]
+fn admin_search_in_legal_docs_allows() {
+    let (mut bridge, session, token) = bridge_and_session_for(&admin_principal());
+
+    let response = bridge
+        .search(&session, &admin_legal_request(&token))
+        .unwrap_allowed();
+
+    assert_eq!(response.target_domain, LEGAL_DOMAIN);
+    assert!(!response.results.is_empty());
+    assert_no_raw_fixture_values(&response_json(&response));
+}
+
+#[test]
+fn guessed_fabricated_token_not_in_session_manifest_denies() {
+    let (mut bridge, session, _) = bridge_and_session();
+
+    let reason = bridge
+        .search(&session, &support_customer_request("<fffffff0:Name_99>"))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::UnknownToken);
+}
+
+#[test]
+fn malformed_token_denies() {
+    let (mut bridge, session, _) = bridge_and_session();
+
+    let reason = bridge
+        .search(&session, &support_customer_request("Name_1"))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::MalformedToken);
+}
+
+#[test]
+fn token_minted_in_different_session_denies() {
+    let (mut bridge, session, _) = bridge_and_session();
+    let other_session = RedactionSession::ephemeral_for(&support_principal().id).unwrap();
+    let foreign_token = other_session
+        .tokenize(&PiiClass::Name, "Markus Gottschaue")
+        .unwrap();
+
+    let reason = bridge
+        .search(&session, &support_customer_request(&foreign_token))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::UnknownToken);
+}
+
+#[test]
+fn entity_class_not_allowed_in_target_domain_denies() {
+    let (mut bridge, session, _) = bridge_and_session_for(&admin_principal());
+    let customer_id_token = session
+        .tokenize(&PiiClass::custom("customer_id"), "91A")
+        .unwrap();
+
+    let reason = bridge
+        .search(&session, &admin_legal_request(&customer_id_token))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::ClassNotAllowed);
+}
+
+#[test]
+fn no_matching_allow_rule_denies_by_default() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let mut request = support_customer_request(&token);
+    request.action = "export_documents".to_string();
+
+    let reason = bridge.search(&session, &request).unwrap_denied();
+
+    assert_eq!(reason, DenyReason::NoMatchingAllowRule);
+}
+
+#[test]
+fn expired_search_handle_denies() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let handle = authorize_handle(&mut bridge, &session, &support_customer_request(&token));
+
+    bridge.advance_clock(10);
+
+    let reason = bridge.execute_handle(&session, &handle).unwrap_err();
+    assert_eq!(reason, DenyReason::ExpiredHandle);
+}
+
+#[test]
+fn replayed_search_handle_denies() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let handle = authorize_handle(&mut bridge, &session, &support_customer_request(&token));
+
+    let first = bridge.execute_handle(&session, &handle);
+    let second = bridge.execute_handle(&session, &handle);
+
+    assert!(first.is_ok());
+    assert_eq!(second.unwrap_err(), DenyReason::ReplayedHandle);
+}
+
+#[test]
+fn cross_domain_search_denies_by_default() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let mut request = support_customer_request(&token);
+    request.requested_scope = RequestedScope::CrossDomain {
+        source_domain: LEGAL_DOMAIN.to_string(),
+    };
+
+    let reason = bridge.search(&session, &request).unwrap_denied();
+
+    assert_eq!(reason, DenyReason::CrossDomainDenied);
+}
+
+#[test]
+fn cross_domain_search_with_elevated_admin_policy_allows_and_is_audited() {
+    let (mut bridge, session, token) = cross_domain_bridge_and_session();
+    let mut request = admin_legal_request(&token);
+    request.requested_scope = RequestedScope::CrossDomain {
+        source_domain: CUSTOMER_DOMAIN.to_string(),
+    };
+
+    let decision = bridge.authorize(&session, &request);
+
+    match decision {
+        BridgeDecision::Allow { elevated_audit, .. } => assert!(elevated_audit),
+        BridgeDecision::Deny { reason } => panic!("unexpected deny: {reason:?}"),
+    }
+    assert_eq!(bridge.audit().len(), 1);
+    assert!(bridge.audit()[0].elevated_audit);
+}
+
+#[test]
+fn returned_snippets_are_translated_to_current_session_tokens() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let alias = bridge
+        .primary_alias(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .unwrap();
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+    let json = response_json(&response);
+
+    assert!(!json.contains(&alias));
+    assert!(!json.contains("<Name_"));
+    assert!(json.contains(&token));
+    assert!(json.contains(":Name_1>"));
+}
+
+#[test]
+fn newly_discovered_snippet_entities_get_fresh_current_session_tokens() {
+    let (mut bridge, session, token) = bridge_and_session();
+    assert_eq!(session.tokens().len(), 1);
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+    let json = response_json(&response);
+
+    assert!(session.tokens().len() >= 4);
+    assert!(json.contains(":Email_1>"));
+    assert!(json.contains(":Organization_1>"));
+    assert!(json.contains(":Custom:customer_id_1>"));
+}
+
+#[test]
+fn raw_pii_never_appears_in_agent_visible_output() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+
+    assert_no_raw_fixture_values(&response_json(&response));
+}
+
+#[test]
+fn one_bridge_audit_event_is_written_per_bridge_decision() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let _ = bridge.authorize(&session, &support_customer_request(&token));
+    let _ = bridge.authorize(&session, &support_customer_request("not-a-token"));
+
+    assert_eq!(bridge.audit().len(), 2);
+    assert_eq!(bridge.audit()[0].decision, AuditDecision::Allow);
+    assert_eq!(bridge.audit()[1].decision, AuditDecision::Deny);
+    assert!(bridge.audit()[0].raw_sha256.is_some());
+    assert!(bridge.audit()[1].raw_sha256.is_none());
+}
+
+#[test]
+fn session_manifest_is_never_exposed_in_agent_visible_output() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+    let json = response_json(&response);
+
+    for forbidden in ["manifest", "snapshot", "restore", "raw", "value_by_token"] {
+        assert!(
+            !json.contains(forbidden),
+            "exposed forbidden field {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn index_domain_alias_and_fingerprint_never_appear_in_agent_visible_output() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let alias = bridge
+        .primary_alias(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .unwrap();
+    let fingerprint = bridge
+        .primary_fingerprint(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .unwrap();
+
+    let response = bridge
+        .search(&session, &support_customer_request(&token))
+        .unwrap_allowed();
+    let json = response_json(&response);
+
+    assert!(!json.contains(&alias));
+    assert!(!json.contains(&fingerprint));
+}
+
+#[test]
+fn handle_reused_with_different_entity_ref_denies() {
+    let (mut bridge, session, markus_token) = bridge_and_session();
+    let schmidt_token = session.tokenize(&PiiClass::Name, "Dr. Schmidt").unwrap();
+
+    let markus_handle = authorize_handle(
+        &mut bridge,
+        &session,
+        &support_customer_request(&markus_token),
+    );
+    let schmidt_handle = authorize_handle(
+        &mut bridge,
+        &session,
+        &support_customer_request(&schmidt_token),
+    );
+
+    let request = SearchRequest {
+        requested_entity_ref: schmidt_handle.entity_ref,
+        filters: Vec::new(),
+    };
+    let reason = bridge
+        .execute_search_request(&session, &markus_handle, request)
+        .unwrap_err();
+
+    assert_eq!(reason, DenyReason::EntityRefMismatch);
+}
+
+#[test]
+fn owner_bound_purpose_ignores_llm_override_and_support_legal_still_denies() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let mut customer_request = support_customer_request(&token);
+    customer_request.purpose = "legal_review".to_string();
+
+    let handle = authorize_handle(&mut bridge, &session, &customer_request);
+    assert_eq!(handle.purpose, "support_lookup");
+
+    let mut legal_request = support_legal_request(&token);
+    legal_request.purpose = "legal_review".to_string();
+    let reason = bridge.search(&session, &legal_request).unwrap_denied();
+
+    assert_eq!(reason, DenyReason::PrincipalNotAllowed);
+}
+
+#[test]
+fn raw_filter_values_are_projected_before_adapter_receives_request() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let handle = authorize_handle(&mut bridge, &session, &support_customer_request(&token));
+    // Filter on an allowed field; the raw PII value must still be projected owner-side
+    // before the adapter sees it (the bridge enforces the handle's filter allowlist).
+    let request = SearchRequest {
+        requested_entity_ref: handle.entity_ref.clone(),
+        filters: vec![FilterClause {
+            field: "doc_id".to_string(),
+            class: PiiClass::Name,
+            value: "Markus Gottschaue".to_string(),
+        }],
+    };
+
+    let response = bridge
+        .execute_search_request(&session, &handle, request)
+        .unwrap();
+    let filters = serde_json::to_string(bridge.last_adapter_filters()).unwrap();
+
+    assert!(!response.results.is_empty());
+    assert!(filters.contains("projected:"));
+    assert!(!filters.contains("Markus Gottschaue"));
+}
+
+#[test]
+fn session_bound_to_principal_rejects_reuse_by_different_principal() {
+    let (mut bridge, session, token) = bridge_and_session();
+
+    let reason = bridge
+        .search(&session, &admin_legal_request(&token))
+        .unwrap_denied();
+
+    assert_eq!(reason, DenyReason::SessionPrincipalMismatch);
+    assert_eq!(session.session_id(), "conversation:principal_support_1");
+}
+
+/// Track-C hardening over the spike: a filter field outside the handle's allowlist fails
+/// closed instead of being silently projected (default-deny — north-star axis 1).
+#[test]
+fn filter_field_outside_handle_allowlist_denies() {
+    let (mut bridge, session, token) = bridge_and_session();
+    let handle = authorize_handle(&mut bridge, &session, &support_customer_request(&token));
+    let request = SearchRequest {
+        requested_entity_ref: handle.entity_ref.clone(),
+        filters: vec![FilterClause {
+            field: "customer_name".to_string(),
+            class: PiiClass::Name,
+            value: "Markus Gottschaue".to_string(),
+        }],
+    };
+
+    let reason = bridge
+        .execute_search_request(&session, &handle, request)
+        .unwrap_err();
+
+    assert_eq!(reason, DenyReason::NoMatchingAllowRule);
+}


### PR DESCRIPTION
## Summary

Track C PR1: the owner-side **bridge runtime** for `gaze-token-bridge`, integrated against the real Track A (policy/projection) and Track B (redact-before-index ingest + search adapter) implementations — no spike dependency.

End-to-end flow per `TokenBridge::search`: **authorize (Track A policy gate) → mint single-use capability (C) → validate + project filters (C) → adapter search (B) → translate to session namespace (C) → audit (C)**. Every error path fails closed to a typed `DenyReason` (north-star axis 1).

### What landed

- **`traits.rs` (R2, master-authorized):** added the `CapabilityIssuer` trait (the one frozen-file edit). Nothing else in the frozen contract changed.
- **`capability.rs` — `CapabilityRuntime`:** issues single-use, entity-bound `SearchHandle`s (logical-clock TTL, monotonic nonce/audit ids); validates handles (entity_ref / domain / expiry / single-use nonce); projects raw filter values into the domain keyspace behind a **handle-scoped filter allowlist** (a filter field outside the allowlist fails closed).
- **`translate.rs` — `SessionResponseTranslator`:** rewrites owner-side index snippets into the active session namespace (fresh tokens for newly-discovered entities; reused tokens for known ones). Fails closed if **any domain alias or raw value** would survive into agent output.
- **`audit.rs` — `VecAuditSink`:** append-only, one event per bridge decision; raw only as sha256.
- **`bridge.rs` — `TokenBridge`:** composes A+B+C. `demo()` / `from_policy_json()` ingest the synthetic corpus through the **real `CorpusIngestor`** (redact-before-index). Public surface: `search`, `authorize`, `execute_handle`, `execute_search_request`, `demo`, `from_policy_json`, `synthetic_docs`, `advance_clock`, `audit`, plus owner-side `primary_alias`/`primary_fingerprint`/`last_adapter_filters` introspection (kept `pub` for the PR3 example).

### Design decisions worth flagging (axis impact)

1. **`TokenBridge` owns the registry (no `<'a>`); the gate is built per `authorize` call.** `RegistryPolicyGate::new(&registry)` borrows the registry, but `demo() -> Result<Self>` must return an owned value — a struct owning the registry *and* a gate borrowing it is self-referential. Consequence: the gate's per-principal **rate-limit buckets reset each call** (the bundled fixture limit is 1000 and never hit in these tests). Tracked as a follow-up (solo todo).
2. **Audit recorded at the authorization decision** (in `authorize`), matching the spike and the `one_bridge_audit_event_is_written_per_bridge_decision` test (which calls `authorize` directly and expects exactly one event). `search` = authorize (audited) + execute (not separately audited). Execute-time denials (expired/replayed/translator-failed) are not yet separately audited — follow-up todo.
3. **Cross-domain elevated rule via augmented policy, not a fixture edit.** The bundled `fixtures/policy.json` deliberately ships without the elevated cross-domain rule (Track A does the same in `registry_with_elevated_cross_domain_rule`). The test augments the policy JSON and feeds it to `from_policy_json`, keeping the shared fixture frozen.
4. **Filter-field allowlist hardening over the spike.** The spike projected any filter field; the brief requires rejecting fields outside `handle.allowed_filters`. Implemented + covered by a dedicated test; the ported `raw_filter_values_are_projected...` test uses an allowed field (`doc_id`) so it still exercises projection.

## Test plan

`tests/track_c_bridge.rs` ports **all 22 spike tests** onto the real `TokenBridge::demo()` (call sites adapted to the frozen API: `ephemeral_for(&str)`, `&BridgeRequest`, `audit()` slice), plus **1 filter-allowlist hardening test** (23 total). Coverage: support→customer allow + translated snippets; support→legal deny; admin→legal allow; fabricated/malformed/foreign-session token denies; class-not-allowed; no-matching-rule; expired/replayed handle; cross-domain deny + elevated allow; snippets translated to current session tokens; new-entity fresh tokens; raw PII never in agent output; one audit event/decision; session manifest never exposed; alias/fingerprint never exposed; handle-reuse-different-entity_ref deny; owner-bound-purpose ignores LLM override; raw filter values projected before adapter; session bound to principal rejects different principal.

Gates (under the repo's pinned toolchain):
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings` — clean
- `cargo test -p gaze-token-bridge` — **56 passed** (13 unit + 13 track_a_policy + 6 track_a_projection + 23 track_c + 1 doc-test), 0 failed
- `cargo build --workspace` — ok

Resolves solo todo #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)