### PR TITLE
[agent] Fix index first-run failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ name = "gaze-token-bridge"
 version = "0.11.1"
 dependencies = [
  "async-trait",
+ "chacha20poly1305",
  "gaze-mcp-core",
  "gaze-pii",
  "hmac",

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -165,6 +165,7 @@ The `index` feature adds a local owner-side search index for `.txt` and `.md`
 corpora:
 
 ```console
+$ export GAZE_INDEX_KEY=$(openssl rand -hex 32)
 $ cargo run -p gaze-cli --features index -- index ingest ./notes
 $ cargo run -p gaze-cli --features index -- index search "alice@example.invalid" --class email
 ```
@@ -172,8 +173,10 @@ $ cargo run -p gaze-cli --features index -- index search "alice@example.invalid"
 By default the index is written under `./.gaze-index/`, or the directory from
 `GAZE_INDEX_PATH`; `--index-path <dir>` overrides both. This store is sensitive
 owner-side material: it contains raw values needed for session-token translation,
-plus generated projection key material. It is gitignored. Encrypt-at-rest support
-is a follow-up; do not place `.gaze-index/` in shared or model-visible storage.
+plus generated projection key material. `GAZE_INDEX_KEY` must contain 32 bytes
+as 64 hex chars or 32 ASCII chars; the on-disk `index.json` is encrypted and
+starts with `GAZEIDX1`. Keep `.gaze-index/` gitignored and out of shared or
+model-visible storage.
 
 Search output is the bridge's agent-facing response: snippets contain only
 current-session tokens, never raw PII or index-domain aliases. The v1 ingest path

--- a/crates/gaze-cli/src/commands/index.rs
+++ b/crates/gaze-cli/src/commands/index.rs
@@ -3,10 +3,14 @@
 //! Available only when the binary is built with `--features index`.
 
 use std::collections::BTreeSet;
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, LocaleTag, PiiClass, Pipeline};
+use gaze::{
+    Action, ClassRule, DefaultRule, Detection, Detector, Error as GazeError, LocaleTag, PiiClass,
+    Pipeline,
+};
 use gaze_recognizers::{LocaleAwareModelRegistry, RegexDetector};
 use gaze_token_bridge::adapter::CorpusIndexStore;
 use gaze_token_bridge::bridge::TokenBridge;
@@ -67,7 +71,7 @@ pub(crate) fn ingest(args: IngestArgs) -> Result<(), CliError> {
     let domain = registry
         .domain(&args.domain)
         .cloned()
-        .ok_or_else(index_failed)?;
+        .ok_or_else(|| index_policy_detail("index domain lookup", "domain is not registered"))?;
     let projector = HmacDomainProjector::new(&registry);
     let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector).with_safety_net_resolution();
 
