### PR TITLE
[agent] Clean token bridge comments and demo coverage

### DIFF
--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`
+   |                         ^^^ function or associated item not found in `ToolCtx<'_>`

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ function or associated item not found in `ToolCtx<'_>`
+   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -3,7 +3,8 @@
 > **Status:** work in progress (`publish = false`). API is pre-1.0 and may change.
 
 The token bridge is the **owner-side authorization + translation layer** that lets an
-agent search long-lived, policy-scoped document corpora **without ever seeing raw PII**.
+agent search long-lived, policy-scoped document corpora while keeping raw values on
+the owner side of the bridge.
 
 An agent works in a short-lived [`RedactionSession`](src/session.rs) whose only
 vocabulary is *session tokens* (e.g. `<…:Name_1>`). When it wants to search a corpus,
@@ -11,9 +12,7 @@ the bridge — running entirely owner-side — resolves the token, checks policy
 (default-deny), mints a single-use, entity-bound capability, runs the search against a
 **redact-before-index** corpus, and translates the owner-side hits back into the
 agent's current session namespace. Raw PII, index aliases, and the restore manifest stay
-owner-side by construction; the agent only ever receives current-session tokens. This
-serves the project's north star directly: **zero PII leaks between the agent and the
-data owner — ever** (fail-closed on every error path).
+owner-side; the agent-visible response is current-session tokens plus non-sensitive text.
 
 For the architecture and the frozen data-model contract, see the crate docs
 ([`src/lib.rs`](src/lib.rs)) and [`src/model.rs`](src/model.rs)'s three visibility tiers.
@@ -21,9 +20,8 @@ For the architecture and the frozen data-model contract, see the crate docs
 ## Local demo (try it)
 
 A runnable, **synthetic-data-only** walkthrough lives in
-[`examples/local_demo.rs`](examples/local_demo.rs). It uses only the crate's public API
-(plus `serde_json`, already a dependency) and exits `0` on success / panics loudly on any
-leak. No setup, no network, no real PII.
+[`examples/local_demo.rs`](examples/local_demo.rs). It uses the crate's public API and
+prints the allow/deny outcomes and translated snippets for the bundled fixture corpus.
 
 ### Run it
 
@@ -34,35 +32,30 @@ cargo run -p gaze-token-bridge --example local_demo
 ### Expected output
 
 ```text
-gaze-token-bridge — local demo (SYNTHETIC DATA ONLY)
-Owner-side authorization + translation bridge. Zero raw PII reaches the agent.
+gaze-token-bridge - local synthetic demo
+Owner-side authorization and translation over bundled fixtures.
 
-=== Step 1 — ingest synthetic corpus (redact-before-index) ===
-Ingested 5 synthetic docs into 2 IndexDomains via the Track B redact-before-index pipeline:
+=== Step 1 - ingest synthetic corpus ===
+Ingested 5 synthetic docs into two policy-scoped domains:
   - tenant_demo/customer_docs/v1
   - tenant_demo/legal_docs/v1
-Raw values were tokenized at ingest; the index holds only projected aliases.
 
-=== Step 2 — support session mints a token for the lookup name ===
-owner-side input (never sent to the agent): name = "Markus Gottschaue"
-session token the agent sees instead:        <0cd5a5d9:Name_1>
+=== Step 2 - mint a lookup token ===
+owner-side synthetic input: name = "Markus Gottschaue"
+session token passed to the bridge: <0cd5a5d9:Name_1>
 
-=== Step 3 — ALLOWED: support -> customer_docs ===
+=== Step 3 - support searches customer docs ===
 ALLOWED. target_domain = tenant_demo/customer_docs/v1
-session-translated snippets (note the <...:Class_n> session tokens):
   [cust-001] Customer profile <0cd5a5d9:Name_1> / <0cd5a5d9:Email_1> / <0cd5a5d9:Custom:customer_id_1> is linked to <0cd5a5d9:Organization_1>.
 
-=== Step 4 — DENIED: support -> legal_docs ===
+=== Step 4 - support searches legal docs ===
 DENIED (authorization failed)
 
-=== Step 4 (contrast) — ALLOWED: admin -> legal_docs ===
+=== Step 5 - admin searches legal docs ===
 ALLOWED. target_domain = tenant_demo/legal_docs/v1
   [cust-001] Legal matter references <48904f81:Name_1> at <48904f81:Organization_1>; contact route <48904f81:Email_1>.
 
-=== Step 5 — assert NO raw PII in agent-visible output ===
-Scanned 480 bytes of agent-visible JSON against 20 raw fixture values.
-✅ NO RAW PII IN AGENT-VISIBLE OUTPUT
-audit events recorded (one per bridge decision): 3
+audit events recorded: 3
 ```
 
 > **Note on the token prefix.** The 8-hex prefix (`0cd5a5d9`, `48904f81`, …) is a
@@ -71,27 +64,20 @@ audit events recorded (one per bridge decision): 3
 > correlated across sessions. Only the structure (`:Name_1>`, `:Email_1>`, …) is stable.
 > The support and admin lines use different prefixes because they are different sessions.
 
-### What each step proves
+### What each step demonstrates
 
-Mapped to the four spike blockers this runtime had to close, plus the never-leak assertion:
+1. **Session and principal binding** - each principal mints tokens in its own
+   principal-bound session. The support principal is denied for `legal_docs`, while
+   the admin principal is allowed from the admin's own session.
+2. **Owner-bound purpose** - the request carries a `purpose`, but the policy gate uses
+   the owner-bound purpose resolved from config.
+3. **entity_ref binding** - authorization mints a single-use capability bound to one
+   specific entity, so the allowed search returns that entity's document.
+4. **Filter and value projection** - the corpus is redacted before indexing, and
+   returned snippets are translated into the active session's tokens.
 
-1. **Session ↔ principal binding** — each principal mints tokens in its *own*
-   principal-bound session. Step 4 shows `support → legal_docs` fail closed (a uniform
-   deny), while `admin → legal_docs` is allowed from the admin's own session; a session
-   may not be reused across principals.
-2. **Owner-bound purpose** — the request carries a `purpose`, but the policy gate ignores
-   it and uses the owner-bound purpose resolved from config. The agent (or a prompt
-   injection) cannot widen its authority by restating intent.
-3. **entity_ref binding** — authorization mints a single-use capability bound to one
-   specific entity, so the ALLOWED search returns only that entity's document
-   (`cust-001`), never the whole corpus.
-4. **Filter / value projection** — the corpus was redacted *before* indexing, so the
-   index holds only projected aliases; returned snippets are translated into the active
-   session's tokens. Raw values never reach the index, the adapter, or the agent.
-5. **Never-leak assertion** — Step 5 serializes *all* agent-visible responses and scans
-   them against every raw value in the synthetic fixture. Any match panics (non-zero
-   exit). The deny path emits a single uniform `DENIED (authorization failed)` line — the
-   typed `DenyReason` is owner-side audit only, so the agent gets no probing oracle.
+Integration coverage for expected outcomes and fixture leak checks lives in
+[`tests/local_demo_assertions.rs`](tests/local_demo_assertions.rs).
 
 ### What's NOT shown
 
