### PR TITLE
[index-search] Fix TokenBridge alias round-trip audit findings

### DIFF
--- a/crates/gaze-token-bridge/fixtures/policy.json
+++ b/crates/gaze-token-bridge/fixtures/policy.json
@@ -6,7 +6,7 @@
       "corpus_type": "customer_docs",
       "purpose": "support_lookup",
       "allowed_roles": ["support", "admin"],
-      "allowed_tools": ["support_search", "legal_search"],
+      "allowed_tools": ["support_search"],
       "allowed_actions": ["search_documents"],
       "allowed_entity_classes": ["name", "email", "custom:customer_id", "organization"],
       "snippets_allowed": true,

--- a/crates/gaze-token-bridge/src/adapter.rs
+++ b/crates/gaze-token-bridge/src/adapter.rs
@@ -1,5 +1,5 @@
-//! Track B — `SearchAdapter` implementation: the real corpus index (store + query by
-//! `IndexedEntityRef`), replacing the spike's in-memory fake. Enforces
+//! Track B — `SearchAdapter` implementation: an in-memory corpus index (store + query by
+//! `IndexedEntityRef`) for v1, replacing the spike's fake. Enforces
 //! entity_ref/domain/expiry/nonce guards defensively. Owner: sub-orchestrator B.
 //! Contract: `crate::traits::SearchAdapter`, `crate::model::{ValidatedSearchRequest, IndexSearchHit}`.
 //! Reference: spike `InMemorySearchAdapter`.

--- a/crates/gaze-token-bridge/src/util.rs
+++ b/crates/gaze-token-bridge/src/util.rs
@@ -62,7 +62,6 @@ pub fn collapse_ascii_whitespace(value: &str) -> String {
 pub fn domain_alias(class: &PiiClass, fingerprint_hex: &str) -> String {
     let suffix = fingerprint_hex
         .chars()
-        .take(4)
         .map(|ch| match ch {
             '0'..='9' => ((ch as u8 - b'0') + b'A') as char,
             'a'..='f' => ((ch as u8 - b'a') + b'K') as char,

--- a/crates/gaze-token-bridge/tests/track_a_policy.rs
+++ b/crates/gaze-token-bridge/tests/track_a_policy.rs
@@ -191,15 +191,14 @@ fn unwrap_deny(outcome: PolicyOutcome) -> (DenyReason, Option<PiiClass>, Option<
 #[test]
 fn default_deny_when_no_allow_rule_matches() {
     let principal = support_principal();
-    let (session, token) = session_with_token(&principal, PiiClass::Name, "Dr. Schmidt");
-    let mut request = support_customer_request(&token);
-    request.tool_name = "legal_search".to_string();
+    let (session, token) = session_with_token(&principal, PiiClass::Organization, "Example GmbH");
+    let request = support_customer_request(&token);
 
     let (reason, entity_class, raw_sha256) = unwrap_deny(evaluate(&session, &request));
 
     assert_eq!(reason, DenyReason::NoMatchingAllowRule);
-    assert_eq!(entity_class, Some(PiiClass::Name));
-    assert_eq!(raw_sha256, Some(sha256_hex("Dr. Schmidt")));
+    assert_eq!(entity_class, Some(PiiClass::Organization));
+    assert_eq!(raw_sha256, Some(sha256_hex("Example GmbH")));
 }
 
 #[test]

--- a/crates/gaze-token-bridge/tests/track_c_bridge.rs
+++ b/crates/gaze-token-bridge/tests/track_c_bridge.rs
@@ -9,6 +9,10 @@
 
 use gaze::PiiClass;
 use gaze_token_bridge::bridge::TokenBridge;
+use gaze_token_bridge::model::{IndexEntity, IndexSearchHit, IndexedEntityRef};
+use gaze_token_bridge::traits::ResponseTranslator;
+use gaze_token_bridge::translate::SessionResponseTranslator;
+use gaze_token_bridge::util::domain_alias;
 use gaze_token_bridge::{
     AuditDecision, BridgeDecision, BridgeRequest, BridgeSearchResponse, DenyReason, FilterClause,
     Principal, RedactionSession, RequestedScope, SearchHandle, SearchRequest,
@@ -349,6 +353,59 @@ fn returned_snippets_are_translated_to_current_session_tokens() {
     assert!(!json.contains("<Name_"));
     assert!(json.contains(&token));
     assert!(json.contains(":Name_1>"));
+}
+
+#[test]
+fn shared_fingerprint_prefix_entities_translate_to_distinct_session_tokens() {
+    let session = RedactionSession::ephemeral_for(&support_principal().id).unwrap();
+    let first_fingerprint = format!("abcd{}", "1".repeat(60));
+    let second_fingerprint = format!("abcd{}", "2".repeat(60));
+    let first_alias = domain_alias(&PiiClass::Email, &first_fingerprint);
+    let second_alias = domain_alias(&PiiClass::Email, &second_fingerprint);
+
+    assert_ne!(first_alias, second_alias);
+
+    let hit = IndexSearchHit {
+        doc_id: "shared-prefix-doc".to_string(),
+        snippet: format!("{first_alias} and {second_alias} require separate restore mappings."),
+        entities: vec![
+            IndexEntity {
+                class: PiiClass::Email,
+                raw_value: "alpha@example.invalid".to_string(),
+                index_ref: IndexedEntityRef {
+                    domain_id: CUSTOMER_DOMAIN.to_string(),
+                    key_id: "customer-v2".to_string(),
+                    entity_class: PiiClass::Email,
+                    fingerprint_hex: first_fingerprint,
+                },
+                domain_alias: first_alias,
+            },
+            IndexEntity {
+                class: PiiClass::Email,
+                raw_value: "bravo@example.invalid".to_string(),
+                index_ref: IndexedEntityRef {
+                    domain_id: CUSTOMER_DOMAIN.to_string(),
+                    key_id: "customer-v2".to_string(),
+                    entity_class: PiiClass::Email,
+                    fingerprint_hex: second_fingerprint,
+                },
+                domain_alias: second_alias,
+            },
+        ],
+    };
+
+    let translated = SessionResponseTranslator::translate(&session, vec![hit]).unwrap();
+    let snippet = &translated[0].snippet;
+    let first_token = session
+        .tokenize(&PiiClass::Email, "alpha@example.invalid")
+        .unwrap();
+    let second_token = session
+        .tokenize(&PiiClass::Email, "bravo@example.invalid")
+        .unwrap();
+
+    assert_ne!(first_token, second_token);
+    assert!(snippet.contains(&first_token));
+    assert!(snippet.contains(&second_token));
 }
 
 #[test]


### PR DESCRIPTION
## What

Fixes the audit follow-up for TokenBridge alias collisions. `domain_alias()` was only using the first 4 fingerprint hex chars, which meant two same-class entities with the same prefix could share an owner-side alias and collapse to the first session token during translation.

## Fix

- use the full fingerprint when building owner-side domain aliases
- add a regression test that proves two same-prefix email fingerprints produce distinct aliases and distinct translated session tokens
- remove `legal_search` from the customer_docs fixture allowlist
- correct the adapter module docs to describe the v1 in-memory corpus index

## Tests

- cargo fmt --all -- --check
- cargo clippy -p gaze-token-bridge --all-targets --all-features -- -D warnings
- cargo test -p gaze-token-bridge --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc -p gaze-token-bridge --all-features --no-deps
- cargo build --workspace

Resolves solo todo #1572
