### PR TITLE
[agent] docs(token-bridge): runnable local demo + walkthrough (synthetic data)

### DIFF
--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,0 +1,110 @@
+# gaze-token-bridge
+
+> **Status:** work in progress (`publish = false`). API is pre-1.0 and may change.
+
+The token bridge is the **owner-side authorization + translation layer** that lets an
+agent search long-lived, policy-scoped document corpora **without ever seeing raw PII**.
+
+An agent works in a short-lived [`RedactionSession`](src/session.rs) whose only
+vocabulary is *session tokens* (e.g. `<…:Name_1>`). When it wants to search a corpus,
+the bridge — running entirely owner-side — resolves the token, checks policy
+(default-deny), mints a single-use, entity-bound capability, runs the search against a
+**redact-before-index** corpus, and translates the owner-side hits back into the
+agent's current session namespace. Raw PII, index aliases, and the restore manifest stay
+owner-side by construction; the agent only ever receives current-session tokens. This
+serves the project's north star directly: **zero PII leaks between the agent and the
+data owner — ever** (fail-closed on every error path).
+
+For the architecture and the frozen data-model contract, see the crate docs
+([`src/lib.rs`](src/lib.rs)) and [`src/model.rs`](src/model.rs)'s three visibility tiers.
+
+## Local demo (try it)
+
+A runnable, **synthetic-data-only** walkthrough lives in
+[`examples/local_demo.rs`](examples/local_demo.rs). It uses only the crate's public API
+(plus `serde_json`, already a dependency) and exits `0` on success / panics loudly on any
+leak. No setup, no network, no real PII.
+
+### Run it
+
+```bash
+cargo run -p gaze-token-bridge --example local_demo
+```
+
+### Expected output
+
+```text
+gaze-token-bridge — local demo (SYNTHETIC DATA ONLY)
+Owner-side authorization + translation bridge. Zero raw PII reaches the agent.
+
+=== Step 1 — ingest synthetic corpus (redact-before-index) ===
+Ingested 5 synthetic docs into 2 IndexDomains via the Track B redact-before-index pipeline:
+  - tenant_demo/customer_docs/v1
+  - tenant_demo/legal_docs/v1
+Raw values were tokenized at ingest; the index holds only projected aliases.
+
+=== Step 2 — support session mints a token for the lookup name ===
+owner-side input (never sent to the agent): name = "Markus Gottschaue"
+session token the agent sees instead:        <0cd5a5d9:Name_1>
+
+=== Step 3 — ALLOWED: support -> customer_docs ===
+ALLOWED. target_domain = tenant_demo/customer_docs/v1
+session-translated snippets (note the <...:Class_n> session tokens):
+  [cust-001] Customer profile <0cd5a5d9:Name_1> / <0cd5a5d9:Email_1> / <0cd5a5d9:Custom:customer_id_1> is linked to <0cd5a5d9:Organization_1>.
+
+=== Step 4 — DENIED: support -> legal_docs ===
+DENIED (authorization failed)
+
+=== Step 4 (contrast) — ALLOWED: admin -> legal_docs ===
+ALLOWED. target_domain = tenant_demo/legal_docs/v1
+  [cust-001] Legal matter references <48904f81:Name_1> at <48904f81:Organization_1>; contact route <48904f81:Email_1>.
+
+=== Step 5 — assert NO raw PII in agent-visible output ===
+Scanned 480 bytes of agent-visible JSON against 20 raw fixture values.
+✅ NO RAW PII IN AGENT-VISIBLE OUTPUT
+audit events recorded (one per bridge decision): 3
+```
+
+> **Note on the token prefix.** The 8-hex prefix (`0cd5a5d9`, `48904f81`, …) is a
+> **per-session salt** and will differ on every run — that is the point: a token minted
+> in one session is meaningless (`UnknownToken`) in another, so tokens cannot be
+> correlated across sessions. Only the structure (`:Name_1>`, `:Email_1>`, …) is stable.
+> The support and admin lines use different prefixes because they are different sessions.
+
+### What each step proves
+
+Mapped to the four spike blockers this runtime had to close, plus the never-leak assertion:
+
+1. **Session ↔ principal binding** — each principal mints tokens in its *own*
+   principal-bound session. Step 4 shows `support → legal_docs` fail closed (a uniform
+   deny), while `admin → legal_docs` is allowed from the admin's own session; a session
+   may not be reused across principals.
+2. **Owner-bound purpose** — the request carries a `purpose`, but the policy gate ignores
+   it and uses the owner-bound purpose resolved from config. The agent (or a prompt
+   injection) cannot widen its authority by restating intent.
+3. **entity_ref binding** — authorization mints a single-use capability bound to one
+   specific entity, so the ALLOWED search returns only that entity's document
+   (`cust-001`), never the whole corpus.
+4. **Filter / value projection** — the corpus was redacted *before* indexing, so the
+   index holds only projected aliases; returned snippets are translated into the active
+   session's tokens. Raw values never reach the index, the adapter, or the agent.
+5. **Never-leak assertion** — Step 5 serializes *all* agent-visible responses and scans
+   them against every raw value in the synthetic fixture. Any match panics (non-zero
+   exit). The deny path emits a single uniform `DENIED (authorization failed)` line — the
+   typed `DenyReason` is owner-side audit only, so the agent gets no probing oracle.
+
+### What's NOT shown
+
+- **Vector / semantic search** is deferred; the demo uses exact entity-bound lookup over
+  the in-memory adapter.
+- **Raw-filter projection over the wire** (passing a raw PII filter value that the bridge
+  projects owner-side before the adapter sees it) is exercised by the test suite
+  (`raw_filter_values_are_projected_before_adapter_receives_request` in
+  [`tests/track_c_bridge.rs`](tests/track_c_bridge.rs)) rather than this script.
+- **The MCP `search_documents` chokepoint tool** (the sealed-handle integration that
+  exposes this bridge as an agent tool) lives behind the `chokepoint` feature — see PR2.
+  This example drives the bridge through its library API directly.
+
+All behavior here is covered by the acceptance suite in
+[`tests/track_c_bridge.rs`](tests/track_c_bridge.rs); run it with
+`cargo test -p gaze-token-bridge`.

