### PR TITLE
Fix index search snippet PII leak

### DIFF
--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -22,7 +22,7 @@ safety-net-kiji = ["gaze-recognizers/safety-net-kiji"]
 runtime-tract = ["safety-net-kiji", "gaze-recognizers/runtime-tract"]
 runtime-candle = ["safety-net-kiji", "gaze-recognizers/runtime-candle"]
 document = ["dep:gaze-document"]
-index = ["dep:gaze-token-bridge"]
+index = ["dep:gaze-token-bridge", "safety-net-kiji"]
 mcp = [
     "dep:async-trait",
     "dep:directories-next",

--- a/crates/gaze-cli/src/commands/index.rs
+++ b/crates/gaze-cli/src/commands/index.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, PiiClass, Pipeline};
-use gaze_recognizers::RegexDetector;
+use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, LocaleTag, PiiClass, Pipeline};
+use gaze_recognizers::{LocaleAwareModelRegistry, RegexDetector};
 use gaze_token_bridge::adapter::CorpusIndexStore;
 use gaze_token_bridge::bridge::TokenBridge;
 use gaze_token_bridge::ingest::CorpusIngestor;
@@ -19,9 +19,12 @@ use gaze_token_bridge::persistent::{
 use gaze_token_bridge::projection::HmacDomainProjector;
 use gaze_token_bridge::registry::IndexDomainRegistry;
 use gaze_token_bridge::util::sha256_hex;
-use gaze_token_bridge::{BridgeError, RedactionSession};
+use gaze_token_bridge::{BridgeError, DenyReason, RedactionSession};
 
 use crate::error::CliError;
+
+const KIJI_COMMAND_ENV: &str = "GAZE_KIJI_DISTILBERT_COMMAND";
+const KIJI_MODEL_DIR_ENV: &str = "GAZE_KIJI_DISTILBERT_MODEL_DIR";
 
 pub(crate) struct IngestArgs {
     pub(crate) dir: PathBuf,
@@ -66,7 +69,7 @@ pub(crate) fn ingest(args: IngestArgs) -> Result<(), CliError> {
         .cloned()
         .ok_or_else(index_failed)?;
     let projector = HmacDomainProjector::new(&registry);
-    let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector);
+    let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector).with_safety_net_resolution();
 
     store.clear_domain(&args.domain);
     let mut ingested_files = 0_usize;
@@ -96,8 +99,10 @@ pub(crate) fn search(args: SearchArgs) -> Result<(), CliError> {
         .cloned()
         .ok_or_else(index_failed)?;
     let policy_json = store.policy_json().map_err(map_bridge_error)?;
-    let mut bridge =
-        TokenBridge::from_policy_json_and_store(&policy_json, store).map_err(map_bridge_error)?;
+    let output_safety_net = build_index_output_safety_net_pipeline()?;
+    let mut bridge = TokenBridge::from_policy_json_and_store(&policy_json, store)
+        .map_err(map_bridge_error)?
+        .with_output_safety_net(output_safety_net, vec![LocaleTag::Global]);
 
     let principal = local_principal(&domain);
     let session = RedactionSession::ephemeral_for(&principal.id).map_err(map_bridge_error)?;
@@ -126,9 +131,10 @@ pub(crate) fn search(args: SearchArgs) -> Result<(), CliError> {
                 println!("snippet: {}", hit.snippet);
             }
         }
-        BridgeSearchOutcome::Allowed(_) | BridgeSearchOutcome::Denied(_) => {
+        BridgeSearchOutcome::Allowed(_) => {
             println!("no hits");
         }
+        BridgeSearchOutcome::Denied(reason) => return Err(index_denied(reason)),
     }
     println!("raw PII never shown (owner-side only)");
 
@@ -195,6 +201,7 @@ fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
     let mut builder = Pipeline::builder()
         .detector(RegexDetector::emails().map_err(|_| index_failed())?)
         .detector(FieldEntityDetector);
+    builder = builder.register_safety_net_registry(index_kiji_registry()?);
 
     let mut rule_classes =
         BTreeSet::from([PiiClass::Email, PiiClass::Name, PiiClass::Organization]);
@@ -207,6 +214,50 @@ fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
         .rule(DefaultRule::new(Action::Preserve))
         .build()
         .map_err(|_| index_failed())
+}
+
+fn build_index_output_safety_net_pipeline() -> Result<Pipeline, CliError> {
+    Pipeline::builder()
+        .register_safety_net_registry(index_kiji_registry()?)
+        .build()
+        .map_err(|_| index_failed())
+}
+
+fn index_kiji_registry() -> Result<LocaleAwareModelRegistry, CliError> {
+    let mut registry = LocaleAwareModelRegistry::new();
+    registry.register(index_kiji_safety_net()?);
+    Ok(registry)
+}
+
+#[cfg(feature = "safety-net-kiji")]
+fn index_kiji_safety_net(
+) -> Result<gaze_recognizers::safety_net::kiji_distilbert::KijiDistilbertSafetyNet, CliError> {
+    use gaze_recognizers::safety_net::kiji_distilbert::{
+        KijiDistilbertConfig, KijiDistilbertSafetyNet, OrtKijiConfig, SubprocessKijiConfig,
+    };
+
+    if let Some(model_dir) = std::env::var_os(KIJI_MODEL_DIR_ENV) {
+        return Ok(KijiDistilbertSafetyNet::new(KijiDistilbertConfig::from(
+            OrtKijiConfig::new(model_dir),
+        )));
+    }
+
+    if let Some(command) = std::env::var_os(KIJI_COMMAND_ENV) {
+        return Ok(KijiDistilbertSafetyNet::new(KijiDistilbertConfig::from(
+            SubprocessKijiConfig::new(command),
+        )));
+    }
+
+    Err(CliError::SafetyNetConfigDetail(format!(
+        "gaze index requires {KIJI_MODEL_DIR_ENV} or {KIJI_COMMAND_ENV}; install the pinned model with scripts/fetch-kiji-safetynet-model.sh"
+    )))
+}
+
+#[cfg(not(feature = "safety-net-kiji"))]
+fn index_kiji_safety_net() -> Result<impl gaze_recognizers::LocaleAwareModel, CliError> {
+    Err(CliError::SafetyNetConfigDetail(
+        "gaze index requires gaze-cli feature safety-net-kiji".to_string(),
+    ))
 }
 
 fn infer_class(entity: &str) -> PiiClass {
@@ -226,8 +277,21 @@ fn local_principal(domain: &gaze_token_bridge::model::IndexDomain) -> Principal 
     }
 }
 
