### PR TITLE
feat(gaze-mcp-bridge): optional policy-gated MCP bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,12 +268,27 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -435,6 +460,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -442,6 +478,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -483,6 +532,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -703,6 +763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1347,6 +1408,7 @@ dependencies = [
  "gaze-assembly",
  "gaze-audit",
  "gaze-document",
+ "gaze-mcp-bridge",
  "gaze-mcp-core",
  "gaze-mcp-rmcp",
  "gaze-pii",
@@ -1386,6 +1448,34 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "gaze-mcp-bridge"
+version = "0.10.1"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chacha20poly1305",
+ "gaze-assembly",
+ "gaze-mcp-core",
+ "gaze-mcp-rmcp",
+ "gaze-pii",
+ "gaze-types",
+ "hex",
+ "proptest",
+ "rand 0.8.6",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "toml 0.8.23",
+ "tracing",
+ "ulid",
 ]
 
 [[package]]
@@ -2207,6 +2297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,6 +2701,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2875,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "option-ext"
@@ -2972,6 +3089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3207,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.10",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3318,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3270,7 +3437,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -3337,6 +3504,15 @@ checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3560,6 +3736,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rand 0.10.1",
  "rmcp-macros",
  "schemars",
@@ -3685,6 +3862,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4636,7 +4825,7 @@ checksum = "c9563b458fc5cdb01121f59b6218e470ce8b8b84d1f387e3aa2ea0ef2c18d053"
 dependencies = [
  "anyhow",
  "anymap3",
- "bit-set",
+ "bit-set 0.10.0",
  "derive-new",
  "downcast-rs",
  "dyn-clone",
@@ -4882,6 +5071,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4922,6 +5117,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -5255,6 +5460,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,6 +5491,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5294,6 +5531,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -5345,6 +5592,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/gaze-types",
     "crates/gaze-cli",
     "crates/gaze-document",
+    "crates/gaze-mcp-bridge",
     "crates/gaze-mcp-core",
     "crates/gaze-mcp-rmcp",
     "crates/gaze-proxy",
@@ -21,8 +22,13 @@ license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
 gaze-audit = { path = "crates/gaze-audit", version = "0.10.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.10.1" }
+gaze = { path = "crates/gaze", version = "0.10.1", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.10.1" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.10.1" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.10.1" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.10.1" }
 gaze-proxy = { path = "crates/gaze-proxy", version = "0.10.1" }
+gaze-types = { path = "crates/gaze-types", version = "0.10.1" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -25,6 +25,7 @@ document = ["dep:gaze-document"]
 mcp = [
     "dep:async-trait",
     "dep:directories-next",
+    "dep:gaze-mcp-bridge",
     "dep:gaze-mcp-core",
     "dep:gaze-mcp-rmcp",
     "dep:pdfium-render",
@@ -48,6 +49,7 @@ gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
 gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
 gaze-audit = { workspace = true }
 gaze-document = { path = "../gaze-document", version = "0.10.1", optional = true }
+gaze-mcp-bridge = { workspace = true, optional = true }
 gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1", optional = true }
 gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.1", optional = true }
 gaze-proxy = { workspace = true, optional = true }

--- a/crates/gaze-cli/src/commands/mcp/bridge.rs
+++ b/crates/gaze-cli/src/commands/mcp/bridge.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use gaze_mcp_bridge::{BridgeConfig, BridgeHost, FileBridgeAuditSink};
+use gaze_mcp_core::{Frontend, ShutdownToken};
+use gaze_mcp_rmcp::{FixedPrincipalResolver, RmcpFrontend};
+
+use crate::error::CliError;
+
+use super::serve::default_manifest_dir;
+use super::BridgeArgs;
+
+pub(crate) fn run(args: BridgeArgs) -> Result<(), CliError> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| CliError::McpDetail(format!("tokio runtime init failed: {err}")))?;
+    runtime.block_on(run_async(args))
+}
+
+async fn run_async(args: BridgeArgs) -> Result<(), CliError> {
+    let mut config = BridgeConfig::from_path(&args.config)
+        .map_err(|err| CliError::McpDetail(err.to_string()))?;
+    if let Some(session_dir) = args.session_dir {
+        config.session.dir = Some(session_dir);
+        config
+            .validate()
+            .map_err(|err| CliError::McpDetail(err.to_string()))?;
+    }
+
+    let audit = Arc::new(FileBridgeAuditSink::new(
+        default_manifest_dir().join("bridge-audit.jsonl"),
+    ));
+    let host = BridgeHost::from_config(config, audit)
+        .await
+        .map_err(|err| CliError::McpDetail(err.to_string()))?;
+
+    if args.dry_run || args.print_tools {
+        for row in host.registry().print_surface() {
+            println!("{row}");
+        }
+        if args.dry_run {
+            println!("policy loaded fail-closed");
+        }
+        return Ok(());
+    }
+
+    let frontend = RmcpFrontend::stdio(Arc::new(FixedPrincipalResolver::agent("gaze-cli")));
+    frontend
+        .serve(Arc::new(host), ShutdownToken::new())
+        .await
+        .map_err(|err| CliError::McpDetail(format!("mcp bridge stdio server failed: {err}")))
+}

--- a/crates/gaze-cli/src/commands/mcp/mod.rs
+++ b/crates/gaze-cli/src/commands/mcp/mod.rs
@@ -1,3 +1,4 @@
+mod bridge;
 mod doctor;
 mod install;
 mod serve;
@@ -37,6 +38,14 @@ pub(crate) struct ServeArgs {
     pub max_file_size: Option<u64>,
 }
 
+#[derive(Debug)]
+pub(crate) struct BridgeArgs {
+    pub config: PathBuf,
+    pub session_dir: Option<PathBuf>,
+    pub dry_run: bool,
+    pub print_tools: bool,
+}
+
 pub(crate) fn install(args: InstallArgs) -> Result<(), CliError> {
     install::run(args)
 }
@@ -47,6 +56,10 @@ pub(crate) fn doctor(args: DoctorArgs) -> Result<(), CliError> {
 
 pub(crate) fn serve(args: ServeArgs) -> Result<(), CliError> {
     serve::run(args)
+}
+
+pub(crate) fn bridge(args: BridgeArgs) -> Result<(), CliError> {
+    bridge::run(args)
 }
 
 #[allow(dead_code)]

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -325,6 +325,21 @@ enum McpCmd {
         #[arg(long)]
         max_file_size: Option<u64>,
     },
+    /// Run the policy-gated MCP bridge over stdio.
+    Bridge {
+        /// Bridge TOML configuration.
+        #[arg(long)]
+        config: PathBuf,
+        /// Override [session].dir from the config.
+        #[arg(long)]
+        session_dir: Option<PathBuf>,
+        /// Load config and discover downstream surface without serving.
+        #[arg(long)]
+        dry_run: bool,
+        /// Print namespaced downstream tools and denied resource/prompt counts.
+        #[arg(long)]
+        print_tools: bool,
+    },
 }
 
 #[cfg(feature = "proxy")]
@@ -901,6 +916,17 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             } => mcp::serve(mcp::ServeArgs {
                 manifest_dir,
                 max_file_size,
+            }),
+            McpCmd::Bridge {
+                config,
+                session_dir,
+                dry_run,
+                print_tools,
+            } => mcp::bridge(mcp::BridgeArgs {
+                config,
+                session_dir,
+                dry_run,
+                print_tools,
             }),
         },
         #[cfg(feature = "proxy")]

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "gaze-mcp-bridge"
+version = "0.10.1"
+edition = "2021"
+rust-version = "1.89"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Policy-gated MCP bridge for Gaze pseudonymization sessions"
+readme = "README.md"
+keywords = ["pii", "mcp", "bridge", "pseudonymization"]
+categories = ["text-processing"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+async-trait = "0.1"
+base64 = "0.22"
+chacha20poly1305 = { version = "0.10", features = ["std"] }
+gaze = { workspace = true }
+gaze-assembly = { workspace = true }
+gaze-mcp-core = { workspace = true }
+gaze-mcp-rmcp = { workspace = true }
+gaze-types = { workspace = true }
+hex = "0.4"
+rand = "0.8"
+rmcp = { version = "1.6.0", features = ["client", "transport-child-process"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+tokio = { version = "1", features = ["fs", "io-util", "process", "sync", "time"] }
+tokio-util = "0.7"
+toml = "0.8"
+tracing = "0.1"
+ulid = "1"
+
+[dev-dependencies]
+proptest = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,0 +1,7 @@
+# gaze-mcp-bridge
+
+`gaze-mcp-bridge = "0.10.1"` is the optional policy-gated MCP bridge for Gaze.
+
+The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
+downstream MCP tools receive restored PII only for explicitly allowed argument
+fields, and downstream results are redacted before returning to the agent.

--- a/crates/gaze-mcp-bridge/src/approval.rs
+++ b/crates/gaze-mcp-bridge/src/approval.rs
@@ -1,0 +1,98 @@
+use std::collections::BTreeSet;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::audit::ArgPath;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApprovalRequest {
+    pub call_id: String,
+    pub session_id: String,
+    pub redacted_arg_sha256: String,
+    pub token_classes: BTreeSet<String>,
+    pub token_list_sha256: String,
+    pub downstream_tool: String,
+    pub discovery_hash: String,
+    pub reason: String,
+    pub arg_paths: Vec<ArgPath>,
+}
+
+impl ApprovalRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        call_id: impl Into<String>,
+        session_id: impl Into<String>,
+        redacted_args: &serde_json::Value,
+        token_classes: BTreeSet<String>,
+        tokens: &[String],
+        downstream_tool: impl Into<String>,
+        discovery_hash: impl Into<String>,
+        reason: impl Into<String>,
+        arg_paths: Vec<ArgPath>,
+    ) -> Self {
+        Self {
+            call_id: call_id.into(),
+            session_id: session_id.into(),
+            redacted_arg_sha256: json_sha256(redacted_args),
+            token_classes,
+            token_list_sha256: string_list_sha256(tokens),
+            downstream_tool: downstream_tool.into(),
+            discovery_hash: discovery_hash.into(),
+            reason: reason.into(),
+            arg_paths,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    Granted,
+    Denied,
+    Pending,
+}
+
+#[async_trait]
+pub trait ApprovalHook: Send + Sync {
+    async fn decide(&self, request: &ApprovalRequest) -> ApprovalDecision;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyApprovalHook;
+
+#[async_trait]
+impl ApprovalHook for DenyApprovalHook {
+    async fn decide(&self, _request: &ApprovalRequest) -> ApprovalDecision {
+        ApprovalDecision::Pending
+    }
+}
+
+fn json_sha256(value: &serde_json::Value) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    sha256_hex(&bytes)
+}
+
+fn string_list_sha256(values: &[String]) -> String {
+    let mut sorted = values.to_vec();
+    sorted.sort();
+    sha256_hex(sorted.join("\n").as_bytes())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AllowApprovalHook;
+
+#[cfg(test)]
+#[async_trait]
+impl ApprovalHook for AllowApprovalHook {
+    async fn decide(&self, _request: &ApprovalRequest) -> ApprovalDecision {
+        ApprovalDecision::Granted
+    }
+}

--- a/crates/gaze-mcp-bridge/src/audit.rs
+++ b/crates/gaze-mcp-bridge/src/audit.rs
@@ -142,7 +142,10 @@ impl BridgeAuditSink for FileBridgeAuditSink {
             .map_err(|err| BridgeError::Audit(format!("write audit failed: {err}")))?;
         file.flush()
             .await
-            .map_err(|err| BridgeError::Audit(format!("flush audit failed: {err}")))
+            .map_err(|err| BridgeError::Audit(format!("flush audit failed: {err}")))?;
+        file.sync_all()
+            .await
+            .map_err(|err| BridgeError::Audit(format!("sync audit failed: {err}")))
     }
 }
 

--- a/crates/gaze-mcp-bridge/src/audit.rs
+++ b/crates/gaze-mcp-bridge/src/audit.rs
@@ -1,0 +1,159 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+
+use crate::error::{BridgeError, BridgeResult};
+use crate::policy::DecisionOutcome;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ArgPath(String);
+
+impl ArgPath {
+    pub fn root() -> Self {
+        Self("$".to_string())
+    }
+
+    pub fn child(&self, segment: impl AsRef<str>) -> BridgeResult<Self> {
+        path_child(&self.0, segment.as_ref()).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ResultPath(String);
+
+impl ResultPath {
+    pub fn root() -> Self {
+        Self("$".to_string())
+    }
+
+    pub fn child(&self, segment: impl AsRef<str>) -> BridgeResult<Self> {
+        path_child(&self.0, segment.as_ref()).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn path_child(base: &str, segment: &str) -> BridgeResult<String> {
+    if base.is_empty() || !base.starts_with('$') {
+        return Err(BridgeError::Audit("invalid audit path base".to_string()));
+    }
+    if segment.is_empty()
+        || segment.len() > 128
+        || !segment
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'[' | b']'))
+    {
+        return Err(BridgeError::Audit(
+            "invalid audit path segment rejected".to_string(),
+        ));
+    }
+    Ok(format!("{base}.{segment}"))
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BridgeAuditEvent {
+    pub ts_unix_ms: u128,
+    pub upstream_request_id: String,
+    pub session_id_hash: String,
+    pub server: String,
+    pub tool: String,
+    pub arg_paths_affected: Vec<ArgPath>,
+    pub result_paths_affected: Vec<ResultPath>,
+    pub decision: String,
+    pub outcome: DecisionOutcome,
+    pub deciding_rule: String,
+}
+
+impl BridgeAuditEvent {
+    pub fn new(
+        upstream_request_id: String,
+        session_id: &str,
+        server: String,
+        tool: String,
+        outcome: DecisionOutcome,
+        deciding_rule: impl Into<String>,
+    ) -> Self {
+        Self {
+            ts_unix_ms: unix_ms(SystemTime::now()),
+            upstream_request_id,
+            session_id_hash: sha256_hex(session_id.as_bytes()),
+            server,
+            tool,
+            arg_paths_affected: Vec::new(),
+            result_paths_affected: Vec::new(),
+            decision: format!("{outcome:?}"),
+            outcome,
+            deciding_rule: deciding_rule.into(),
+        }
+    }
+}
+
+#[async_trait]
+pub trait BridgeAuditSink: Send + Sync {
+    async fn record(&self, event: &BridgeAuditEvent) -> BridgeResult<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FileBridgeAuditSink {
+    path: PathBuf,
+}
+
+impl FileBridgeAuditSink {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait]
+impl BridgeAuditSink for FileBridgeAuditSink {
+    async fn record(&self, event: &BridgeAuditEvent) -> BridgeResult<()> {
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|err| BridgeError::Audit(format!("create audit dir failed: {err}")))?;
+        }
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await
+            .map_err(|err| BridgeError::Audit(format!("open audit sink failed: {err}")))?;
+        let mut line = serde_json::to_vec(event)
+            .map_err(|err| BridgeError::Audit(format!("serialize audit failed: {err}")))?;
+        line.push(b'\n');
+        file.write_all(&line)
+            .await
+            .map_err(|err| BridgeError::Audit(format!("write audit failed: {err}")))?;
+        file.flush()
+            .await
+            .map_err(|err| BridgeError::Audit(format!("flush audit failed: {err}")))
+    }
+}
+
+fn unix_ms(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}

--- a/crates/gaze-mcp-bridge/src/bridge.rs
+++ b/crates/gaze-mcp-bridge/src/bridge.rs
@@ -169,9 +169,7 @@ impl BridgeHost {
                 message,
                 data,
             )?,
-            Err(DownstreamError::Service(message)) => {
-                return Err(BridgeError::Downstream(message));
-            }
+            Err(DownstreamError::Service(_)) => process_downstream_service_error()?,
         };
 
         self.session_store
@@ -615,6 +613,19 @@ fn process_downstream_error(
             }
         })),
         result_paths,
+    })
+}
+
+fn process_downstream_service_error() -> BridgeResult<IngressResult> {
+    Ok(IngressResult {
+        response: ToolResponse::json(serde_json::json!({
+            "isError": true,
+            "error": {
+                "message": "downstream service error",
+                "data": null,
+            }
+        })),
+        result_paths: vec![ResultPath::root().child("error")?.child("message")?],
     })
 }
 

