### PR TITLE
release: v0.11.0

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -70,7 +70,8 @@ jobs:
 
           # Topological order, dependency crates first. The core package is
           # published as gaze-pii while its library target remains `gaze`.
-          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-mcp-bridge gaze-document gaze-proxy gaze-cli; do
+          # gaze-mcp-bridge: first crates.io publish is manual (no trusted publisher yet); re-add here after the trusted publisher is linked.
+          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-document gaze-proxy gaze-cli; do
             echo "=== publishing $crate ==="
             attempt=1
             while true; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-20
+
+### Added
+
+- **`gaze-mcp-bridge`: optional policy-gated MCP bridge.** Gaze can now sit as
+  an MCP server toward the agent and an MCP client toward downstream MCP
+  servers, with restore-on-egress / redact-on-ingress handling, fail-closed
+  errors, and default-deny policy behavior.
+- **`gaze-token-bridge`: owner-side gated search over redacted corpora.** This
+  experimental crate is not published to crates.io. It keeps search
+  authorization and translation owner-side; output never-leak backstop
+  verification is still pending.
+- **`scan_folder` example for `gaze`.** The new bring-your-own-data redaction
+  demo shows how to scan a local folder through the core runtime.
+
+### Changed
+
+- **Documentation now follows a Diátaxis × feature information architecture.**
+  The docs were reorganized around task, reference, explanation, and tutorial
+  needs while staying anchored to product features.
+- **GDPR adopter guidance was substantially expanded.** The new material covers
+  per-party identifiability, Article 25, Chapter V transfers, enterprise
+  security expectations, and DPO-grade DPIA support.
+- **Top-level repository layout was decluttered.** Examples, benches, and assets
+  moved into crate-scoped docs, and the internal lint crate moved from `xtask/`
+  to `lint/`.
+- **Release notes are now sourced from `CHANGELOG.md` plus GitHub generated
+  notes.** The committed `dist/release-notes` artifact was removed.
+
 ## [0.10.1] - 2026-06-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-bridge"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ homepage = "https://github.com/EmpireTwo/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.10.1" }
-gaze = { path = "crates/gaze", version = "0.10.1", package = "gaze-pii" }
-gaze-assembly = { path = "crates/gaze-assembly", version = "0.10.1" }
-gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.10.1" }
-gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.10.1" }
-gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.10.1" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.10.1" }
-gaze-types = { path = "crates/gaze-types", version = "0.10.1" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.11.0" }
+gaze = { path = "crates/gaze", version = "0.11.0", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.11.0" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.11.0" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.11.0" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.11.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.11.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
+gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.1"
-gaze-assembly = "0.10.1"
-gaze-recognizers = "0.10.1"
+gaze-pii = "0.11.0"
+gaze-assembly = "0.11.0"
+gaze-recognizers = "0.11.0"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.1"
-gaze-audit = "0.10.1"
+gaze-pii = "0.11.0"
+gaze-audit = "0.11.0"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -46,15 +46,15 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
+gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.10.1", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.11.0", optional = true }
 gaze-mcp-bridge = { workspace = true, optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.1", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
 gaze-token-bridge = { path = "../gaze-token-bridge", optional = true }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
@@ -70,7 +70,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.10.1
+$ cargo install gaze-cli --version 0.11.0
 ```
 
 Build from the workspace root:
@@ -110,7 +110,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.10.1 --features mcp
+$ cargo install gaze-cli --version 0.11.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
+gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.10.1" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.10.1"
+gaze-document = "0.11.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.10.1 --features document
+cargo install gaze-cli --version 0.11.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-bridge"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,6 +1,6 @@
 # gaze-mcp-bridge
 
-`gaze-mcp-bridge = "0.10.1"` is the optional policy-gated MCP bridge for Gaze.
+`gaze-mcp-bridge = "0.11.0"` is the optional policy-gated MCP bridge for Gaze.
 
 The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
 downstream MCP tools receive restored PII only for explicitly allowed argument

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/EmpireTwo/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.10.1) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.11.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.10.1" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.10.1" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.11.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.10.1"
-gaze-mcp-rmcp = "0.10.1"
+gaze-mcp-core = "0.11.0"
+gaze-mcp-rmcp = "0.11.0"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,8 +28,8 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.10.1", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.10.1" }
+gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.10.1"
+gaze-proxy = "0.11.0"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.10.1
+cargo install gaze-cli --version 0.11.0
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.1"
-gaze-recognizers = "0.10.1"
+gaze-pii = "0.11.0"
+gaze-recognizers = "0.11.0"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.10.1", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.11.0", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.10.1"
+gaze-types = "0.11.0"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.10.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.10.1"
-gaze-assembly = "0.10.1"
-gaze-recognizers = "0.10.1"
+gaze-pii = "0.11.0"
+gaze-assembly = "0.11.0"
+gaze-recognizers = "0.11.0"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -20,11 +20,12 @@ Source: [`.github/workflows/publish-crates.yml`](../../../.github/workflows/publ
 
 - Triggered on `v*` tag pushes (with `workflow_dispatch` dry-run available).
 - Authenticates to crates.io via OIDC trusted-publisher (`rust-lang/crates-io-auth-action`); no long-lived `CARGO_REGISTRY_TOKEN` secret.
-- Publishes all eleven workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-mcp-bridge` → `gaze-document` → `gaze-proxy` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
+- Publishes the trusted-publisher-linked workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-proxy` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
 - Skips crates already at the published version (idempotent re-runs) and retries on index-propagation lag.
+- New crates require a one-time manual `cargo publish` with a crates.io token, followed by trusted-publisher linking, before they join the OIDC publish loop.
 - Browse crates at <https://crates.io/crates/gaze-pii> (and sibling crate pages).
 
-Cutting a release: tag the merge commit on `main` with `vX.Y.Z` and push the tag. Both workflows fire from the same tag push; no manual crates.io step needed.
+Cutting a release: tag the merge commit on `main` with `vX.Y.Z` and push the tag. Both workflows fire from the same tag push; no manual crates.io step is needed for crates already in the OIDC publish loop.
 
 ## Homebrew Tap Location
 


### PR DESCRIPTION
## Summary

- Bump published workspace crates, workspace dependency pins, crate READMEs, and Cargo.lock from 0.10.1 to 0.11.0.
- Add the curated CHANGELOG.md section for v0.11.0.
- Keep gaze-token-bridge unpublished at 0.1.0.
- Remove gaze-mcp-bridge from the OIDC publish loop until its first manual crates.io publish and trusted-publisher link are complete.

release-prep, not the tag