-fn map_bridge_error(_err: BridgeError) -> CliError {
-    index_failed()
+fn map_bridge_error(err: BridgeError) -> CliError {
+    match err {
+        BridgeError::Session(message)
+            if message.contains("safety net") || message.contains("SafetyNet") =>
+        {
+            CliError::SafetyNetFailure {
+                variant: "IndexSafetyNet",
+            }
+        }
+        _ => index_failed(),
+    }
+}
+
+fn index_denied(reason: DenyReason) -> CliError {
+    CliError::PolicyConfigDetail(format!("index search failed closed: {reason:?}"))
 }
 
 fn index_failed() -> CliError {

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "index")]
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
 
@@ -11,6 +13,7 @@ fn index_ingest_then_search_returns_tokenized_hits_without_raw_values() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
     let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
     fs::create_dir_all(&corpus).expect("corpus dir");
     fs::write(
         corpus.join("alpha.md"),
@@ -35,8 +38,7 @@ Second support note for search isolation.
     )
     .expect("write beta");
 
-    let ingest = Command::cargo_bin("gaze")
-        .expect("gaze bin")
+    let ingest = gaze_index_command(&fake_kiji)
         .args(["index", "ingest"])
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
@@ -49,8 +51,7 @@ Second support note for search isolation.
         String::from_utf8_lossy(&ingest.stderr)
     );
 
-    let search = Command::cargo_bin("gaze")
-        .expect("gaze bin")
+    let search = gaze_index_command(&fake_kiji)
         .args(["index", "search", "alice@example.invalid"])
         .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -82,4 +83,141 @@ Second support note for search isolation.
             "search stdout leaked raw fixture value {raw}: {stdout}"
         );
     }
