### PR TITLE
ci(release): auto-derive publish order + pre-flight manifest/new-crate guards

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -7,6 +7,10 @@ on:
         description: "Dry-run only (no actual publish)"
         type: boolean
         default: true
+      check_new_crates:
+        description: "Fail if the derived plan includes crates that need one-time manual crates.io seeding"
+        type: boolean
+        default: true
   push:
     tags:
       - 'v*'
@@ -52,41 +56,115 @@ jobs:
 
           cargo run -p xtask -- scrub-public-text "$changelog_section"
 
+      - name: Derive crates.io publish plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cargo run -p xtask --quiet -- publish-plan > publish-plan.txt
+          if [ ! -s publish-plan.txt ]; then
+            echo "publish-plan produced no crates" >&2
+            exit 1
+          fi
+
+          echo "Publish plan:"
+          sed 's/^/  - /' publish-plan.txt
+
+      - name: Pre-flight package manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r crate; do
+            [ -n "$crate" ] || continue
+            echo "=== packaging $crate ==="
+            cargo package --no-verify -p "$crate"
+          done < publish-plan.txt
+
+      - name: Check crates.io first-publish preconditions
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.check_new_crates }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          new_crates=()
+          user_agent="CertaMesh/gaze release workflow (https://github.com/CertaMesh/gaze)"
+          response="$(mktemp)"
+          while IFS= read -r crate; do
+            [ -n "$crate" ] || continue
+            http_status="$(
+              curl \
+                --silent \
+                --show-error \
+                --output "$response" \
+                --write-out "%{http_code}" \
+                --header "User-Agent: $user_agent" \
+                "https://crates.io/api/v1/crates/$crate"
+            )"
+            case "$http_status" in
+              200)
+                echo "crates.io: $crate exists"
+                ;;
+              404)
+                echo "crates.io: $crate is new and needs manual seed publishing"
+                new_crates+=("$crate")
+                ;;
+              *)
+                echo "crates.io lookup for $crate failed with HTTP $http_status" >&2
+                cat "$response" >&2
+                exit 1
+                ;;
+            esac
+          done < publish-plan.txt
+
+          if [ "${#new_crates[@]}" -ne 0 ]; then
+            echo "::error::New crates cannot be first-published with OIDC trusted publishing: ${new_crates[*]}"
+            echo "Seed each crate with 'cargo publish -p <crate>' using a crates.io token, add the Trusted Publisher, then re-run this workflow."
+            echo "See docs/how-to/maintainers/release-process.md."
+            printf '  - %s\n' "${new_crates[@]}"
+            exit 1
+          fi
+
       - name: Authenticate to crates.io via OIDC
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: cargo-auth
 
-      - name: Publish workspace crates (topological order, skip already-published)
+      - name: Publish workspace crates (derived topological order, skip already-published)
+        shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cargo-auth.outputs.token }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          set -eu
-          DRY_RUN=""
+          set -euo pipefail
+
+          DRY_RUN=()
+          summary_label="published"
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_DRY_RUN" = "true" ]; then
-            DRY_RUN="--dry-run"
+            DRY_RUN=(--dry-run)
+            summary_label="dry-run passed"
           fi
 
-          # Topological order, dependency crates first. The core package is
-          # published as gaze-pii while its library target remains `gaze`.
-          # gaze-mcp-bridge: first crates.io publish is manual (no trusted publisher yet); re-add here after the trusted publisher is linked.
-          # gaze-token-bridge: first crates.io publish is manual; keep it out of this loop until after v0.11.1 is seeded.
-          for crate in gaze-types gaze-audit gaze-recognizers gaze-pii gaze-assembly gaze-mcp-core gaze-mcp-rmcp gaze-document gaze-proxy gaze-cli; do
+          published=()
+          skipped=()
+          while IFS= read -r crate; do
+            [ -n "$crate" ] || continue
             echo "=== publishing $crate ==="
             attempt=1
             while true; do
               rc=0
-              out=$(cargo publish $DRY_RUN -p "$crate" --locked 2>&1) || rc=$? && rc=${rc:-0}
+              out=$(cargo publish "${DRY_RUN[@]}" -p "$crate" --locked 2>&1) || rc=$?
               echo "$out"
               if [ "$rc" -eq 0 ]; then
+                published+=("$crate")
                 break
               fi
               if echo "$out" | grep -qiE "crate version .* is already uploaded|already exists|version .* has already been published"; then
                 echo "  [warn] $crate already on crates.io at this version; skipping (not a failure)"
+                skipped+=("$crate")
                 break
               fi
