### PR TITLE
[agent] Redact residual index safety-net hits

### DIFF
--- a/crates/gaze-cli/src/commands/index.rs
+++ b/crates/gaze-cli/src/commands/index.rs
@@ -6,7 +6,11 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, LocaleTag, PiiClass, Pipeline};
+use clap::ValueEnum;
+use gaze::{
+    Action, ClassRule, DefaultRule, Detection, Detector, LocaleTag, PiiClass, Pipeline,
+    SafetyNetFallback,
+};
 use gaze_recognizers::{LocaleAwareModelRegistry, RegexDetector};
 use gaze_token_bridge::adapter::CorpusIndexStore;
 use gaze_token_bridge::bridge::TokenBridge;
@@ -30,6 +34,7 @@ pub(crate) struct IngestArgs {
     pub(crate) dir: PathBuf,
     pub(crate) domain: String,
     pub(crate) index_path: Option<PathBuf>,
+    pub(crate) on_residual: OnResidual,
 }
 
 pub(crate) struct SearchArgs {
@@ -37,6 +42,21 @@ pub(crate) struct SearchArgs {
     pub(crate) domain: String,
     pub(crate) class: Option<PiiClass>,
     pub(crate) index_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum OnResidual {
+    Redact,
+    Strict,
+}
+
+impl OnResidual {
+    fn fallback(self) -> SafetyNetFallback {
+        match self {
+            Self::Redact => SafetyNetFallback::Redact,
+            Self::Strict => SafetyNetFallback::Strict,
+        }
+    }
 }
 
 pub(crate) fn parse_index_class(value: &str) -> Result<PiiClass, String> {
@@ -69,7 +89,8 @@ pub(crate) fn ingest(args: IngestArgs) -> Result<(), CliError> {
         .cloned()
         .ok_or_else(index_failed)?;
     let projector = HmacDomainProjector::new(&registry);
-    let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector).with_safety_net_resolution();
+    let ingestor = CorpusIngestor::new(&pipeline, &domain, &projector)
+        .with_safety_net_resolution_fallback(args.on_residual.fallback());
 
     store.clear_domain(&args.domain);
     let mut ingested_files = 0_usize;
@@ -199,7 +220,9 @@ fn classes_for_docs(docs: &[SourceDoc]) -> Vec<PiiClass> {
 
 fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
     let mut builder = Pipeline::builder()
-        .detector(RegexDetector::emails().map_err(|_| index_failed())?)
+        .detector(RegexDetector::emails().map_err(|err| {
+            CliError::PolicyConfigDetail(format!("index email detector failed: {err}"))
+        })?)
         .detector(FieldEntityDetector);
     builder = builder.register_safety_net_registry(index_kiji_registry()?);
 
@@ -213,14 +236,16 @@ fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
     builder
         .rule(DefaultRule::new(Action::Preserve))
         .build()
-        .map_err(|_| index_failed())
+        .map_err(|err| CliError::PolicyConfigDetail(format!("index pipeline build failed: {err}")))
 }
 
 fn build_index_output_safety_net_pipeline() -> Result<Pipeline, CliError> {
     Pipeline::builder()
         .register_safety_net_registry(index_kiji_registry()?)
         .build()
-        .map_err(|_| index_failed())
+        .map_err(|err| {
+            CliError::PolicyConfigDetail(format!("index output safety-net build failed: {err}"))
+        })
 }
 
 fn index_kiji_registry() -> Result<LocaleAwareModelRegistry, CliError> {
@@ -279,14 +304,15 @@ fn local_principal(domain: &gaze_token_bridge::model::IndexDomain) -> Principal 
 
 fn map_bridge_error(err: BridgeError) -> CliError {
     match err {
+        BridgeError::Policy(message) => CliError::PolicyConfigDetail(message),
         BridgeError::Session(message)
             if message.contains("safety net") || message.contains("SafetyNet") =>
         {
-            CliError::SafetyNetFailure {
-                variant: "IndexSafetyNet",
-            }
+            CliError::SafetyNetConfigDetail(format!("index safety net failed closed: {message}"))
         }
-        _ => index_failed(),
+        BridgeError::Session(message) => {
+            CliError::PolicyConfigDetail(format!("index session failed closed: {message}"))
+        }
     }
 }
 

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -309,6 +309,9 @@ enum IndexCmd {
         /// Owner-side index directory. Defaults to `GAZE_INDEX_PATH` or `./.gaze-index/`.
         #[arg(long)]
         index_path: Option<PathBuf>,
+        /// Safety-net fallback for residual suspects after resolver pass.
+        #[arg(long, value_enum, default_value_t = index::OnResidual::Redact)]
+        on_residual: index::OnResidual,
     },
     /// Search the local owner-side index by one entity.
     Search {
@@ -934,10 +937,12 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 dir,
                 domain,
                 index_path,
+                on_residual,
             } => index::ingest(index::IngestArgs {
                 dir,
                 domain,
                 index_path,
+                on_residual,
             }),
             IndexCmd::Search {
                 entity,

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use assert_cmd::Command;
 
 const DOMAIN: &str = "local_owner/support_notes/v1";
+const TEST_INDEX_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const WRONG_INDEX_KEY: &str = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
 
 #[test]
 fn index_ingest_then_search_returns_tokenized_hits_without_raw_values() {
@@ -83,6 +85,220 @@ Second support note for search isolation.
             "search stdout leaked raw fixture value {raw}: {stdout}"
         );
     }
+}
+
+#[test]
+fn index_ingest_redacts_safety_net_only_prose_by_default_without_raw_persistence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("safety-net-only.md"),
+        "\
+Support summary mentions Dr. Schmidt after triage.
+",
+    )
+    .expect("write safety-net-only");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    let search = gaze_index_command(&fake_kiji)
+        .args(["index", "search", "Dr. Schmidt"])
+        .args(["--class", "name", "--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search");
+    assert!(
+        search.status.success(),
+        "search failed: stderr={}",
+        String::from_utf8_lossy(&search.stderr)
+    );
+
+    let stdout = String::from_utf8(search.stdout).expect("utf8 stdout");
+    assert!(stdout.contains("doc: doc:"));
+    assert!(stdout.contains(":Name_"));
+    assert!(
+        !stdout.contains("Dr. Schmidt"),
+        "search stdout leaked raw fixture value: {stdout}"
+    );
+
+    let sealed = fs::read(index.join("index.json")).expect("read sealed index");
+    assert!(sealed.starts_with(b"GAZEIDX1"));
+    assert!(
+        !bytes_contain(&sealed, b"Dr. Schmidt"),
+        "sealed index bytes contain raw fixture value"
+    );
+}
+
+#[test]
+fn index_ingest_redacts_residual_suspects_by_default_without_raw_persistence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_residual_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("residual.md"),
+        "\
+Email: alice@example.invalid
+Support summary mentions Dr. Schmidt marker after triage.
+",
+    )
+    .expect("write residual");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "default residual ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    let search = gaze_index_command(&fake_kiji)
+        .args(["index", "search", "alice@example.invalid"])
+        .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search");
+    assert!(
+        search.status.success(),
+        "search failed: stderr={}",
+        String::from_utf8_lossy(&search.stderr)
+    );
+
+    let stdout = String::from_utf8(search.stdout).expect("utf8 stdout");
+    assert!(stdout.contains(":Email_"));
+    for raw in ["alice@example.invalid", "Dr. Schmidt"] {
+        assert!(
+            !stdout.contains(raw),
+            "search stdout leaked raw fixture value {raw}: {stdout}"
+        );
+    }
+
+    let sealed = fs::read(index.join("index.json")).expect("read sealed index");
+    assert!(sealed.starts_with(b"GAZEIDX1"));
+    for raw in [
+        b"alice@example.invalid".as_slice(),
+        b"Dr. Schmidt".as_slice(),
+    ] {
+        assert!(
+            !bytes_contain(&sealed, raw),
+            "sealed index bytes contain raw fixture value"
+        );
+    }
+}
+
+#[test]
+fn index_ingest_strict_residual_mode_fails_closed_with_reason() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_residual_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("strict.md"),
+        "\
+Support summary mentions Dr. Schmidt marker after triage.
+",
+    )
+    .expect("write strict");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args([
+            "--on-residual",
+            "strict",
+            "--domain",
+            DOMAIN,
+            "--index-path",
+        ])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+
+    assert!(
+        !ingest.status.success(),
+        "strict residual ingest unexpectedly succeeded"
+    );
+    let stderr = String::from_utf8_lossy(&ingest.stderr);
+    assert!(stderr.contains("ResidualSuspect"), "stderr={stderr}");
+    assert!(
+        stderr.contains("index safety net failed closed"),
+        "stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("index operation failed closed"),
+        "stderr swallowed the real reason: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Dr. Schmidt"),
+        "stderr leaked raw fixture value: {stderr}"
+    );
+}
+
+#[test]
+fn index_search_wrong_key_surfaces_decrypt_reason() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(corpus.join("alpha.md"), "Email: alice@example.invalid\n").expect("write alpha");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .args(["index", "ingest"])
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    let search = gaze_index_command_with_key(&fake_kiji, WRONG_INDEX_KEY)
+        .args(["index", "search", "alice@example.invalid"])
+        .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search");
+
+    assert!(
+        !search.status.success(),
+        "wrong-key search unexpectedly succeeded"
+    );
+    let stderr = String::from_utf8_lossy(&search.stderr);
+    assert!(stderr.contains("decrypt"), "stderr={stderr}");
+    assert!(stderr.contains("aead"), "stderr={stderr}");
+    assert!(
+        !stderr.contains("index operation failed closed"),
+        "stderr swallowed the real reason: {stderr}"
+    );
+    assert!(
+        !stderr.contains("alice@example.invalid"),
+        "stderr leaked raw fixture value: {stderr}"
+    );
 }
 
 #[test]