--- a/crates/gaze-token-bridge/examples/local_demo.rs
+++ b/crates/gaze-token-bridge/examples/local_demo.rs
@@ -1,0 +1,224 @@
+//! Runnable, synthetic-data-only walkthrough of the gaze-token-bridge owner-side
+//! authorization + translation bridge.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run -p gaze-token-bridge --example local_demo
+//! ```
+//!
+//! What it proves, end to end, over a SYNTHETIC corpus (no real PII anywhere):
+//!   1. `TokenBridge::demo()` ingests the synthetic corpus into two policy-scoped
+//!      IndexDomains using the real Track B redact-before-index pipeline.
+//!   2. A support-bound `RedactionSession` mints a session token for a name — the
+//!      agent only ever sees the token, never the raw name.
+//!   3. An ALLOWED search returns snippets carrying *session* tokens (not raw PII,
+//!      not index aliases).
+//!   4. A DENIED search fails closed with a single uniform line (no typed-reason
+//!      oracle is leaked to the agent).
+//!   5. Every agent-visible byte is scanned for raw fixture values; the program
+//!      fails loudly (panics, non-zero exit) if any leak is found.
+//!
+//! This is a demo of the *runtime*, not of detector quality: the corpus is redacted
+//! at ingest by a deterministic literal detector over known synthetic values.
+
+use gaze::PiiClass;
+use gaze_token_bridge::bridge::{synthetic_docs, TokenBridge};
+use gaze_token_bridge::{
+    BridgeRequest, BridgeSearchOutcome, BridgeSearchResponse, Principal, RedactionSession,
+    RequestedScope,
+};
+
+// Owner-side domain identifiers (`tenant/corpus/version`). These live in policy
+// config; the LLM never chooses them.
+const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
+const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+
+// The canonical happy-path entity from the synthetic corpus.
+const DEMO_NAME: &str = "Markus Gottschaue";
+
+fn support_principal() -> Principal {
+    Principal {
+        id: "principal_support_1".to_string(),
+        roles: vec!["support".to_string()],
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+    }
+}
+
+fn admin_principal() -> Principal {
+    Principal {
+        id: "principal_admin_1".to_string(),
+        roles: vec!["admin".to_string()],
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+    }
+}
+
+/// Build a bridge request. `purpose` here is the request-stated purpose; the
+/// owner-side policy gate ignores it and substitutes the owner-bound purpose
+/// resolved from config (so an LLM cannot widen its own authority).
+fn bridge_request(
+    principal: Principal,
+    tool_name: &str,
+    purpose: &str,
+    target_domain: &str,
+    source_token: &str,
+) -> BridgeRequest {
+    BridgeRequest {
+        principal,
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+        agent_run_id: "agent-run-1".to_string(),
+        conversation_session_id: "conversation-1".to_string(),
+        tool_name: tool_name.to_string(),
+        action: "search_documents".to_string(),
+        purpose: purpose.to_string(),
+        source_token: source_token.to_string(),
+        target_domain: target_domain.to_string(),
+        requested_scope: RequestedScope::SameDomain,
+    }
+}
+
+/// Every raw value in the synthetic corpus — the exact strings that must NEVER
+/// appear in agent-visible output. Derived from `synthetic_docs()` so the scan
+/// stays in lockstep with the fixture.
+fn raw_fixture_values() -> Vec<String> {
+    let mut values = Vec::new();
+    for doc in synthetic_docs() {
+        values.push(doc.name.to_string());
+        values.push(doc.email.to_string());
+        values.push(doc.customer_id.to_string());
+        values.push(doc.organization.to_string());
+    }
+    values
+}
+
+fn print_header(step: &str) {
+    println!("\n=== {step} ===");
+}
+
+fn print_results(response: &BridgeSearchResponse) {
+    for hit in &response.results {
+        println!("  [{}] {}", hit.doc_id, hit.snippet);
+    }
+}
+
+fn main() {
+    println!("gaze-token-bridge — local demo (SYNTHETIC DATA ONLY)");
+    println!("Owner-side authorization + translation bridge. Zero raw PII reaches the agent.");
+
+    // -- Step 1: ingest the synthetic corpus into two policy-scoped IndexDomains. --
+    print_header("Step 1 — ingest synthetic corpus (redact-before-index)");
+    let mut bridge = TokenBridge::demo().expect("demo bridge builds");
+    let doc_count = synthetic_docs().len();
+    println!(
+        "Ingested {doc_count} synthetic docs into 2 IndexDomains via the Track B \
+         redact-before-index pipeline:"
+    );
+    println!("  - {CUSTOMER_DOMAIN}");
+    println!("  - {LEGAL_DOMAIN}");
+    println!("Raw values were tokenized at ingest; the index holds only projected aliases.");
+
+    // -- Step 2: a support-bound session mints a token for the lookup name. --
+    print_header("Step 2 — support session mints a token for the lookup name");
+    let session =
+        RedactionSession::ephemeral_for(&support_principal().id).expect("ephemeral session builds");
+    // The raw name is OWNER-SIDE input — printed once here, labeled, and never again.
+    println!("owner-side input (never sent to the agent): name = \"{DEMO_NAME}\"");
+    let name_token = session
+        .tokenize(&PiiClass::Name, DEMO_NAME)
+        .expect("tokenize name");
+    println!("session token the agent sees instead:        {name_token}");
+
+    // Collect every agent-visible response so we can scan it for leaks at the end.
+    let mut agent_visible: Vec<BridgeSearchResponse> = Vec::new();
+
+    // -- Step 3: ALLOWED — support may search customer_docs. --
+    print_header("Step 3 — ALLOWED: support -> customer_docs");
+    let allowed_request = bridge_request(
+        support_principal(),
+        "support_search",
+        "support_lookup",
+        CUSTOMER_DOMAIN,
+        &name_token,
+    );
+    match bridge.search(&session, &allowed_request) {
+        BridgeSearchOutcome::Allowed(response) => {
+            println!("ALLOWED. target_domain = {}", response.target_domain);
+            println!("session-translated snippets (note the <...:Class_n> session tokens):");
+            print_results(&response);
+            agent_visible.push(response);
+        }
+        BridgeSearchOutcome::Denied(_) => {
+            panic!("expected support -> customer_docs to be ALLOWED");
+        }
+    }
+
+    // -- Step 4: DENIED — support may NOT search legal_docs. --
+    print_header("Step 4 — DENIED: support -> legal_docs");
+    let denied_request = bridge_request(
+        support_principal(),
+        "legal_search",
+        "legal_lookup",
+        LEGAL_DOMAIN,
+        &name_token,
+    );
+    match bridge.search(&session, &denied_request) {
+        BridgeSearchOutcome::Allowed(_) => {
+            panic!("expected support -> legal_docs to be DENIED");
+        }
+        // No-oracle posture: the agent gets ONE uniform line. The typed DenyReason
+        // is owner-side audit only — never surfaced to the agent.
+        BridgeSearchOutcome::Denied(_) => {
+            println!("DENIED (authorization failed)");
+        }
+    }
+
+    // -- Step 4 (contrast): admin MAY search legal_docs, in its own session. --
+    print_header("Step 4 (contrast) — ALLOWED: admin -> legal_docs");
+    let admin_session =
+        RedactionSession::ephemeral_for(&admin_principal().id).expect("admin session builds");
+    let admin_token = admin_session
+        .tokenize(&PiiClass::Name, DEMO_NAME)
+        .expect("tokenize name for admin");
+    let admin_request = bridge_request(
+        admin_principal(),
+        "legal_search",
+        "legal_lookup",
+        LEGAL_DOMAIN,
+        &admin_token,
+    );
+    match bridge.search(&admin_session, &admin_request) {
+        BridgeSearchOutcome::Allowed(response) => {
+            println!("ALLOWED. target_domain = {}", response.target_domain);
+            print_results(&response);
+            agent_visible.push(response);
+        }
+        BridgeSearchOutcome::Denied(_) => {
+            panic!("expected admin -> legal_docs to be ALLOWED");
+        }
+    }
+
+    // -- Step 5: prove no raw PII reached the agent. --
+    print_header("Step 5 — assert NO raw PII in agent-visible output");
+    let raws = raw_fixture_values();
+    let agent_visible_json =
+        serde_json::to_string(&agent_visible).expect("agent-visible responses serialize");
+    for raw in &raws {
+        assert!(
+            !agent_visible_json.contains(raw),
+            "LEAK: raw fixture value {raw:?} appeared in agent-visible output"
+        );
+    }
+    println!(
+        "Scanned {} bytes of agent-visible JSON against {} raw fixture values.",
+        agent_visible_json.len(),
+        raws.len()
+    );
+    println!("✅ NO RAW PII IN AGENT-VISIBLE OUTPUT");
+    println!(
+        "audit events recorded (one per bridge decision): {}",
+        bridge.audit().len()
+    );
+}


