### PR TITLE
[agent] feat(token-bridge): search_documents MCP chokepoint tool (feature-gated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,8 @@ dependencies = [
 name = "gaze-token-bridge"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "gaze-mcp-core",
  "gaze-pii",
  "hmac",
  "serde",

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -16,3 +16,14 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 hmac = "0.12"
 sha2 = "0.10"
+# Track C chokepoint integration — optional, OFF by default. Pulled in only by
+# the `chokepoint` feature below; the default build/test graph is byte-identical.
+gaze-mcp-core = { path = "../gaze-mcp-core", optional = true }
+async-trait = { version = "0.1", optional = true }
+
+[features]
+# Opt-in MCP chokepoint: compiles the owner-side `SearchDocumentsTool`, which
+# implements `gaze_mcp_core::Tool`. Default-OFF so adopters who only want the
+# bridge runtime never compile the MCP surface (north-star axis 5 — ergonomics)
+# and the default graph stays unchanged.
+chokepoint = ["dep:gaze-mcp-core", "dep:async-trait"]

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -35,6 +35,14 @@ use crate::traits::{
 use crate::translate::SessionResponseTranslator;
 use crate::util::sha256_hex;
 
+// Track C chokepoint integration — gated, OFF by default. Implements
+// `gaze_mcp_core::Tool` for the owner-side `SearchDocumentsTool` without touching
+// gaze-mcp-core's sealed surface. See `chokepoint` module docs.
+#[cfg(feature = "chokepoint")]
+mod chokepoint;
+#[cfg(feature = "chokepoint")]
+pub use chokepoint::SearchDocumentsTool;
+
 /// Bundled demo policy (two domains, support + admin rules). Owner-side fixture.
 const DEMO_POLICY_JSON: &str = include_str!("../fixtures/policy.json");
 const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";

--- a/crates/gaze-token-bridge/src/bridge/chokepoint.rs
+++ b/crates/gaze-token-bridge/src/bridge/chokepoint.rs
@@ -1,0 +1,251 @@
+//! Track C (gated) — the `search_documents` MCP chokepoint tool.
+//!
+//! [`SearchDocumentsTool`] implements [`gaze_mcp_core::Tool`] so the bridge can be
+//! driven from a gaze-mcp-core dispatch without touching that crate's published,
+//! trybuild-sealed surface (`Tool` / `ToolCtx` / `ToolResources` / dispatch).
+//!
+//! # Owner-side session model (the chokepoint invariant)
+//! The sealed [`gaze_mcp_core::ToolCtx`] only exposes the *external* session id; its
+//! inner `gaze::Session` is unreachable, and the frozen [`RedactionSession`] has no
+//! constructor that wraps a foreign session. So this tool owns the conversation's
+//! redaction namespace **owner-side**: a per-principal [`RedactionSession`] registry.
+//! The owner tokenizes PII via [`SearchDocumentsTool::tokenize_for`]; the agent only
+//! ever holds the resulting token and passes it back as `source_token`; the tool
+//! resolves it owner-side against the *same* session before driving the bridge. Raw
+//! PII, the manifest, and index aliases never cross to the agent path.
+//!
+//! Unifying this owner-side session with the dispatch's own `gaze::Session` (one
+//! shared manifest spanning both) is deliberately out of scope — it needs a frozen
+//! `RedactionSession` constructor or a gaze-mcp-core wiring change, and is deferred
+//! as a future contract refinement (R3).
+//!
+//! # No-oracle deny
+//! Every failure — unknown principal, malformed args, or any typed [`DenyReason`]
+//! from the bridge — collapses to one uniform `{authorized: false, results: []}`
+//! payload. The typed reason lives only in the bridge audit; the agent-visible
+//! surface never reveals which path fired (north-star axis 1 — never leak).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use async_trait::async_trait;
+use gaze::PiiClass;
+use gaze_mcp_core::{Tool, ToolCtx, ToolDescriptor, ToolError, ToolResponse};
+use serde_json::{json, Value};
+
+use crate::bridge::TokenBridge;
+use crate::error::BridgeError;
+use crate::model::{
+    BridgeRequest, BridgeSearchOutcome, BridgeSearchResponse, Principal, RequestedScope,
+};
+use crate::session::RedactionSession;
+
+/// Wire name of this agent-tier tool **and** the policy `tool_name` the bridge
+/// authorizes it under. Adopters MUST author an allow-rule (and list the tool in
+/// each domain's `allowed_tools`) under `"search_documents"`. The agent never
+/// supplies the policy tool_name — that would hand authorization to the LLM
+/// (north-star axis 4: the LLM never decides authorization).
+const TOOL_NAME: &str = "search_documents";
+
+/// Bridge action this tool performs. Target domains must list it in
+/// `allowed_actions`.
+const ACTION: &str = "search_documents";
+
+/// Owner-side, agent-tier `search_documents` tool.
+///
+/// One instance is shared (behind `Arc<dyn Tool>`) across concurrent dispatches,
+/// so the mutable bridge and the session registry live behind mutexes.
+pub struct SearchDocumentsTool {
+    bridge: Mutex<TokenBridge>,
+    principals: HashMap<String, Principal>,
+    sessions: Mutex<HashMap<String, RedactionSession>>,
+    descriptor: ToolDescriptor,
+}
+
+impl SearchDocumentsTool {
+    /// Build the tool over an owner-side bridge and a principal registry. The
+    /// principal registry is the trusted runtime's resolution of `principal_id`
+    /// to a [`Principal`]; the agent's `principal_id` is looked up here and any
+    /// unknown id fails closed.
+    pub fn new(bridge: TokenBridge, principals: HashMap<String, Principal>) -> Self {
+        Self {
+            bridge: Mutex::new(bridge),
+            principals,
+            sessions: Mutex::new(HashMap::new()),
+            descriptor: ToolDescriptor::agent(TOOL_NAME, input_schema()).with_description(
+                "Search an owner-registered index domain by a session token minted earlier in \
+                 this conversation. Results carry only current-session tokens — never raw PII.",
+            ),
+        }
+    }
+
+    /// Owner-side helper: mint (or reuse) a conversation token for `raw` of `class`
+    /// in `principal_id`'s owner-side redaction namespace.
+    ///
+    /// This is how the owner establishes the namespace the agent's `source_token`
+    /// later resolves against: the owner tokenizes PII here, hands the agent the
+    /// returned token, and the agent passes it back into [`Self::run`]. Tests use
+    /// it to seed the happy path.
+    pub fn tokenize_for(
+        &self,
+        principal_id: &str,
+        class: &PiiClass,
+        raw: &str,
+    ) -> Result<String, BridgeError> {
+        let mut sessions = lock(&self.sessions);
+        get_or_create_session(&mut sessions, principal_id)?.tokenize(class, raw)
+    }
+
+    /// Synchronous tool core, driven by [`Tool::invoke`] and by tests directly.
+    ///
+    /// The sealed [`ToolCtx`] cannot be constructed outside `gaze-mcp-core`, so the
+    /// body lives here where it is unit-testable without fabricating a context.
+    /// Always fails closed to a uniform, no-oracle deny.
+    pub fn run(&self, principal_id: &str, args: &Value) -> Value {
+        // Parsed first so every deny path can echo the caller's own target_domain
+        // (echoing the caller's input reveals nothing about owner-side state).
+        let target_domain = args
+            .get("target_domain")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+
+        // Fail-closed pre-checks. Each returns the SAME uniform deny so the agent
+        // cannot distinguish unknown-principal from bad-args from policy-deny.
+        let Some(principal) = self.principals.get(principal_id) else {
+            return deny_response(target_domain);
+        };
+        let Some(source_token) = args.get("source_token").and_then(Value::as_str) else {
+            return deny_response(target_domain);
+        };
+        if target_domain.is_empty() {
+            return deny_response(target_domain);
+        }
+
+        let mut sessions = lock(&self.sessions);
+        let session = match get_or_create_session(&mut sessions, principal_id) {
+            Ok(session) => session,
+            Err(_) => return deny_response(target_domain),
+        };
+
+        let request = BridgeRequest {
+            principal: principal.clone(),
+            tenant_id: principal.tenant_id.clone(),
+            workspace_id: principal.workspace_id.clone(),
+            agent_run_id: args
+                .get("agent_run_id")
+                .and_then(Value::as_str)
+                .unwrap_or("agent-run")
+                .to_string(),
+            conversation_session_id: args
+                .get("conversation_session_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| session.session_id().to_string()),
+            tool_name: TOOL_NAME.to_string(),
+            action: ACTION.to_string(),
+            // Request-stated purpose only; the gate ignores it and uses the
+            // owner-bound purpose resolved from policy config.
+            purpose: args
+                .get("purpose")
+                .and_then(Value::as_str)
+                .unwrap_or("agent_search")
+                .to_string(),
+            source_token: source_token.to_string(),
+            target_domain: target_domain.to_string(),
+            requested_scope: RequestedScope::SameDomain,
+        };
+
+        let mut bridge = lock(&self.bridge);
+        match bridge.search(session, &request) {
+            BridgeSearchOutcome::Allowed(response) => allowed_response(&response),
+            // The typed DenyReason stays in the bridge audit ONLY — never emitted.
+            BridgeSearchOutcome::Denied(_) => deny_response(target_domain),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for SearchDocumentsTool {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.descriptor
+    }
+
+    async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        // Thin wrapper: the dispatcher already redacted args and authorized the
+        // principal. Delegate to the sync, testable core. The dispatcher re-redacts
+        // the response anyway (defense in depth); our output is already clean.
+        let output = self.run(ctx.principal_id(), ctx.redacted_args());
+        Ok(ToolResponse::json(output))
+    }
+}
+
+/// Get the principal's owner-side session, creating an ephemeral one on first use.
+fn get_or_create_session<'a>(
+    sessions: &'a mut HashMap<String, RedactionSession>,
+    principal_id: &str,
+) -> Result<&'a RedactionSession, BridgeError> {
+    if !sessions.contains_key(principal_id) {
+        sessions.insert(
+            principal_id.to_string(),
+            RedactionSession::ephemeral_for(principal_id)?,
+        );
+    }
+    Ok(sessions
+        .get(principal_id)
+        .expect("session inserted above is present"))
+}
+
+/// JSON-schema metadata for the tool's input arguments. Surface-only; the
+/// dispatcher does not validate against it, and [`SearchDocumentsTool::run`]
+/// validates the shape itself and fails closed on mismatch.
+fn input_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "source_token": {
+                "type": "string",
+                "description": "A session token minted earlier in this conversation for the entity to search by."
+            },
+            "target_domain": {
+                "type": "string",
+                "description": "The owner-registered index domain to search (e.g. tenant_demo/customer_docs/v1)."
+            },
+            "filters": {
+                "type": "array",
+                "description": "Reserved. The bounded same-entity search path does not accept agent-supplied filters.",
+                "items": { "type": "object" }
+            }
+        },
+        "required": ["source_token", "target_domain"]
+    })
+}
+
+/// Uniform, no-oracle deny. Byte-identical across unknown-principal, malformed-args,
+/// and every typed [`crate::error::DenyReason`] for a given `target_domain` echo.
+fn deny_response(target_domain: &str) -> Value {
+    json!({
+        "target_domain": target_domain,
+        "results": [],
+        "authorized": false,
+    })
+}
+
+/// Allow payload: the agent-visible [`BridgeSearchResponse`] (session-token-only
+/// results) plus the binary `authorized` flag.
+fn allowed_response(response: &BridgeSearchResponse) -> Value {
+    match serde_json::to_value(response) {
+        Ok(Value::Object(mut map)) => {
+            map.insert("authorized".to_string(), Value::Bool(true));
+            Value::Object(map)
+        }
+        // Serializing a frozen-contract struct cannot realistically fail; if it
+        // ever did, fail closed rather than emit a half-formed allow.
+        _ => deny_response(&response.target_domain),
+    }
+}
+
+/// Lock a mutex, recovering the guard on poison so a prior panic elsewhere cannot
+/// turn into a hard failure here (fail-closed: the wrapped data stays valid).
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}