-              if [ -z "$DRY_RUN" ] && [ "$attempt" -lt 10 ] && echo "$out" | grep -qiE "failed to select a version|could not find .* in registry|no matching package named"; then
+              if [ "${#DRY_RUN[@]}" -eq 0 ] && [ "$attempt" -lt 10 ] && echo "$out" | grep -qiE "failed to select a version|could not find .* in registry|no matching package named"; then
                 echo "  [warn] crates.io index not ready for $crate dependencies; retrying in 30s ($attempt/10)"
                 attempt=$((attempt + 1))
                 sleep 30
@@ -97,5 +175,19 @@ jobs:
             done
             # Give the crates.io index time to propagate before publishing
             # dependents. Dry-runs do not touch the index.
-            [ -z "$DRY_RUN" ] && sleep 30 || true
-          done
+            [ "${#DRY_RUN[@]}" -eq 0 ] && sleep 30 || true
+          done < publish-plan.txt
+
+          echo "=== publish summary ==="
+          if [ "${#published[@]}" -eq 0 ]; then
+            echo "$summary_label: (none)"
+          else
+            printf '%s:\n' "$summary_label"
+            printf '  - %s\n' "${published[@]}"
+          fi
+          if [ "${#skipped[@]}" -eq 0 ]; then
+            echo "skipped: (none)"
+          else
+            printf 'skipped:\n'
+            printf '  - %s\n' "${skipped[@]}"
+          fi

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -14,6 +14,7 @@ mod fixture_citation;
 mod locale_cue_bundle_coherence;
 mod mcp_tier_isolation;
 mod no_tenant_knowledge;
+mod publish_plan;
 mod readme_version_check;
 mod safety_net_sanity;
 mod scrub_public_text;
@@ -43,6 +44,7 @@ enum Command {
     SafetyNetSanity,
     TokenbridgeNoRawIndex(tokenbridge_no_raw_index::Args),
     McpTierIsolation,
+    PublishPlan,
     ReadmeVersionCheck,
     ScrubPublicText(scrub_public_text::Args),
 }
@@ -65,6 +67,7 @@ fn main() -> Result<()> {
         Command::SafetyNetSanity => safety_net_sanity::run(),
         Command::TokenbridgeNoRawIndex(args) => tokenbridge_no_raw_index::run(args),
         Command::McpTierIsolation => mcp_tier_isolation::run(),
+        Command::PublishPlan => publish_plan::run(),
         Command::ReadmeVersionCheck => readme_version_check::run(),
         Command::ScrubPublicText(args) => scrub_public_text::run(args),
     }