@@ -174,10 +390,15 @@ fn index_ingest_fails_closed_without_kiji_model_or_command() {
 }
 
 fn gaze_index_command(fake_kiji: &Path) -> Command {
+    gaze_index_command_with_key(fake_kiji, TEST_INDEX_KEY)
+}
+
+fn gaze_index_command_with_key(fake_kiji: &Path, index_key: &str) -> Command {
     let mut command = Command::cargo_bin("gaze").expect("gaze bin");
     command
         .env("GAZE_KIJI_DISTILBERT_COMMAND", fake_kiji)
-        .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR");
+        .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+        .env("GAZE_INDEX_KEY", index_key);
     command
 }
 
@@ -220,4 +441,48 @@ print(json.dumps(spans))
     permissions.set_mode(0o755);
     fs::set_permissions(&script, permissions).expect("chmod fake kiji");
     script
+}
+
+fn write_residual_fake_kiji(temp: &tempfile::TempDir) -> PathBuf {
+    let script = temp.path().join("fake-kiji-residual.py");
+    fs::write(
+        &script,
+        r#"#!/usr/bin/env python3
+import json
+import sys
+
+text = sys.stdin.read()
+spans = []
+
+target = "Dr. Schmidt"
+index = text.find(target)
+if index >= 0:
+    start = len(text[:index].encode("utf-8"))
+    end = start + len(target.encode("utf-8"))
+    spans.append({"label": "PER", "start": start, "end": end, "score": 0.99})
+
+name_index = text.find(":Name_")
+token_index = text.rfind("<", 0, name_index)
+marker_index = text.find(" marker", name_index)
+if name_index >= 0 and token_index >= 0 and marker_index >= 0:
+    start = len(text[:token_index].encode("utf-8"))
+    end = len(text[:marker_index + len(" marker")].encode("utf-8"))
+    spans.append({"label": "PER", "start": start, "end": end, "score": 0.99})
+
+print(json.dumps(spans))
+"#,
+    )
+    .expect("write residual fake kiji");
+    let mut permissions = fs::metadata(&script)
+        .expect("residual fake kiji metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).expect("chmod residual fake kiji");
+    script
+}
+
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }

