### PR TITLE
[agent] Fix email TLD allowlist leak

### DIFF
--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -15,7 +15,9 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co))\b'''
+# The structural TLD branch excludes reserved restore/fake-token TLDs (`invalid`,
+# `test`); the explicit branches above keep example.invalid/test.local behavior.
+pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))\b'''
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -169,6 +169,24 @@ fn pipeline_from_rulepack(rulepack: &Rulepack) -> Pipeline {
     builder.build().expect("pipeline")
 }
 
+fn email_global_spec() -> RecognizerSpec {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+    core.recognizers
+        .into_iter()
+        .find(|recognizer| recognizer.id == "email.global")
+        .expect("email.global")
+}
+
+fn email_global_pipeline() -> Pipeline {
+    let email_spec = email_global_spec();
+    Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .recognizer(regex_from_spec(&email_spec))
+        .build()
+        .expect("pipeline")
+}
+
 fn clean_text(pipeline: &Pipeline, session: &Session, input: &str, locale: LocaleTag) -> String {
     let clean = pipeline
         .pseudonymize_with_context(
@@ -189,6 +207,80 @@ fn restore_tokens(session: &Session, clean: &str) -> String {
             session.restore_strict(&captures[0]).expect("known token")
         })
         .to_string()
+}
+
+#[test]
+fn email_global_structural_tlds_tokenize_and_restore() {
+    let email_spec = email_global_spec();
+    assert_eq!(
+        email_spec
+            .validator
+            .as_ref()
+            .map(|validator| validator.kind.as_str()),
+        Some("email_rfc")
+    );
+    assert!(matches!(
+        ValidatorKind::EmailRfc.validate("missingdot@example"),
+        ValidatorOutcome::Fail { .. }
+    ));
+    let pipeline = email_global_pipeline();
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "Contacts ada@datapuente.es legal@medfleet.health k@kettenmacher.at b@bancodelnorte.mx user@northwave-labs.io ops@mail.corp.example.es";
+
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+
+    for raw in [
+        "ada@datapuente.es",
+        "legal@medfleet.health",
+        "k@kettenmacher.at",
+        "b@bancodelnorte.mx",
+        "user@northwave-labs.io",
+        "ops@mail.corp.example.es",
+    ] {
+        assert!(!clean.contains(raw), "{raw} leaked in {clean}");
+    }
+    assert_eq!(clean.matches(":Email_").count(), 6, "{clean}");
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn email_global_overlapping_host_rival_keeps_email_span_intact() {
+    let email_spec = email_global_spec();
+    let host_rival = RegexDetector::with_rulepack_fields(
+        r"(?i)\b(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z]{2,}\b",
+        PiiClass::Custom("host".to_string()),
+        "test.host.rival",
+        vec![LocaleTag::Global],
+        0.99,
+        120,
+        "counter",
+        None,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("host rival");
+    let pipeline = Pipeline::builder()
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("host".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve))
+        .recognizer(regex_from_spec(&email_spec))
+        .recognizer(host_rival)
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let input = "visit acme.es or mail ada@acme.es";
+
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+
+    assert!(!clean.contains("ada@acme.es"), "{clean}");
+    assert!(!clean.contains("ada@"), "{clean}");
+    assert!(clean.contains(":Email_1>"), "{clean}");
+    assert_custom_token(&clean, "host");
+    assert_eq!(restore_tokens(&session, &clean), input);
 }
 
 fn assert_custom_token(clean: &str, class: &str) {

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1189,7 +1189,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.(?:com|org|net|edu|gov|de|uk|fr|nl|io|ai|co))\b'''
+pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))\b'''
 
 [recognizers.context]
 exclusions = ["test.local"]


### PR DESCRIPTION
## Summary

The embedded email.global recognizer was only producing candidates for a closed set of TLDs. Valid-looking email addresses on other TLDs never reached validation or tokenization and could pass through clean output unchanged.

This replaces the closed TLD branch with a structural multi-label domain branch, while keeping the explicit example.invalid / test.local handling intact. The structural branch excludes Gaze's reserved restore/fake-token TLDs so the token-shape shadow guard continues to reject recognizers that would match emitted pseudonyms.

Resolves dogfooding finding 1 (email TLD allowlist)

## Fixtures

- Leak repro fixture, then flipped: email_global_structural_tlds_tokenize_and_restore covers .es, .health, .at, .mx, existing .io, and multi-label mail.corp.example.es, and asserts tokenization plus exact restore.
- Overlap fixture: email_global_overlapping_host_rival_keeps_email_span_intact adds a test-only host rival so resolver tiers keep the full email span intact while still handling a bare host.
- Validator wiring: the fixture asserts email.global still declares email_rfc and that the validator remains fail-closed for a no-dot domain.

## Checks

- rustup run 1.96.0 rustc --version -> rustc 1.96.0 (ac68faa20 2026-05-25)
- rustup run 1.96.0 cargo fmt --all -- --check passed
- rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings passed
- rustup run 1.96.0 cargo test -p gaze-recognizers --test core_extended email_global_ --features phone-parser passed
- rustup run 1.96.0 cargo test --workspace --all-features reached the known pre-existing gaze-mcp-core trybuild .stderr wording drift only
- rustup run 1.96.0 cargo test --workspace --all-features --exclude gaze-mcp-core passed after rerunning a transient kiji_distilbert_subprocess timeout successfully
- rustup run 1.96.0 cargo run -p xtask -- fixture-citation-lint passed
- rustup run 1.96.0 cargo run -p xtask -- family-policy-table-coherence passed
- rustup run 1.96.0 cargo run -p xtask -- recognizer-composition-validator passed
- rustup run 1.96.0 cargo run -p xtask -- ci-feature-matrix passed all earlier matrix steps and then stopped at the same known gaze-mcp-core trybuild .stderr wording drift during its full workspace test step