### PR DESCRIPTION
## What

The user-facing deliverable for the token bridge: a **runnable, synthetic-data-only**
local demo plus a walkthrough README a human can follow without reading code.

- `crates/gaze-token-bridge/examples/local_demo.rs` — auto-discovered example binary,
  uses only the crate's existing public API (`TokenBridge::demo` / `search` / `audit`)
  + `serde_json` (already a dep). **No Cargo.toml / src / frozen-file edits.**
- `crates/gaze-token-bridge/README.md` — the crate had none. Adds a one-paragraph
  "what this is" plus a `## Local demo (try it)` section with the exact command, the
  exact expected stdout, a step→blocker mapping, and a "what's NOT shown" note.

## Try it

```bash
cargo run -p gaze-token-bridge --example local_demo
```

Over synthetic data only, it: ingests the corpus into two IndexDomains
(redact-before-index) → mints a support session token for a name → runs an **ALLOWED**
`support -> customer_docs` search → a **DENIED** `support -> legal_docs` search (single
uniform `DENIED (authorization failed)` line, no `DenyReason` oracle) → a contrast
**ALLOWED** `admin -> legal_docs` → then **serializes all agent-visible responses and
asserts no raw fixture value leaked**, printing `✅ NO RAW PII IN AGENT-VISIBLE OUTPUT`.
Exits `0` on success, panics loudly (non-zero) on any leak — fail closed.

## North star

Headline is axis 1 (never-leak): the demo *proves*, with an assertion, that zero raw PII
reaches the agent path — and axis 5 (ergonomics): a human runs one command and reads the
result in minutes.

## Gates (all green, pinned stable toolchain)

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings` ✓
- `cargo test -p gaze-token-bridge` ✓ (23 acceptance tests + crate tests, 0 failed)
- `cargo build --workspace` ✓
- `cargo run -p gaze-token-bridge --example local_demo` ✓ (exit 0, PASS assertion, 3 audit events)

Resolves solo todo #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