@@ -102,9 +88,11 @@ Mapped to the four spike blockers this runtime had to close, plus the never-leak
   (`raw_filter_values_are_projected_before_adapter_receives_request` in
   [`tests/track_c_bridge.rs`](tests/track_c_bridge.rs)) rather than this script.
 - **The MCP `search_documents` chokepoint tool** (the sealed-handle integration that
-  exposes this bridge as an agent tool) lives behind the `chokepoint` feature — see PR2.
+  exposes this bridge as an agent tool) lives behind the `chokepoint` feature.
   This example drives the bridge through its library API directly.
 
-All behavior here is covered by the acceptance suite in
-[`tests/track_c_bridge.rs`](tests/track_c_bridge.rs); run it with
-`cargo test -p gaze-token-bridge`.
+For bring-your-own-data redaction, use the core folder scan example:
+
+```bash
+cargo run -p gaze-pii --example scan_folder -- --path ./my-data
+```

--- a/crates/gaze-token-bridge/src/adapter.rs
+++ b/crates/gaze-token-bridge/src/adapter.rs
@@ -1,8 +1,5 @@
-//! Track B — `SearchAdapter` implementation: an in-memory corpus index (store + query by
-//! `IndexedEntityRef`) for v1, replacing the spike's fake. Enforces
-//! entity_ref/domain/expiry/nonce guards defensively. Owner: sub-orchestrator B.
-//! Contract: `crate::traits::SearchAdapter`, `crate::model::{ValidatedSearchRequest, IndexSearchHit}`.
-//! Reference: spike `InMemorySearchAdapter`.
+//! In-memory owner-side corpus index keyed by `IndexedEntityRef`.
+//! Enforces entity_ref/domain/expiry/nonce guards defensively.
 //!
 //! Owner-side hits deliberately have no serde path:
 //!

--- a/crates/gaze-token-bridge/src/audit.rs
+++ b/crates/gaze-token-bridge/src/audit.rs
@@ -1,7 +1,5 @@
-//! Track C (gated) — `BridgeAuditSink`: append-only audit, one event per bridge
-//! decision, raw values only as sha256. Follow the `gaze-audit` restricted-column +
-//! Dylint-isolation pattern when persisting durably. Owner: sub-orchestrator C.
-//! Contract: `crate::traits::BridgeAuditSink`, `crate::model::AuditEvent`. Reference: spike `BridgeAudit`.
+//! Append-only bridge audit sink: one event per bridge decision, raw values only as sha256.
+//! Durable implementations should preserve restricted-column isolation.
 
 use crate::model::AuditEvent;
 use crate::traits::BridgeAuditSink;

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -1,16 +1,6 @@
-//! Track C (gated) — `TokenBridge` runtime: orchestrate resolve → canonicalize →
-//! project (A) → policy (A) → mint capability (C) → adapter (B) → translate (C) → audit (C).
+//! `TokenBridge` runtime: orchestrate resolve → canonicalize → project → policy →
+//! mint capability → adapter → translate → audit.
 //! Also the chokepoint integration (ToolResources sealed handle, `search_documents` tool).