--- a/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
+++ b/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
@@ -1,0 +1,280 @@
+//! Track C — `search_documents` chokepoint tool acceptance tests.
+//!
+//! Drives [`SearchDocumentsTool::run`] directly: the sealed `gaze_mcp_core::ToolCtx`
+//! cannot be constructed outside its crate, so the unit-testable sync core is the
+//! seam. Asserts the owner-side session model (token resolves owner-side), the
+//! never-leak invariant (no raw PII / alias / fingerprint in agent output), and the
+//! no-oracle deny (no `DenyReason` variant ever surfaces; denies are
+//! indistinguishable across causes).
+//!
+//! The whole file is gated on the `chokepoint` feature; with the feature off it
+//! compiles to an empty crate, so the default test graph is unchanged.
+#![cfg(feature = "chokepoint")]
+
+use std::collections::HashMap;
+
+use gaze::PiiClass;
+use gaze_token_bridge::bridge::{SearchDocumentsTool, TokenBridge};
+use gaze_token_bridge::Principal;
+use serde_json::{json, Value};
+
+const POLICY_JSON: &str = include_str!("../fixtures/policy.json");
+const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
+const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+const SUPPORT_ID: &str = "principal_support_1";
+
+fn support_principal() -> Principal {
+    Principal {
+        id: SUPPORT_ID.to_string(),
+        roles: vec!["support".to_string()],
+        tenant_id: "tenant_demo".to_string(),
+        workspace_id: "workspace_demo".to_string(),
+    }
+}
+
+/// The bundled demo policy, rewritten so the single agent-tier `search_documents`
+/// tool is the authorized policy `tool_name` in both domains. The bundled fixture
+/// keys on `support_search` / `legal_search`; this tool fixes its policy tool_name
+/// to its wire name, so adopters author rules under `search_documents`. Patching
+/// the frozen fixture in-test keeps projection keys correct without editing it.
+fn search_documents_policy() -> String {
+    let mut policy: Value = serde_json::from_str(POLICY_JSON).expect("fixture policy parses");
+    for domain in policy["domains"]
+        .as_array_mut()
+        .expect("policy has domains array")
+    {
+        domain["allowed_tools"] = json!(["search_documents"]);
+    }
+    for rule in policy["rules"]
+        .as_array_mut()
+        .expect("policy has rules array")
+    {
+        rule["tool_name"] = json!("search_documents");
+    }
+    serde_json::to_string(&policy).expect("augmented policy serializes")
+}
+
+fn demo_bridge() -> TokenBridge {
+    TokenBridge::from_policy_json(&search_documents_policy()).expect("bridge builds from policy")
+}
+
+/// A tool wired with the support principal over the search_documents-keyed bridge.
+fn support_tool() -> SearchDocumentsTool {
+    let mut principals = HashMap::new();
+    let principal = support_principal();
+    principals.insert(principal.id.clone(), principal);
+    SearchDocumentsTool::new(demo_bridge(), principals)
+}
+
+/// Every `DenyReason` variant name (error.rs). None may appear in agent output.
+const DENY_REASON_VARIANTS: &[&str] = &[
+    "MalformedToken",
+    "UnknownToken",
+    "TenantOrWorkspaceMismatch",
+    "DomainNotFound",
+    "PrincipalNotAllowed",
+    "ClassNotAllowed",
+    "NoMatchingAllowRule",
+    "CrossDomainDenied",
+    "ExpiredHandle",
+    "ReplayedHandle",
+    "HandleDomainMismatch",
+    "EntityRefMismatch",
+    "SessionPrincipalMismatch",
+    "SnippetsDisabled",
+    "TranslatorFailed",
+];
+
+/// Raw fixture values that must never reach agent-visible output.
+const RAW_FIXTURE_VALUES: &[&str] = &[
+    "Markus Gottschaue",
+    "markus@example.invalid",
+    "91A",
+    "Globex GmbH",
+    "Dr. Schmidt",
+    "schmidt@example.invalid",
+    "72B",
+    "Initech AG",
+    "Lena Torres",
+    "lena@example.invalid",
+    "48C",
+    "Umbrella LLC",
+    "Prof. Weber",
+    "weber@example.invalid",
+    "54D",
+    "Soylent GmbH",
+    "Ana Rossi",
+    "ana@example.invalid",
+    "33E",
+    "Vehement Capital Partners",
+];
+
+fn assert_no_raw_leak(json_str: &str) {
+    for raw in RAW_FIXTURE_VALUES {
+        assert!(
+            !json_str.contains(raw),
+            "agent-visible output leaked raw fixture value {raw}"
+        );
+    }
+}
+
+fn assert_no_deny_oracle(json_str: &str) {
+    for variant in DENY_REASON_VARIANTS {
+        assert!(
+            !json_str.contains(variant),
+            "agent-visible deny leaked DenyReason variant {variant}"
+        );
+    }
+}
+
+#[test]
+fn support_search_customer_docs_allows_with_translated_results() {
+    // Capture owner-side alias + fingerprint before the bridge moves into the tool,
+    // so we can prove neither leaks into agent-visible output.
+    let bridge = demo_bridge();
+    let alias = bridge
+        .primary_alias(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .expect("known customer Name alias");
+    let fingerprint = bridge
+        .primary_fingerprint(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .expect("known customer Name fingerprint");
+
+    let mut principals = HashMap::new();
+    let principal = support_principal();
+    principals.insert(principal.id.clone(), principal);
+    let tool = SearchDocumentsTool::new(bridge, principals);
+
+    // Owner-side: the owner tokenizes the PII; the agent only ever sees the token.
+    let token = tool
+        .tokenize_for(SUPPORT_ID, &PiiClass::Name, "Markus Gottschaue")
+        .expect("owner-side token mint");
+
+    let out = tool.run(
+        SUPPORT_ID,
+        &json!({ "source_token": token, "target_domain": CUSTOMER_DOMAIN }),
+    );
+
+    assert_eq!(out["authorized"], json!(true));
+    assert_eq!(out["target_domain"], json!(CUSTOMER_DOMAIN));
+    assert!(
+        !out["results"].as_array().expect("results array").is_empty(),
+        "expected non-empty translated results"
+    );
+
+    let json_str = out.to_string();
+    assert!(
+        json_str.contains(&token),
+        "translated results must carry the conversation token"
+    );
+    assert_no_raw_leak(&json_str);
+    assert!(
+        !json_str.contains(&alias),
+        "agent output leaked the owner-side domain alias"
+    );
+    assert!(
+        !json_str.contains(&fingerprint),
+        "agent output leaked the owner-side projection fingerprint"
+    );
+}
+
+#[test]
+fn support_search_legal_docs_denies_uniformly() {
+    let tool = support_tool();
+    let token = tool
+        .tokenize_for(SUPPORT_ID, &PiiClass::Name, "Markus Gottschaue")
+        .expect("owner-side token mint");
+
+    let out = tool.run(
+        SUPPORT_ID,
+        &json!({ "source_token": token, "target_domain": LEGAL_DOMAIN }),
+    );
+
+    assert_eq!(out["authorized"], json!(false));
+    assert_eq!(out["target_domain"], json!(LEGAL_DOMAIN));
+    assert_eq!(out["results"], json!([]));
+    assert_no_deny_oracle(&out.to_string());
+}
+
+#[test]
+fn unknown_principal_denies_uniformly() {
+    let tool = support_tool();
+
+    let out = tool.run(
+        "principal_ghost",
+        &json!({ "source_token": "<deadbeef:Name_1>", "target_domain": CUSTOMER_DOMAIN }),
+    );
+
+    assert_eq!(out["authorized"], json!(false));
+    assert_eq!(out["target_domain"], json!(CUSTOMER_DOMAIN));
+    assert_eq!(out["results"], json!([]));
+    assert_no_deny_oracle(&out.to_string());
+}
+
+#[test]
+fn malformed_args_deny_uniformly() {
+    let tool = support_tool();
+
+    for args in [
+        json!({}),                                                           // both fields missing
+        json!({ "source_token": "<deadbeef:Name_1>" }), // missing target_domain
+        json!({ "target_domain": CUSTOMER_DOMAIN }),    // missing source_token
+        json!({ "source_token": 42, "target_domain": CUSTOMER_DOMAIN }), // wrong type
+        json!({ "source_token": "<deadbeef:Name_1>", "target_domain": "" }), // empty domain
+    ] {
+        let out = tool.run(SUPPORT_ID, &args);
+        assert_eq!(out["authorized"], json!(false), "args {args} must deny");
+        assert_eq!(
+            out["results"],
+            json!([]),
+            "args {args} must return no results"
+        );
+        assert_no_deny_oracle(&out.to_string());
+    }
+}
+
+#[test]
+fn guessed_or_foreign_token_denies_uniformly() {
+    let tool = support_tool();
+    // A well-formed token never minted in this principal's owner-side session.
+    let out = tool.run(
+        SUPPORT_ID,
+        &json!({ "source_token": "<fffffff0:Name_99>", "target_domain": CUSTOMER_DOMAIN }),
+    );
+
+    assert_eq!(out["authorized"], json!(false));
+    assert_eq!(out["results"], json!([]));
+    assert_no_deny_oracle(&out.to_string());
+}
+
+#[test]
+fn deny_outputs_are_indistinguishable_across_causes() {
+    let tool = support_tool();
+    let token = tool
+        .tokenize_for(SUPPORT_ID, &PiiClass::Name, "Markus Gottschaue")
+        .expect("owner-side token mint");
+
+    // Policy deny (support principal lacks the legal-domain role).
+    let policy_deny = tool.run(
+        SUPPORT_ID,
+        &json!({ "source_token": token, "target_domain": LEGAL_DOMAIN }),
+    );
+    // Unknown principal, same target_domain echo.
+    let unknown_deny = tool.run(
+        "principal_ghost",
+        &json!({ "source_token": "<deadbeef:Name_1>", "target_domain": LEGAL_DOMAIN }),
+    );
+    // Unknown-token deny, same target_domain echo.
+    let token_deny = tool.run(
+        SUPPORT_ID,
+        &json!({ "source_token": "<fffffff0:Name_99>", "target_domain": LEGAL_DOMAIN }),
+    );
+
+    assert_eq!(
+        policy_deny, unknown_deny,
+        "deny shape must not reveal whether the principal is known"
+    );
+    assert_eq!(
+        policy_deny, token_deny,
+        "deny shape must not reveal whether the token resolved"
+    );
+}


### PR DESCRIPTION
## Summary
Agent-tier `search_documents` tool that drives the owner-side `TokenBridge` by **implementing `gaze_mcp_core::Tool`** — with **no change** to gaze-mcp-core's published, trybuild-sealed surface (`Tool` / `ToolCtx` / `ToolResources` / `Principal` / dispatch) and **no change** to any frozen gaze-token-bridge contract file (model/traits/lib/error/session/util/fixtures).

## What landed
- `crates/gaze-token-bridge/src/bridge/chokepoint.rs` (new, gated `#[cfg(feature = "chokepoint")]`): `SearchDocumentsTool` + `impl Tool` (thin async `invoke`) + sync `run()` core + `tokenize_for()` owner-side mint helper.
- `crates/gaze-token-bridge/src/bridge.rs`: gated `mod chokepoint;` + `pub use chokepoint::SearchDocumentsTool;` (Track C owns bridge.rs; not a frozen file).
- `crates/gaze-token-bridge/Cargo.toml`: **pure addition** — default-OFF `chokepoint` feature gating two **optional** deps (`gaze-mcp-core`, `async-trait`).
- `crates/gaze-token-bridge/tests/track_c_chokepoint.rs` (new, gated): ALLOW / DENY / unknown-principal / malformed-args / foreign-token + a no-oracle indistinguishability test.

## Owner-side session model (the chokepoint)
The sealed `ToolCtx` exposes only the external session id, and the frozen `RedactionSession` has no foreign-session constructor — so the tool owns the conversation's redaction namespace **owner-side** via a per-principal `RedactionSession` registry. The owner mints conversation tokens (`tokenize_for`); the agent only ever holds a token and passes it back as `source_token`; the tool resolves it owner-side against the **same** session before driving `TokenBridge::search`. Raw PII, the manifest, and index aliases never cross to the agent path.

## No-oracle deny (north-star axis 1)
Unknown principal, missing/malformed args, and every typed `DenyReason` collapse to one uniform `{ "authorized": false, "results": [] }` payload (byte-identical for a given `target_domain` echo). The typed reason lives **only** in the bridge audit; the agent-visible surface never reveals which path fired. A dedicated test asserts policy-deny == unknown-principal-deny == unknown-token-deny.

## Pure-addition Cargo / default graph unchanged
The `chokepoint` feature is OFF by default. `cargo build --workspace` and `cargo test -p gaze-token-bridge` (no features) behave exactly as before — the default-graph test run reports **0** chokepoint tests because the gated test file compiles to an empty crate. (`Cargo.lock` records the two optional deps under gaze-token-bridge; both packages already existed in the lock — no version churn, no change to the default compiled graph.)

## ToolCtx seal respected
The sealed `ToolCtx` cannot be constructed outside gaze-mcp-core, so the tool body is extracted into a sync, unit-testable `run()`; tests drive `run()` directly rather than fabricating a context. No constructor was added to gaze-mcp-core.

## Policy tool_name convention
`BridgeRequest.tool_name` is fixed to this tool's wire name `"search_documents"` (the LLM never chooses the policy tool_name — north-star axis 4). Adopters author allow-rules and `allowed_tools` under `search_documents`. (Tests rewrite the bundled fixture's `support_search`/`legal_search` keys accordingly.)

## Deferred: R3 namespace unification
Unifying the owner-side bridge session with the gaze-mcp-core dispatch's own `gaze::Session` (one shared manifest) needs a frozen `RedactionSession` constructor **or** a gaze-mcp-core wiring change → master-designated NEED-DIRECTION, **not** attempted here. Filed as contract refinement **R3** (solo todo #1567).

## Gates (all green, pinned toolchain)
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings` ✓
- `cargo test -p gaze-token-bridge --all-features` ✓ (23 existing + 6 new + doctest)
- `cargo test -p gaze-token-bridge` (default graph) ✓ (23 + 0 chokepoint + doctest)
- `cargo build --workspace` ✓

Resolves solo todo #1563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)