+}
+
+#[test]
+fn realistic_prose_name_org_email_regression_never_returns_raw_values() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("prose.md"),
+        "\
+Support summary: Alice Mueller from Globex GmbH wrote from alice@example.invalid about onboarding. Follow up next week.
+",
+    )
+    .expect("write prose");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+    let ingest_stdout = String::from_utf8(ingest.stdout).expect("utf8 ingest stdout");
+    assert!(
+        ingest_stdout.contains("entities: 3"),
+        "expected name + org + email entities, got: {ingest_stdout}"
+    );
+
+    let search = gaze_index_command(&fake_kiji)
+        .args(["index", "search", "alice@example.invalid"])
+        .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search");
+    assert!(
+        search.status.success(),
+        "search failed: stderr={}",
+        String::from_utf8_lossy(&search.stderr)
+    );
+
+    let stdout = String::from_utf8(search.stdout).expect("utf8 stdout");
+    assert!(stdout.contains("doc: doc:"));
+    assert!(stdout.contains(":Email_"));
+    assert!(stdout.contains(":Name_"));
+    for raw in ["Alice Mueller", "Globex GmbH", "alice@example.invalid"] {
+        assert!(
+            !stdout.contains(raw),
+            "realistic prose search stdout leaked raw fixture value {raw}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn index_ingest_fails_closed_without_kiji_model_or_command() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(corpus.join("alpha.md"), "Email: alice@example.invalid\n").expect("write alpha");
+
+    let ingest = Command::cargo_bin("gaze")
+        .expect("gaze bin")
+        .env_remove("GAZE_KIJI_DISTILBERT_COMMAND")
+        .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+
+    assert!(
+        !ingest.status.success(),
+        "ingest unexpectedly succeeded without Kiji backend"
+    );
+    let stderr = String::from_utf8_lossy(&ingest.stderr);
+    assert!(stderr.contains("SafetyNetConfig"), "stderr={stderr}");
+    assert!(
+        stderr.contains("GAZE_KIJI_DISTILBERT_MODEL_DIR"),
+        "stderr={stderr}"
+    );
+}
+
+fn gaze_index_command(fake_kiji: &Path) -> Command {
+    let mut command = Command::cargo_bin("gaze").expect("gaze bin");
+    command
+        .env("GAZE_KIJI_DISTILBERT_COMMAND", fake_kiji)
+        .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR");
+    command
+}
+
+fn write_fake_kiji(temp: &tempfile::TempDir) -> PathBuf {
+    let script = temp.path().join("fake-kiji.py");
+    fs::write(
+        &script,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+text = sys.stdin.read()
+targets = [
+    ("Dr. Schmidt", "PER"),
+    ("Prof. Weber", "PER"),
+    ("Alice Mueller", "PER"),
+    ("Globex GmbH", "ORG"),
+    ("Initech AG", "ORG"),
+]
+
+spans = []
+for value, label in targets:
+    cursor = 0
+    while True:
+        index = text.find(value, cursor)
+        if index < 0:
+            break
+        start = len(text[:index].encode("utf-8"))
+        end = start + len(value.encode("utf-8"))
+        spans.append({"label": label, "start": start, "end": end, "score": 0.99})
+        cursor = index + len(value)
+
+print(json.dumps(spans))
+"#,
+    )
+    .expect("write fake kiji");
+    let mut permissions = fs::metadata(&script)
+        .expect("fake kiji metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).expect("chmod fake kiji");
+    script
 }

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -15,7 +15,10 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, PiiClass, Pipeline};
+use gaze::{
+    Action, ClassRule, DefaultRule, Detection, Detector, LocaleTag, PiiClass, Pipeline, Scope,
+    Session,
+};
 
 use crate::adapter::{CorpusIndexStore, InMemoryCorpusIndexStore, InMemorySearchAdapter};
 use crate::audit::VecAuditSink;
@@ -23,7 +26,7 @@ use crate::capability::CapabilityRuntime;
 use crate::error::{BridgeError, DenyReason};
 use crate::ingest::CorpusIngestor;
 use crate::model::{
-    AdapterFilterClause, AuditDecision, AuditEvent, BridgeDecision, BridgeRequest,
+    AdapterFilterClause, AgentSearchHit, AuditDecision, AuditEvent, BridgeDecision, BridgeRequest,
     BridgeSearchOutcome, BridgeSearchResponse, DomainId, IndexSearchHit, PolicyOutcome,
     SearchHandle, SearchRequest,
 };
@@ -67,6 +70,23 @@ pub struct TokenBridge<S = InMemoryCorpusIndexStore> {
     /// Persistent per-principal rate-limit buckets, injected into each per-call policy gate
     /// so the corpus-enumeration cap accumulates across calls (blocker #1564).
     rate_limit: RateLimitState,
+    /// Required Pass-3 scan over every translated, agent-visible snippet.
+    output_safety_net: Option<OutputSafetyNet>,
+}
+
+#[derive(Clone)]
+struct OutputSafetyNet {
+    pipeline: Pipeline,
+    locale_chain: Vec<LocaleTag>,
+}
+
+impl std::fmt::Debug for OutputSafetyNet {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OutputSafetyNet")
+            .field("locale_chain", &self.locale_chain)
+            .finish_non_exhaustive()
+    }
 }
 
 impl TokenBridge<InMemoryCorpusIndexStore> {
@@ -110,6 +130,7 @@ impl TokenBridge<InMemoryCorpusIndexStore> {
             corpus,
             last_adapter_filters: Vec::new(),
             rate_limit: RateLimitState::new(),
+            output_safety_net: None,
         })
     }
 }