-//! Owner: sub-orchestrator C. Reference: spike `TokenBridge`.
-//!
-//! # Ownership note
-//! [`crate::policy::RegistryPolicyGate`] borrows its registry, while [`TokenBridge::demo`]
-//! must return an owned value. A struct that owns the registry *and* a gate borrowing it
-//! would be self-referential, so the bridge owns the registry and constructs a fresh gate
-//! per authorization. The per-principal rate-limit buckets, however, are owned by the bridge
-//! (the `TokenBridge::rate_limit` field) and injected by `&mut` into each per-call gate, so
-//! they persist and accumulate across calls (blocker #1564). The immutable borrow of `registry`
-//! and the mutable borrow of `rate_limit` are disjoint fields, so both are legal at once.
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -40,7 +30,7 @@ use crate::traits::{
 use crate::translate::SessionResponseTranslator;
 use crate::util::sha256_hex;
 
-// Track C chokepoint integration — gated, OFF by default. Implements
+// Optional chokepoint integration. Implements
 // `gaze_mcp_core::Tool` for the owner-side `SearchDocumentsTool` without touching
 // gaze-mcp-core's sealed surface. See `chokepoint` module docs.
 #[cfg(feature = "chokepoint")]
@@ -53,8 +43,8 @@ const DEMO_POLICY_JSON: &str = include_str!("../fixtures/policy.json");
 const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
 const LEGAL_DOMAIN: &str = "tenant_demo/legal_docs/v1";
 
-/// Owner-side bridge runtime. Composes the registry-backed policy gate (A), the corpus
-/// search adapter (B), the capability runtime (C), and an append-only audit sink (C).
+/// Owner-side bridge runtime. Composes the registry-backed policy gate, corpus
+/// search adapter, capability runtime, and append-only audit sink.
 #[derive(Debug)]
 pub struct TokenBridge<S = InMemoryCorpusIndexStore> {
     registry: IndexDomainRegistry,
@@ -68,7 +58,7 @@ pub struct TokenBridge<S = InMemoryCorpusIndexStore> {
     /// projected owner-side before the adapter sees them).
     last_adapter_filters: Vec<AdapterFilterClause>,
     /// Persistent per-principal rate-limit buckets, injected into each per-call policy gate
-    /// so the corpus-enumeration cap accumulates across calls (blocker #1564).
+    /// so the corpus-enumeration cap accumulates across calls.
     rate_limit: RateLimitState,
     /// Required Pass-3 scan over every translated, agent-visible snippet.
     output_safety_net: Option<OutputSafetyNet>,
@@ -91,7 +81,7 @@ impl std::fmt::Debug for OutputSafetyNet {
 
 impl TokenBridge<InMemoryCorpusIndexStore> {
     /// Build the bundled demo bridge: load the demo policy, ingest the synthetic corpus
-    /// into both domains via the Track B redact-before-index ingestor, and compose.
+    /// into both domains via the redact-before-index ingestor, and compose.
     pub fn demo() -> Result<Self, BridgeError> {
         Self::from_policy_json(DEMO_POLICY_JSON)
     }
@@ -180,7 +170,7 @@ impl<S: CorpusIndexStore> TokenBridge<S> {
         // Scope the gate's borrows of `self.registry` / `self.rate_limit` to this block so
         // the subsequent mutable borrows of `self.capability` / `self.audit` are legal. The
         // gate reads+updates the bridge-owned rate-limit buckets, so the cap persists across
-        // calls (blocker #1564); `registry` and `rate_limit` are disjoint fields.
+        // calls; `registry` and `rate_limit` are disjoint fields.
         let outcome = {
             let mut gate = RegistryPolicyGate::new(&self.registry, &mut self.rate_limit);
             gate.evaluate(session, request)
@@ -367,7 +357,7 @@ impl<S: CorpusIndexStore> TokenBridge<S> {
     }
 }
 
-/// A structured synthetic record. Mirrors the spike fixture set; reused by the PR3 example.
+/// A structured synthetic record for the bundled demo corpus.
 #[derive(Debug, Clone)]
 pub struct SyntheticDoc {
     pub id: &'static str,
@@ -379,7 +369,7 @@ pub struct SyntheticDoc {
 
 impl SyntheticDoc {
     /// Render this record as raw corpus text for a domain. The text is fed through the
-    /// Track B redact-before-index ingestor, so the raw values below never enter the
+    /// redact-before-index ingestor, so the raw values below never enter the
     /// index in cleartext — only their projected aliases and owner-side raw fields do.
     fn raw_text(&self, domain_id: &str) -> String {
         if domain_id == CUSTOMER_DOMAIN {
@@ -396,7 +386,7 @@ impl SyntheticDoc {
     }
 }
 
-/// The bundled synthetic corpus (mirrors the spike). Reused by the PR3 example.
+/// The bundled synthetic corpus.
 pub fn synthetic_docs() -> Vec<SyntheticDoc> {
     vec![
         SyntheticDoc {

--- a/crates/gaze-token-bridge/src/bridge/chokepoint.rs
+++ b/crates/gaze-token-bridge/src/bridge/chokepoint.rs
@@ -1,4 +1,4 @@
-//! Track C (gated) — the `search_documents` MCP chokepoint tool.
+//! The `search_documents` MCP chokepoint tool.
 //!
 //! [`SearchDocumentsTool`] implements [`gaze_mcp_core::Tool`] so the bridge can be
 //! driven from a gaze-mcp-core dispatch without touching that crate's published,
@@ -23,7 +23,7 @@
 //! Every failure — unknown principal, malformed args, or any typed [`DenyReason`]
 //! from the bridge — collapses to one uniform `{authorized: false, results: []}`
 //! payload. The typed reason lives only in the bridge audit; the agent-visible
-//! surface never reveals which path fired (north-star axis 1 — never leak).
+//! surface never reveals which path fired.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard, PoisonError};
@@ -44,7 +44,7 @@ use crate::session::RedactionSession;
 /// authorizes it under. Adopters MUST author an allow-rule (and list the tool in
 /// each domain's `allowed_tools`) under `"search_documents"`. The agent never
 /// supplies the policy tool_name — that would hand authorization to the LLM
-/// (north-star axis 4: the LLM never decides authorization).
+/// (the LLM never decides authorization).
 const TOOL_NAME: &str = "search_documents";
 
 /// Bridge action this tool performs. Target domains must list it in

--- a/crates/gaze-token-bridge/src/capability.rs
+++ b/crates/gaze-token-bridge/src/capability.rs
@@ -1,8 +1,5 @@
-//! Track C (gated) — capability issuance + lifecycle: mint entity-bound `SearchHandle`s
-//! (nonce, expiry, single-use), validate them (entity_ref match, not expired, nonce
-//! unused), project raw filter values before they reach the adapter. Owner: sub-orchestrator C.
-//! Contract: `crate::model::{SearchHandle, SearchRequest, ValidatedSearchRequest}`.
-//! Reference: spike `TokenBridge::{issue_handle, project_search_request}`.
+//! Capability issuance and lifecycle: mint entity-bound `SearchHandle`s, validate them,
+//! and project raw filter values before they reach the adapter.
 
 use std::collections::HashSet;
 
@@ -20,7 +17,7 @@ use crate::util::sha256_hex;
 const HANDLE_TTL_TICKS: u64 = 2;
 
 /// Monotonic logical clock. Tests advance it explicitly; nothing wall-clock-derived
-/// leaks into handle expiry (keeps the contract deterministic — north-star axis 4).
+/// leaks into handle expiry, which keeps the contract deterministic.
 #[derive(Debug, Default)]
 pub struct LogicalClock {
     tick: u64,
@@ -77,7 +74,7 @@ impl CapabilityRuntime {
     /// Validate a handle against the entity_ref it is being used for. Fails closed on
     /// confused-deputy (entity_ref mismatch), domain mismatch, expiry, and replay.
     /// Consuming the nonce is the authoritative single-use gate; the adapter repeats
-    /// these checks defensively (defense in depth — north-star axis 1).
+    /// these checks defensively.
     pub fn validate_handle(
         &mut self,
         handle: &SearchHandle,

--- a/crates/gaze-token-bridge/src/error.rs
+++ b/crates/gaze-token-bridge/src/error.rs
@@ -1,7 +1,7 @@
-//! FROZEN CONTRACT — error + deny taxonomy. Master-owned.
+//! Error and deny taxonomy.
 //!
-//! `DenyReason` is `#[non_exhaustive]`: adding a variant is a master decision so
-//! all match sites stay exhaustive-with-wildcard. Every deny is typed and audited;
+//! `DenyReason` is `#[non_exhaustive]`: callers should keep wildcard match arms.
+//! Every deny is typed and audited;
 //! the agent-facing surface must never reveal which variant fired (no oracle).
 
 use serde::{Deserialize, Serialize};

--- a/crates/gaze-token-bridge/src/ingest.rs
+++ b/crates/gaze-token-bridge/src/ingest.rs
@@ -1,8 +1,6 @@
-//! Track B — ingest pipeline: redact-before-index (run corpus text through the gaze
-//! Pipeline so raw PII NEVER enters the index), canonicalize + project entities, build
-//! the index. Add a CI gate asserting no raw PII enters the store. Owner: sub-orchestrator B.
-//! Contract: `crate::model::{CanonicalEntity, IndexEntity, IndexSearchHit}`, `crate::util::domain_alias`.
-//! Reference: spike `build_internal_hit` / `synthetic_docs`.
+//! Redact-before-index ingest pipeline: run corpus text through the gaze Pipeline,
+//! canonicalize and project entities, then build owner-side index hits.
+//! Raw PII must not enter the searchable index.
 
 use std::ops::Range;
 

--- a/crates/gaze-token-bridge/src/keys.rs
+++ b/crates/gaze-token-bridge/src/keys.rs
@@ -1,6 +1,5 @@
-//! Track A — `KeyManager`: per-domain projection key material + rotation (retain old
-//! keys for read, addressed by `key_id`; missing key fails closed). Owner: sub-orchestrator A.
-//! Contract: `crate::traits::KeyManager`. Reference: spike `IndexDomainRegistry::projection_key`.
+//! Per-domain projection key material and rotation.
+//! Old keys are retained for reads; missing keys fail closed.
 
 use std::collections::HashMap;
 

--- a/crates/gaze-token-bridge/src/lib.rs
+++ b/crates/gaze-token-bridge/src/lib.rs
@@ -1,45 +1,41 @@
 //! gaze-token-bridge — owner-side authorization + translation bridge between a
 //! short-lived [`RedactionSession`] and long-lived, policy-scoped IndexDomains.
 //!
-//! # Frozen contract (master-owned)
+//! # Contract modules
 //! The modules [`model`], [`error`], [`session`], [`traits`], and [`util`] are the
-//! shared contract. Sub-orchestrators OBEY them; they never re-derive or edit them.
-//! A change to any of these is a master decision, made once and re-injected.
+//! shared public contract.
 //!
-//! # Implementation module ownership (one track each — disjoint file surface)
-//! - **Track A** (policy & projection): [`registry`], [`policy`], [`projection`], [`keys`]
-//! - **Track B** (index & search):      [`adapter`], [`ingest`]
-//! - **Track C** (bridge runtime, gated): [`bridge`], [`capability`], [`translate`], [`audit`]
+//! # Implementation modules
+//! - **Policy and projection**: [`registry`], [`policy`], [`projection`], [`keys`]
+//! - **Index and search**: [`adapter`], [`ingest`]
+//! - **Bridge runtime**: [`bridge`], [`capability`], [`translate`], [`audit`]
 //!
-//! Reference implementation (lift from, do not depend on): the throwaway spike crate
-//! `crates/spike-token-bridge` on branch `agent/tokenbridge-mvp-spike` (22 passing tests).
-//!
-//! # Invariants (north-star axis 1 — never leak)
+//! # Invariants
 //! - Raw PII and the session manifest never reach agent-visible output.
 //! - Index-domain aliases / fingerprints never reach agent-visible output.
 //! - The LLM never decides authorization; `purpose` is owner-bound.
 //! - Default-deny: no matching allow rule ⇒ deny. Every error path fails closed.
 //! - HMAC projection is `(tenant, domain)`-keyed only — never salted with principal.
 
-// --- Frozen contract (master) ---
+// --- Shared contract ---
 pub mod error;
 pub mod model;
 pub mod session;
 pub mod traits;
 pub mod util;
 
-// --- Track A: policy & projection ---
+// --- Policy and projection ---
 pub mod keys;
 pub mod policy;
 pub mod projection;
 pub mod registry;
 
-// --- Track B: index & search ---
+// --- Index and search ---
 pub mod adapter;
 pub mod ingest;
 pub mod persistent;
 
-// --- Track C: bridge runtime (gated) ---
+// --- Bridge runtime ---
 pub mod audit;
 pub mod bridge;
 pub mod capability;

--- a/crates/gaze-token-bridge/src/model.rs
+++ b/crates/gaze-token-bridge/src/model.rs
@@ -1,4 +1,4 @@
-//! FROZEN CONTRACT — shared data model. Master-owned.
+//! Shared data model.
 //!
 //! Three visibility tiers, do not blur them:
 //! - **Agent-visible** ([`AgentSearchHit`], [`BridgeSearchResponse`]): safe for the LLM.
@@ -64,7 +64,7 @@ pub struct BridgeRequest {
 }
 
 /// A raw value reduced to its canonical, class-tagged form prior to projection.
-/// Canonicalization is frozen here so ingest (Track B) and query (Track A) agree.
+/// Canonicalization is frozen here so ingest and query agree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CanonicalEntity {
     pub class: PiiClass,
@@ -199,7 +199,7 @@ pub struct AdapterFilterClause {
 }
 
 /// A search request after runtime validation + filter projection. Produced by the
-/// bridge runtime (Track C); consumed by the adapter (Track B). The adapter trusts
+/// bridge runtime; consumed by the adapter. The adapter trusts
 /// that entity_ref/nonce/expiry checks live in the runtime, but still enforces the
 /// entity_ref/domain/expiry/nonce guards defensively.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -267,7 +267,7 @@ impl BridgeSearchOutcome {
 }
 
 /// Authorization decision: an issued handle (+ whether elevated audit applies), or a deny.
-// Transient decision value matched immediately by every track; boxing the handle would
+// Transient decision value matched immediately by callers; boxing the handle would
 // add deref friction at each match site for negligible benefit. Allow the size asymmetry.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -281,8 +281,8 @@ pub enum BridgeDecision {
     },
 }
 
-/// Authorization grant emitted by Track A policy evaluation. Track C turns this into
-/// a short-lived capability; Track A does not mint handles.
+/// Authorization grant emitted by policy evaluation. The bridge turns this into
+/// a short-lived capability; policy evaluation does not mint handles.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthGrant {
     pub entity_ref: IndexedEntityRef,
@@ -294,7 +294,7 @@ pub struct AuthGrant {
     pub raw_sha256: String,
 }
 
-/// Policy outcome: either enough owner-side authorization data for Track C to issue
+/// Policy outcome: either enough owner-side authorization data for the bridge to issue
 /// a capability, or a typed fail-closed deny.
 // Transient decision value matched immediately by bridge runtime; keep it direct to
 // mirror BridgeDecision and avoid allocation in the hot path.

--- a/crates/gaze-token-bridge/src/policy.rs
+++ b/crates/gaze-token-bridge/src/policy.rs
@@ -1,8 +1,5 @@
-//! Track A — `PolicyGate` implementation: default-deny evaluation over
+//! `PolicyGate` implementation: default-deny evaluation over
 //! principal/tenant/workspace/role/tool/action/owner-bound-purpose/domain/entity-class/scope.
-//! Owner: sub-orchestrator A.
-//! Contract: `crate::traits::PolicyGate`, `crate::model::{BridgeRequest, PolicyOutcome}`.
-//! Reference: spike `TokenBridge::try_authorize` + `owner_bound_purpose`.
 
 use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -24,7 +21,7 @@ use crate::util::sha256_hex;
 /// (e.g. [`crate::bridge::TokenBridge`]) and injected by `&mut` into each short-lived
 /// [`RegistryPolicyGate`]. Keeping the buckets OUTSIDE the per-call gate is what lets the
 /// corpus-enumeration rate limit accumulate across calls instead of resetting every call
-/// (blocker #1564). Default-constructs empty.
+/// Default-constructs empty.
 #[derive(Debug, Default)]
 pub struct RateLimitState {
     buckets: HashMap<RateLimitBucket, HashSet<String>>,
@@ -40,9 +37,8 @@ impl RateLimitState {
 /// Policy gate backed by an [`IndexDomainRegistry`].
 ///
 /// The gate is short-lived: a fresh one is built per authorization because it borrows the
-/// registry, while the long-lived runtime owns the registry (a self-referential struct would
-/// otherwise result). The per-principal rate-limit buckets do NOT live on the gate — they are
-/// borrowed from caller-owned [`RateLimitState`] so they persist across gates (blocker #1564).
+/// registry. The per-principal rate-limit buckets do NOT live on the gate — they are
+/// borrowed from caller-owned [`RateLimitState`] so they persist across gates.
 #[derive(Debug)]
 pub struct RegistryPolicyGate<'a> {
     registry: &'a IndexDomainRegistry,

--- a/crates/gaze-token-bridge/src/projection.rs
+++ b/crates/gaze-token-bridge/src/projection.rs
@@ -1,7 +1,6 @@
-//! Track A — `DomainProjector` implementation: deterministic
-//! `HMAC((tenant,domain) key, canonical_value)` → `IndexedEntityRef`. NEVER salt with
-//! principal. Owner: sub-orchestrator A.
-//! Contract: `crate::traits::DomainProjector`. Reference: spike `DomainProjection`.
+//! Deterministic `DomainProjector` implementation:
+//! `HMAC((tenant,domain) key, canonical_value)` → `IndexedEntityRef`.
+//! Never salt with principal.
 
 use hmac::{Hmac, Mac};
 use sha2::Sha256;

--- a/crates/gaze-token-bridge/src/registry.rs
+++ b/crates/gaze-token-bridge/src/registry.rs
@@ -1,6 +1,5 @@
-//! Track A — `IndexDomainRegistry`: load `IndexDomain`s + `PolicyRule`s from a policy
-//! file, expose domain/rule/key lookup. Owner: sub-orchestrator A.
-//! Contract: `crate::model::{IndexDomain, PolicyRule}`. Reference: spike `IndexDomainRegistry`.
+//! `IndexDomainRegistry`: load `IndexDomain`s and `PolicyRule`s from a policy file,
+//! then expose domain, rule, and key lookup.
 
 use std::collections::HashMap;
 

--- a/crates/gaze-token-bridge/src/session.rs
+++ b/crates/gaze-token-bridge/src/session.rs
@@ -1,10 +1,9 @@
-//! FROZEN CONTRACT — the RedactionSession wrapper. Master-owned.
+//! The RedactionSession wrapper.
 //!
 //! A `RedactionSession` is the short-lived, conversation-local pseudonym namespace.
 //! It wraps a `gaze::Session` and is **bound to exactly one principal** at creation:
-//! a request from a different principal is denied before token resolution. This is the
-//! refined fix for the shared-session correlation threat — the projection stays
-//! `(tenant,domain)`-keyed, while session reuse across principals is rejected here.
+//! a request from a different principal is denied before token resolution. This blocks
+//! shared-session correlation while projection stays `(tenant,domain)`-keyed.
 
 use gaze::{PiiClass, Scope, Session};
 

--- a/crates/gaze-token-bridge/src/traits.rs
+++ b/crates/gaze-token-bridge/src/traits.rs
@@ -1,8 +1,7 @@
-//! FROZEN CONTRACT — trait surfaces each track implements. Master-owned.
+//! Trait surfaces used by token bridge components.
 //!
-//! These signatures are the seam between tracks. Tracks add `impl`s in their own
-//! modules; they do not change these signatures. A signature change is a master
-//! decision (raise NEED DIRECTION).
+//! These signatures define the boundaries between projection, policy, search,
+//! translation, audit, and capability issuance.
 
 use crate::error::{BridgeError, DenyReason};
 use crate::model::{
@@ -11,7 +10,7 @@ use crate::model::{
 };
 use crate::session::RedactionSession;
 
-/// Track A — deterministic domain projection.
+/// Deterministic domain projection.
 /// Implementations MUST key only on `(tenant, domain)` (via the domain's
 /// `projection_key_id`); never salt with principal (would break shared-corpus lookup).
 pub trait DomainProjector {
@@ -22,19 +21,19 @@ pub trait DomainProjector {
     ) -> Result<IndexedEntityRef, BridgeError>;
 }
 
-/// Track A — owner-side authorization. Default-deny; resolves an owner-bound purpose
+/// Owner-side authorization. Default-deny; resolves an owner-bound purpose
 /// from policy config (ignoring any request-supplied purpose); emits a typed decision.
 pub trait PolicyGate {
     fn evaluate(&mut self, session: &RedactionSession, request: &BridgeRequest) -> PolicyOutcome;
 }
 
-/// Track A — projection key material, addressed by `key_id`. Supports rotation by
+/// Projection key material, addressed by `key_id`. Supports rotation by
 /// retaining old keys for read; a missing key fails closed (no silent re-key).
 pub trait KeyManager {
     fn key(&self, key_id: &str) -> Option<&[u8]>;
 }
 
-/// Track B — the corpus index + search. Receives an already-validated, filter-projected
+/// Corpus index + search. Receives an already-validated, filter-projected
 /// request. Still enforces entity_ref/domain/expiry/nonce guards defensively, returning
 /// owner-side hits (never agent-visible output).
 pub trait SearchAdapter {
@@ -46,7 +45,7 @@ pub trait SearchAdapter {
     ) -> Result<Vec<IndexSearchHit>, DenyReason>;
 }
 
-/// Track C — translate owner-side hits into the active session namespace, minting
+/// Translate owner-side hits into the active session namespace, minting
 /// fresh session tokens for newly-discovered entities. MUST fail closed if any domain
 /// alias or raw value would remain in the output.
 pub trait ResponseTranslator {
@@ -56,14 +55,14 @@ pub trait ResponseTranslator {
     ) -> Result<Vec<AgentSearchHit>, DenyReason>;
 }
 
-/// Track C — append-only audit sink. One event per bridge decision; raw values only
+/// Append-only audit sink. One event per bridge decision; raw values only
 /// as sha256.
 pub trait BridgeAuditSink {
     fn record(&mut self, event: AuditEvent);
     fn events(&self) -> &[AuditEvent];
 }
 
-/// Track C (R2, master-authorized) — mint a short-lived, entity-bound capability from a
+/// Mint a short-lived, entity-bound capability from a
 /// policy grant. The issuer copies trusted request context + the grant's owner-side
 /// authorization into a single-use [`SearchHandle`]; it never re-authorizes (the grant
 /// already encodes the owner-side decision) and never decides scope itself.

--- a/crates/gaze-token-bridge/src/translate.rs
+++ b/crates/gaze-token-bridge/src/translate.rs
@@ -1,8 +1,5 @@
-//! Track C (gated) — `ResponseTranslator`: rewrite owner-side index snippets into the
-//! active session namespace (mint fresh session tokens for newly-discovered entities),
-//! fail closed if any domain alias or raw value would remain. Owner: sub-orchestrator C.
-//! Contract: `crate::traits::ResponseTranslator`, `crate::util::contains_domain_alias`.
-//! Reference: spike `ResponseTranslator`.
+//! `ResponseTranslator`: rewrite owner-side index snippets into the active session namespace.
+//! Fails closed if any domain alias or raw value would remain.
 
 use crate::error::DenyReason;
 use crate::model::{AgentSearchHit, IndexSearchHit};

--- a/crates/gaze-token-bridge/src/util.rs
+++ b/crates/gaze-token-bridge/src/util.rs
@@ -1,9 +1,8 @@
-//! FROZEN CONTRACT — shared deterministic helpers. Master-owned.
+//! Shared deterministic helpers.
 //!
-//! These are correctness-critical and shared across tracks (token parsing, the
-//! index-alias format, canonicalization whitespace rules, hashing). Keep them here
-//! so Track A (projection) and Track B (ingest) canonicalize/alias identically —
-//! divergence breaks index lookup.
+//! These are correctness-critical for token parsing, the index-alias format,
+//! canonicalization whitespace rules, projection, ingest, and hashing. Keep them
+//! centralized; divergence breaks index lookup.
 
 use gaze::PiiClass;
 use sha2::{Digest, Sha256};

--- a/crates/gaze-token-bridge/tests/local_demo_assertions.rs
+++ b/crates/gaze-token-bridge/tests/local_demo_assertions.rs
@@ -1,26 +1,10 @@
-//! Synthetic-data walkthrough of the gaze-token-bridge owner-side authorization and
-//! translation bridge.
-//!
-//! Run with:
-//!
-//! ```text
-//! cargo run -p gaze-token-bridge --example local_demo
-//! ```
-//!
-//! This uses bundled synthetic fixtures to show the bridge flow. For a
-//! bring-your-own-data redaction example, run:
-//!
-//! ```text
-//! cargo run -p gaze-pii --example scan_folder -- --path ./my-data
-//! ```
-
 use gaze::{
     LeakSuspect, LocaleTag, PiiClass, Pipeline, SafetyNet, SafetyNetContext, SafetyNetError,
 };
-use gaze_token_bridge::bridge::{synthetic_docs, TokenBridge};
+use gaze_token_bridge::bridge::{synthetic_docs, SyntheticDoc, TokenBridge};
 use gaze_token_bridge::{
-    BridgeRequest, BridgeSearchOutcome, BridgeSearchResponse, Principal, RedactionSession,
-    RequestedScope,
+    BridgeRequest, BridgeSearchOutcome, BridgeSearchResponse, DenyReason, Principal,
+    RedactionSession, RequestedScope,
 };
 
 const CUSTOMER_DOMAIN: &str = "tenant_demo/customer_docs/v1";
@@ -67,13 +51,24 @@ fn bridge_request(
     }
 }
 
+fn raw_fixture_values(docs: &[SyntheticDoc]) -> Vec<String> {
+    let mut values = Vec::new();
+    for doc in docs {
+        values.push(doc.name.to_string());
+        values.push(doc.email.to_string());
+        values.push(doc.customer_id.to_string());
+        values.push(doc.organization.to_string());
+    }
+    values
+}
+
 #[derive(Debug)]
 struct SyntheticFixtureOutputSafetyNet {
     entries: Vec<(String, PiiClass)>,
 }
 
 impl SyntheticFixtureOutputSafetyNet {
-    fn from_docs(docs: &[gaze_token_bridge::bridge::SyntheticDoc]) -> Self {
+    fn from_docs(docs: &[SyntheticDoc]) -> Self {
         let mut entries = Vec::with_capacity(docs.len() * 4);
         for doc in docs {
             entries.push((doc.name.to_string(), PiiClass::Name));
@@ -126,58 +121,44 @@ impl SafetyNet for SyntheticFixtureOutputSafetyNet {
     }
 }
 
-fn print_header(step: &str) {
-    println!("\n=== {step} ===");
-}
-
-fn print_results(response: &BridgeSearchResponse) {
-    for hit in &response.results {
-        println!("  [{}] {}", hit.doc_id, hit.snippet);
-    }
-}
-
-fn print_outcome(outcome: BridgeSearchOutcome) {
-    match outcome {
-        BridgeSearchOutcome::Allowed(response) => {
-            println!("ALLOWED. target_domain = {}", response.target_domain);
-            print_results(&response);
-        }
-        BridgeSearchOutcome::Denied(_) => {
-            println!("DENIED (authorization failed)");
-        }
-    }
-}
-
-fn main() {
-    println!("gaze-token-bridge - local synthetic demo");
-    println!("Owner-side authorization and translation over bundled fixtures.");
-
-    print_header("Step 1 - ingest synthetic corpus");
-    let docs = synthetic_docs();
+fn bridge_with_fixture_safety(docs: &[SyntheticDoc]) -> TokenBridge {
     let output_safety_pipeline = Pipeline::builder()
-        .register_safety_net(SyntheticFixtureOutputSafetyNet::from_docs(&docs))
+        .register_safety_net(SyntheticFixtureOutputSafetyNet::from_docs(docs))
         .build()
         .expect("demo output safety pipeline builds");
-    let mut bridge = TokenBridge::demo()
-        .expect("demo bridge builds")
-        .with_output_safety_net(output_safety_pipeline, vec![LocaleTag::Global]);
-    println!(
-        "Ingested {} synthetic docs into two policy-scoped domains:",
-        docs.len()
-    );
-    println!("  - {CUSTOMER_DOMAIN}");
-    println!("  - {LEGAL_DOMAIN}");
 
-    print_header("Step 2 - mint a lookup token");
+    TokenBridge::demo()
+        .expect("demo bridge builds")
+        .with_output_safety_net(output_safety_pipeline, vec![LocaleTag::Global])
+}
+
+fn unwrap_allowed(outcome: BridgeSearchOutcome) -> BridgeSearchResponse {
+    match outcome {
+        BridgeSearchOutcome::Allowed(response) => response,
+        BridgeSearchOutcome::Denied(reason) => panic!("expected allow, got deny: {reason:?}"),
+    }
+}
+
+fn unwrap_denied(outcome: BridgeSearchOutcome) -> DenyReason {
+    match outcome {
+        BridgeSearchOutcome::Allowed(response) => {
+            panic!("expected deny, got allow: {response:?}")
+        }
+        BridgeSearchOutcome::Denied(reason) => reason,
+    }
+}
+
+#[test]
+fn local_demo_flow_has_explicit_integration_coverage() {
+    let docs = synthetic_docs();
+    let mut bridge = bridge_with_fixture_safety(&docs);
+
     let support = support_principal();
-    let session = RedactionSession::ephemeral_for(&support.id).expect("ephemeral session builds");
-    println!("owner-side synthetic input: name = \"{DEMO_NAME}\"");
+    let session = RedactionSession::ephemeral_for(&support.id).expect("support session builds");
     let name_token = session
         .tokenize(&PiiClass::Name, DEMO_NAME)
-        .expect("tokenize name");
-    println!("session token passed to the bridge: {name_token}");
+        .expect("tokenize support name");
 
-    print_header("Step 3 - support searches customer docs");
     let support_customer = bridge_request(
         support_principal(),
         "support_search",
@@ -185,9 +166,10 @@ fn main() {
         CUSTOMER_DOMAIN,
         &name_token,
     );
-    print_outcome(bridge.search(&session, &support_customer));
+    let customer_response = unwrap_allowed(bridge.search(&session, &support_customer));
+    assert_eq!(customer_response.target_domain, CUSTOMER_DOMAIN);
+    assert!(!customer_response.results.is_empty());
 
-    print_header("Step 4 - support searches legal docs");
     let support_legal = bridge_request(
         support_principal(),
         "legal_search",
@@ -195,14 +177,14 @@ fn main() {
         LEGAL_DOMAIN,
         &name_token,
     );
-    print_outcome(bridge.search(&session, &support_legal));
+    let support_legal_reason = unwrap_denied(bridge.search(&session, &support_legal));
+    assert_eq!(support_legal_reason, DenyReason::PrincipalNotAllowed);
 
-    print_header("Step 5 - admin searches legal docs");
     let admin = admin_principal();
     let admin_session = RedactionSession::ephemeral_for(&admin.id).expect("admin session builds");
     let admin_token = admin_session
         .tokenize(&PiiClass::Name, DEMO_NAME)
-        .expect("tokenize name for admin");
+        .expect("tokenize admin name");
     let admin_request = bridge_request(
         admin,
         "legal_search",
@@ -210,7 +192,18 @@ fn main() {
         LEGAL_DOMAIN,
         &admin_token,
     );
-    print_outcome(bridge.search(&admin_session, &admin_request));
+    let legal_response = unwrap_allowed(bridge.search(&admin_session, &admin_request));
+    assert_eq!(legal_response.target_domain, LEGAL_DOMAIN);
+    assert!(!legal_response.results.is_empty());
 
-    println!("\naudit events recorded: {}", bridge.audit().len());
+    let agent_visible =
+        serde_json::to_string(&[customer_response, legal_response]).expect("serialize responses");
+    for raw in raw_fixture_values(&docs) {
+        assert!(
+            !agent_visible.contains(raw.as_str()),
+            "agent-visible output leaked raw fixture value {raw:?}"
+        );
+    }
+
+    assert_eq!(bridge.audit().len(), 3);
 }

--- a/crates/gaze-token-bridge/tests/track_c_bridge.rs
+++ b/crates/gaze-token-bridge/tests/track_c_bridge.rs
@@ -1,11 +1,4 @@
-//! Track C — end-to-end bridge runtime acceptance tests.
-//!
-//! Ports the throwaway spike's 22 tests (`crates/spike-token-bridge`) onto the REAL
-//! `TokenBridge::demo()`, which integrates the real Track A policy/projection, Track B
-//! redact-before-index ingest + search adapter, and the Track C capability/translate/audit
-//! runtime. Call sites are adapted to the frozen contract API (e.g. `ephemeral_for(&str)`,
-//! `&BridgeRequest`, `audit()` slice). One extra test covers the filter-field allowlist
-//! hardening the bridge adds over the spike.
+//! End-to-end bridge runtime acceptance tests.
 
 use gaze::{
     LeakSuspect, LocaleTag, PiiClass, Pipeline, SafetyNet, SafetyNetContext, SafetyNetError,
@@ -87,8 +80,8 @@ fn bridge_and_session_for(principal: &Principal) -> (TokenBridge, RedactionSessi
 }
 
 /// A demo bridge whose policy is augmented with an elevated cross-domain admin rule
-/// (mirrors the Track A `registry_with_elevated_cross_domain_rule` helper). The bundled
-/// fixture deliberately ships without this rule; augmenting JSON keeps the fixture frozen.
+/// The bundled fixture deliberately ships without this rule; augmenting JSON keeps
+/// the fixture frozen.
 fn cross_domain_bridge_and_session() -> (TokenBridge, RedactionSession, String) {
     let mut policy: serde_json::Value =
         serde_json::from_str(POLICY_JSON).expect("fixture policy parses as json");
@@ -597,7 +590,7 @@ fn session_bound_to_principal_rejects_reuse_by_different_principal() {
 }
 
 /// A demo bridge whose support→customer rule carries a low per-principal entity cap. Used
-/// to prove the rate-limit bucket persists across separate bridge calls (blocker #1564).
+/// to prove the rate-limit bucket persists across separate bridge calls.
 fn low_rate_limit_customer_bridge(max_entities_per_window: usize) -> TokenBridge {
     let mut policy: serde_json::Value =
         serde_json::from_str(POLICY_JSON).expect("fixture policy parses as json");
@@ -618,12 +611,11 @@ fn low_rate_limit_customer_bridge(max_entities_per_window: usize) -> TokenBridge
     )
 }
 
-/// Regression for blocker #1564: the per-principal rate-limit bucket MUST accumulate across
-/// separate bridge calls. The bridge owns the bucket state and injects it into each per-call
-/// policy gate, so distinct-entity lookups count toward the cap instead of resetting every
-/// call. With the cap at 2, two distinct-entity authorizations succeed and the third — issued
-/// as a SEPARATE call — fails closed. Pre-fix the gate was rebuilt empty each call, so the
-/// cap never tripped and the third lookup was (wrongly) allowed.
+/// The per-principal rate-limit bucket MUST accumulate across separate bridge calls.
+/// The bridge owns the bucket state and injects it into each per-call policy gate, so
+/// distinct-entity lookups count toward the cap instead of resetting every call. With
+/// the cap at 2, two distinct-entity authorizations succeed and the third — issued as
+/// a SEPARATE call — fails closed.
 #[test]
 fn rate_limit_accumulates_across_separate_authorize_calls() {
     let principal = support_principal();
@@ -651,8 +643,8 @@ fn rate_limit_accumulates_across_separate_authorize_calls() {
     }
 }
 
-/// Track-C hardening over the spike: a filter field outside the handle's allowlist fails
-/// closed instead of being silently projected (default-deny — north-star axis 1).
+/// A filter field outside the handle's allowlist fails closed instead of being silently
+/// projected.
 #[test]
 fn filter_field_outside_handle_allowlist_denies() {
     let (mut bridge, session, token) = bridge_and_session();

--- a/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
+++ b/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
@@ -1,4 +1,4 @@
-//! Track C — `search_documents` chokepoint tool acceptance tests.
+//! `search_documents` chokepoint tool acceptance tests.
 //!
 //! Drives [`SearchDocumentsTool::run`] directly: the sealed `gaze_mcp_core::ToolCtx`
 //! cannot be constructed outside its crate, so the unit-testable sync core is the

--- a/crates/gaze/examples/scan_folder.rs
+++ b/crates/gaze/examples/scan_folder.rs
@@ -76,8 +76,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             CleanDocument::Text(text) => text,
             CleanDocument::Structured(_) => unreachable!("text input returns text output"),
             _ => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     "text input returned an unsupported clean document variant",
                 )
                 .into());

--- a/crates/gaze/examples/scan_folder.rs
+++ b/crates/gaze/examples/scan_folder.rs
@@ -1,0 +1,237 @@
+//! Scan a folder of UTF-8 text files with a small gaze redaction pipeline.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo run -p gaze-pii --example scan_folder -- --path ./my-data
+//! ```
+//!
+//! Omitting `--path` runs a tiny synthetic sample.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, EmittedTokenSpan, LocaleTag, PiiClass, Pipeline,
+    RawDocument, Scope, Session,
+};
+use gaze_recognizers::RegexDetector;
+
+const SYNTHETIC_SAMPLE: &str =
+    "Contact Dr. Schmidt at alice@example.invalid or +1-555-0100 about order ORD-1042.";
+
+struct InputFile {
+    label: String,
+    text: String,
+}
+
+#[derive(Default)]
+struct Summary {
+    files: usize,
+    skipped: usize,
+    detections: usize,
+    by_class: BTreeMap<String, usize>,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let path = parse_path_arg()?;
+    let pipeline = build_pipeline()?;
+    let locale_chain = [LocaleTag::Global];
+    let (files, skipped) = match path {
+        Some(path) => read_text_files(&path)?,
+        None => (
+            vec![InputFile {
+                label: "synthetic-sample.txt".to_string(),
+                text: SYNTHETIC_SAMPLE.to_string(),
+            }],
+            0,
+        ),
+    };
+
+    if files.is_empty() {
+        println!("No UTF-8 text files found.");
+        if skipped > 0 {
+            println!("Skipped {skipped} non-text file(s).");
+        }
+        return Ok(());
+    }
+
+    let mut summary = Summary {
+        skipped,
+        ..Summary::default()
+    };
+
+    for file in files {
+        let session = Session::new(Scope::Ephemeral)?;
+        let (clean, manifest, _report) = pipeline.clean_with_safety_net(
+            &session,
+            RawDocument::Text(file.text),
+            &locale_chain,
+        )?;
+        let tokenized = match clean {
+            CleanDocument::Text(text) => text,
+            CleanDocument::Structured(_) => unreachable!("text input returns text output"),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "text input returned an unsupported clean document variant",
+                )
+                .into());
+            }
+        };
+        let counts = counts_by_class(&manifest);
+
+        summary.files += 1;
+        summary.detections += manifest.len();
+        for (class, count) in &counts {
+            *summary.by_class.entry(class.clone()).or_insert(0) += count;
+        }
+
+        println!("\n== {} ==", file.label);
+        print_counts(&counts);
+        println!("Tokenized output:");
+        println!("{tokenized}");
+    }
+
+    print_summary(&summary);
+    Ok(())
+}
+
+fn build_pipeline() -> Result<Pipeline, Box<dyn Error>> {
+    let phone = PiiClass::custom("phone");
+    let case_id = PiiClass::custom("case_id");
+
+    Ok(Pipeline::builder()
+        .detector(RegexDetector::emails()?)
+        .detector(RegexDetector::with_source(
+            r"(?:\+1-555-01\d{2}|\+44-7700-900\d{3}|\+49 1555 0\d{6})",
+            phone.clone(),
+            "example.phone",
+        )?)
+        .detector(RegexDetector::with_source(
+            r"\b(?:ORD|CASE)-\d{4,}\b",
+            case_id.clone(),
+            "example.case_id",
+        )?)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(phone, Action::Tokenize))
+        .rule(ClassRule::new(case_id, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()?)
+}
+
+fn parse_path_arg() -> Result<Option<PathBuf>, Box<dyn Error>> {
+    let mut args = env::args().skip(1);
+    let mut path = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--path" => {
+                let Some(value) = args.next() else {
+                    return Err(invalid_input("--path requires a directory"));
+                };
+                path = Some(PathBuf::from(value));
+            }
+            "-h" | "--help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => {
+                return Err(invalid_input(format!("unrecognized argument: {other}")));
+            }
+        }
+    }
+
+    Ok(path)
+}
+
+fn print_usage() {
+    eprintln!("usage: cargo run -p gaze-pii --example scan_folder -- [--path <dir>]");
+}
+
+fn invalid_input(message: impl Into<String>) -> Box<dyn Error> {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into()).into()
+}
+
+fn read_text_files(root: &Path) -> Result<(Vec<InputFile>, usize), Box<dyn Error>> {
+    if !root.is_dir() {
+        return Err(invalid_input(format!(
+            "--path must point to a directory: {}",
+            root.display()
+        )));
+    }
+
+    let mut files = Vec::new();
+    let mut skipped = 0;
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+
+    while let Some(dir) = queue.pop_front() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let metadata = entry.metadata()?;
+            if metadata.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+
+            match fs::read_to_string(&path) {
+                Ok(text) => files.push(InputFile {
+                    label: path
+                        .strip_prefix(root)
+                        .unwrap_or(path.as_path())
+                        .display()
+                        .to_string(),
+                    text,
+                }),
+                Err(error) if error.kind() == io::ErrorKind::InvalidData => {
+                    skipped += 1;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    files.sort_by(|left, right| left.label.cmp(&right.label));
+    Ok((files, skipped))
+}
+
+fn counts_by_class(manifest: &[EmittedTokenSpan]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for span in manifest {
+        *counts.entry(span.class.class_name()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn print_counts(counts: &BTreeMap<String, usize>) {
+    if counts.is_empty() {
+        println!("Detections: none");
+        return;
+    }
+
+    println!("Detections:");
+    for (class, count) in counts {
+        println!("  {class}: {count}");
+    }
+}
+
+fn print_summary(summary: &Summary) {
+    println!("\nSummary:");
+    println!("  files scanned: {}", summary.files);
+    println!("  files skipped: {}", summary.skipped);
+    println!("  detections: {}", summary.detections);
+    if !summary.by_class.is_empty() {
+        println!("  detections by class:");
+        for (class, count) in &summary.by_class {
+            println!("    {class}: {count}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Phase A: stripped internal process-history comments from the token bridge source/test surfaces while keeping consumer-relevant docs and API rationale.
- Phase B: moved the test-like `local_demo.rs` assertions into `crates/gaze-token-bridge/tests/local_demo_assertions.rs`, kept the example as a synthetic walkthrough, and added `crates/gaze/examples/scan_folder.rs`.
- Gate compatibility: aligned the MCP trybuild stderr fixture with Rust 1.96 wording and committed the clippy cleanup separately to respect the no-amend rule.

## Files Touched

- `crates/gaze-token-bridge/src/**/*.rs`
- `crates/gaze-token-bridge/tests/local_demo_assertions.rs`
- `crates/gaze-token-bridge/tests/track_c_bridge.rs`
- `crates/gaze-token-bridge/tests/track_c_chokepoint.rs`
- `crates/gaze-token-bridge/examples/local_demo.rs`
- `crates/gaze-token-bridge/README.md`
- `crates/gaze/examples/scan_folder.rs`
- `crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr`

## Hygiene Notes

- Removed 85 internal-process comment lines.
- Residual scan for Track/Owner/sub-orchestrator/spike/blocker/process-history comment markers is clean.
- New folder scan example command: `cargo run -p gaze-pii --example scan_folder -- --path ./my-data`

## Verification

All required gates were run under `rustup run 1.96.0`:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run -p xtask -- ci-feature-matrix`

Focused checks also run:

- `cargo test -p gaze-token-bridge --test local_demo_assertions`
- `cargo run -p gaze-token-bridge --example local_demo`
- `cargo run -p gaze-pii --example scan_folder`
- `cargo run -p gaze-pii --example scan_folder -- --path <tempdir>`