--- a/crates/gaze-token-bridge/src/ingest.rs
+++ b/crates/gaze-token-bridge/src/ingest.rs
@@ -58,9 +58,12 @@ impl<'a> CorpusIngestor<'a> {
         }
     }
 
-    pub fn with_safety_net_resolution(mut self) -> Self {
-        self.safety_net_policy =
-            SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Strict);
+    pub fn with_safety_net_resolution(self) -> Self {
+        self.with_safety_net_resolution_fallback(SafetyNetFallback::Redact)
+    }
+
+    pub fn with_safety_net_resolution_fallback(mut self, fallback: SafetyNetFallback) -> Self {
+        self.safety_net_policy = SafetyNetPolicy::new(SafetyNetMode::Resolve, fallback);
         self.reject_safety_net_suspects = false;
         self
     }


### PR DESCRIPTION
## What & why

`gaze index ingest` was using safety-net resolve with a strict residual fallback, so a residual suspect from the follow-up safety-net pass failed the whole ingest. This keeps resolve mode, defaults residual fallback to `redact`, and adds `--on-residual strict` for the old fail-closed behavior.

The index CLI was also collapsing bridge errors to `index operation failed closed`. `BridgeError::Policy` and index safety-net/session failures now preserve the sanitized cause, so wrong-key encrypted-index failures surface the decrypt/AEAD reason without echoing doc text.

Resolves #1750 #1746
Resolves #1750
Resolves #1746

## Never-leak proof

- default residual fallback test ingests a synthetic doc with a stubborn safety-net residual, returns tokenized search output for the other indexed entity, and verifies sealed `GAZEIDX1` bytes contain neither raw synthetic value
- safety-net-only prose test verifies a synthetic name is stored/searchable through a token and not returned raw
- strict opt-out test verifies `--on-residual strict` still fails closed with `ResidualSuspect`
- wrong-key test verifies stderr includes `decrypt`/`aead` and does not include raw fixture text

## Local gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p gaze-cli -p gaze-token-bridge -p gaze-recognizers --all-features --all-targets -- -D warnings`
- [x] `cargo test -p gaze-cli --features index`
- [x] `cargo test -p gaze-token-bridge`
- [x] `cargo build -p gaze-cli --features index`
- [ ] full workspace/xtask gates not run in this delegate pass

## Fixtures & PII hygiene

- [x] synthetic fixtures only; no real docs read
- [x] raw fixture values are asserted absent from search output, errors, and sealed index bytes where relevant

## DCO

- [x] Commit is signed off (`git commit -s`)

## Commit discipline

- [x] `[agent]` prefix used; files staged by name; no force-push or auto-merge
