### PR TITLE
release: v0.11.1

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -71,6 +71,7 @@ jobs:
           # Topological order, dependency crates first. The core package is
           # published as gaze-pii while its library target remains `gaze`.
           # gaze-mcp-bridge: first crates.io publish is manual (no trusted publisher yet); re-add here after the trusted publisher is linked.
+          # gaze-token-bridge: first crates.io publish is manual; keep it out of this loop until after v0.11.1 is seeded.
           for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-document gaze-proxy gaze-cli; do
             echo "=== publishing $crate ==="
             attempt=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-06-20
+
+### Added
+
+- **`gaze-token-bridge` is now published to crates.io.** The crate remains
+  experimental and focused on gated index-search; output backstop verification
+  is still pending.
+
+### Fixed
+
+- **`gaze-cli` index installs now resolve from crates.io.** The optional
+  `gaze-token-bridge` dependency now carries a publishable version so
+  `gaze-cli` can publish and install with its `index` feature.
+
 ## [0.11.0] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.1.0"
+version = "0.11.1"
 dependencies = [
  "async-trait",
  "gaze-mcp-core",

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -55,7 +55,7 @@ gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true
 gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
 gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
-gaze-token-bridge = { path = "../gaze-token-bridge", optional = true }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.1", optional = true }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.11.0
+$ cargo install gaze-cli --version 0.11.1
 ```
 
 Build from the workspace root:
@@ -110,7 +110,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.11.0 --features mcp
+$ cargo install gaze-cli --version 0.11.1 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,17 +1,22 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.1.0"
+version = "0.11.1"
 edition = "2021"
-publish = false
-license = "Apache-2.0 OR MIT"
+rust-version = "1.89"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Owner-side authorization + translation bridge between a RedactionSession and IndexDomains (work in progress)."
+readme = "README.md"
+keywords = ["pii", "search", "pseudonymization", "privacy"]
+categories = ["text-processing"]
 
 # FROZEN CONTRACT — master-owned. Sub-orchestrators must NOT edit this file
 # except: Track B may APPEND index/ingest dependencies it needs (it is the only
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 hmac = "0.12"
@@ -19,7 +24,7 @@ sha2 = "0.10"
 rand = "0.8"
 # Track C chokepoint integration — optional, OFF by default. Pulled in only by
 # the `chokepoint` feature below; the default build/test graph is byte-identical.
-gaze-mcp-core = { path = "../gaze-mcp-core", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,6 +1,12 @@
 # gaze-token-bridge
 
-> **Status:** work in progress (`publish = false`). API is pre-1.0 and may change.
+> **Status:** experimental and published as `gaze-token-bridge = "0.11.1"`.
+> API is pre-1.0 and may change.
+
+```toml
+[dependencies]
+gaze-token-bridge = "0.11.1"
+```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an
 agent search long-lived, policy-scoped document corpora while keeping raw values on


### PR DESCRIPTION
## Summary

- Publish `gaze-token-bridge` as experimental `0.11.1`, with publish metadata and versioned path dependencies against the already-live `0.11.0` crates.
- Bump `gaze-cli` to `0.11.1` and give its optional `gaze-token-bridge` dependency a publishable `0.11.1` version.
- Add `CHANGELOG.md` notes for the token-bridge first publish and the `gaze-cli` index install fix.
- Keep the publish workflow crate loop unchanged; `gaze-token-bridge` remains a manual first publish for this release.

## Release Order Note

`gaze-cli` publish is validated post-token-bridge-publish: the orchestrator publishes `gaze-token-bridge` first, then publishes `gaze-cli` after `gaze-token-bridge 0.11.1` is visible in the crates.io index.

## Validation

- `rustup run 1.96.0 cargo fmt --all -- --check`
- `rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `rustup run 1.96.0 cargo run -p xtask -- readme-version-check`
- `rustup run 1.96.0 cargo publish -p gaze-token-bridge --dry-run`
- `CHANGELOG.md` `[0.11.1]` dogfooded via `gaze clean`
