### PR TITLE
[agent] fix(token-bridge): persist rate-limit buckets across calls (#1564)

### DIFF
--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -8,8 +8,8 @@
 //! must return an owned value. A struct that owns the registry *and* a gate borrowing it
 //! would be self-referential, so the bridge owns the registry and constructs a fresh gate
 //! per authorization. The per-principal rate-limit buckets, however, are owned by the bridge
-//! ([`TokenBridge::rate_limit`]) and injected by `&mut` into each per-call gate, so they
-//! persist and accumulate across calls (blocker #1564). The immutable borrow of `registry`
+//! (the `TokenBridge::rate_limit` field) and injected by `&mut` into each per-call gate, so
+//! they persist and accumulate across calls (blocker #1564). The immutable borrow of `registry`
 //! and the mutable borrow of `rate_limit` are disjoint fields, so both are legal at once.
 
 use std::collections::HashMap;

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -7,8 +7,10 @@
 //! [`crate::policy::RegistryPolicyGate`] borrows its registry, while [`TokenBridge::demo`]
 //! must return an owned value. A struct that owns the registry *and* a gate borrowing it
 //! would be self-referential, so the bridge owns the registry and constructs a fresh gate
-//! per authorization. Consequence: the gate's per-principal rate-limit buckets do not
-//! persist across calls. Tracked as a follow-up (the bundled fixture limit is never hit).
+//! per authorization. The per-principal rate-limit buckets, however, are owned by the bridge
+//! ([`TokenBridge::rate_limit`]) and injected by `&mut` into each per-call gate, so they
+//! persist and accumulate across calls (blocker #1564). The immutable borrow of `registry`
+//! and the mutable borrow of `rate_limit` are disjoint fields, so both are legal at once.
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -25,7 +27,7 @@ use crate::model::{
     BridgeSearchOutcome, BridgeSearchResponse, DomainId, IndexSearchHit, PolicyOutcome,
     SearchHandle, SearchRequest,
 };
-use crate::policy::RegistryPolicyGate;
+use crate::policy::{RateLimitState, RegistryPolicyGate};
 use crate::projection::HmacDomainProjector;
 use crate::registry::IndexDomainRegistry;
 use crate::session::RedactionSession;
@@ -62,6 +64,9 @@ pub struct TokenBridge {
     /// The projected filters last handed to the adapter (proves raw filter values are
     /// projected owner-side before the adapter sees them).
     last_adapter_filters: Vec<AdapterFilterClause>,
+    /// Persistent per-principal rate-limit buckets, injected into each per-call policy gate
+    /// so the corpus-enumeration cap accumulates across calls (blocker #1564).
+    rate_limit: RateLimitState,
 }
 
 impl TokenBridge {
@@ -104,6 +109,7 @@ impl TokenBridge {
             audit: VecAuditSink::new(),
             corpus,
             last_adapter_filters: Vec::new(),
+            rate_limit: RateLimitState::new(),
         })
     }
 
