### PR TITLE
[agent] Gate IBANs by ISO country length

### DIFF
--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1061,6 +1061,104 @@ fn phase2_formatted_iban_with_spaces_tokenizes_and_round_trips() {
 }
 
 #[test]
+fn phase2_short_iso_iban_with_anchor_tokenizes_and_round_trips() {
+    let rulepack = core_extended();
+    let pipeline = pipeline_from_rulepack(&rulepack);
+
+    for (input, expected, canonical, locale) in [
+        (
+            "Bank IBAN: NO93 8601 1117 947",
+            "NO93 8601 1117 947",
+            "NO9386011117947",
+            LocaleTag::EnUs,
+        ),
+        (
+            "Bank IBAN: NO9386011117947",
+            "NO9386011117947",
+            "NO9386011117947",
+            LocaleTag::EnUs,
+        ),
+        (
+            "Bank IBAN: AT48 3200 0000 1234 5864",
+            "AT48 3200 0000 1234 5864",
+            "AT483200000012345864",
+            LocaleTag::DeDe,
+        ),
+        (
+            "Bank IBAN: MT84 MALT 0110 0001 2345 MTLC AST0 01S",
+            "MT84 MALT 0110 0001 2345 MTLC AST0 01S",
+            "MT84MALT011000012345MTLCAST001S",
+            LocaleTag::EnUs,
+        ),
+        (
+            "Bank IBAN: LC14 BOSL 1234 5678 9012 3456 7890 1234",
+            "LC14 BOSL 1234 5678 9012 3456 7890 1234",
+            "LC14BOSL123456789012345678901234",
+            LocaleTag::EnUs,
+        ),
+    ] {
+        assert_eq!(
+            detect_recognizer(&rulepack, "iban.structural", input, locale.clone()),
+            vec![expected.to_string()],
+            "{input}"
+        );
+        assert_eq!(
+            detect_recognizer_canonical_forms(&rulepack, "iban.structural", input, locale.clone()),
+            vec![Some(canonical.to_string())],
+            "{input}"
+        );
+
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let clean = clean_text(&pipeline, &session, input, locale);
+        assert_custom_token(&clean, "iban");
+        assert_eq!(restore_tokens(&session, &clean), input);
+    }
+}
+
+#[test]
+fn phase2_anchored_iban_overlapping_card_tail_keeps_single_iban_span() {
+    let rulepack = core_extended();
+    let input = "Bank IBAN: AT70 4111 1111 1111 1111";
+
+    assert_eq!(
+        detect_recognizer(&rulepack, "iban.structural", input, LocaleTag::DeDe),
+        vec!["AT70 4111 1111 1111 1111".to_string()]
+    );
+    assert_eq!(
+        detect_recognizer(&rulepack, "card.structural", input, LocaleTag::DeDe),
+        vec!["4111 1111 1111 1111".to_string()]
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::DeDe);
+
+    assert_custom_token(&clean, "iban");
+    assert!(
+        !clean.contains(":Custom:credit_card_"),
+        "contained card tail must not double-tokenize inside anchored IBAN: {clean}"
+    );
+    assert_eq!(gaze::token_shape::pattern().find_iter(&clean).count(), 1);
+    assert_eq!(restore_tokens(&session, &clean), input);
+}
+
+#[test]
+fn phase2_mod97_passing_wrong_length_iban_shape_is_vetoed() {
+    let rulepack = core_extended();
+    let input = "Bank IBAN: NO37 8601 1117 9470";
+
+    assert!(
+        detect_recognizer(&rulepack, "iban.structural", input, LocaleTag::EnUs).is_empty(),
+        "iban.structural must reject MOD-97-passing wrong-length IBAN shapes"
+    );
+
+    let pipeline = pipeline_from_rulepack(&rulepack);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let clean = clean_text(&pipeline, &session, input, LocaleTag::EnUs);
+    assert_eq!(clean, input);
+}
+
+#[test]
 fn phase2_mod97_failing_iban_shape_can_still_tokenize_phone_tail() {
     let rulepack = core_extended();
     let input = "My IBAN DE12 3456 7890 01555 0112233";

--- a/crates/gaze-recognizers/tests/validators.rs
+++ b/crates/gaze-recognizers/tests/validators.rs
@@ -88,15 +88,32 @@ fn luhn_algorithm_accepts_public_test_numbers_and_rejects_mutants() {
 #[test]
 fn iban_mod97_accepts_spec_examples_and_rejects_check_digit_mutants() {
     for input in [
+        "NO93 8601 1117 947",
+        "NO9386011117947",
         "BE71 0961 2345 6769",
         "DE89 3704 0044 0532 0130 00",
         "FR14 2004 1010 0505 0001 3M02 606",
         "GB82 WEST 1234 5698 7654 32",
+        "MT84 MALT 0110 0001 2345 MTLC AST0 01S",
+        "LC14 BOSL 1234 5678 9012 3456 7890 1234",
     ] {
         assert!(ValidatorKind::IbanMod97.validates(input), "{input}");
     }
 
     for input in ["GB99WEST12345698765432", "DE99370400440532013000"] {
+        assert!(!ValidatorKind::IbanMod97.validates(input), "{input}");
+    }
+}
+
+#[test]
+fn iban_mod97_rejects_mod97_passing_wrong_country_lengths() {
+    for input in [
+        "NO37 8601 1117 9470",
+        "DE81 3704 0044 0532 0130 000",
+        "GB76 WEST 1234 5698 7654 320",
+        "BE30 0961 2345 6769 0",
+        "LC22 BOSL 1234 5678 9012 3456 7890 1234 0",
+    ] {
         assert!(!ValidatorKind::IbanMod97.validates(input), "{input}");
     }
 }

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -765,21 +765,35 @@ fn luhn_check(input: &str) -> bool {
 
 fn iban_mod97_check(input: &str) -> bool {
     let canonical = iban_canonicalize(input);
-    if !(15..=34).contains(&canonical.len()) {
+    let bytes = canonical.as_bytes();
+    if bytes.len() < 4 {
         return false;
     }
-    if !canonical.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+    if !bytes[0].is_ascii_uppercase()
+        || !bytes[1].is_ascii_uppercase()
+        || !bytes[2].is_ascii_digit()
+        || !bytes[3].is_ascii_digit()
+    {
+        return false;
+    }
+    let Some(expected_len) = iban_country_length(&bytes[..2]) else {
+        return false;
+    };
+    if bytes.len() != expected_len {
+        return false;
+    }
+    if !bytes.iter().all(u8::is_ascii_alphanumeric) {
         return false;
     }
 
     let mut remainder = 0u32;
-    for ch in canonical[4..].chars().chain(canonical[..4].chars()) {
-        match ch {
-            '0'..='9' => {
-                remainder = (remainder * 10 + ch.to_digit(10).expect("digit")) % 97;
+    for byte in bytes[4..].iter().chain(bytes[..4].iter()).copied() {
+        match byte {
+            b'0'..=b'9' => {
+                remainder = (remainder * 10 + u32::from(byte - b'0')) % 97;
             }
-            'A'..='Z' => {
-                let value = u32::from(ch) - u32::from('A') + 10;
+            b'A'..=b'Z' => {
+                let value = u32::from(byte - b'A') + 10;
                 remainder = (remainder * 10 + value / 10) % 97;
                 remainder = (remainder * 10 + value % 10) % 97;
             }
@@ -787,6 +801,103 @@ fn iban_mod97_check(input: &str) -> bool {
         }
     }
     remainder == 1
+}
+
+fn iban_country_length(country: &[u8]) -> Option<usize> {
+    // ISO 13616 IBAN Registry country lengths. MOD-97 alone has a false-accept
+    // rate near 1/97, so exact country length gates candidates before checksum.
+    match country {
+        b"AD" => Some(24),
+        b"AE" => Some(23),
+        b"AL" => Some(28),
+        b"AT" => Some(20),
+        b"AZ" => Some(28),
+        b"BA" => Some(20),
+        b"BE" => Some(16),
+        b"BG" => Some(22),
+        b"BH" => Some(22),
+        b"BI" => Some(27),
+        b"BR" => Some(29),
+        b"BY" => Some(28),
+        b"CH" => Some(21),
+        b"CR" => Some(22),
+        b"CY" => Some(28),
+        b"CZ" => Some(24),
+        b"DE" => Some(22),
+        b"DJ" => Some(27),
+        b"DK" => Some(18),
+        b"DO" => Some(28),
+        b"EE" => Some(20),
+        b"EG" => Some(29),
+        b"ES" => Some(24),
+        b"FI" => Some(18),
+        b"FK" => Some(18),
+        b"FO" => Some(18),
+        b"FR" => Some(27),
+        b"GB" => Some(22),
+        b"GE" => Some(22),
+        b"GI" => Some(23),
+        b"GL" => Some(18),
+        b"GR" => Some(27),
+        b"GT" => Some(28),
+        b"HN" => Some(28),
+        b"HR" => Some(21),
+        b"HU" => Some(28),
+        b"IE" => Some(22),
+        b"IL" => Some(23),
+        b"IQ" => Some(23),
+        b"IS" => Some(26),
+        b"IT" => Some(27),
+        b"JO" => Some(30),
+        b"KW" => Some(30),
+        b"KZ" => Some(20),
+        b"LB" => Some(28),
+        b"LC" => Some(32),
+        b"LI" => Some(21),
+        b"LT" => Some(20),
+        b"LU" => Some(20),
+        b"LV" => Some(21),
+        b"LY" => Some(25),
+        b"MC" => Some(27),
+        b"MD" => Some(24),
+        b"ME" => Some(22),
+        b"MK" => Some(19),
+        b"MN" => Some(20),
+        b"MR" => Some(27),
+        b"MT" => Some(31),
+        b"MU" => Some(30),
+        b"NI" => Some(28),
+        b"NL" => Some(18),
+        b"NO" => Some(15),
+        b"OM" => Some(23),
+        b"PK" => Some(24),
+        b"PL" => Some(28),
+        b"PS" => Some(29),
+        b"PT" => Some(25),
+        b"QA" => Some(29),
+        b"RO" => Some(24),
+        b"RS" => Some(22),
+        b"RU" => Some(33),
+        b"SA" => Some(24),
+        b"SC" => Some(31),
+        b"SD" => Some(18),
+        b"SE" => Some(24),
+        b"SI" => Some(19),
+        b"SK" => Some(24),
+        b"SM" => Some(27),
+        b"SO" => Some(23),
+        b"ST" => Some(25),
+        b"SV" => Some(28),
+        b"TL" => Some(23),
+        b"TN" => Some(24),
+        b"TR" => Some(26),
+        b"UA" => Some(29),
+        b"VA" => Some(22),
+        b"VG" => Some(24),
+        b"XK" => Some(20),
+        b"YE" => Some(30),
+        _ => None,
+    }
 }
 
 fn iban_canonicalize(input: &str) -> String {


### PR DESCRIPTION
Resolves dogfooding finding 3 (IBAN ISO-13616 length coverage)

## Summary
- Adds exact ISO-13616 country-length gating to the existing `iban_mod97` validator before the MOD-97 checksum loop, reusing the existing validator kind and fail reason.
- Keeps the bundled IBAN recognizer mandatory `iban` anchor and `payment-card-or-iban` collision metadata unchanged.
- Adds anchored NO93 coverage for spaced and contiguous Norwegian IBANs, plus AT/MT/LC length examples and wrong-length MOD-97-passing veto cases.
- Adds an overlap fixture where an anchored AT IBAN contains a Luhn-valid card-shaped tail; the final pipeline emits one IBAN token, no card token, and restores the full original span.

## Validation
- Leak repro/regression: `NO93 8601 1117 947` with an `IBAN` anchor tokenizes and round-trips; contiguous `NO9386011117947` also round-trips.
- No regression: `DE89 3704 0044 0532 0130 00` remains covered by existing tests; `AT48 3200 0000 1234 5864` was added as an explicit AT round-trip.
- Precision: MOD-97-passing wrong-length forms such as `NO37 8601 1117 9470` are vetoed by the validator and do not tokenize.
- Overlap: anchored `AT70 4111 1111 1111 1111` wins as IBAN over the contained card-shaped tail with no double-token and no span loss.
- Gates passed: `family-policy-table-coherence`, `recognizer-composition-validator`, `locale-cue-bundle-coherence`, `fixture-citation-lint`, and `no-tenant-knowledge`.
- `rustup run 1.96.0 cargo fmt --all -- --check`: passed.
- `rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings`: passed.
- `rustup run 1.96.0 cargo test --workspace --all-features`: only the known local `gaze-mcp-core` trybuild stderr wording drift failed; rerun with `--exclude gaze-mcp-core` passed.
- `rustup run 1.96.0 cargo run -p xtask -- ci-feature-matrix`: all steps passed until the final full-suite step hit the same known local `gaze-mcp-core` trybuild stderr drift.