--- a/crates/gaze-mcp-bridge/src/bridge.rs
+++ b/crates/gaze-mcp-bridge/src/bridge.rs
@@ -1,0 +1,766 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use gaze::{CleanDocument, RawDocument};
+use gaze_assembly::CorePipelineConfig;
+use gaze_mcp_core::{
+    AuthHook, DenyAllAuthHook, DispatchError, DispatchHost, Principal, SessionIdError,
+    SessionIdPolicy, ToolDescriptor, ToolResponse,
+};
+use rmcp::model::{CallToolResult, RawContent};
+use ulid::Ulid;
+
+use crate::approval::{ApprovalDecision, ApprovalHook, ApprovalRequest, DenyApprovalHook};
+use crate::audit::{ArgPath, BridgeAuditEvent, BridgeAuditSink, ResultPath};
+use crate::client::{DownstreamClient, DownstreamError, RmcpChildClient};
+use crate::config::BridgeConfig;
+use crate::error::{BridgeError, BridgeResult};
+use crate::policy::{DecisionOutcome, ResolvedToolPolicy, ResultMode};
+use crate::registry::{BridgeRegistry, NamespacedTool};
+use crate::session_store::BridgeSessionStore;
+
+pub struct BridgeHost {
+    registry: Arc<BridgeRegistry>,
+    auth: Arc<dyn AuthHook>,
+    approval: Arc<dyn ApprovalHook>,
+    audit: Arc<dyn BridgeAuditSink>,
+    session_store: Arc<BridgeSessionStore>,
+    pipeline: gaze::Pipeline,
+    locale_chain: Vec<gaze::LocaleTag>,
+    session_id_policy: SessionIdPolicy,
+    policy: crate::policy::PolicyConfig,
+    limits: crate::config::LimitCfg,
+}
+
+impl BridgeHost {
+    pub async fn from_config(
+        config: BridgeConfig,
+        audit: Arc<dyn BridgeAuditSink>,
+    ) -> BridgeResult<Self> {
+        let mut clients = BTreeMap::<String, Arc<dyn DownstreamClient>>::new();
+        for (name, server) in &config.servers {
+            clients.insert(name.clone(), RmcpChildClient::spawn(server).await?);
+        }
+        let registry =
+            Arc::new(BridgeRegistry::discover(clients, config.limits.call_timeout()).await?);
+        let session_store = Arc::new(BridgeSessionStore::from_config(&config.session)?);
+        let core = CorePipelineConfig::new()
+            .build()
+            .map_err(|err| BridgeError::Config(format!("core pipeline build failed: {err}")))?;
+        let locale_chain = core.locale_chain().as_slice().to_vec();
+        Ok(BridgeHostBuilder::new(registry, session_store, audit)
+            .pipeline(core.into_pipeline(), locale_chain)
+            .policy(config.policy)
+            .limits(config.limits)
+            .build())
+    }
+
+    pub fn registry(&self) -> &BridgeRegistry {
+        &self.registry
+    }
+
+    async fn dispatch_inner(
+        &self,
+        principal: &Principal,
+        tool_name: &str,
+        raw_args: serde_json::Value,
+        external_session_id: Option<&str>,
+    ) -> BridgeResult<ToolResponse> {
+        let session_id = external_session_id.ok_or(SessionIdError::Empty)?;
+        self.session_id_policy.validate(session_id)?;
+        self.auth.authorize_agent(principal, tool_name).await?;
+
+        let tool = self
+            .registry
+            .get(tool_name)
+            .ok_or_else(|| BridgeError::UnknownTool(tool_name.to_string()))?;
+        let resolved_policy =
+            self.policy
+                .resolve(&tool.server, &tool.namespaced_name, &tool.sanitized_tool);
+
+        let call_id = Ulid::new().to_string();
+        let shared_session = self.session_store.get(session_id).await?;
+        let session_guard = shared_session.lock().await;
+
+        let egress = process_egress(
+            &self.pipeline,
+            &self.locale_chain,
+            &session_guard,
+            &resolved_policy,
+            &raw_args,
+        )?;
+        if let Some(blocked) = egress.blocked_response.clone() {
+            self.record_audit(AuditRecord {
+                call_id: &call_id,
+                session_id,
+                tool,
+                arg_paths: egress.arg_paths.clone(),
+                result_paths: Vec::new(),
+                outcome: DecisionOutcome::Blocked,
+                deciding_rule: egress.deciding_rule.clone(),
+            })
+            .await?;
+            return Ok(blocked);
+        }
+
+        if egress.requires_approval {
+            let approval_request = ApprovalRequest::new(
+                call_id.clone(),
+                session_id.to_string(),
+                &raw_args,
+                egress.token_classes.clone(),
+                &egress.tokens,
+                tool.namespaced_name.clone(),
+                tool.discovery_hash.clone(),
+                "sensitive token restore requires approval",
+                egress.arg_paths.clone(),
+            );
+            match self.approval.decide(&approval_request).await {
+                ApprovalDecision::Granted => {}
+                ApprovalDecision::Denied | ApprovalDecision::Pending => {
+                    self.record_audit(AuditRecord {
+                        call_id: &call_id,
+                        session_id,
+                        tool,
+                        arg_paths: egress.arg_paths.clone(),
+                        result_paths: Vec::new(),
+                        outcome: DecisionOutcome::RequiresApproval,
+                        deciding_rule: "approval.required".to_string(),
+                    })
+                    .await?;
+                    return Ok(approval_required_response(&approval_request));
+                }
+            }
+        }
+
+        self.record_audit(AuditRecord {
+            call_id: &call_id,
+            session_id,
+            tool,
+            arg_paths: egress.arg_paths.clone(),
+            result_paths: Vec::new(),
+            outcome: DecisionOutcome::Allowed,
+            deciding_rule: egress.deciding_rule.clone(),
+        })
+        .await?;
+
+        let downstream_result = tool
+            .client
+            .call_tool(
+                &tool.raw_tool,
+                egress.restored_args,
+                self.limits.call_timeout(),
+            )
+            .await;
+        let processed = match downstream_result {
+            Ok(result) => process_ingress(
+                &self.pipeline,
+                &self.locale_chain,
+                &session_guard,
+                &resolved_policy,
+                &self.limits,
+                result,
+            )?,
+            Err(DownstreamError::Mcp { message, data }) => process_downstream_error(
+                &self.pipeline,
+                &self.locale_chain,
+                &session_guard,
+                message,
+                data,
+            )?,
+            Err(DownstreamError::Service(message)) => {
+                return Err(BridgeError::Downstream(message));
+            }
+        };
+
+        self.session_store
+            .persist(session_id, &session_guard)
+            .await?;
+        self.record_audit(AuditRecord {
+            call_id: &call_id,
+            session_id,
+            tool,
+            arg_paths: Vec::new(),
+            result_paths: processed.result_paths,
+            outcome: DecisionOutcome::Allowed,
+            deciding_rule: "ingress.processed".to_string(),
+        })
+        .await?;
+        Ok(processed.response)
+    }
+
+    async fn record_audit(&self, record: AuditRecord<'_>) -> BridgeResult<()> {
+        let mut event = BridgeAuditEvent::new(
+            record.call_id.to_string(),
+            record.session_id,
+            record.tool.server.clone(),
+            record.tool.sanitized_tool.clone(),
+            record.outcome,
+            record.deciding_rule,
+        );
+        event.arg_paths_affected = record.arg_paths;
+        event.result_paths_affected = record.result_paths;
+        self.audit.record(&event).await
+    }
+}
+
+struct AuditRecord<'a> {
+    call_id: &'a str,
+    session_id: &'a str,
+    tool: &'a NamespacedTool,
+    arg_paths: Vec<ArgPath>,
+    result_paths: Vec<ResultPath>,
+    outcome: DecisionOutcome,
+    deciding_rule: String,
+}
+
+#[async_trait]
+impl DispatchHost for BridgeHost {
+    async fn dispatch(
+        &self,
+        principal: &Principal,
+        tool_name: &str,
+        raw_args: serde_json::Value,
+        external_session_id: Option<&str>,
+    ) -> Result<ToolResponse, DispatchError> {
+        self.dispatch_inner(principal, tool_name, raw_args, external_session_id)
+            .await
+            .map_err(BridgeError::into_dispatch)
+    }
+
+    fn list_tools(&self) -> Vec<ToolDescriptor> {
+        self.registry.list_descriptors()
+    }
+}
+
+pub struct BridgeHostBuilder {
+    registry: Arc<BridgeRegistry>,
+    session_store: Arc<BridgeSessionStore>,
+    audit: Arc<dyn BridgeAuditSink>,
+    auth: Arc<dyn AuthHook>,
+    approval: Arc<dyn ApprovalHook>,
+    pipeline: Option<(gaze::Pipeline, Vec<gaze::LocaleTag>)>,
+    session_id_policy: SessionIdPolicy,
+    policy: crate::policy::PolicyConfig,
+    limits: crate::config::LimitCfg,
+}
+
+impl BridgeHostBuilder {
+    pub fn new(
+        registry: Arc<BridgeRegistry>,
+        session_store: Arc<BridgeSessionStore>,
+        audit: Arc<dyn BridgeAuditSink>,
+    ) -> Self {
+        Self {
+            registry,
+            session_store,
+            audit,
+            auth: Arc::new(DenyAllAuthHook),
+            approval: Arc::new(DenyApprovalHook),
+            pipeline: None,
+            session_id_policy: SessionIdPolicy::default_strict(),
+            policy: crate::policy::PolicyConfig::default(),
+            limits: crate::config::LimitCfg::default(),
+        }
+    }
+
+    pub fn auth(mut self, auth: Arc<dyn AuthHook>) -> Self {
+        self.auth = auth;
+        self
+    }
+
+    pub fn approval(mut self, approval: Arc<dyn ApprovalHook>) -> Self {
+        self.approval = approval;
+        self
+    }
+
+    pub fn pipeline(
+        mut self,
+        pipeline: gaze::Pipeline,
+        locale_chain: Vec<gaze::LocaleTag>,
+    ) -> Self {
+        self.pipeline = Some((pipeline, locale_chain));
+        self
+    }
+
+    pub fn session_id_policy(mut self, policy: SessionIdPolicy) -> Self {
+        self.session_id_policy = policy;
+        self
+    }
+
+    pub fn policy(mut self, policy: crate::policy::PolicyConfig) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    pub fn limits(mut self, limits: crate::config::LimitCfg) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub fn build(self) -> BridgeHost {
+        let (pipeline, locale_chain) = self.pipeline.unwrap_or_else(default_pipeline);
+        BridgeHost {
+            registry: self.registry,
+            auth: self.auth,
+            approval: self.approval,
+            audit: self.audit,
+            session_store: self.session_store,
+            pipeline,
+            locale_chain,
+            session_id_policy: self.session_id_policy,
+            policy: self.policy,
+            limits: self.limits,
+        }
+    }
+}
+
+fn default_pipeline() -> (gaze::Pipeline, Vec<gaze::LocaleTag>) {
+    let core = CorePipelineConfig::new()
+        .build()
+        .expect("bundled core pipeline should build");
+    let locale_chain = core.locale_chain().as_slice().to_vec();
+    (core.into_pipeline(), locale_chain)
+}
+
+#[derive(Clone)]
+struct EgressResult {
+    restored_args: serde_json::Value,
+    arg_paths: Vec<ArgPath>,
+    tokens: Vec<String>,
+    token_classes: BTreeSet<String>,
+    requires_approval: bool,
+    blocked_response: Option<ToolResponse>,
+    deciding_rule: String,
+}
+
+fn process_egress(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    policy: &ResolvedToolPolicy,
+    raw_args: &serde_json::Value,
+) -> BridgeResult<EgressResult> {
+    let mut state = EgressState {
+        pipeline,
+        locale_chain,
+        session,
+        policy,
+        arg_paths: Vec::new(),
+        tokens: Vec::new(),
+        token_classes: BTreeSet::new(),
+        requires_approval: false,
+        blocked_response: None,
+        deciding_rule: "egress.allowed".to_string(),
+    };
+    let restored_args = state.walk(raw_args, &ArgPath::root())?;
+    Ok(EgressResult {
+        restored_args,
+        arg_paths: state.arg_paths,
+        tokens: state.tokens,
+        token_classes: state.token_classes,
+        requires_approval: state.requires_approval,
+        blocked_response: state.blocked_response,
+        deciding_rule: state.deciding_rule,
+    })
+}
+
+struct EgressState<'a> {
+    pipeline: &'a gaze::Pipeline,
+    locale_chain: &'a [gaze::LocaleTag],
+    session: &'a gaze::Session,
+    policy: &'a ResolvedToolPolicy,
+    arg_paths: Vec<ArgPath>,
+    tokens: Vec<String>,
+    token_classes: BTreeSet<String>,
+    requires_approval: bool,
+    blocked_response: Option<ToolResponse>,
+    deciding_rule: String,
+}
+
+impl EgressState<'_> {
+    fn walk(
+        &mut self,
+        value: &serde_json::Value,
+        path: &ArgPath,
+    ) -> BridgeResult<serde_json::Value> {
+        if self.blocked_response.is_some() {
+            return Ok(value.clone());
+        }
+        match value {
+            serde_json::Value::String(text) => self.process_string(text, path),
+            serde_json::Value::Array(items) => {
+                let mut out = Vec::with_capacity(items.len());
+                for (idx, item) in items.iter().enumerate() {
+                    out.push(self.walk(item, &path.child(format!("[{idx}]"))?)?);
+                }
+                Ok(serde_json::Value::Array(out))
+            }
+            serde_json::Value::Object(map) => {
+                let mut out = serde_json::Map::with_capacity(map.len());
+                for (key, item) in map {
+                    out.insert(key.clone(), self.walk(item, &path.child(key)?)?);
+                }
+                Ok(serde_json::Value::Object(out))
+            }
+            other => Ok(other.clone()),
+        }
+    }
+
+    fn process_string(&mut self, text: &str, path: &ArgPath) -> BridgeResult<serde_json::Value> {
+        let field_policy = self.policy.argument_policy(path.as_str());
+        if contains_raw_pii(self.pipeline, self.locale_chain, text)? {
+            self.arg_paths.push(path.clone());
+            self.deciding_rule = "egress.raw_pii".to_string();
+            self.blocked_response = Some(blocked_response("raw_pii_in_args", "egress.raw_pii"));
+            return Ok(serde_json::Value::String(text.to_string()));
+        }
+
+        let matches = gaze::token_shape::find_tokens(text)
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if matches.is_empty() {
+            return Ok(serde_json::Value::String(text.to_string()));
+        }
+        self.arg_paths.push(path.clone());
+        if !field_policy.allow_sensitive_fields {
+            self.deciding_rule = "egress.token_not_allowed".to_string();
+            self.blocked_response = Some(blocked_response(
+                "sensitive_field_not_allowed",
+                "egress.token_not_allowed",
+            ));
+            return Ok(serde_json::Value::String(text.to_string()));
+        }
+        if field_policy.requires_approval {
+            self.requires_approval = true;
+        }
+        for token in &matches {
+            if self.session.restore(token).is_none() {
+                self.deciding_rule = "egress.unknown_token".to_string();
+                self.blocked_response =
+                    Some(blocked_response("unknown_token", "egress.unknown_token"));
+                return Ok(serde_json::Value::String(text.to_string()));
+            }
+            self.token_classes.insert(token_class(token));
+        }
+        self.tokens.extend(matches);
+        let restored = self
+            .session
+            .restore_strict_text(text)
+            .map_err(|err| BridgeError::Policy(format!("unknown token rejected: {err}")))?;
+        Ok(serde_json::Value::String(restored))
+    }
+}
+
+struct IngressResult {
+    response: ToolResponse,
+    result_paths: Vec<ResultPath>,
+}
+
+fn process_ingress(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    policy: &ResolvedToolPolicy,
+    limits: &crate::config::LimitCfg,
+    result: CallToolResult,
+) -> BridgeResult<IngressResult> {
+    let raw_len = serde_json::to_vec(&result)
+        .map_err(|err| BridgeError::Downstream(format!("serialize result failed: {err}")))?
+        .len();
+    if raw_len > limits.response_bytes {
+        return Ok(IngressResult {
+            response: blocked_response("response_too_large", "ingress.limit.bytes"),
+            result_paths: vec![ResultPath::root()],
+        });
+    }
+    if result.content.len() > limits.content_blocks {
+        return Ok(IngressResult {
+            response: blocked_response("too_many_content_blocks", "ingress.limit.blocks"),
+            result_paths: vec![ResultPath::root()],
+        });
+    }
+
+    match policy.result.mode {
+        ResultMode::Deny => {
+            return Ok(IngressResult {
+                response: blocked_response("result_denied", "ingress.result.deny"),
+                result_paths: vec![ResultPath::root()],
+            });
+        }
+        ResultMode::Allow => {
+            return Ok(IngressResult {
+                response: ToolResponse::json(
+                    serde_json::to_value(result)
+                        .map_err(|err| BridgeError::Downstream(err.to_string()))?,
+                ),
+                result_paths: Vec::new(),
+            });
+        }
+        ResultMode::Process => {}
+    }
+
+    let mut result_paths = Vec::new();
+    let mut content_values = Vec::with_capacity(result.content.len());
+    for (idx, mut content) in result.content.into_iter().enumerate() {
+        match &mut content.raw {
+            RawContent::Text(text) => {
+                let text_path = ResultPath::root()
+                    .child("content")?
+                    .child(format!("[{idx}]"))?
+                    .child("text")?;
+                let redacted = redact_text(pipeline, locale_chain, session, &text.text)?;
+                if redacted != text.text {
+                    result_paths.push(text_path);
+                }
+                text.text = redacted;
+                if let Some(meta) = &mut text.meta {
+                    let meta_value = serde_json::Value::Object(meta.0.clone());
+                    let redacted_meta =
+                        redact_json_value(pipeline, locale_chain, session, &meta_value)?;
+                    if redacted_meta != meta_value {
+                        result_paths.push(
+                            ResultPath::root()
+                                .child("content")?
+                                .child(format!("[{idx}]"))?
+                                .child("_meta")?,
+                        );
+                    }
+                    if let serde_json::Value::Object(map) = redacted_meta {
+                        meta.0 = map;
+                    }
+                }
+            }
+            RawContent::Image(_)
+            | RawContent::Audio(_)
+            | RawContent::Resource(_)
+            | RawContent::ResourceLink(_) => {
+                return Ok(IngressResult {
+                    response: blocked_response("unsupported_content_block", "ingress.kind.deny"),
+                    result_paths: vec![ResultPath::root()
+                        .child("content")?
+                        .child(format!("[{idx}]"))?],
+                });
+            }
+        }
+        content_values.push(
+            serde_json::to_value(content).map_err(|err| {
+                BridgeError::Downstream(format!("serialize content failed: {err}"))
+            })?,
+        );
+    }
+
+    let structured_content = match result.structured_content {
+        Some(value) => {
+            let redacted = redact_json_value(pipeline, locale_chain, session, &value)?;
+            if redacted != value {
+                result_paths.push(ResultPath::root().child("structured_content")?);
+            }
+            Some(redacted)
+        }
+        None => None,
+    };
+    let meta = match result.meta {
+        Some(meta) => {
+            let value = serde_json::Value::Object(meta.0);
+            let redacted = redact_json_value(pipeline, locale_chain, session, &value)?;
+            if redacted != value {
+                result_paths.push(ResultPath::root().child("_meta")?);
+            }
+            Some(redacted)
+        }
+        None => None,
+    };
+
+    Ok(IngressResult {
+        response: ToolResponse::json(serde_json::json!({
+            "content": content_values,
+            "structuredContent": structured_content,
+            "isError": result.is_error.unwrap_or(false),
+            "_meta": meta,
+        })),
+        result_paths,
+    })
+}
+
+fn process_downstream_error(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    message: String,
+    data: Option<serde_json::Value>,
+) -> BridgeResult<IngressResult> {
+    let redacted_message = redact_text(pipeline, locale_chain, session, &message)?;
+    let mut result_paths = Vec::new();
+    if redacted_message != message {
+        result_paths.push(ResultPath::root().child("error")?.child("message")?);
+    }
+    let redacted_data = match data {
+        Some(value) => {
+            let redacted = redact_json_value(pipeline, locale_chain, session, &value)?;
+            if redacted != value {
+                result_paths.push(ResultPath::root().child("error")?.child("data")?);
+            }
+            Some(redacted)
+        }
+        None => None,
+    };
+    Ok(IngressResult {
+        response: ToolResponse::json(serde_json::json!({
+            "isError": true,
+            "error": {
+                "message": redacted_message,
+                "data": redacted_data,
+            }
+        })),
+        result_paths,
+    })
+}
+
+fn contains_raw_pii(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    text: &str,
+) -> BridgeResult<bool> {
+    if text.is_empty() {
+        return Ok(false);
+    }
+    let scan_session = gaze::Session::new(gaze::Scope::Ephemeral)
+        .map_err(|err| BridgeError::Redaction(err.to_string()))?;
+    let clean = pipeline
+        .pseudonymize_with_context(
+            &scan_session,
+            RawDocument::Text(text.to_string()),
+            locale_chain,
+        )
+        .map_err(|err| BridgeError::Redaction(err.to_string()))?;
+    match clean {
+        CleanDocument::Text(redacted) => Ok(redacted != text),
+        _ => Err(BridgeError::Redaction(
+            "unexpected non-text redaction result".to_string(),
+        )),
+    }
+}
+
+fn redact_json_value(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    value: &serde_json::Value,
+) -> BridgeResult<serde_json::Value> {
+    match value {
+        serde_json::Value::String(text) => Ok(serde_json::Value::String(redact_text(
+            pipeline,
+            locale_chain,
+            session,
+            text,
+        )?)),
+        serde_json::Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(redact_json_value(pipeline, locale_chain, session, item)?);
+            }
+            Ok(serde_json::Value::Array(out))
+        }
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (key, item) in map {
+                out.insert(
+                    key.clone(),
+                    redact_json_value(pipeline, locale_chain, session, item)?,
+                );
+            }
+            Ok(serde_json::Value::Object(out))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+fn redact_text(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    text: &str,
+) -> BridgeResult<String> {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for token in gaze::token_shape::pattern().find_iter(text) {
+        if !session.contains_token(token.as_str()) {
+            continue;
+        }
+        out.push_str(&redact_segment(
+            pipeline,
+            locale_chain,
+            session,
+            &text[cursor..token.start()],
+        )?);
+        out.push_str(token.as_str());
+        cursor = token.end();
+    }
+    out.push_str(&redact_segment(
+        pipeline,
+        locale_chain,
+        session,
+        &text[cursor..],
+    )?);
+    Ok(out)
+}
+
+fn redact_segment(
+    pipeline: &gaze::Pipeline,
+    locale_chain: &[gaze::LocaleTag],
+    session: &gaze::Session,
+    segment: &str,
+) -> BridgeResult<String> {
+    if segment.is_empty() {
+        return Ok(String::new());
+    }
+    match pipeline
+        .pseudonymize_with_context(
+            session,
+            RawDocument::Text(segment.to_string()),
+            locale_chain,
+        )
+        .map_err(|err| BridgeError::Redaction(err.to_string()))?
+    {
+        CleanDocument::Text(text) => Ok(text),
+        _ => Err(BridgeError::Redaction(
+            "unexpected non-text redaction result".to_string(),
+        )),
+    }
+}
+
+fn token_class(token: &str) -> String {
+    let trimmed = token.trim_matches(|c| c == '<' || c == '>');
+    let after_prefix = trimmed
+        .split_once(':')
+        .map(|(_, tail)| tail)
+        .unwrap_or(trimmed);
+    after_prefix
+        .rsplit_once('_')
+        .map(|(class, _)| class.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn blocked_response(reason: &str, rule: &str) -> ToolResponse {
+    ToolResponse::json(serde_json::json!({
+        "gaze_bridge": {
+            "outcome": "blocked",
+            "reason": reason,
+            "rule": rule,
+        }
+    }))
+}
+
+fn approval_required_response(request: &ApprovalRequest) -> ToolResponse {
+    ToolResponse::json(serde_json::json!({
+        "gaze_bridge": {
+            "outcome": "approval_required",
+            "call_id": request.call_id,
+            "redacted_arg_sha256": request.redacted_arg_sha256,
+            "token_classes": request.token_classes,
+            "reason": request.reason,
+        }
+    }))
+}

--- a/crates/gaze-mcp-bridge/src/client.rs
+++ b/crates/gaze-mcp-bridge/src/client.rs
@@ -1,0 +1,190 @@
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rmcp::model::{
+    CallToolRequest, CallToolRequestParams, CallToolResult, ClientRequest, JsonObject,
+    ServerResult, Tool,
+};
+use rmcp::service::{PeerRequestOptions, RoleClient, RunningService, ServiceError};
+use rmcp::transport::TokioChildProcess;
+use rmcp::{serve_client, Peer};
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::config::ServerSpec;
+use crate::error::{BridgeError, BridgeResult};
+
+#[derive(Debug, Clone)]
+pub struct DownstreamTool {
+    pub raw_name: String,
+    pub description: Option<String>,
+    pub input_schema: serde_json::Value,
+    pub output_schema: Option<serde_json::Value>,
+}
+
+impl DownstreamTool {
+    pub fn from_rmcp(tool: Tool) -> Self {
+        Self {
+            raw_name: tool.name.into_owned(),
+            description: tool.description.map(|value| value.into_owned()),
+            input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
+            output_schema: tool
+                .output_schema
+                .map(|schema| serde_json::Value::Object((*schema).clone())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DownstreamError {
+    #[error("downstream json-rpc error: {message}")]
+    Mcp {
+        message: String,
+        data: Option<serde_json::Value>,
+    },
+    #[error("downstream service error: {0}")]
+    Service(String),
+}
+
+#[async_trait]
+pub trait DownstreamClient: Send + Sync {
+    async fn list_tools(&self, timeout: Duration) -> BridgeResult<Vec<DownstreamTool>>;
+
+    async fn list_resources(&self, timeout: Duration) -> BridgeResult<usize>;
+
+    async fn list_prompts(&self, timeout: Duration) -> BridgeResult<usize>;
+
+    async fn call_tool(
+        &self,
+        tool_name: &str,
+        args: serde_json::Value,
+        timeout: Duration,
+    ) -> Result<CallToolResult, DownstreamError>;
+}
+
+pub struct RmcpChildClient {
+    peer: Peer<RoleClient>,
+    _service: Mutex<RunningService<RoleClient, ()>>,
+}
+
+impl RmcpChildClient {
+    pub async fn spawn(spec: &ServerSpec) -> BridgeResult<Arc<Self>> {
+        let mut command = Command::new(&spec.command);
+        command.args(&spec.args);
+        if let Some(cwd) = &spec.cwd {
+            command.current_dir(cwd);
+        }
+        for (key, value) in &spec.env {
+            command.env(key, value);
+        }
+
+        let (transport, stderr) = TokioChildProcess::builder(command)
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| BridgeError::Downstream(format!("child spawn failed: {err}")))?;
+        if let Some(stderr) = stderr {
+            tokio::spawn(drain_stderr(stderr));
+        }
+        let service = serve_client((), transport)
+            .await
+            .map_err(|err| BridgeError::Downstream(format!("client initialize failed: {err}")))?;
+        let peer = service.peer().clone();
+        Ok(Arc::new(Self {
+            peer,
+            _service: Mutex::new(service),
+        }))
+    }
+
+    fn peer(&self) -> Peer<RoleClient> {
+        self.peer.clone()
+    }
+}
+
+#[async_trait]
+impl DownstreamClient for RmcpChildClient {
+    async fn list_tools(&self, timeout: Duration) -> BridgeResult<Vec<DownstreamTool>> {
+        let peer = self.peer();
+        let tools = tokio::time::timeout(timeout, peer.list_all_tools())
+            .await
+            .map_err(|_| BridgeError::Downstream("list_tools timed out".to_string()))?
+            .map_err(service_error_to_bridge)?;
+        Ok(tools.into_iter().map(DownstreamTool::from_rmcp).collect())
+    }
+
+    async fn list_resources(&self, timeout: Duration) -> BridgeResult<usize> {
+        let peer = self.peer();
+        match tokio::time::timeout(timeout, peer.list_all_resources()).await {
+            Ok(Ok(resources)) => Ok(resources.len()),
+            Ok(Err(_)) | Err(_) => Ok(0),
+        }
+    }
+
+    async fn list_prompts(&self, timeout: Duration) -> BridgeResult<usize> {
+        let peer = self.peer();
+        match tokio::time::timeout(timeout, peer.list_all_prompts()).await {
+            Ok(Ok(prompts)) => Ok(prompts.len()),
+            Ok(Err(_)) | Err(_) => Ok(0),
+        }
+    }
+
+    async fn call_tool(
+        &self,
+        tool_name: &str,
+        args: serde_json::Value,
+        timeout: Duration,
+    ) -> Result<CallToolResult, DownstreamError> {
+        let arguments = match args {
+            serde_json::Value::Object(map) => map,
+            _ => JsonObject::new(),
+        };
+        let params = CallToolRequestParams::new(tool_name.to_string()).with_arguments(arguments);
+        let request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
+        let mut options = PeerRequestOptions::no_options();
+        options.timeout = Some(timeout);
+        let handle = self
+            .peer()
+            .send_request_with_option(request, options)
+            .await
+            .map_err(downstream_error)?;
+        let response = handle.await_response().await.map_err(downstream_error)?;
+        match response {
+            ServerResult::CallToolResult(result) => Ok(result),
+            _ => Err(DownstreamError::Service(
+                "unexpected downstream response type".to_string(),
+            )),
+        }
+    }
+}
+
+async fn drain_stderr(mut stderr: tokio::process::ChildStderr) {
+    let mut buf = [0_u8; 4096];
+    loop {
+        match stderr.read(&mut buf).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+    }
+}
+
+fn service_error_to_bridge(err: ServiceError) -> BridgeError {
+    match err {
+        ServiceError::McpError(mcp) => BridgeError::Downstream(format!(
+            "downstream method rejected with code {:?}",
+            mcp.code
+        )),
+        other => BridgeError::Downstream(other.to_string()),
+    }
+}
+
+fn downstream_error(err: ServiceError) -> DownstreamError {
+    match err {
+        ServiceError::McpError(mcp) => DownstreamError::Mcp {
+            message: mcp.message.into_owned(),
+            data: mcp.data,
+        },
+        other => DownstreamError::Service(other.to_string()),
+    }
+}

--- a/crates/gaze-mcp-bridge/src/config.rs
+++ b/crates/gaze-mcp-bridge/src/config.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::error::{BridgeError, BridgeResult};
+use crate::policy::{PolicyConfig, ResultMode};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BridgeConfig {
+    pub session: SessionCfg,
+    #[serde(default)]
+    pub limits: LimitCfg,
+    #[serde(default)]
+    pub servers: BTreeMap<String, ServerSpec>,
+    #[serde(default)]
+    pub policy: PolicyConfig,
+}
+
+impl BridgeConfig {
+    pub fn from_path(path: &Path) -> BridgeResult<Self> {
+        let raw = std::fs::read_to_string(path).map_err(|err| {
+            BridgeError::Config(format!("failed to read `{}`: {err}", path.display()))
+        })?;
+        Self::from_toml_str(&raw)
+    }
+
+    pub fn from_toml_str(raw: &str) -> BridgeResult<Self> {
+        let config: Self = toml::from_str(raw)
+            .map_err(|err| BridgeError::Config(format!("TOML parse failed: {err}")))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> BridgeResult<()> {
+        self.session.validate()?;
+        if self.servers.is_empty() {
+            return Err(BridgeError::Config(
+                "at least one [servers.<name>] entry is required".to_string(),
+            ));
+        }
+        for (name, server) in &self.servers {
+            if name.trim().is_empty() {
+                return Err(BridgeError::Config(
+                    "server name cannot be empty".to_string(),
+                ));
+            }
+            server.validate(name)?;
+        }
+        self.policy.validate()?;
+        if self.policy.contains_result_mode(ResultMode::Allow) {
+            tracing::warn!(
+                "gaze-mcp-bridge result.mode=\"allow\" is an explicit unsafe opt-in; raw downstream output may reach the agent"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SessionCfg {
+    pub mode: SessionMode,
+    pub dir: Option<PathBuf>,
+    pub key_env: Option<String>,
+}
+
+impl SessionCfg {
+    fn validate(&self) -> BridgeResult<()> {
+        match self.mode {
+            SessionMode::File => {
+                let Some(key_env) = self.key_env.as_deref().filter(|value| !value.is_empty())
+                else {
+                    return Err(BridgeError::Config(
+                        "session.mode=\"file\" requires non-empty session.key_env".to_string(),
+                    ));
+                };
+                let key = std::env::var(key_env).map_err(|_| {
+                    BridgeError::Config(format!(
+                        "session.mode=\"file\" requires environment key `{key_env}`"
+                    ))
+                })?;
+                if key.trim().is_empty() {
+                    return Err(BridgeError::Config(format!(
+                        "session key env `{key_env}` is empty"
+                    )));
+                }
+                if self.dir.is_none() {
+                    return Err(BridgeError::Config(
+                        "session.mode=\"file\" requires session.dir".to_string(),
+                    ));
+                }
+            }
+            SessionMode::Ephemeral => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionMode {
+    File,
+    Ephemeral,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServerSpec {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl ServerSpec {
+    fn validate(&self, name: &str) -> BridgeResult<()> {
+        if self.command.trim().is_empty() {
+            return Err(BridgeError::Config(format!(
+                "servers.{name}.command cannot be empty"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LimitCfg {
+    #[serde(default = "default_call_timeout_ms")]
+    pub call_timeout_ms: u64,
+    #[serde(default = "default_response_bytes")]
+    pub response_bytes: usize,
+    #[serde(default = "default_content_blocks")]
+    pub content_blocks: usize,
+}
+
+impl LimitCfg {
+    pub fn call_timeout(&self) -> Duration {
+        Duration::from_millis(self.call_timeout_ms)
+    }
+}
+
+impl Default for LimitCfg {
+    fn default() -> Self {
+        Self {
+            call_timeout_ms: default_call_timeout_ms(),
+            response_bytes: default_response_bytes(),
+            content_blocks: default_content_blocks(),
+        }
+    }
+}
+
+fn default_call_timeout_ms() -> u64 {
+    30_000
+}
+
+fn default_response_bytes() -> usize {
+    1_048_576
+}
+
+fn default_content_blocks() -> usize {
+    64
+}

--- a/crates/gaze-mcp-bridge/src/error.rs
+++ b/crates/gaze-mcp-bridge/src/error.rs
@@ -1,0 +1,55 @@
+use gaze_mcp_core::{AuthError, DispatchError, ManifestError, ToolError};
+
+pub type BridgeResult<T> = Result<T, BridgeError>;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BridgeError {
+    #[error("configuration rejected: {0}")]
+    Config(String),
+    #[error("policy rejected: {0}")]
+    Policy(String),
+    #[error("session id rejected: {0}")]
+    SessionId(#[from] gaze_mcp_core::SessionIdError),
+    #[error("authorization rejected: {0}")]
+    Auth(#[from] AuthError),
+    #[error("unknown bridge tool: {0}")]
+    UnknownTool(String),
+    #[error("session store failure: {0}")]
+    SessionStore(String),
+    #[error("approval required")]
+    ApprovalRequired,
+    #[error("audit persistence failure: {0}")]
+    Audit(String),
+    #[error("downstream MCP failure: {0}")]
+    Downstream(String),
+    #[error("redaction failed: {0}")]
+    Redaction(String),
+    #[error("limit exceeded: {0}")]
+    LimitExceeded(String),
+}
+
+impl BridgeError {
+    pub fn into_dispatch(self) -> DispatchError {
+        match self {
+            Self::SessionId(err) => DispatchError::SessionId(err),
+            Self::Auth(err) => DispatchError::Auth(err),
+            Self::UnknownTool(tool) => DispatchError::UnknownTool(tool),
+            Self::Audit(message) => {
+                DispatchError::Manifest(ManifestError::backend(std::io::Error::other(message)))
+            }
+            Self::LimitExceeded(message) => {
+                DispatchError::ToolError(ToolError::LimitExceeded(message))
+            }
+            Self::Policy(message) | Self::Config(message) => {
+                DispatchError::ToolError(ToolError::InvalidArgs(message))
+            }
+            Self::SessionStore(message) | Self::Downstream(message) | Self::Redaction(message) => {
+                DispatchError::ToolError(ToolError::BackendFailure(message))
+            }
+            Self::ApprovalRequired => {
+                DispatchError::ToolError(ToolError::BackendFailure("approval required".to_string()))
+            }
+        }
+    }
+}

--- a/crates/gaze-mcp-bridge/src/error.rs
+++ b/crates/gaze-mcp-bridge/src/error.rs
@@ -44,9 +44,15 @@ impl BridgeError {
             Self::Policy(message) | Self::Config(message) => {
                 DispatchError::ToolError(ToolError::InvalidArgs(message))
             }
-            Self::SessionStore(message) | Self::Downstream(message) | Self::Redaction(message) => {
-                DispatchError::ToolError(ToolError::BackendFailure(message))
-            }
+            Self::SessionStore(_) => DispatchError::ToolError(ToolError::BackendFailure(
+                "bridge session store failure".to_string(),
+            )),
+            Self::Downstream(_) => DispatchError::ToolError(ToolError::BackendFailure(
+                "downstream bridge failure".to_string(),
+            )),
+            Self::Redaction(_) => DispatchError::ToolError(ToolError::BackendFailure(
+                "bridge redaction failure".to_string(),
+            )),
             Self::ApprovalRequired => {
                 DispatchError::ToolError(ToolError::BackendFailure("approval required".to_string()))
             }

--- a/crates/gaze-mcp-bridge/src/lib.rs
+++ b/crates/gaze-mcp-bridge/src/lib.rs
@@ -1,0 +1,22 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub mod approval;
+pub mod audit;
+pub mod bridge;
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod registry;
+pub mod session_store;
+
+pub mod policy;
+
+pub use approval::{ApprovalDecision, ApprovalHook, ApprovalRequest, DenyApprovalHook};
+pub use audit::{ArgPath, BridgeAuditEvent, BridgeAuditSink, FileBridgeAuditSink, ResultPath};
+pub use bridge::{BridgeHost, BridgeHostBuilder};
+pub use client::{DownstreamClient, DownstreamTool, RmcpChildClient};
+pub use config::{BridgeConfig, SessionMode};
+pub use error::{BridgeError, BridgeResult};
+pub use policy::{DecisionOutcome, FieldPolicy, ResultMode, ResultPolicy};
+pub use registry::{BridgeRegistry, NamespacedTool};
+pub use session_store::{BridgeSessionStore, SessionStoreMode};

--- a/crates/gaze-mcp-bridge/src/policy/mod.rs
+++ b/crates/gaze-mcp-bridge/src/policy/mod.rs
@@ -135,6 +135,17 @@ impl ToolPolicy {
     }
 }
 
+/// Policy applied at default, server, tool, and argument scopes.
+///
+/// Argument-specific policy is selected only by the full audit path
+/// (`$.field`) or by a top-level argument key (`field`). Nested selectors such
+/// as `contact.email` do not match `$.contact.email`; nested values fall back to
+/// the nearest top-level or base policy.
+///
+/// Policy merging is monotonic for boolean guard fields. If an outer scope sets
+/// `allow_sensitive_fields`, `requires_approval`, or `log_raw` to `true`, an
+/// inner scope cannot narrow that value back to `false`. Keep broad scopes
+/// least-privilege and allow only the smallest top-level argument needed.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FieldPolicy {

--- a/crates/gaze-mcp-bridge/src/policy/mod.rs
+++ b/crates/gaze-mcp-bridge/src/policy/mod.rs
@@ -1,0 +1,271 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::error::{BridgeError, BridgeResult};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyConfig {
+    #[serde(default)]
+    pub default: FieldPolicy,
+    #[serde(default)]
+    pub servers: BTreeMap<String, ServerPolicy>,
+    #[serde(default)]
+    pub tools: BTreeMap<String, ToolPolicy>,
+}
+
+impl PolicyConfig {
+    pub fn validate(&self) -> BridgeResult<()> {
+        self.default.validate("policy.default")?;
+        for (name, server) in &self.servers {
+            server.validate(&format!("policy.servers.{name}"))?;
+        }
+        for (name, tool) in &self.tools {
+            tool.validate(&format!("policy.tools.{name}"))?;
+        }
+        Ok(())
+    }
+
+    pub fn resolve(
+        &self,
+        server: &str,
+        namespaced_tool: &str,
+        bare_tool: &str,
+    ) -> ResolvedToolPolicy {
+        let mut resolved = ResolvedToolPolicy {
+            base: self.default.clone(),
+            arguments: BTreeMap::new(),
+            result: self.default.result.clone().unwrap_or_default(),
+        };
+
+        if let Some(server_policy) = self.servers.get(server) {
+            resolved.base = resolved.base.merge(&server_policy.base);
+            if let Some(result) = &server_policy.result {
+                resolved.result = resolved.result.merge(result);
+            }
+            for (path, policy) in &server_policy.arguments {
+                resolved.arguments.insert(path.clone(), policy.clone());
+            }
+            if let Some(tool_policy) = server_policy.tools.get(bare_tool) {
+                resolved.apply_tool(tool_policy);
+            }
+        }
+
+        if let Some(tool_policy) = self
+            .tools
+            .get(namespaced_tool)
+            .or_else(|| self.tools.get(bare_tool))
+        {
+            resolved.apply_tool(tool_policy);
+        }
+
+        resolved
+    }
+
+    pub fn contains_result_mode(&self, mode: ResultMode) -> bool {
+        self.default.result.as_ref().is_some_and(|r| r.mode == mode)
+            || self
+                .servers
+                .values()
+                .any(|server| server.contains_result_mode(mode))
+            || self
+                .tools
+                .values()
+                .any(|tool| tool.result.as_ref().is_some_and(|r| r.mode == mode))
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServerPolicy {
+    #[serde(flatten)]
+    pub base: FieldPolicy,
+    #[serde(default)]
+    pub arguments: BTreeMap<String, FieldPolicy>,
+    #[serde(default)]
+    pub tools: BTreeMap<String, ToolPolicy>,
+    pub result: Option<ResultPolicy>,
+}
+
+impl ServerPolicy {
+    fn validate(&self, context: &str) -> BridgeResult<()> {
+        self.base.validate(context)?;
+        if let Some(result) = &self.result {
+            result.validate(&format!("{context}.result"))?;
+        }
+        for (path, field) in &self.arguments {
+            field.validate(&format!("{context}.arguments.{path}"))?;
+        }
+        for (tool, policy) in &self.tools {
+            policy.validate(&format!("{context}.tools.{tool}"))?;
+        }
+        Ok(())
+    }
+
+    fn contains_result_mode(&self, mode: ResultMode) -> bool {
+        self.result.as_ref().is_some_and(|r| r.mode == mode)
+            || self
+                .tools
+                .values()
+                .any(|tool| tool.result.as_ref().is_some_and(|r| r.mode == mode))
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolPolicy {
+    #[serde(flatten)]
+    pub base: FieldPolicy,
+    #[serde(default)]
+    pub arguments: BTreeMap<String, FieldPolicy>,
+    pub result: Option<ResultPolicy>,
+}
+
+impl ToolPolicy {
+    fn validate(&self, context: &str) -> BridgeResult<()> {
+        self.base.validate(context)?;
+        if let Some(result) = &self.result {
+            result.validate(&format!("{context}.result"))?;
+        }
+        for (path, field) in &self.arguments {
+            field.validate(&format!("{context}.arguments.{path}"))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FieldPolicy {
+    #[serde(default)]
+    pub allow_sensitive_fields: bool,
+    #[serde(default)]
+    pub requires_approval: bool,
+    #[serde(default = "default_on_block")]
+    pub on_block: BlockAction,
+    #[serde(default)]
+    pub log_raw: bool,
+    pub result: Option<ResultPolicy>,
+}
+
+impl Default for FieldPolicy {
+    fn default() -> Self {
+        Self {
+            allow_sensitive_fields: false,
+            requires_approval: false,
+            on_block: BlockAction::Refuse,
+            log_raw: false,
+            result: None,
+        }
+    }
+}
+
+impl FieldPolicy {
+    fn validate(&self, context: &str) -> BridgeResult<()> {
+        if self.log_raw {
+            return Err(BridgeError::Config(format!(
+                "{context}.log_raw=true is forbidden"
+            )));
+        }
+        if let Some(result) = &self.result {
+            result.validate(&format!("{context}.result"))?;
+        }
+        Ok(())
+    }
+
+    fn merge(&self, overlay: &FieldPolicy) -> FieldPolicy {
+        FieldPolicy {
+            allow_sensitive_fields: overlay.allow_sensitive_fields || self.allow_sensitive_fields,
+            requires_approval: overlay.requires_approval || self.requires_approval,
+            on_block: overlay.on_block,
+            log_raw: overlay.log_raw || self.log_raw,
+            result: overlay.result.clone().or_else(|| self.result.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockAction {
+    Refuse,
+}
+
+fn default_on_block() -> BlockAction {
+    BlockAction::Refuse
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResultPolicy {
+    #[serde(default)]
+    pub mode: ResultMode,
+}
+
+impl ResultPolicy {
+    fn validate(&self, _context: &str) -> BridgeResult<()> {
+        Ok(())
+    }
+
+    fn merge(&self, overlay: &ResultPolicy) -> ResultPolicy {
+        ResultPolicy { mode: overlay.mode }
+    }
+}
+
+impl Default for ResultPolicy {
+    fn default() -> Self {
+        Self {
+            mode: ResultMode::Process,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultMode {
+    #[default]
+    Process,
+    Deny,
+    Allow,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedToolPolicy {
+    pub base: FieldPolicy,
+    pub arguments: BTreeMap<String, FieldPolicy>,
+    pub result: ResultPolicy,
+}
+
+impl ResolvedToolPolicy {
+    fn apply_tool(&mut self, tool: &ToolPolicy) {
+        self.base = self.base.merge(&tool.base);
+        if let Some(result) = &tool.result {
+            self.result = self.result.merge(result);
+        }
+        for (path, field) in &tool.arguments {
+            self.arguments.insert(path.clone(), field.clone());
+        }
+    }
+
+    pub fn argument_policy(&self, path: &str) -> FieldPolicy {
+        if let Some(policy) = self.arguments.get(path) {
+            return self.base.merge(policy);
+        }
+        if let Some(top_level) = path
+            .strip_prefix("$.")
+            .and_then(|rest| rest.split('.').next())
+            .and_then(|key| self.arguments.get(key))
+        {
+            return self.base.merge(top_level);
+        }
+        self.base.clone()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionOutcome {
+    Allowed,
+    Blocked,
+    RequiresApproval,
+}

--- a/crates/gaze-mcp-bridge/src/registry.rs
+++ b/crates/gaze-mcp-bridge/src/registry.rs
@@ -1,0 +1,221 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use gaze_mcp_core::{ToolDescriptor, ToolTier};
+use sha2::{Digest, Sha256};
+
+use crate::client::{DownstreamClient, DownstreamTool};
+use crate::error::{BridgeError, BridgeResult};
+
+#[derive(Clone)]
+pub struct NamespacedTool {
+    pub namespaced_name: String,
+    pub server: String,
+    pub raw_server: String,
+    pub raw_tool: String,
+    pub sanitized_tool: String,
+    pub descriptor: ToolDescriptor,
+    pub discovery_hash: String,
+    pub client: Arc<dyn DownstreamClient>,
+}
+
+pub struct BridgeRegistry {
+    tools: BTreeMap<String, NamespacedTool>,
+    resources_discovered: BTreeMap<String, usize>,
+    prompts_discovered: BTreeMap<String, usize>,
+}
+
+impl BridgeRegistry {
+    pub async fn discover(
+        clients: BTreeMap<String, Arc<dyn DownstreamClient>>,
+        timeout: Duration,
+    ) -> BridgeResult<Self> {
+        let mut tools = BTreeMap::new();
+        let mut resources_discovered = BTreeMap::new();
+        let mut prompts_discovered = BTreeMap::new();
+        let mut sanitized_servers = BTreeSet::new();
+
+        for (raw_server, client) in clients {
+            let server = sanitize_component(&raw_server)?;
+            if !sanitized_servers.insert(server.clone()) {
+                return Err(BridgeError::Config(format!(
+                    "server name collision after sanitization: {raw_server}"
+                )));
+            }
+
+            let downstream_tools = client.list_tools(timeout).await?;
+            let mut within_server = BTreeSet::new();
+            for downstream in downstream_tools {
+                let tool = register_tool(
+                    &raw_server,
+                    &server,
+                    Arc::clone(&client),
+                    downstream,
+                    &mut within_server,
+                )?;
+                if tools
+                    .insert(tool.namespaced_name.clone(), tool.clone())
+                    .is_some()
+                {
+                    return Err(BridgeError::Config(
+                        "tool collision after namespacing".to_string(),
+                    ));
+                }
+            }
+
+            resources_discovered.insert(
+                server.clone(),
+                client.list_resources(timeout).await.unwrap_or_default(),
+            );
+            prompts_discovered.insert(
+                server,
+                client.list_prompts(timeout).await.unwrap_or_default(),
+            );
+        }
+
+        Ok(Self {
+            tools,
+            resources_discovered,
+            prompts_discovered,
+        })
+    }
+
+    pub fn from_tools(tools: Vec<NamespacedTool>) -> BridgeResult<Self> {
+        let mut map = BTreeMap::new();
+        for tool in tools {
+            if map.insert(tool.namespaced_name.clone(), tool).is_some() {
+                return Err(BridgeError::Config("duplicate tool name".to_string()));
+            }
+        }
+        Ok(Self {
+            tools: map,
+            resources_discovered: BTreeMap::new(),
+            prompts_discovered: BTreeMap::new(),
+        })
+    }
+
+    pub fn get(&self, name: &str) -> Option<&NamespacedTool> {
+        self.tools.get(name)
+    }
+
+    pub fn list_descriptors(&self) -> Vec<ToolDescriptor> {
+        self.tools
+            .values()
+            .map(|tool| tool.descriptor.clone())
+            .collect()
+    }
+
+    pub fn print_surface(&self) -> Vec<String> {
+        let mut rows = Vec::new();
+        for tool in self.tools.keys() {
+            rows.push(format!("tool allow {tool}"));
+        }
+        for (server, count) in &self.resources_discovered {
+            rows.push(format!("resources deny {server} count={count}"));
+        }
+        for (server, count) in &self.prompts_discovered {
+            rows.push(format!("prompts deny {server} count={count}"));
+        }
+        rows
+    }
+}
+
+fn register_tool(
+    raw_server: &str,
+    server: &str,
+    client: Arc<dyn DownstreamClient>,
+    downstream: DownstreamTool,
+    within_server: &mut BTreeSet<String>,
+) -> BridgeResult<NamespacedTool> {
+    let sanitized_tool = sanitize_component(&downstream.raw_name)?;
+    if !within_server.insert(sanitized_tool.clone()) {
+        return Err(BridgeError::Config(format!(
+            "duplicate downstream tool after sanitization on server {raw_server}"
+        )));
+    }
+    let namespaced_name = format!("{server}.{sanitized_tool}");
+    validate_component(&namespaced_name)?;
+    let discovery_hash = discovery_hash(server, &sanitized_tool, &downstream);
+    let descriptor =
+        ToolDescriptor::agent(namespaced_name.clone(), downstream.input_schema.clone())
+            .with_description(downstream.description.unwrap_or_else(|| {
+                format!(
+                    "Gaze MCP bridge proxy for {raw_server}.{}",
+                    downstream.raw_name
+                )
+            }));
+    let descriptor = if let Some(output_schema) = downstream.output_schema {
+        descriptor.with_output_schema(output_schema)
+    } else {
+        descriptor
+    };
+    if descriptor.tier() != ToolTier::Agent {
+        return Err(BridgeError::Config(
+            "bridge only exposes agent-tier downstream tools".to_string(),
+        ));
+    }
+    Ok(NamespacedTool {
+        namespaced_name,
+        server: server.to_string(),
+        raw_server: raw_server.to_string(),
+        raw_tool: downstream.raw_name,
+        sanitized_tool,
+        descriptor,
+        discovery_hash,
+        client,
+    })
+}
+
+pub fn sanitize_component(input: &str) -> BridgeResult<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(BridgeError::Config(
+            "tool/server name cannot be empty".to_string(),
+        ));
+    }
+    let sanitized = trimmed
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    validate_component(&sanitized)?;
+    Ok(sanitized)
+}
+
+fn validate_component(input: &str) -> BridgeResult<()> {
+    if input.is_empty() || input.len() > 128 {
+        return Err(BridgeError::Config(format!(
+            "MCP name length must be 1..=128, got {}",
+            input.len()
+        )));
+    }
+    if !input
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+    {
+        return Err(BridgeError::Config(
+            "MCP name contains invalid characters".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn discovery_hash(server: &str, tool: &str, downstream: &DownstreamTool) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(server.as_bytes());
+    hasher.update([0]);
+    hasher.update(tool.as_bytes());
+    hasher.update([0]);
+    hasher.update(serde_json::to_vec(&downstream.input_schema).unwrap_or_default());
+    if let Some(output_schema) = &downstream.output_schema {
+        hasher.update([0]);
+        hasher.update(serde_json::to_vec(output_schema).unwrap_or_default());
+    }
+    hex::encode(hasher.finalize())
+}

--- a/crates/gaze-mcp-bridge/src/session_store.rs
+++ b/crates/gaze-mcp-bridge/src/session_store.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use base64::Engine;
+use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+
+use crate::config::{SessionCfg, SessionMode};
+use crate::error::{BridgeError, BridgeResult};
+
+const MAGIC: &[u8] = b"gaze-bridge-session-v1\n";
+const NONCE_LEN: usize = 12;
+
+pub type SharedSession = Arc<Mutex<gaze::Session>>;
+
+#[derive(Clone)]
+pub enum SessionStoreMode {
+    Ephemeral,
+    File { dir: PathBuf, key: [u8; 32] },
+}
+
+pub struct BridgeSessionStore {
+    mode: SessionStoreMode,
+    sessions: Mutex<HashMap<String, SharedSession>>,
+    file_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl BridgeSessionStore {
+    pub fn from_config(config: &SessionCfg) -> BridgeResult<Self> {
+        let mode = match config.mode {
+            SessionMode::Ephemeral => SessionStoreMode::Ephemeral,
+            SessionMode::File => {
+                let dir = config
+                    .dir
+                    .clone()
+                    .ok_or_else(|| BridgeError::Config("file session dir missing".to_string()))?;
+                let key_env = config.key_env.as_deref().ok_or_else(|| {
+                    BridgeError::Config("file session key_env missing".to_string())
+                })?;
+                let key_raw = std::env::var(key_env)
+                    .map_err(|_| BridgeError::Config(format!("session key `{key_env}` missing")))?;
+                let key = parse_key(&key_raw)?;
+                SessionStoreMode::File { dir, key }
+            }
+        };
+        Ok(Self {
+            mode,
+            sessions: Mutex::new(HashMap::new()),
+            file_locks: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn ephemeral() -> Self {
+        Self {
+            mode: SessionStoreMode::Ephemeral,
+            sessions: Mutex::new(HashMap::new()),
+            file_locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub async fn get(&self, validated_session_id: &str) -> BridgeResult<SharedSession> {
+        let mut sessions = self.sessions.lock().await;
+        if let Some(session) = sessions.get(validated_session_id) {
+            return Ok(Arc::clone(session));
+        }
+
+        let session = match &self.mode {
+            SessionStoreMode::Ephemeral => gaze::Session::new(gaze::Scope::Ephemeral)
+                .map_err(|err| BridgeError::SessionStore(err.to_string()))?,
+            SessionStoreMode::File { dir, key } => {
+                self.load_file_session(dir, key, validated_session_id)
+                    .await?
+            }
+        };
+        let shared = Arc::new(Mutex::new(session));
+        sessions.insert(validated_session_id.to_string(), Arc::clone(&shared));
+        Ok(shared)
+    }
+
+    pub async fn persist(
+        &self,
+        validated_session_id: &str,
+        session: &gaze::Session,
+    ) -> BridgeResult<()> {
+        let SessionStoreMode::File { dir, key } = &self.mode else {
+            return Ok(());
+        };
+
+        let file_lock = self.file_lock(validated_session_id).await;
+        let _guard = file_lock.lock().await;
+        tokio::fs::create_dir_all(dir).await.map_err(|err| {
+            BridgeError::SessionStore(format!("create session dir failed: {err}"))
+        })?;
+
+        let snapshot = session
+            .export()
+            .map_err(|err| BridgeError::SessionStore(format!("session export failed: {err}")))?;
+        let plaintext = snapshot.into_bytes();
+        let encrypted = encrypt_snapshot(key, validated_session_id.as_bytes(), &plaintext)?;
+        let path = session_path(dir, validated_session_id);
+        let tmp = path.with_extension(format!("tmp-{}", random_hex(8)));
+        let mut file = tokio::fs::File::create(&tmp).await.map_err(|err| {
+            BridgeError::SessionStore(format!("create temp session failed: {err}"))
+        })?;
+        use tokio::io::AsyncWriteExt;
+        file.write_all(&encrypted)
+            .await
+            .map_err(|err| BridgeError::SessionStore(format!("write session failed: {err}")))?;
+        file.sync_all()
+            .await
+            .map_err(|err| BridgeError::SessionStore(format!("sync session failed: {err}")))?;
+        drop(file);
+        tokio::fs::rename(&tmp, &path)
+            .await
+            .map_err(|err| BridgeError::SessionStore(format!("rename session failed: {err}")))
+    }
+
+    async fn load_file_session(
+        &self,
+        dir: &Path,
+        key: &[u8; 32],
+        validated_session_id: &str,
+    ) -> BridgeResult<gaze::Session> {
+        let file_lock = self.file_lock(validated_session_id).await;
+        let _guard = file_lock.lock().await;
+        let path = session_path(dir, validated_session_id);
+        match tokio::fs::read(&path).await {
+            Ok(bytes) => {
+                let plaintext = decrypt_snapshot(key, validated_session_id.as_bytes(), &bytes)?;
+                gaze::Session::import(gaze::SensitiveSnapshot::from(plaintext)).map_err(|err| {
+                    BridgeError::SessionStore(format!("session import failed: {err}"))
+                })
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                gaze::Session::new(gaze::Scope::Conversation(validated_session_id.to_string()))
+                    .map_err(|err| BridgeError::SessionStore(err.to_string()))
+            }
+            Err(err) => Err(BridgeError::SessionStore(format!(
+                "read session file failed: {err}"
+            ))),
+        }
+    }
+
+    async fn file_lock(&self, validated_session_id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.file_locks.lock().await;
+        Arc::clone(
+            locks
+                .entry(validated_session_id.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
+    }
+}
+
+fn parse_key(raw: &str) -> BridgeResult<[u8; 32]> {
+    let trimmed = raw.trim();
+    let bytes = if trimmed.len() == 64 && trimmed.bytes().all(|b| b.is_ascii_hexdigit()) {
+        hex::decode(trimmed).map_err(|err| BridgeError::Config(format!("hex key failed: {err}")))?
+    } else if trimmed.len() == 32 {
+        trimmed.as_bytes().to_vec()
+    } else {
+        base64::engine::general_purpose::STANDARD
+            .decode(trimmed)
+            .map_err(|err| BridgeError::Config(format!("base64 session key failed: {err}")))?
+    };
+    bytes
+        .try_into()
+        .map_err(|_| BridgeError::Config("session key must decode to 32 bytes".to_string()))
+}
+
+fn encrypt_snapshot(key: &[u8; 32], aad: &[u8], plaintext: &[u8]) -> BridgeResult<Vec<u8>> {
+    let cipher = ChaCha20Poly1305::new(key.into());
+    let mut nonce_bytes = [0_u8; NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|err| BridgeError::SessionStore(format!("session encrypt failed: {err}")))?;
+    let mut out = Vec::with_capacity(MAGIC.len() + NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+fn decrypt_snapshot(key: &[u8; 32], aad: &[u8], bytes: &[u8]) -> BridgeResult<Vec<u8>> {
+    if bytes.len() < MAGIC.len() + NONCE_LEN || &bytes[..MAGIC.len()] != MAGIC {
+        return Err(BridgeError::SessionStore(
+            "session file has invalid encrypted header".to_string(),
+        ));
+    }
+    let nonce_start = MAGIC.len();
+    let nonce_end = nonce_start + NONCE_LEN;
+    let nonce = Nonce::from_slice(&bytes[nonce_start..nonce_end]);
+    let cipher = ChaCha20Poly1305::new(key.into());
+    cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: &bytes[nonce_end..],
+                aad,
+            },
+        )
+        .map_err(|err| BridgeError::SessionStore(format!("session decrypt failed: {err}")))
+}
+
+fn session_path(dir: &Path, validated_session_id: &str) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(validated_session_id.as_bytes());
+    dir.join(format!("{}.gaze-session", hex::encode(hasher.finalize())))
+}
+
+fn random_hex(len: usize) -> String {
+    let mut bytes = vec![0_u8; len];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hex_key_accepts_32_bytes() {
+        let key = parse_key(&"11".repeat(32)).expect("key");
+        assert_eq!(key, [0x11; 32]);
+    }
+}

--- a/crates/gaze-mcp-bridge/tests/contract.rs
+++ b/crates/gaze-mcp-bridge/tests/contract.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -13,7 +14,9 @@ use gaze_mcp_bridge::policy::{
     DecisionOutcome, FieldPolicy, PolicyConfig, ResultMode, ResultPolicy, ToolPolicy,
 };
 use gaze_mcp_bridge::{BridgeHostBuilder, BridgeRegistry, BridgeSessionStore, NamespacedTool};
-use gaze_mcp_core::{AuthError, AuthHook, DispatchError, DispatchHost, Principal, ToolDescriptor};
+use gaze_mcp_core::{
+    AuthError, AuthHook, DispatchError, DispatchHost, Principal, ToolDescriptor, ToolError,
+};
 use proptest::prop_assert;
 use rmcp::model::{CallToolResult, Content, RawResource};
 use serde_json::{json, Value};
@@ -77,6 +80,7 @@ enum FakeResponse {
         message: String,
         data: Option<Value>,
     },
+    ServiceError(String),
 }
 
 struct FakeClient {
@@ -129,6 +133,7 @@ impl DownstreamClient for FakeClient {
         match self.response.lock().await.clone() {
             FakeResponse::Result(result) => Ok(result),
             FakeResponse::McpError { message, data } => Err(DownstreamError::Mcp { message, data }),
+            FakeResponse::ServiceError(message) => Err(DownstreamError::Service(message)),
         }
     }
 }
@@ -451,6 +456,26 @@ async fn raw_pii_in_args_is_blocked_even_without_token() {
 }
 
 #[tokio::test]
+async fn pii_object_key_in_args_fails_closed_without_raw_path() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let audit = Arc::new(MemoryAudit::default());
+    let (host, _) = host_with_fake(client.clone(), allow_to_policy(), audit.clone()).await;
+    let err = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({RAW_EMAIL: "hello"}),
+            Some(SID_A),
+        )
+        .await
+        .expect_err("PII-bearing object key fails closed");
+    assert!(!format!("{err:?}").contains(RAW_EMAIL));
+    assert!(client.calls().await.is_empty());
+    let audit = serde_json::to_string(&*audit.events.lock().await).expect("audit json");
+    assert!(!audit.contains(RAW_EMAIL));
+}
+
+#[tokio::test]
 async fn approval_required_is_structured_and_not_forwarded() {
     let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
     let (host, store) = host_with_fake(
@@ -692,6 +717,50 @@ async fn downstream_json_rpc_error_data_is_redacted() {
 }
 
 #[tokio::test]
+async fn downstream_service_error_detail_is_generic_and_audit_is_clean() {
+    let client = FakeClient::new(FakeResponse::ServiceError(format!(
+        "downstream transport echoed {RAW_EMAIL}"
+    )));
+    let audit = Arc::new(MemoryAudit::default());
+    let (host, store) = host_with_fake(client, allow_to_policy(), audit.clone()).await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("generic service error response");
+    let rendered = serde_json::to_string(&response.payload).expect("json");
+    assert!(!rendered.contains(RAW_EMAIL));
+    assert_eq!(response.payload["isError"], true);
+    assert_eq!(
+        response.payload["error"]["message"],
+        "downstream service error"
+    );
+
+    let audit = serde_json::to_string(&*audit.events.lock().await).expect("audit json");
+    assert!(!audit.contains(RAW_EMAIL));
+}
+
+#[test]
+fn backend_failure_agent_messages_are_generic() {
+    for err in [
+        gaze_mcp_bridge::BridgeError::SessionStore(format!("session load saw {RAW_EMAIL}")),
+        gaze_mcp_bridge::BridgeError::Downstream(format!("downstream saw {RAW_EMAIL}")),
+        gaze_mcp_bridge::BridgeError::Redaction(format!("redaction saw {RAW_EMAIL}")),
+    ] {
+        let dispatch = err.into_dispatch();
+        let DispatchError::ToolError(ToolError::BackendFailure(message)) = dispatch else {
+            panic!("expected generic backend failure");
+        };
+        assert!(!message.contains(RAW_EMAIL));
+    }
+}
+
+#[tokio::test]
 async fn encrypted_file_store_does_not_write_raw_pii_and_reloads() {
     let dir = TempDir::new().expect("tempdir");
     std::env::set_var("GAZE_BRIDGE_TEST_KEY", "22".repeat(32));
@@ -765,6 +834,8 @@ proptest::proptest! {
     #[test]
     fn audit_event_serializes_paths_only(local in "[a-z]{1,12}") {
         let raw = format!("{local}@example.invalid");
+        prop_assert!(ArgPath::root().child("x@y.z").is_err());
+        prop_assert!(ArgPath::root().child(&raw).is_err());
         let mut event = BridgeAuditEvent::new(
             "01HRT7K6P6X5Q9M0V8YQ4N7TBC".to_string(),
             SID_A,
@@ -830,6 +901,57 @@ async fn rmcp_child_process_fixture_spawns_lists_calls_and_bridge_redacts() {
     assert!(!rendered.contains(RAW_EMAIL));
     let audit = std::fs::read_to_string(audit_path).expect("audit");
     assert!(!audit.contains(RAW_EMAIL));
+}
+
+#[tokio::test]
+async fn child_stderr_is_not_inherited_by_bridge_process() {
+    let temp = TempDir::new().expect("tempdir");
+    let script = temp.path().join("fixture_mcp.py");
+    write_python_fixture(&script);
+
+    let output = Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("--exact")
+        .arg("rmcp_child_stderr_capture_helper")
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env("GAZE_BRIDGE_STDERR_HELPER", "1")
+        .env("GAZE_BRIDGE_STDERR_FIXTURE", &script)
+        .output()
+        .expect("run stderr helper");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "stderr helper failed: {combined}");
+    assert!(
+        !combined.contains(RAW_EMAIL),
+        "bridge process leaked raw stderr: {combined}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "invoked by child_stderr_is_not_inherited_by_bridge_process"]
+async fn rmcp_child_stderr_capture_helper() {
+    if std::env::var_os("GAZE_BRIDGE_STDERR_HELPER").is_none() {
+        return;
+    }
+    let script = std::env::var("GAZE_BRIDGE_STDERR_FIXTURE").expect("fixture path");
+    let spec = ServerSpec {
+        command: "python3".to_string(),
+        args: vec![script],
+        env: BTreeMap::new(),
+        cwd: None,
+    };
+    let client = RmcpChildClient::spawn(&spec).await.expect("client");
+    client
+        .list_tools(Duration::from_secs(5))
+        .await
+        .expect("tools");
+    client
+        .call_tool("send", json!({"to": RAW_EMAIL}), Duration::from_secs(5))
+        .await
+        .expect("call");
 }
 
 fn read_all_files(dir: &Path) -> Vec<u8> {

--- a/crates/gaze-mcp-bridge/tests/contract.rs
+++ b/crates/gaze-mcp-bridge/tests/contract.rs
@@ -1,0 +1,875 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use gaze::PiiClass;
+use gaze_mcp_bridge::approval::ApprovalRequest;
+use gaze_mcp_bridge::audit::{ArgPath, BridgeAuditEvent, BridgeAuditSink};
+use gaze_mcp_bridge::client::{DownstreamClient, DownstreamError, DownstreamTool, RmcpChildClient};
+use gaze_mcp_bridge::config::{BridgeConfig, LimitCfg, ServerSpec};
+use gaze_mcp_bridge::policy::{
+    DecisionOutcome, FieldPolicy, PolicyConfig, ResultMode, ResultPolicy, ToolPolicy,
+};
+use gaze_mcp_bridge::{BridgeHostBuilder, BridgeRegistry, BridgeSessionStore, NamespacedTool};
+use gaze_mcp_core::{AuthError, AuthHook, DispatchError, DispatchHost, Principal, ToolDescriptor};
+use proptest::prop_assert;
+use rmcp::model::{CallToolResult, Content, RawResource};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+const SID_A: &str = "01HRT7K6P6X5Q9M0V8YQ4N7TBC";
+const SID_B: &str = "01HRT7K6P6X5Q9M0V8YQ4N7TBD";
+const RAW_EMAIL: &str = "alice@example.invalid";
+
+#[derive(Default)]
+struct AllowAuth;
+
+#[async_trait]
+impl AuthHook for AllowAuth {
+    async fn authorize_agent(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Ok(())
+    }
+
+    async fn authorize_operator(
+        &self,
+        _principal: &Principal,
+        _tool_name: &str,
+    ) -> Result<(), AuthError> {
+        Err(AuthError::Denied("operator not exposed".to_string()))
+    }
+}
+
+#[derive(Default)]
+struct MemoryAudit {
+    events: Mutex<Vec<BridgeAuditEvent>>,
+}
+
+#[async_trait]
+impl BridgeAuditSink for MemoryAudit {
+    async fn record(&self, event: &BridgeAuditEvent) -> gaze_mcp_bridge::BridgeResult<()> {
+        self.events.lock().await.push(event.clone());
+        Ok(())
+    }
+}
+
+struct FailingAudit;
+
+#[async_trait]
+impl BridgeAuditSink for FailingAudit {
+    async fn record(&self, _event: &BridgeAuditEvent) -> gaze_mcp_bridge::BridgeResult<()> {
+        Err(gaze_mcp_bridge::BridgeError::Audit(
+            "planned failure".to_string(),
+        ))
+    }
+}
+
+#[derive(Clone)]
+enum FakeResponse {
+    Result(CallToolResult),
+    McpError {
+        message: String,
+        data: Option<Value>,
+    },
+}
+
+struct FakeClient {
+    calls: Mutex<Vec<Value>>,
+    response: Mutex<FakeResponse>,
+}
+
+impl FakeClient {
+    fn new(response: FakeResponse) -> Arc<Self> {
+        Arc::new(Self {
+            calls: Mutex::new(Vec::new()),
+            response: Mutex::new(response),
+        })
+    }
+
+    async fn calls(&self) -> Vec<Value> {
+        self.calls.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl DownstreamClient for FakeClient {
+    async fn list_tools(
+        &self,
+        _timeout: Duration,
+    ) -> gaze_mcp_bridge::BridgeResult<Vec<DownstreamTool>> {
+        Ok(vec![DownstreamTool {
+            raw_name: "send".to_string(),
+            description: Some("send".to_string()),
+            input_schema: json!({"type": "object"}),
+            output_schema: None,
+        }])
+    }
+
+    async fn list_resources(&self, _timeout: Duration) -> gaze_mcp_bridge::BridgeResult<usize> {
+        Ok(1)
+    }
+
+    async fn list_prompts(&self, _timeout: Duration) -> gaze_mcp_bridge::BridgeResult<usize> {
+        Ok(1)
+    }
+
+    async fn call_tool(
+        &self,
+        _tool_name: &str,
+        args: Value,
+        _timeout: Duration,
+    ) -> Result<CallToolResult, DownstreamError> {
+        self.calls.lock().await.push(args);
+        match self.response.lock().await.clone() {
+            FakeResponse::Result(result) => Ok(result),
+            FakeResponse::McpError { message, data } => Err(DownstreamError::Mcp { message, data }),
+        }
+    }
+}
+
+fn result_text(text: &str) -> CallToolResult {
+    CallToolResult::success(vec![Content::text(text.to_string())])
+}
+
+async fn host_with_fake(
+    client: Arc<FakeClient>,
+    policy: PolicyConfig,
+    audit: Arc<dyn BridgeAuditSink>,
+) -> (gaze_mcp_bridge::BridgeHost, Arc<BridgeSessionStore>) {
+    host_with_fake_and_limits(client, policy, audit, LimitCfg::default()).await
+}
+
+async fn host_with_fake_and_limits(
+    client: Arc<FakeClient>,
+    policy: PolicyConfig,
+    audit: Arc<dyn BridgeAuditSink>,
+    limits: LimitCfg,
+) -> (gaze_mcp_bridge::BridgeHost, Arc<BridgeSessionStore>) {
+    let tool = NamespacedTool {
+        namespaced_name: "mail.send".to_string(),
+        server: "mail".to_string(),
+        raw_server: "mail".to_string(),
+        raw_tool: "send".to_string(),
+        sanitized_tool: "send".to_string(),
+        descriptor: ToolDescriptor::agent("mail.send", json!({"type": "object"})),
+        discovery_hash: "discovery-hash".to_string(),
+        client,
+    };
+    let registry = Arc::new(BridgeRegistry::from_tools(vec![tool]).expect("registry"));
+    let store = Arc::new(BridgeSessionStore::ephemeral());
+    let host = BridgeHostBuilder::new(registry, Arc::clone(&store), audit)
+        .auth(Arc::new(AllowAuth))
+        .policy(policy)
+        .limits(limits)
+        .build();
+    (host, store)
+}
+
+async fn seed_email_token(store: &BridgeSessionStore, sid: &str) -> String {
+    let session = store.get(sid).await.expect("session");
+    let guard = session.lock().await;
+    guard.tokenize(&PiiClass::Email, RAW_EMAIL).expect("token")
+}
+
+fn allow_to_policy() -> PolicyConfig {
+    let mut policy = PolicyConfig::default();
+    let mut tool = ToolPolicy::default();
+    let field = FieldPolicy {
+        allow_sensitive_fields: true,
+        ..FieldPolicy::default()
+    };
+    tool.arguments.insert("to".to_string(), field);
+    policy.tools.insert("mail.send".to_string(), tool);
+    policy
+}
+
+fn approval_to_policy() -> PolicyConfig {
+    let mut policy = allow_to_policy();
+    let tool = policy.tools.get_mut("mail.send").expect("tool");
+    let field = tool.arguments.get_mut("to").expect("to field");
+    field.requires_approval = true;
+    policy
+}
+
+fn deny_result_policy() -> PolicyConfig {
+    let mut policy = allow_to_policy();
+    let tool = policy.tools.get_mut("mail.send").expect("tool");
+    tool.result = Some(ResultPolicy {
+        mode: ResultMode::Deny,
+    });
+    policy
+}
+
+#[tokio::test]
+async fn config_rejects_file_mode_without_key_and_log_raw() {
+    let no_key = r#"
+        [session]
+        mode = "file"
+        dir = ".gaze/sessions"
+        key_env = "GAZE_MISSING_TEST_KEY"
+
+        [servers.mail]
+        command = "mcp-mail"
+    "#;
+    assert!(BridgeConfig::from_toml_str(no_key).is_err());
+
+    let log_raw = r#"
+        [session]
+        mode = "ephemeral"
+
+        [servers.mail]
+        command = "mcp-mail"
+
+        [policy.default]
+        log_raw = true
+    "#;
+    assert!(BridgeConfig::from_toml_str(log_raw).is_err());
+}
+
+#[tokio::test]
+async fn discovery_namespaces_tools_and_reports_denied_resources_prompts() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("ok")));
+    let mut clients: BTreeMap<String, Arc<dyn DownstreamClient>> = BTreeMap::new();
+    clients.insert("mail server".to_string(), client);
+    let registry = BridgeRegistry::discover(clients, Duration::from_secs(1))
+        .await
+        .expect("discover");
+    let rows = registry.print_surface();
+    assert!(rows.iter().any(|row| row == "tool allow mail_server.send"));
+    assert!(rows
+        .iter()
+        .any(|row| row.starts_with("resources deny mail_server")));
+    assert!(rows
+        .iter()
+        .any(|row| row.starts_with("prompts deny mail_server")));
+}
+
+#[tokio::test]
+async fn sanitize_collision_is_registration_error() {
+    let left = FakeClient::new(FakeResponse::Result(result_text("ok")));
+    let right = FakeClient::new(FakeResponse::Result(result_text("ok")));
+    let mut clients: BTreeMap<String, Arc<dyn DownstreamClient>> = BTreeMap::new();
+    clients.insert("mail server".to_string(), left);
+    clients.insert("mail/server".to_string(), right);
+    let err = match BridgeRegistry::discover(clients, Duration::from_secs(1)).await {
+        Ok(_) => panic!("sanitized collision should fail"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("collision"));
+}
+
+#[tokio::test]
+async fn oversize_tool_name_is_registration_error() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("ok")));
+    let mut clients: BTreeMap<String, Arc<dyn DownstreamClient>> = BTreeMap::new();
+    clients.insert("s".repeat(129), client);
+    let err = match BridgeRegistry::discover(clients, Duration::from_secs(1)).await {
+        Ok(_) => panic!("oversize name should fail"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("1..=128"));
+}
+
+#[tokio::test]
+async fn default_auth_denies_before_forward() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("ok")));
+    let tool = NamespacedTool {
+        namespaced_name: "mail.send".to_string(),
+        server: "mail".to_string(),
+        raw_server: "mail".to_string(),
+        raw_tool: "send".to_string(),
+        sanitized_tool: "send".to_string(),
+        descriptor: ToolDescriptor::agent("mail.send", json!({"type": "object"})),
+        discovery_hash: "hash".to_string(),
+        client: client.clone(),
+    };
+    let registry = Arc::new(BridgeRegistry::from_tools(vec![tool]).expect("registry"));
+    let host = BridgeHostBuilder::new(
+        registry,
+        Arc::new(BridgeSessionStore::ephemeral()),
+        Arc::new(MemoryAudit::default()),
+    )
+    .build();
+    let err = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({}),
+            Some(SID_A),
+        )
+        .await
+        .expect_err("auth denies");
+    assert!(matches!(err, DispatchError::Auth(_)));
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn per_field_allow_restores_token_and_routes_downstream() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, store) = host_with_fake(
+        client.clone(),
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token, "subject": "hello"}),
+            Some(SID_A),
+        )
+        .await
+        .expect("dispatch");
+    assert_eq!(response.payload["content"][0]["text"], "sent");
+    assert_eq!(
+        client.calls().await,
+        vec![json!({"to": RAW_EMAIL, "subject": "hello"})]
+    );
+}
+
+#[tokio::test]
+async fn token_on_default_deny_field_is_blocked() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, store) = host_with_fake(
+        client.clone(),
+        PolicyConfig::default(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked response");
+    assert_eq!(
+        response.payload["gaze_bridge"]["reason"],
+        "sensitive_field_not_allowed"
+    );
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn cross_session_token_is_not_restorable() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, store) = host_with_fake(
+        client.clone(),
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_B),
+        )
+        .await
+        .expect("blocked response");
+    assert_eq!(response.payload["gaze_bridge"]["reason"], "unknown_token");
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn trap_token_on_sensitive_field_is_blocked() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, _) = host_with_fake(
+        client.clone(),
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": "<Email_1>"}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked response");
+    assert_eq!(response.payload["gaze_bridge"]["reason"], "unknown_token");
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn forged_session_id_is_rejected() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, _) = host_with_fake(
+        client.clone(),
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let err = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": "hello"}),
+            Some("session-1"),
+        )
+        .await
+        .expect_err("bad session id");
+    assert!(matches!(err, DispatchError::SessionId(_)));
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn raw_pii_in_args_is_blocked_even_without_token() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, _) = host_with_fake(
+        client.clone(),
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": RAW_EMAIL}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked response");
+    assert_eq!(response.payload["gaze_bridge"]["reason"], "raw_pii_in_args");
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn approval_required_is_structured_and_not_forwarded() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, store) = host_with_fake(
+        client.clone(),
+        approval_to_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("approval response");
+    assert_eq!(
+        response.payload["gaze_bridge"]["outcome"],
+        "approval_required"
+    );
+    assert!(client.calls().await.is_empty());
+}
+
+#[test]
+fn approval_request_hash_binds_changed_args() {
+    let left = ApprovalRequest::new(
+        "call",
+        SID_A,
+        &json!({"to": "<deadbeef:Email_1>"}),
+        ["Email".to_string()].into_iter().collect(),
+        &["<deadbeef:Email_1>".to_string()],
+        "mail.send",
+        "discovery",
+        "reason",
+        vec![ArgPath::root().child("to").expect("path")],
+    );
+    let right = ApprovalRequest::new(
+        "call",
+        SID_A,
+        &json!({"to": "<deadbeef:Email_2>"}),
+        ["Email".to_string()].into_iter().collect(),
+        &["<deadbeef:Email_2>".to_string()],
+        "mail.send",
+        "discovery",
+        "reason",
+        vec![ArgPath::root().child("to").expect("path")],
+    );
+    assert_ne!(left.redacted_arg_sha256, right.redacted_arg_sha256);
+    assert_ne!(left.token_list_sha256, right.token_list_sha256);
+}
+
+#[tokio::test]
+async fn audit_must_succeed_before_forward() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("sent")));
+    let (host, store) =
+        host_with_fake(client.clone(), allow_to_policy(), Arc::new(FailingAudit)).await;
+    let token = seed_email_token(&store, SID_A).await;
+    let err = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect_err("audit failure");
+    assert!(matches!(err, DispatchError::Manifest(_)));
+    assert!(client.calls().await.is_empty());
+}
+
+#[tokio::test]
+async fn is_error_text_structured_and_meta_are_redacted() {
+    let mut result = CallToolResult::error(vec![Content::text(format!("missing {RAW_EMAIL}"))]);
+    result.structured_content = Some(json!({"owner": RAW_EMAIL}));
+    result.meta = Some(rmcp::model::Meta({
+        let mut map = rmcp::model::JsonObject::new();
+        map.insert("trace".to_string(), json!(RAW_EMAIL));
+        map
+    }));
+    let client = FakeClient::new(FakeResponse::Result(result));
+    let (host, store) =
+        host_with_fake(client, allow_to_policy(), Arc::new(MemoryAudit::default())).await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("dispatch");
+    let rendered = serde_json::to_string(&response.payload).expect("json");
+    assert!(!rendered.contains(RAW_EMAIL));
+    assert!(rendered.contains("isError"));
+}
+
+#[tokio::test]
+async fn embedded_resource_resource_link_and_image_are_denied() {
+    for content in [
+        Content::embedded_text("file:///secret", RAW_EMAIL),
+        Content::resource_link(RawResource {
+            uri: "file:///secret".to_string(),
+            name: "secret".to_string(),
+            title: Some(RAW_EMAIL.to_string()),
+            description: None,
+            mime_type: None,
+            size: None,
+            icons: None,
+            meta: None,
+        }),
+        Content::image("AAAA", "image/png"),
+    ] {
+        let client = FakeClient::new(FakeResponse::Result(CallToolResult::success(vec![content])));
+        let (host, store) = host_with_fake(
+            client.clone(),
+            allow_to_policy(),
+            Arc::new(MemoryAudit::default()),
+        )
+        .await;
+        let token = seed_email_token(&store, SID_A).await;
+        let response = host
+            .dispatch(
+                &Principal::new("agent"),
+                "mail.send",
+                json!({"to": token}),
+                Some(SID_A),
+            )
+            .await
+            .expect("blocked");
+        assert_eq!(
+            response.payload["gaze_bridge"]["reason"],
+            "unsupported_content_block"
+        );
+    }
+}
+
+#[tokio::test]
+async fn result_deny_policy_blocks_successful_result() {
+    let client = FakeClient::new(FakeResponse::Result(result_text("screen bytes")));
+    let (host, store) = host_with_fake(
+        client,
+        deny_result_policy(),
+        Arc::new(MemoryAudit::default()),
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked");
+    assert_eq!(response.payload["gaze_bridge"]["reason"], "result_denied");
+}
+
+#[tokio::test]
+async fn response_byte_and_block_limits_block_before_return() {
+    let client = FakeClient::new(FakeResponse::Result(result_text(
+        "this response is too long",
+    )));
+    let limits = LimitCfg {
+        call_timeout_ms: 1_000,
+        response_bytes: 16,
+        content_blocks: 64,
+    };
+    let (host, store) = host_with_fake_and_limits(
+        client,
+        allow_to_policy(),
+        Arc::new(MemoryAudit::default()),
+        limits,
+    )
+    .await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked");
+    assert_eq!(
+        response.payload["gaze_bridge"]["reason"],
+        "response_too_large"
+    );
+
+    let many = CallToolResult::success(
+        (0..65)
+            .map(|idx| Content::text(format!("block {idx}")))
+            .collect::<Vec<_>>(),
+    );
+    let client = FakeClient::new(FakeResponse::Result(many));
+    let (host, store) =
+        host_with_fake(client, allow_to_policy(), Arc::new(MemoryAudit::default())).await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("blocked");
+    assert_eq!(
+        response.payload["gaze_bridge"]["reason"],
+        "too_many_content_blocks"
+    );
+}
+
+#[tokio::test]
+async fn downstream_json_rpc_error_data_is_redacted() {
+    let client = FakeClient::new(FakeResponse::McpError {
+        message: format!("not found {RAW_EMAIL}"),
+        data: Some(json!({"email": RAW_EMAIL})),
+    });
+    let (host, store) =
+        host_with_fake(client, allow_to_policy(), Arc::new(MemoryAudit::default())).await;
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("error response");
+    let rendered = serde_json::to_string(&response.payload).expect("json");
+    assert!(!rendered.contains(RAW_EMAIL));
+    assert_eq!(response.payload["isError"], true);
+}
+
+#[tokio::test]
+async fn encrypted_file_store_does_not_write_raw_pii_and_reloads() {
+    let dir = TempDir::new().expect("tempdir");
+    std::env::set_var("GAZE_BRIDGE_TEST_KEY", "22".repeat(32));
+    let config = format!(
+        r#"
+        [session]
+        mode = "file"
+        dir = "{}"
+        key_env = "GAZE_BRIDGE_TEST_KEY"
+
+        [servers.mail]
+        command = "mail"
+        "#,
+        dir.path().display()
+    );
+    let bridge_config = BridgeConfig::from_toml_str(&config).expect("config");
+    let store = BridgeSessionStore::from_config(&bridge_config.session).expect("store");
+    let session = store.get(SID_A).await.expect("session");
+    {
+        let guard = session.lock().await;
+        guard
+            .tokenize(&PiiClass::Email, RAW_EMAIL)
+            .expect("tokenize");
+        store.persist(SID_A, &guard).await.expect("persist");
+    }
+    let bytes = read_all_files(dir.path());
+    assert!(!String::from_utf8_lossy(&bytes).contains(RAW_EMAIL));
+    let reloaded = BridgeSessionStore::from_config(&bridge_config.session).expect("reload store");
+    let loaded = reloaded.get(SID_A).await.expect("load session");
+    assert_eq!(loaded.lock().await.snapshot_entries().len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_mode_parallel_sessions_do_not_corrupt_each_other() {
+    let dir = TempDir::new().expect("tempdir");
+    std::env::set_var("GAZE_BRIDGE_TEST_KEY_CONC", "33".repeat(32));
+    let config = format!(
+        r#"
+        [session]
+        mode = "file"
+        dir = "{}"
+        key_env = "GAZE_BRIDGE_TEST_KEY_CONC"
+
+        [servers.mail]
+        command = "mail"
+        "#,
+        dir.path().display()
+    );
+    let bridge_config = BridgeConfig::from_toml_str(&config).expect("config");
+    let store = Arc::new(BridgeSessionStore::from_config(&bridge_config.session).expect("store"));
+    let mut handles = Vec::new();
+    for idx in 0..8 {
+        let store = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            let sid = format!("01HRT7K6P6X5Q9M0V8YQ4N7T{idx:02}");
+            let session = store.get(&sid).await.expect("session");
+            let guard = session.lock().await;
+            guard
+                .tokenize(&PiiClass::Email, &format!("user{idx}@example.invalid"))
+                .expect("token");
+            store.persist(&sid, &guard).await.expect("persist");
+        }));
+    }
+    for handle in handles {
+        handle.await.expect("join");
+    }
+    assert_eq!(std::fs::read_dir(dir.path()).expect("read dir").count(), 8);
+}
+
+proptest::proptest! {
+    #[test]
+    fn audit_event_serializes_paths_only(local in "[a-z]{1,12}") {
+        let raw = format!("{local}@example.invalid");
+        let mut event = BridgeAuditEvent::new(
+            "01HRT7K6P6X5Q9M0V8YQ4N7TBC".to_string(),
+            SID_A,
+            "mail".to_string(),
+            "send".to_string(),
+            DecisionOutcome::Allowed,
+            "test",
+        );
+        event.arg_paths_affected.push(ArgPath::root().child("to").expect("path"));
+        let serialized = serde_json::to_string(&event).expect("json");
+        prop_assert!(!serialized.contains(&raw));
+        prop_assert!(!serialized.contains("@example.invalid"));
+    }
+}
+
+#[tokio::test]
+async fn rmcp_child_process_fixture_spawns_lists_calls_and_bridge_redacts() {
+    let temp = TempDir::new().expect("tempdir");
+    let script = temp.path().join("fixture_mcp.py");
+    write_python_fixture(&script);
+
+    let spec = ServerSpec {
+        command: "python3".to_string(),
+        args: vec![script.display().to_string()],
+        env: BTreeMap::new(),
+        cwd: None,
+    };
+    let client = RmcpChildClient::spawn(&spec).await.expect("client");
+    let tools = client
+        .list_tools(Duration::from_secs(5))
+        .await
+        .expect("tools");
+    assert_eq!(tools[0].raw_name, "send");
+
+    let mut clients: BTreeMap<String, Arc<dyn DownstreamClient>> = BTreeMap::new();
+    clients.insert("mail".to_string(), client);
+    let registry = Arc::new(
+        BridgeRegistry::discover(clients, Duration::from_secs(5))
+            .await
+            .expect("registry"),
+    );
+    let audit_path = temp.path().join("audit.jsonl");
+    let store = Arc::new(BridgeSessionStore::ephemeral());
+    let host = BridgeHostBuilder::new(
+        registry,
+        Arc::clone(&store),
+        Arc::new(gaze_mcp_bridge::FileBridgeAuditSink::new(&audit_path)),
+    )
+    .auth(Arc::new(AllowAuth))
+    .policy(allow_to_policy())
+    .build();
+    let token = seed_email_token(&store, SID_A).await;
+    let response = host
+        .dispatch(
+            &Principal::new("agent"),
+            "mail.send",
+            json!({"to": token}),
+            Some(SID_A),
+        )
+        .await
+        .expect("dispatch");
+    let rendered = serde_json::to_string(&response.payload).expect("json");
+    assert!(!rendered.contains(RAW_EMAIL));
+    let audit = std::fs::read_to_string(audit_path).expect("audit");
+    assert!(!audit.contains(RAW_EMAIL));
+}
+
+fn read_all_files(dir: &Path) -> Vec<u8> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir).expect("read dir") {
+        let entry = entry.expect("entry");
+        if entry.file_type().expect("file type").is_file() {
+            out.extend(std::fs::read(entry.path()).expect("read file"));
+        }
+    }
+    out
+}
+
+fn write_python_fixture(path: &Path) {
+    let script = r#"
+import json
+import sys
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialize":
+        send({"jsonrpc":"2.0","id":mid,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"fixture","version":"0.0.0"}}})
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        send({"jsonrpc":"2.0","id":mid,"result":{"tools":[{"name":"send","description":"send","inputSchema":{"type":"object","properties":{"to":{"type":"string"}}}}]}})
+    elif method == "tools/call":
+        args = msg.get("params", {}).get("arguments", {})
+        print("stderr planted alice@example.invalid", file=sys.stderr, flush=True)
+        send({"jsonrpc":"2.0","id":mid,"result":{"content":[{"type":"text","text":"sent to " + args.get("to", "")}],"isError":False}})
+    else:
+        send({"jsonrpc":"2.0","id":mid,"error":{"code":-32601,"message":"unknown"}})
+"#;
+    std::fs::write(path, script).expect("write fixture");
+}

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ function or associated item not found in `ToolCtx<'_>`
+   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`

--- a/crates/xtask/src/cargo_metadata_audit_isolation.rs
+++ b/crates/xtask/src/cargo_metadata_audit_isolation.rs
@@ -41,6 +41,10 @@ const SAFETY_NET_MEMBER_EXEMPTIONS: &[WorkspaceMemberExemption] = &[
         reason: "rmcp transport sink; tokio is a runtime dep for the MCP transport, not the safety-net pipeline",
     },
     WorkspaceMemberExemption {
+        workspace_member: "gaze-mcp-bridge",
+        reason: "MCP bridge transport/client boundary; tokio is a downstream MCP runtime dep, not the safety-net pipeline",
+    },
+    WorkspaceMemberExemption {
         workspace_member: "gaze-proxy",
         reason: "HTTP provider proxy; reqwest/tokio/hyper are proxy transport deps, not safety-net pipeline deps",
     },

--- a/docs/architecture/mcp-bridge.md
+++ b/docs/architecture/mcp-bridge.md
@@ -1,0 +1,87 @@
+# MCP Bridge Architecture
+
+`gaze-mcp-bridge` is an optional MCP bridge for deployments where an agent
+should call real downstream MCP servers without ever seeing raw PII. Gaze is
+the only MCP server exposed to the agent. The bridge is also an MCP client to
+the real servers.
+
+## Fit
+
+The bridge is for side-effecting agent workflows that already use Gaze tokens:
+email and calendar actions, filesystem tools, and computer-use agents. The
+agent sends pseudonymous tokens such as `<Email_1>`. The bridge restores those
+tokens only for fields that policy explicitly marks as sensitive and allowed,
+forwards the call to the downstream server, then redacts every text result
+before returning it to the agent.
+
+Resources and prompts are discovered in v1 so operators can see the downstream
+surface, but they are denied by default. Tool calls are the only proxied path.
+
+## Trust Model
+
+The agent is untrusted. It must never receive raw PII and must not be able to
+smuggle raw PII into downstream tools. Missing auth, missing session IDs,
+unknown tokens, unsupported content blocks, oversized responses, and audit
+write failures all fail closed.
+
+The key inversion is that normal Gaze redacts on egress to an untrusted model.
+Redaction is a safe, lossy operation. The bridge restores on egress from an
+untrusted agent into a real tool. Restore is dangerous and lossless: a wrong
+restore injects raw PII into a real side effect. For that reason the bridge is
+stricter than the core redaction path.
+
+## Dispatch Order
+
+`BridgeHost` implements `gaze_mcp_core::DispatchHost`, so it does not inherit
+`PiiEnvelope` internals. It re-implements the required guards:
+
+1. Validate the external session ID before using it as a session key.
+2. Authorize with a default-deny auth hook.
+3. Load the per-session Gaze session.
+4. Apply egress policy and scan all arguments for raw PII.
+5. Require approval when policy says a sensitive field needs approval.
+6. Persist path-only audit metadata before forwarding.
+7. Forward to the downstream MCP server with a timeout.
+8. Deny unsupported content and redact all text-bearing result fields.
+9. Persist encrypted session state when file mode is enabled.
+
+## Session Storage
+
+Ephemeral mode uses `Scope::Ephemeral` and never exports a session snapshot.
+File mode stores one encrypted file per validated external session ID. Gaze's
+`Session::export()` is signed plaintext, so the bridge encrypts it with AEAD
+before writing. The AEAD key comes from `session.key_env`; file mode refuses to
+start if the variable is absent or empty.
+
+The session key is a restore key. If it is exposed, an attacker with session
+files can decrypt the token-to-PII map. Operators should inject it through a
+secret manager, rotate it deliberately, and treat old encrypted session files
+as unreadable after rotation unless migrated.
+
+## Stderr Containment
+
+Downstream child MCP servers can log restored arguments. rmcp's child process
+transport inherits stderr by default, which would leak raw PII to parent logs.
+The bridge forces child stderr to a pipe and drains it without writing raw
+bytes to stdout, stderr, tracing, or audit. Operators should still review
+downstream server logging because those processes may write to their own files.
+
+## Result Handling
+
+Only fully handled text content blocks pass in v1. Image, audio, embedded
+resource, resource link, blob, and unknown future content kinds are denied.
+`isError=true` results and downstream JSON-RPC errors are redacted through the
+same path as successful text results. `result.mode = "allow"` is an explicit
+unsafe opt-in and emits a startup warning; it should not be used in normal
+agent-facing deployments.
+
+## CLI
+
+```bash
+gaze mcp bridge --config gaze.mcp.toml
+gaze mcp bridge --config gaze.mcp.toml --dry-run
+gaze mcp bridge --config gaze.mcp.toml --print-tools
+```
+
+`--session-dir` overrides `[session].dir` for file mode. Audit JSONL is written
+under the same MCP manifest directory used by `gaze mcp serve`.

--- a/docs/architecture/mcp-bridge.md
+++ b/docs/architecture/mcp-bridge.md
@@ -45,6 +45,21 @@ stricter than the core redaction path.
 8. Deny unsupported content and redact all text-bearing result fields.
 9. Persist encrypted session state when file mode is enabled.
 
+## Policy Resolution
+
+Argument policy is fail-closed by default and resolves at top-level argument
+boundaries. A policy entry such as `[policy.tools."email.send".arguments.to]`
+matches `$.to`; nested selectors such as `contact.email` are not interpreted as
+JSONPath and do not match `$.contact.email`. Nested values inherit the nearest
+matching top-level argument policy, or the base tool/server/default policy when
+none exists.
+
+Policy merges are least-privilege only when broad scopes stay restrictive.
+Boolean guard fields are monotonic: if an outer scope sets
+`allow_sensitive_fields` or `requires_approval` to `true`, a narrower scope
+cannot reset that flag to `false`. Keep `[policy.default]` and server-wide
+policy deny-by-default, then allow only the smallest top-level argument needed.
+
 ## Session Storage
 
 Ephemeral mode uses `Scope::Ephemeral` and never exports a session snapshot.

--- a/examples/mcp-bridge/cua.toml
+++ b/examples/mcp-bridge/cua.toml
@@ -1,0 +1,27 @@
+[session]
+mode = "file"
+dir = ".gaze/cua-sessions"
+key_env = "GAZE_BRIDGE_SESSION_KEY"
+
+[servers.cua]
+command = "example-cua-mcp"
+args = ["--stdio"]
+
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = true
+on_block = "refuse"
+log_raw = false
+
+[policy.tools."cua.type_text".arguments.text]
+allow_sensitive_fields = true
+requires_approval = true
+
+[policy.tools."cua.click".arguments.selector]
+allow_sensitive_fields = false
+
+[policy.tools."cua.screenshot".result]
+mode = "deny"
+
+[policy.tools."cua.type_text".result]
+mode = "process"

--- a/examples/mcp-bridge/dangerous-outputs.toml
+++ b/examples/mcp-bridge/dangerous-outputs.toml
@@ -1,0 +1,17 @@
+[session]
+mode = "ephemeral"
+
+[servers.lab]
+command = "example-lab-mcp"
+args = ["--stdio"]
+
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+# Unsafe opt-in. This can return raw downstream output to the agent.
+# Use only in isolated tests where no raw PII can be produced.
+[policy.tools."lab.raw_result_demo".result]
+mode = "allow"

--- a/examples/mcp-bridge/email-calendar.toml
+++ b/examples/mcp-bridge/email-calendar.toml
@@ -1,0 +1,41 @@
+[session]
+mode = "file"
+dir = ".gaze/sessions"
+key_env = "GAZE_BRIDGE_SESSION_KEY"
+
+[servers.email]
+command = "example-email-mcp"
+args = ["--stdio"]
+
+[servers.calendar]
+command = "example-calendar-mcp"
+args = ["--stdio"]
+
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+[policy.tools."email.send".arguments.to]
+allow_sensitive_fields = true
+
+[policy.tools."email.send".arguments.cc]
+allow_sensitive_fields = true
+
+[policy.tools."email.send".arguments.body]
+allow_sensitive_fields = true
+requires_approval = true
+
+[policy.tools."calendar.create_event".arguments.attendees]
+allow_sensitive_fields = true
+
+[policy.tools."calendar.create_event".arguments.description]
+allow_sensitive_fields = true
+requires_approval = true
+
+[policy.tools."email.send".result]
+mode = "process"
+
+[policy.tools."calendar.create_event".result]
+mode = "process"

--- a/examples/mcp-bridge/filesystem.toml
+++ b/examples/mcp-bridge/filesystem.toml
@@ -1,0 +1,28 @@
+[session]
+mode = "ephemeral"
+
+[servers.filesystem]
+command = "example-filesystem-mcp"
+args = ["--root", "/safe/project"]
+
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+[policy.tools."filesystem.read_file".arguments.path]
+allow_sensitive_fields = false
+
+[policy.tools."filesystem.write_file".arguments.path]
+allow_sensitive_fields = false
+
+[policy.tools."filesystem.write_file".arguments.content]
+allow_sensitive_fields = false
+requires_approval = true
+
+[policy.tools."filesystem.read_file".result]
+mode = "process"
+
+[policy.tools."filesystem.write_file".result]
+mode = "process"

--- a/examples/mcp-bridge/policy.toml
+++ b/examples/mcp-bridge/policy.toml
@@ -1,0 +1,24 @@
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+[policy.default.result]
+mode = "process"
+
+[policy.servers.email]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+[policy.servers.email.tools.send.arguments.to]
+allow_sensitive_fields = true
+
+[policy.servers.email.tools.send.arguments.body]
+allow_sensitive_fields = true
+requires_approval = true
+
+[policy.servers.email.tools.send.result]
+mode = "process"

--- a/examples/mcp-bridge/safe-defaults.toml
+++ b/examples/mcp-bridge/safe-defaults.toml
@@ -1,0 +1,19 @@
+[session]
+mode = "ephemeral"
+
+[limits]
+call_timeout_ms = 30000
+response_bytes = 1048576
+content_blocks = 64
+
+[servers.echo]
+command = "example-safe-mcp-server"
+
+[policy.default]
+allow_sensitive_fields = false
+requires_approval = false
+on_block = "refuse"
+log_raw = false
+
+[policy.default.result]
+mode = "process"


### PR DESCRIPTION
Summary
- Adds `gaze-mcp-bridge` v0.9.1 as an optional policy-gated MCP bridge crate.
- Reimplements PiiEnvelope guard order at the bridge host: validated session IDs, default-deny auth, durable path-only audit before forwarding, per-session manifests, fail-closed egress/ingress policy, approval binding, stderr containment, encrypted file sessions, and rmcp child-process transport.
- Wires `gaze mcp bridge` behind the CLI `mcp` feature and documents the security model plus example bridge configs.

Per-phase test plan
- Phase 1-4 core: `cargo check -p gaze-mcp-bridge --all-targets` plus full required gates before commit.
- Phase 5 tests: `cargo test -p gaze-mcp-bridge --all-targets` plus full required gates before commit.
- Phase 6 CLI: `cargo check -p gaze-cli --features mcp --all-targets` plus full required gates before commit.
- Phase 7 docs: `cargo run -p gaze-cli -- clean --format json < docs/architecture/mcp-bridge.md > /tmp/gaze-mcp-bridge-doc-clean.json`.
- Phase 8 gates: `cargo fmt --all -- --check`; `cargo clippy --workspace --all-features --all-targets -- -D warnings`; `cargo test --workspace --all-features`; `cargo run -p xtask -- ci-feature-matrix`.

Resolves todo #1578