@@ -97,7 +101,7 @@ pub(crate) fn search(args: SearchArgs) -> Result<(), CliError> {
     let domain = store
         .domain(&args.domain)
         .cloned()
-        .ok_or_else(index_failed)?;
+        .ok_or_else(|| index_policy_detail("index domain lookup", "domain is not registered"))?;
     let policy_json = store.policy_json().map_err(map_bridge_error)?;
     let output_safety_net = build_index_output_safety_net_pipeline()?;
     let mut bridge = TokenBridge::from_policy_json_and_store(&policy_json, store)
@@ -199,7 +203,10 @@ fn classes_for_docs(docs: &[SourceDoc]) -> Vec<PiiClass> {
 
 fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
     let mut builder = Pipeline::builder()
-        .detector(RegexDetector::emails().map_err(|_| index_failed())?)
+        .detector(
+            RegexDetector::emails()
+                .map_err(|err| index_policy_detail("index email detector build", err))?,
+        )
         .detector(FieldEntityDetector);
     builder = builder.register_safety_net_registry(index_kiji_registry()?);
 
@@ -213,14 +220,14 @@ fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
     builder
         .rule(DefaultRule::new(Action::Preserve))
         .build()
-        .map_err(|_| index_failed())
+        .map_err(|err| map_pipeline_error("index pipeline build", err))
 }
 
 fn build_index_output_safety_net_pipeline() -> Result<Pipeline, CliError> {
     Pipeline::builder()
         .register_safety_net_registry(index_kiji_registry()?)
         .build()
-        .map_err(|_| index_failed())
+        .map_err(|err| map_pipeline_error("index output safety-net pipeline build", err))
 }
 
 fn index_kiji_registry() -> Result<LocaleAwareModelRegistry, CliError> {
@@ -279,14 +286,11 @@ fn local_principal(domain: &gaze_token_bridge::model::IndexDomain) -> Principal 
 
 fn map_bridge_error(err: BridgeError) -> CliError {
     match err {
-        BridgeError::Session(message)
-            if message.contains("safety net") || message.contains("SafetyNet") =>
-        {
-            CliError::SafetyNetFailure {
-                variant: "IndexSafetyNet",
-            }
+        BridgeError::Policy(message) => index_policy_detail("index policy", message),
+        BridgeError::Session(message) if is_safety_net_message(&message) => {
+            index_safety_net_detail("index safety net", message)
         }
-        _ => index_failed(),
+        BridgeError::Session(message) => index_policy_detail("index session", message),
     }
 }
 
@@ -294,8 +298,25 @@ fn index_denied(reason: DenyReason) -> CliError {
     CliError::PolicyConfigDetail(format!("index search failed closed: {reason:?}"))
 }
 
-fn index_failed() -> CliError {
-    CliError::PolicyConfigDetail("index operation failed closed".to_string())
+fn map_pipeline_error(context: &'static str, err: GazeError) -> CliError {
+    let message = err.to_string();
+    if is_safety_net_message(&message) {
+        index_safety_net_detail(context, message)
+    } else {
+        index_policy_detail(context, message)
+    }
+}
+
+fn is_safety_net_message(message: &str) -> bool {
+    message.contains("safety net") || message.contains("SafetyNet")
+}
+
+fn index_policy_detail(context: &'static str, detail: impl fmt::Display) -> CliError {
+    CliError::PolicyConfigDetail(format!("{context} failed closed: {detail}"))
+}
+
+fn index_safety_net_detail(context: &'static str, detail: impl fmt::Display) -> CliError {
+    CliError::SafetyNetConfigDetail(format!("{context} failed closed: {detail}"))
 }
 
 struct SourceDoc {

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use assert_cmd::Command;
 
 const DOMAIN: &str = "local_owner/support_notes/v1";
+const INDEX_KEY: &str = "1111111111111111111111111111111111111111111111111111111111111111";
 
 #[test]
 fn index_ingest_then_search_returns_tokenized_hits_without_raw_values() {
@@ -49,6 +50,14 @@ Second support note for search isolation.
         ingest.status.success(),
         "ingest failed: stderr={}",
         String::from_utf8_lossy(&ingest.stderr)
+    );
+    let index_bytes = fs::read(index.join("index.json")).expect("read encrypted index");
+    assert!(index_bytes.starts_with(b"GAZEIDX1"));
+    assert!(
+        !index_bytes
+            .windows(b"alice@example.invalid".len())
+            .any(|window| window == b"alice@example.invalid"),
+        "encrypted index contains raw fixture email"
     );
 
     let search = gaze_index_command(&fake_kiji)
@@ -152,6 +161,7 @@ fn index_ingest_fails_closed_without_kiji_model_or_command() {
 
     let ingest = Command::cargo_bin("gaze")
         .expect("gaze bin")
+        .env("GAZE_INDEX_KEY", INDEX_KEY)
         .env_remove("GAZE_KIJI_DISTILBERT_COMMAND")
         .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR")
         .args(["index", "ingest"])
@@ -173,10 +183,44 @@ fn index_ingest_fails_closed_without_kiji_model_or_command() {
     );
 }
 
+#[test]
+fn index_ingest_surfaces_safety_net_failure_detail() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_failing_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(corpus.join("alpha.md"), "Email: alice@example.invalid\n").expect("write alpha");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+
+    assert!(
+        !ingest.status.success(),
+        "ingest unexpectedly succeeded with failing Kiji backend"
+    );
+    let stderr = String::from_utf8_lossy(&ingest.stderr);
+    assert!(stderr.contains("SafetyNetConfig"), "stderr={stderr}");
+    assert!(
+        stderr.contains("exit status: 13"),
+        "stderr omitted backend detail: {stderr}"
+    );
+    assert!(
+        !stderr.contains("alice@example.invalid"),
+        "stderr leaked raw fixture value: {stderr}"
+    );
+}
+
 fn gaze_index_command(fake_kiji: &Path) -> Command {
     let mut command = Command::cargo_bin("gaze").expect("gaze bin");
     command
         .env("GAZE_KIJI_DISTILBERT_COMMAND", fake_kiji)
+        .env("GAZE_INDEX_KEY", INDEX_KEY)
         .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR");
     command
 }
@@ -219,5 +263,25 @@ print(json.dumps(spans))
         .permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&script, permissions).expect("chmod fake kiji");
+    script
+}
+
+fn write_failing_fake_kiji(temp: &tempfile::TempDir) -> PathBuf {
+    let script = temp.path().join("failing-fake-kiji.py");
+    fs::write(
+        &script,
+        r#"#!/usr/bin/env python3
+import sys
+
+sys.stderr.write("fixture boot failure\n")
+sys.exit(13)
+"#,
+    )
+    .expect("write failing fake kiji");
+    let mut permissions = fs::metadata(&script)
+        .expect("failing fake kiji metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).expect("chmod failing fake kiji");
     script
 }

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["text-processing"]
 gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+chacha20poly1305 = { version = "0.10", features = ["std"] }
 hmac = "0.12"
 sha2 = "0.10"
 rand = "0.8"

--- a/crates/gaze-token-bridge/src/persistent.rs
+++ b/crates/gaze-token-bridge/src/persistent.rs
@@ -9,6 +9,8 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use chacha20poly1305::aead::{Aead, Payload};
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
 use gaze::PiiClass;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -22,6 +24,7 @@ use crate::util::hex;
 
 pub const DEFAULT_INDEX_DIR: &str = ".gaze-index";
 pub const INDEX_FILE_NAME: &str = "index.json";
+pub const INDEX_KEY_ENV: &str = "GAZE_INDEX_KEY";
 pub const DEFAULT_DOMAIN_ID: &str = "local_owner/docs/v1";
 pub const LOCAL_PRINCIPAL_ID: &str = "local_owner";
 pub const LOCAL_ROLE: &str = "owner";
@@ -33,6 +36,9 @@ pub const LOCAL_PURPOSE: &str = "owner_lookup";
 
 const SCHEMA_VERSION: u32 = 1;
 const DEFAULT_MAX_RESULTS: usize = 20;
+const INDEX_MAGIC: &[u8] = b"GAZEIDX1";
+const INDEX_NONCE_LEN: usize = 12;
+const INDEX_AAD: &[u8] = b"gaze-token-bridge:index:v1";
 
 /// File-backed owner-side corpus index store.
 #[derive(Debug, Clone)]
@@ -46,13 +52,14 @@ impl FileCorpusIndexStore {
     pub fn load(dir: impl AsRef<Path>) -> Result<Self, BridgeError> {
         let dir = dir.as_ref().to_path_buf();
         let index_path = dir.join(INDEX_FILE_NAME);
-        let contents = fs::read_to_string(&index_path).map_err(|err| {
+        let encrypted = fs::read(&index_path).map_err(|err| {
             BridgeError::Policy(format!(
                 "failed to read owner-side index {}: {err}",
                 index_path.display()
             ))
         })?;
-        let file: PersistentIndexFile = serde_json::from_str(&contents).map_err(|err| {
+        let contents = decrypt_index_file(&encrypted)?;
+        let file: PersistentIndexFile = serde_json::from_slice(&contents).map_err(|err| {
             BridgeError::Policy(format!(
                 "failed to parse owner-side index {}: {err}",
                 index_path.display()
@@ -101,7 +108,8 @@ impl FileCorpusIndexStore {
         let tmp_path = self.dir.join(format!("{INDEX_FILE_NAME}.tmp"));
         let contents = serde_json::to_vec_pretty(&self.file)
             .map_err(|err| BridgeError::Policy(format!("failed to encode index: {err}")))?;
-        fs::write(&tmp_path, contents).map_err(|err| {
+        let encrypted = encrypt_index_file(&contents)?;
+        fs::write(&tmp_path, encrypted).map_err(|err| {
             BridgeError::Policy(format!(
                 "failed to write owner-side index {}: {err}",
                 tmp_path.display()
@@ -515,6 +523,110 @@ fn generated_projection_key() -> String {
     hex(&bytes)
 }
 
+fn encrypt_index_file(plaintext: &[u8]) -> Result<Vec<u8>, BridgeError> {
+    let key = index_key_from_env()?;
+    encrypt_index_bytes(&key, plaintext)
+}
+
+fn decrypt_index_file(bytes: &[u8]) -> Result<Vec<u8>, BridgeError> {
+    let key = index_key_from_env()?;
+    decrypt_index_bytes(&key, bytes)
+}
+
+fn encrypt_index_bytes(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>, BridgeError> {
+    let cipher = ChaCha20Poly1305::new(key.into());
+    let mut nonce_bytes = [0_u8; INDEX_NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(
+            nonce,
+            Payload {
+                msg: plaintext,
+                aad: INDEX_AAD,
+            },
+        )
+        .map_err(|err| BridgeError::Policy(format!("failed to encrypt owner-side index: {err}")))?;
+
+    let mut out = Vec::with_capacity(INDEX_MAGIC.len() + INDEX_NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(INDEX_MAGIC);
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+fn decrypt_index_bytes(key: &[u8; 32], bytes: &[u8]) -> Result<Vec<u8>, BridgeError> {
+    if bytes.len() < INDEX_MAGIC.len() + INDEX_NONCE_LEN
+        || &bytes[..INDEX_MAGIC.len()] != INDEX_MAGIC
+    {
+        return Err(BridgeError::Policy(
+            "owner-side index has invalid encrypted header; re-ingest with GAZE_INDEX_KEY"
+                .to_string(),
+        ));
+    }
+
+    let nonce_start = INDEX_MAGIC.len();
+    let nonce_end = nonce_start + INDEX_NONCE_LEN;
+    let nonce = Nonce::from_slice(&bytes[nonce_start..nonce_end]);
+    let cipher = ChaCha20Poly1305::new(key.into());
+    cipher
+        .decrypt(
+            nonce,
+            Payload {
+                msg: &bytes[nonce_end..],
+                aad: INDEX_AAD,
+            },
+        )
+        .map_err(|err| BridgeError::Policy(format!("failed to decrypt owner-side index: {err}")))
+}
+
+fn index_key_from_env() -> Result<[u8; 32], BridgeError> {
+    let raw = std::env::var(INDEX_KEY_ENV).map_err(|_| {
+        BridgeError::Policy(format!(
+            "{INDEX_KEY_ENV} is required for encrypted owner-side index"
+        ))
+    })?;
+    parse_index_key(&raw)
+}
+
+fn parse_index_key(raw: &str) -> Result<[u8; 32], BridgeError> {
+    let trimmed = raw.trim();
+    if trimmed.len() == 64 && trimmed.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return decode_hex_key(trimmed);
+    }
+    if trimmed.len() == 32 {
+        let mut key = [0_u8; 32];
+        key.copy_from_slice(trimmed.as_bytes());
+        return Ok(key);
+    }
+    Err(BridgeError::Policy(format!(
+        "{INDEX_KEY_ENV} must be 32 bytes, provided as 64 hex chars or 32 ASCII chars"
+    )))
+}
+
+fn decode_hex_key(input: &str) -> Result<[u8; 32], BridgeError> {
+    let mut key = [0_u8; 32];
+    for (index, chunk) in input.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_nibble(chunk[0]).ok_or_else(invalid_index_key)?;
+        let low = hex_nibble(chunk[1]).ok_or_else(invalid_index_key)?;
+        key[index] = (high << 4) | low;
+    }
+    Ok(key)
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn invalid_index_key() -> BridgeError {
+    BridgeError::Policy(format!("{INDEX_KEY_ENV} contains invalid hex"))
+}
+
 #[cfg(unix)]
 fn restrict_dir_permissions(path: &Path) -> Result<(), BridgeError> {
     use std::os::unix::fs::PermissionsExt;
@@ -547,4 +659,37 @@ fn restrict_file_permissions(path: &Path) -> Result<(), BridgeError> {
 #[cfg(not(unix))]
 fn restrict_file_permissions(_path: &Path) -> Result<(), BridgeError> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypted_index_envelope_round_trips_with_magic() {
+        let key = [0x11; 32];
+        let plaintext = br#"{"schema_version":1}"#;
+        let encrypted = encrypt_index_bytes(&key, plaintext).expect("encrypt");
+
+        assert!(encrypted.starts_with(INDEX_MAGIC));
+        assert_ne!(&encrypted[INDEX_MAGIC.len()..], plaintext);
+        let decrypted = decrypt_index_bytes(&key, &encrypted).expect("decrypt");
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn parse_index_key_accepts_openssl_hex() {
+        let key = parse_index_key(&"22".repeat(32)).expect("parse key");
+        assert_eq!(key, [0x22; 32]);
+    }
+
+    #[test]
+    fn decrypt_index_rejects_plain_json() {
+        let key = [0x33; 32];
+        let error = decrypt_index_bytes(&key, br#"{"schema_version":1}"#).expect_err("decrypt");
+
+        assert!(
+            matches!(error, BridgeError::Policy(message) if message.contains("encrypted header"))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Surface the real sanitized failure detail from `gaze index` policy/session/pipeline errors instead of collapsing them to opaque `{"error":"PolicyConfig"}` or detail-free `SafetyNet` output.
- Encrypt the owner-side `.gaze-index/index.json` store with `GAZE_INDEX_KEY`, writing a `GAZEIDX1` envelope and rejecting plaintext/invalid encrypted headers.
- Add regression coverage for index safety-net failure details and encrypted index output.

## Root Cause
F1: `crates/gaze-cli/src/commands/index.rs` mapped bridge, registry, pipeline, and safety-net failures through generic `index_failed()` / `SafetyNetFailure`, which hid the backend's existing sanitized diagnostics.

F2 verification: with F1 fixed, synthetic ingest using the pinned local Kiji ORT model at `/Users/krishankoenig/.local/share/gaze/models/kiji-distilbert` succeeded. The reproducible first-run verification defect was that `FileCorpusIndexStore` ignored `GAZE_INDEX_KEY` and wrote raw JSON, so `.gaze-index/index.json` did not have the required `GAZEIDX1` encrypted envelope.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p gaze-cli -p gaze-recognizers --all-features --all-targets -- -D warnings`
- `cargo test -p gaze-cli --features index --test index_cli`
- `cargo test -p gaze-cli -p gaze-recognizers`
- `cargo test -p gaze-token-bridge`
- `cargo build -p gaze-cli --features index`
- Synthetic `gaze index ingest` + `gaze index search` with `GAZE_INDEX_KEY=$(openssl rand -hex 32)` and the pinned Kiji model dir; ingest wrote `GAZEIDX1` and search returned tokenized snippets.

Resolves #1746