@@ -128,7 +149,24 @@ impl<S: CorpusIndexStore> TokenBridge<S> {
             corpus: HashMap::new(),
             last_adapter_filters: Vec::new(),
             rate_limit: RateLimitState::new(),
+            output_safety_net: None,
         })
+    }
+
+    /// Install the mandatory output SafetyNet used after response translation.
+    ///
+    /// The bridge denies searches when this scanner is absent or unavailable, so
+    /// callers cannot accidentally return unscanned snippets to an agent.
+    pub fn with_output_safety_net(
+        mut self,
+        pipeline: Pipeline,
+        locale_chain: Vec<LocaleTag>,
+    ) -> Self {
+        self.output_safety_net = Some(OutputSafetyNet {
+            pipeline,
+            locale_chain,
+        });
+        self
     }
 
     /// Authorize a request and, on success, mint a single-use capability. Records exactly
@@ -222,6 +260,7 @@ impl<S: CorpusIndexStore> TokenBridge<S> {
         let now = self.capability.now();
         let hits = self.adapter.search(handle, validated, now)?;
         let results = SessionResponseTranslator::translate(session, hits)?;
+        let results = self.enforce_output_safety_net(results)?;
 
         Ok(BridgeSearchResponse {
             target_domain: handle.target_domain.clone(),
@@ -291,6 +330,40 @@ impl<S: CorpusIndexStore> TokenBridge<S> {
             .entities
             .iter()
             .find(|entity| &entity.class == class)
+    }
+
+    fn enforce_output_safety_net(
+        &self,
+        results: Vec<AgentSearchHit>,
+    ) -> Result<Vec<AgentSearchHit>, DenyReason> {
+        let safety_net = self
+            .output_safety_net
+            .as_ref()
+            .ok_or(DenyReason::TranslatorFailed)?;
+        let scan_session =
+            Session::new(Scope::Ephemeral).map_err(|_| DenyReason::TranslatorFailed)?;
+        let fallback_locale_chain = [LocaleTag::Global];
+        let locale_chain = if safety_net.locale_chain.is_empty() {
+            fallback_locale_chain.as_slice()
+        } else {
+            safety_net.locale_chain.as_slice()
+        };
+
+        let mut safe_results = Vec::with_capacity(results.len());
+        for hit in results {
+            let scan = safety_net
+                .pipeline
+                .scan_safety_nets(&scan_session, &hit.snippet, locale_chain)
+                .map_err(|_| DenyReason::TranslatorFailed)?;
+            if scan.nets_run == 0 {
+                return Err(DenyReason::TranslatorFailed);
+            }
+            if scan.report.stats.suspect_count == 0 {
+                safe_results.push(hit);
+            }
+        }
+
+        Ok(safe_results)
     }
 }
 

--- a/crates/gaze-token-bridge/src/ingest.rs
+++ b/crates/gaze-token-bridge/src/ingest.rs
@@ -6,7 +6,10 @@
 
 use std::ops::Range;
 
-use gaze::{CleanDocument, EmittedTokenSpan, LocaleTag, Pipeline, RawDocument, Scope, Session};
+use gaze::{
+    CleanDocument, DictionaryBundle, EmittedTokenSpan, LocaleTag, Pipeline, RawDocument,
+    SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope, Session,
+};
 
 use crate::adapter::CorpusIndexStore;
 use crate::error::BridgeError;
@@ -25,6 +28,8 @@ pub struct CorpusIngestor<'a> {
     domain: &'a IndexDomain,
     projector: &'a dyn DomainProjector,
     locale_chain: Vec<LocaleTag>,
+    safety_net_policy: SafetyNetPolicy,
+    reject_safety_net_suspects: bool,
 }
 
 impl<'a> CorpusIngestor<'a> {
@@ -47,7 +52,19 @@ impl<'a> CorpusIngestor<'a> {
             domain,
             projector,
             locale_chain,
+            safety_net_policy: SafetyNetPolicy::new(
+                SafetyNetMode::Strict,
+                SafetyNetFallback::Redact,
+            ),
+            reject_safety_net_suspects: true,
         }
+    }
+
+    pub fn with_safety_net_resolution(mut self) -> Self {
+        self.safety_net_policy =
+            SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Strict);
+        self.reject_safety_net_suspects = false;
+        self
     }
 
     pub fn ingest_text(
@@ -66,14 +83,16 @@ impl<'a> CorpusIngestor<'a> {
         };
         let (clean_doc, spans, leak_report) = self
             .pipeline
-            .clean_with_safety_net(
+            .clean_with_safety_net_policy_detect_context(
                 &session,
                 RawDocument::Text(raw_text.to_string()),
                 locale_chain,
+                &DictionaryBundle::default(),
+                self.safety_net_policy,
             )
             .map_err(|err| BridgeError::Session(format!("failed to clean corpus text: {err}")))?;
 
-        if leak_report.stats.suspect_count > 0 {
+        if self.reject_safety_net_suspects && leak_report.stats.suspect_count > 0 {
             return Err(BridgeError::Session(format!(
                 "safety net reported {} possible ingest leak(s)",
                 leak_report.stats.suspect_count

--- a/crates/gaze-token-bridge/tests/track_c_bridge.rs
+++ b/crates/gaze-token-bridge/tests/track_c_bridge.rs
@@ -7,7 +7,9 @@
 //! `&BridgeRequest`, `audit()` slice). One extra test covers the filter-field allowlist
 //! hardening the bridge adds over the spike.
 
-use gaze::PiiClass;
+use gaze::{
+    LeakSuspect, LocaleTag, PiiClass, Pipeline, SafetyNet, SafetyNetContext, SafetyNetError,
+};
 use gaze_token_bridge::bridge::TokenBridge;
 use gaze_token_bridge::model::{IndexEntity, IndexSearchHit, IndexedEntityRef};
 use gaze_token_bridge::traits::ResponseTranslator;
@@ -21,6 +23,35 @@ use gaze_token_bridge::{
 const POLICY_JSON: &str = include_str!("../fixtures/policy.json");
 const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
 const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
+
+#[derive(Debug)]
+struct NoopOutputSafetyNet;
+
+impl SafetyNet for NoopOutputSafetyNet {
+    fn id(&self) -> &str {
+        "test-noop-output-safety-net"
+    }
+
+    fn supported_locales(&self) -> &[LocaleTag] {
+        &[LocaleTag::Global]
+    }
+
+    fn check(
+        &self,
+        _clean_text: &str,
+        _context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        Ok(Vec::new())
+    }
+}
+
+fn with_test_output_safety(bridge: TokenBridge) -> TokenBridge {
+    let pipeline = Pipeline::builder()
+        .register_safety_net(NoopOutputSafetyNet)
+        .build()
+        .expect("test output safety pipeline");
+    bridge.with_output_safety_net(pipeline, vec![LocaleTag::Global])
+}
 
 fn support_principal() -> Principal {
     Principal {
@@ -47,7 +78,7 @@ fn bridge_and_session() -> (TokenBridge, RedactionSession, String) {
 }
 
 fn bridge_and_session_for(principal: &Principal) -> (TokenBridge, RedactionSession, String) {
-    let bridge = TokenBridge::demo().unwrap();
+    let bridge = with_test_output_safety(TokenBridge::demo().unwrap());
     let session = RedactionSession::ephemeral_for(&principal.id).unwrap();
     let token = session
         .tokenize(&PiiClass::Name, "Markus Gottschaue")
@@ -81,7 +112,7 @@ fn cross_domain_bridge_and_session() -> (TokenBridge, RedactionSession, String) 
     }));
     let policy = serde_json::to_string(&policy).expect("augmented policy serializes");
 
-    let bridge = TokenBridge::from_policy_json(&policy).unwrap();
+    let bridge = with_test_output_safety(TokenBridge::from_policy_json(&policy).unwrap());
     let session = RedactionSession::ephemeral_for(&admin_principal().id).unwrap();
     let token = session
         .tokenize(&PiiClass::Name, "Markus Gottschaue")
@@ -582,7 +613,9 @@ fn low_rate_limit_customer_bridge(max_entities_per_window: usize) -> TokenBridge
     support_rule["max_entities_per_window"] = serde_json::json!(max_entities_per_window);
     support_rule["rate_limit_window_seconds"] = serde_json::json!(3600);
     let policy = serde_json::to_string(&policy).expect("rate-limited policy serializes");
-    TokenBridge::from_policy_json(&policy).expect("rate-limited bridge builds")
+    with_test_output_safety(
+        TokenBridge::from_policy_json(&policy).expect("rate-limited bridge builds"),
+    )
 }
 
 /// Regression for blocker #1564: the per-principal rate-limit bucket MUST accumulate across

--- a/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
+++ b/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
@@ -13,7 +13,9 @@
 
 use std::collections::HashMap;
 
-use gaze::PiiClass;
+use gaze::{
+    LeakSuspect, LocaleTag, PiiClass, Pipeline, SafetyNet, SafetyNetContext, SafetyNetError,
+};
 use gaze_token_bridge::bridge::{SearchDocumentsTool, TokenBridge};
 use gaze_token_bridge::Principal;
 use serde_json::{json, Value};
@@ -22,6 +24,35 @@ const POLICY_JSON: &str = include_str!("../fixtures/policy.json");
 const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
 const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
 const SUPPORT_ID: &str = "principal_support_1";
+
+#[derive(Debug)]
+struct NoopOutputSafetyNet;
+
+impl SafetyNet for NoopOutputSafetyNet {
+    fn id(&self) -> &str {
+        "test-noop-output-safety-net"
+    }
+
+    fn supported_locales(&self) -> &[LocaleTag] {
+        &[LocaleTag::Global]
+    }
+
+    fn check(
+        &self,
+        _clean_text: &str,
+        _context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        Ok(Vec::new())
+    }
+}
+
+fn with_test_output_safety(bridge: TokenBridge) -> TokenBridge {
+    let pipeline = Pipeline::builder()
+        .register_safety_net(NoopOutputSafetyNet)
+        .build()
+        .expect("test output safety pipeline");
+    bridge.with_output_safety_net(pipeline, vec![LocaleTag::Global])
+}
 
 fn support_principal() -> Principal {
     Principal {
@@ -55,7 +86,10 @@ fn search_documents_policy() -> String {
 }
 
 fn demo_bridge() -> TokenBridge {
-    TokenBridge::from_policy_json(&search_documents_policy()).expect("bridge builds from policy")
+    with_test_output_safety(
+        TokenBridge::from_policy_json(&search_documents_policy())
+            .expect("bridge builds from policy"),
+    )
 }
 
 /// A tool wired with the support principal over the search_documents-keyed bridge.


### PR DESCRIPTION
## Summary

- Requires the Kiji safety-net backend for `gaze index` and runs it during ingest in resolve/strict mode so prose names/orgs are tokenized instead of rejected or silently missed.
- Adds a mandatory bridge output SafetyNet pass over every translated agent-visible search snippet; residual suspects are withheld and scanner absence/unavailability fails closed.
- Propagates SafetyNet failures through the CLI instead of returning `no hits`, and keeps bridge tests explicit about their output scanner.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p gaze-cli --features index --test index_cli`
- `cargo test -p gaze-token-bridge`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --exclude gaze-cli`
- `cargo run -p xtask -- ci-feature-matrix`

## Notes

No frozen model/traits/util/session/error contracts were changed. Kiji `ORG` spans currently flow through the existing safety-net class map as `Name` because the frozen shared SafetyNet class contract has no Organization variant; the leak is still closed by tokenization/withholding, but org-class preservation would need a separately approved contract change.

Resolves solo todo #1577.