--- a/crates/xtask/src/publish_plan.rs
+++ b/crates/xtask/src/publish_plan.rs
@@ -1,0 +1,287 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+
+pub fn run() -> Result<()> {
+    for package in build_publish_plan(&cargo_metadata()?)? {
+        println!("{}", package.name);
+    }
+    Ok(())
+}
+
+fn cargo_metadata() -> Result<Metadata> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .context("failed to run cargo metadata")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    serde_json::from_slice(&output.stdout).context("failed to parse cargo metadata")
+}
+
+fn build_publish_plan(metadata: &Metadata) -> Result<Vec<PublishPackage>> {
+    let packages_by_id: HashMap<String, &Package> = metadata
+        .packages
+        .iter()
+        .map(|package| (package.id.clone(), package))
+        .collect();
+    let package_ids_by_dir = package_ids_by_dir(metadata)?;
+    let workspace_order: HashMap<String, usize> = metadata
+        .workspace_members
+        .iter()
+        .enumerate()
+        .map(|(index, id)| (id.clone(), index))
+        .collect();
+    let publishable_ids: HashSet<String> = metadata
+        .workspace_members
+        .iter()
+        .filter_map(|id| packages_by_id.get(id).copied())
+        .filter(|package| is_publishable(package))
+        .map(|package| package.id.clone())
+        .collect();
+
+    let mut indegree: HashMap<String, usize> = publishable_ids
+        .iter()
+        .cloned()
+        .map(|id| (id, 0_usize))
+        .collect();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+
+    for id in &metadata.workspace_members {
+        let Some(package) = packages_by_id.get(id).copied() else {
+            bail!("publish-plan: workspace member {id} missing from package list");
+        };
+        if !publishable_ids.contains(&package.id) {
+            continue;
+        }
+
+        let mut deps = BTreeSet::new();
+        for dependency in publish_dependencies(package, &package_ids_by_dir) {
+            let dependency = dependency?;
+            if dependency == package.id.as_str() {
+                continue;
+            }
+            let dependency_package = packages_by_id
+                .get(&dependency)
+                .with_context(|| format!("publish-plan: dependency {dependency} missing"))?;
+            if !publishable_ids.contains(&dependency) {
+                bail!(
+                    "publish-plan: published crate {} depends on workspace member {} with publish = false",
+                    package.name,
+                    dependency_package.name
+                );
+            }
+            deps.insert(dependency);
+        }
+
+        for dependency in deps {
+            dependents
+                .entry(dependency)
+                .or_default()
+                .push(package.id.clone());
+            *indegree
+                .get_mut(&package.id)
+                .expect("publishable package has indegree") += 1;
+        }
+    }
+
+    let mut ready: BTreeSet<(usize, String)> = indegree
+        .iter()
+        .filter(|(_, degree)| **degree == 0)
+        .map(|(id, _)| {
+            (
+                *workspace_order
+                    .get(id)
+                    .expect("publishable package has workspace order"),
+                id.clone(),
+            )
+        })
+        .collect();
+    let mut ordered = Vec::with_capacity(publishable_ids.len());
+
+    while let Some((_, id)) = ready.pop_first() {
+        let package = packages_by_id
+            .get(&id)
+            .copied()
+            .expect("ready package exists");
+        ordered.push(PublishPackage {
+            name: package.name.clone(),
+        });
+
+        if let Some(next_packages) = dependents.get(&id) {
+            for next in next_packages {
+                let degree = indegree
+                    .get_mut(next)
+                    .expect("dependent publishable package has indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    ready.insert((
+                        *workspace_order
+                            .get(next)
+                            .expect("dependent package has workspace order"),
+                        next.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    if ordered.len() != publishable_ids.len() {
+        let unresolved = indegree
+            .into_iter()
+            .filter(|(_, degree)| *degree > 0)
+            .map(|(id, _)| id)
+            .filter_map(|id| packages_by_id.get(&id).map(|package| package.name.as_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("publish-plan: workspace publish dependencies contain a cycle: {unresolved}");
+    }
+
+    Ok(ordered)
+}
+
+fn package_ids_by_dir(metadata: &Metadata) -> Result<HashMap<PathBuf, String>> {
+    let mut by_dir = HashMap::new();
+    for package in &metadata.packages {
+        let package_dir = package
+            .manifest_path
+            .parent()
+            .with_context(|| format!("{}: Cargo.toml has no parent directory", package.name))?;
+        by_dir.insert(package_dir.to_path_buf(), package.id.clone());
+    }
+    Ok(by_dir)
+}
+
+fn publish_dependencies<'a>(
+    package: &'a Package,
+    package_ids_by_dir: &'a HashMap<PathBuf, String>,
+) -> impl Iterator<Item = Result<String>> + 'a {
+    package
+        .dependencies
+        .iter()
+        .filter(|dependency| dependency.kind.as_deref() != Some("dev"))
+        .filter(|dependency| dependency.source.is_none())
+        .filter_map(|dependency| {
+            dependency.path.as_ref().map(|path| {
+                package_ids_by_dir.get(path).cloned().with_context(|| {
+                    format!(
+                        "publish-plan: {} has local dependency {} at {}, but no package was found there",
+                        package.name,
+                        dependency.name,
+                        path.display()
+                    )
+                })
+            })
+        })
+}
+
+fn is_publishable(package: &Package) -> bool {
+    package
+        .publish
+        .as_ref()
+        .is_none_or(|registries| !registries.is_empty())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublishPackage {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    packages: Vec<Package>,
+    workspace_members: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Package {
+    id: String,
+    name: String,
+    manifest_path: PathBuf,
+    publish: Option<Vec<String>>,
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Dependency {
+    name: String,
+    kind: Option<String>,
+    path: Option<PathBuf>,
+    source: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_publish_plan_is_topological_and_keeps_cli_last() -> Result<()> {
+        let metadata = cargo_metadata()?;
+        let plan = build_publish_plan(&metadata)?;
+        let positions: HashMap<&str, usize> = plan
+            .iter()
+            .enumerate()
+            .map(|(index, package)| (package.name.as_str(), index))
+            .collect();
+
+        assert_eq!(
+            plan.last().map(|package| package.name.as_str()),
+            Some("gaze-cli")
+        );
+        assert!(positions.contains_key("gaze-mcp-bridge"));
+        assert!(positions.contains_key("gaze-token-bridge"));
+
+        assert_before(&positions, "gaze-pii", "gaze-cli");
+        assert_before(&positions, "gaze-mcp-bridge", "gaze-cli");
+        assert_before(&positions, "gaze-token-bridge", "gaze-cli");
+
+        let package_ids_by_dir = package_ids_by_dir(&metadata)?;
+        let packages_by_id: HashMap<&str, &Package> = metadata
+            .packages
+            .iter()
+            .map(|package| (package.id.as_str(), package))
+            .collect();
+        let package_names_by_id: HashMap<&str, &str> = metadata
+            .packages
+            .iter()
+            .map(|package| (package.id.as_str(), package.name.as_str()))
+            .collect();
+        let publishable_ids: HashSet<&str> = metadata
+            .workspace_members
+            .iter()
+            .filter_map(|id| packages_by_id.get(id.as_str()).copied())
+            .filter(|package| is_publishable(package))
+            .map(|package| package.id.as_str())
+            .collect();
+
+        for id in &publishable_ids {
+            let package = packages_by_id[id];
+            for dependency in publish_dependencies(package, &package_ids_by_dir) {
+                let dependency = dependency?;
+                if dependency == package.id.as_str()
+                    || !publishable_ids.contains(dependency.as_str())
+                {
+                    continue;
+                }
+                let dependency_name = package_names_by_id[dependency.as_str()];
+                assert_before(&positions, dependency_name, &package.name);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn assert_before(positions: &HashMap<&str, usize>, before: &str, after: &str) {
+        assert!(
+            positions[before] < positions[after],
+            "{before} should publish before {after}"
+        );
+    }
+}

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -20,9 +20,17 @@ Source: [`.github/workflows/publish-crates.yml`](../../../.github/workflows/publ
 
 - Triggered on `v*` tag pushes (with `workflow_dispatch` dry-run available).
 - Authenticates to crates.io via OIDC trusted-publisher (`rust-lang/crates-io-auth-action`); no long-lived `CARGO_REGISTRY_TOKEN` secret.
-- Publishes the trusted-publisher-linked workspace crates in topological order: `gaze-types` → `gaze-audit` → `gaze-recognizers` → `gaze-pii` → `gaze-assembly` → `gaze-mcp-core` → `gaze-mcp-rmcp` → `gaze-document` → `gaze-proxy` → `gaze-cli`. The core crate is published as `gaze-pii` while its library target remains `gaze`.
+- Derives the publish set and topological order from `cargo metadata` with `cargo run -p xtask -- publish-plan`. Every workspace member with `publish != false` is included automatically, including new crates. The core crate is published as `gaze-pii` while its library target remains `gaze`.
+- Runs a manifest pre-flight before any real publish: `cargo package --no-verify -p <crate>` for each crate in the derived plan. This catches unpublishable workspace dependency manifests before OIDC auth or partial publishing.
+- Checks crates.io for every planned crate before publishing. If any crate is absent, the workflow fails up front because OIDC trusted publishing cannot first-publish a new crate.
 - Skips crates already at the published version (idempotent re-runs) and retries on index-propagation lag.
-- New crates require a one-time manual `cargo publish` with a crates.io token, followed by trusted-publisher linking, before they join the OIDC publish loop.
+- New crates require a one-time manual seed publish with a crates.io token, followed by trusted-publisher linking, before a tag publish can proceed:
+
+```bash
+cargo publish -p <crate>
+```
+
+After the seed publish, add the crate's Trusted Publisher on crates.io for `CertaMesh/gaze` and `.github/workflows/publish-crates.yml`, then re-run the publish workflow. `workflow_dispatch` has a `check_new_crates` input for exceptional dry-run diagnostics, but tag releases keep the guard on.
 - Browse crates at <https://crates.io/crates/gaze-pii> (and sibling crate pages).
 
 Cutting a release: tag the merge commit on `main` with `vX.Y.Z` and push the tag. Both workflows fire from the same tag push; no manual crates.io step is needed for crates already in the OIDC publish loop.


### PR DESCRIPTION
## Summary
- add `xtask publish-plan` to derive the crates.io publish set and topological order from cargo metadata
- add package manifest preflight and new-crate crates.io guard before OIDC publishing
- update release docs for derived publish plans and one-time new-crate seed publishing

Fixes #1606.
Fixes #1608.

## Tests
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy --workspace --all-features -- -D warnings`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --workspace --all-features`
- `PATH="$HOME/.cargo/bin:$PATH" cargo run -p xtask -- ci-feature-matrix`
- `PATH="$HOME/.cargo/bin:$PATH" cargo run -p xtask -- readme-version-check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p xtask publish_plan::tests::workspace_publish_plan_is_topological_and_keeps_cli_last`
- manifest preflight: `cargo package --no-verify -p <crate>` for every crate in `xtask publish-plan`

`actionlint` was not available locally.