@@ -115,10 +121,12 @@ impl TokenBridge {
         session: &RedactionSession,
         request: &BridgeRequest,
     ) -> BridgeDecision {
-        // Scope the gate's borrow of `self.registry` to this block so the subsequent
-        // mutable borrows of `self.capability` / `self.audit` are legal.
+        // Scope the gate's borrows of `self.registry` / `self.rate_limit` to this block so
+        // the subsequent mutable borrows of `self.capability` / `self.audit` are legal. The
+        // gate reads+updates the bridge-owned rate-limit buckets, so the cap persists across
+        // calls (blocker #1564); `registry` and `rate_limit` are disjoint fields.
         let outcome = {
-            let mut gate = RegistryPolicyGate::new(&self.registry);
+            let mut gate = RegistryPolicyGate::new(&self.registry, &mut self.rate_limit);
             gate.evaluate(session, request)
         };
 

--- a/crates/gaze-token-bridge/src/policy.rs
+++ b/crates/gaze-token-bridge/src/policy.rs
@@ -20,18 +20,40 @@ use crate::session::RedactionSession;
 use crate::traits::{DomainProjector, PolicyGate};
 use crate::util::sha256_hex;
 
+/// Persistent per-principal rate-limit bucket state. Owned by the long-lived runtime
+/// (e.g. [`crate::bridge::TokenBridge`]) and injected by `&mut` into each short-lived
+/// [`RegistryPolicyGate`]. Keeping the buckets OUTSIDE the per-call gate is what lets the
+/// corpus-enumeration rate limit accumulate across calls instead of resetting every call
+/// (blocker #1564). Default-constructs empty.
+#[derive(Debug, Default)]
+pub struct RateLimitState {
+    buckets: HashMap<RateLimitBucket, HashSet<String>>,
+}
+
+impl RateLimitState {
+    /// Create empty rate-limit state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Policy gate backed by an [`IndexDomainRegistry`].
+///
+/// The gate is short-lived: a fresh one is built per authorization because it borrows the
+/// registry, while the long-lived runtime owns the registry (a self-referential struct would
+/// otherwise result). The per-principal rate-limit buckets do NOT live on the gate — they are
+/// borrowed from caller-owned [`RateLimitState`] so they persist across gates (blocker #1564).
 #[derive(Debug)]
 pub struct RegistryPolicyGate<'a> {
     registry: &'a IndexDomainRegistry,
-    rate_limit_buckets: HashMap<RateLimitBucket, HashSet<String>>,
+    rate_limit: &'a mut RateLimitState,
 }
 
 impl<'a> RegistryPolicyGate<'a> {
-    pub fn new(registry: &'a IndexDomainRegistry) -> Self {
+    pub fn new(registry: &'a IndexDomainRegistry, rate_limit: &'a mut RateLimitState) -> Self {
         Self {
             registry,
-            rate_limit_buckets: HashMap::new(),
+            rate_limit,
         }
     }
 }
@@ -150,7 +172,7 @@ impl RegistryPolicyGate<'_> {
             match scope_authorization(self.registry, domain, rule, request) {
                 ScopeAuthorization::Allowed => {
                     enforce_rate_limit(
-                        &mut self.rate_limit_buckets,
+                        &mut self.rate_limit.buckets,
                         rate_limit,
                         request,
                         &resolved_class,

--- a/crates/gaze-token-bridge/tests/track_a_policy.rs
+++ b/crates/gaze-token-bridge/tests/track_a_policy.rs
@@ -1,5 +1,5 @@
 use gaze::PiiClass;
-use gaze_token_bridge::policy::RegistryPolicyGate;
+use gaze_token_bridge::policy::{RateLimitState, RegistryPolicyGate};
 use gaze_token_bridge::registry::IndexDomainRegistry;
 use gaze_token_bridge::traits::PolicyGate;
 use gaze_token_bridge::util::sha256_hex;
@@ -165,7 +165,8 @@ fn evaluate_with_registry(
     session: &RedactionSession,
     request: &BridgeRequest,
 ) -> PolicyOutcome {
-    let mut gate = RegistryPolicyGate::new(registry);
+    let mut rate_limit = RateLimitState::new();
+    let mut gate = RegistryPolicyGate::new(registry, &mut rate_limit);
     gate.evaluate(session, request)
 }
 
@@ -379,7 +380,8 @@ fn rate_limit_trips_per_principal_domain_window_without_raw_pii() {
         .tokenize(&PiiClass::Email, "bob@example.invalid")
         .expect("second token mints");
     let registry = registry_with_support_entity_limit(1);
-    let mut gate = RegistryPolicyGate::new(&registry);
+    let mut rate_limit = RateLimitState::new();
+    let mut gate = RegistryPolicyGate::new(&registry, &mut rate_limit);
 
     let first_grant =
         unwrap_grant(gate.evaluate(&session, &support_customer_request(&first_token)));

--- a/crates/gaze-token-bridge/tests/track_c_bridge.rs
+++ b/crates/gaze-token-bridge/tests/track_c_bridge.rs
@@ -508,6 +508,59 @@ fn session_bound_to_principal_rejects_reuse_by_different_principal() {
     assert_eq!(session.session_id(), "conversation:principal_support_1");
 }
 
+/// A demo bridge whose support→customer rule carries a low per-principal entity cap. Used
+/// to prove the rate-limit bucket persists across separate bridge calls (blocker #1564).
+fn low_rate_limit_customer_bridge(max_entities_per_window: usize) -> TokenBridge {
+    let mut policy: serde_json::Value =
+        serde_json::from_str(POLICY_JSON).expect("fixture policy parses as json");
+    let support_rule = policy
+        .get_mut("rules")
+        .and_then(serde_json::Value::as_array_mut)
+        .and_then(|rules| {
+            rules
+                .iter_mut()
+                .find(|rule| rule["target_domain"] == CUSTOMER_DOMAIN)
+        })
+        .expect("fixture policy has support customer rule");
+    support_rule["max_entities_per_window"] = serde_json::json!(max_entities_per_window);
+    support_rule["rate_limit_window_seconds"] = serde_json::json!(3600);
+    let policy = serde_json::to_string(&policy).expect("rate-limited policy serializes");
+    TokenBridge::from_policy_json(&policy).expect("rate-limited bridge builds")
+}
+
+/// Regression for blocker #1564: the per-principal rate-limit bucket MUST accumulate across
+/// separate bridge calls. The bridge owns the bucket state and injects it into each per-call
+/// policy gate, so distinct-entity lookups count toward the cap instead of resetting every
+/// call. With the cap at 2, two distinct-entity authorizations succeed and the third — issued
+/// as a SEPARATE call — fails closed. Pre-fix the gate was rebuilt empty each call, so the
+/// cap never tripped and the third lookup was (wrongly) allowed.
+#[test]
+fn rate_limit_accumulates_across_separate_authorize_calls() {
+    let principal = support_principal();
+    let session = RedactionSession::ephemeral_for(&principal.id).unwrap();
+    // Three DISTINCT entities for one principal; the bucket counts distinct raw entities.
+    let first = session
+        .tokenize(&PiiClass::Name, "Markus Gottschaue")
+        .unwrap();
+    let second = session.tokenize(&PiiClass::Name, "Dr. Schmidt").unwrap();
+    let third = session.tokenize(&PiiClass::Name, "Lena Torres").unwrap();
+
+    let mut bridge = low_rate_limit_customer_bridge(2);
+
+    // First two distinct-entity lookups fit under the cap of 2 — across SEPARATE calls.
+    let _ = authorize_handle(&mut bridge, &session, &support_customer_request(&first));
+    let _ = authorize_handle(&mut bridge, &session, &support_customer_request(&second));
+
+    // The bucket persisted on the bridge across calls, so the third distinct entity trips
+    // the cap and is denied.
+    match bridge.authorize(&session, &support_customer_request(&third)) {
+        BridgeDecision::Deny { reason } => assert_eq!(reason, DenyReason::NoMatchingAllowRule),
+        BridgeDecision::Allow { .. } => {
+            panic!("rate limit did not accumulate across calls: third lookup was allowed")
+        }
+    }
+}
+
 /// Track-C hardening over the spike: a filter field outside the handle's allowlist fails
 /// closed instead of being silently projected (default-deny — north-star axis 1).
 #[test]


### PR DESCRIPTION
## What

Fixes blocker **#1564**: `TokenBridge` rebuilt its `RegistryPolicyGate` fresh on every `authorize()` call, and the gate *owned* its per-principal rate-limit buckets. Each fresh gate started with empty buckets, so the corpus-enumeration rate limit never accumulated across calls and never tripped — a silent authorization-control gap.

## Fix

- New persistent `RateLimitState` (in `policy.rs`) holds the per-principal/domain/window buckets. It is **owned by `TokenBridge`** and injected by `&mut` into each per-call gate: `RegistryPolicyGate::new(&self.registry, &mut self.rate_limit)`.
- The immutable borrow of `registry` and the mutable borrow of `rate_limit` are **disjoint fields** of the bridge, so the self-reference that originally motivated the per-call gate is avoided cleanly — the gate stays short-lived, the bucket state lives as long as the bridge.
- The **frozen contract is untouched**: `PolicyGate::evaluate(&mut self, session, request) -> PolicyOutcome` (`traits.rs`) and `model.rs` types are unchanged. Only `RegistryPolicyGate`'s struct + `new()` (not part of the trait) changed.

## Test (proves the fix)

New bridge-level regression `rate_limit_accumulates_across_separate_authorize_calls`: builds a bridge with a low cap (`max_entities_per_window = 2`), then issues three **distinct-entity** lookups for one principal across **separate** `authorize()` calls — first two allowed, third denied (`DenyReason::NoMatchingAllowRule`). Written TDD: confirmed RED on the pre-fix code (third lookup wrongly allowed), GREEN after the fix. Existing `track_a_policy` gate constructions updated to inject `RateLimitState`.

## North star

Correctness hardening — axis 1 (never-leak / fail-closed) and axis 4 (auditable, deterministic authz). A rate limit that silently never trips is a broken control; this restores it. "Never ship broken code."

## Gates (all green, pinned toolchain)

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings` ✅
- `cargo test -p gaze-token-bridge --all-features` ✅ (track_a 13, track_c bridge 24, chokepoint 6, doc-test 1)
- `cargo build --workspace` ✅

Resolves solo todo #1564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENiPCKoh39TxpQJDHnqYtB