### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-06-23
+
+### Added
+
+- **`gaze setup` provides the one-command onboarding path.** The CLI now installs
+  and SHA-verifies the pinned NER model, writes a working policy, and runs a
+  doctor check so OPF model setup is verified or fails closed.
+- **Recognizer coverage expanded for outbound DLP workflows.** EU VAT IDs,
+  ISO-length-gated IBANs, and spaced international E.164 phone numbers are now
+  detected by default recognizers.
+
+### Changed
+
+- **Owner-side TokenBridge indexes are encrypted at rest.** Index files now use
+  ChaCha20-Poly1305 bound to a per-index id, with `GAZE_INDEX_KEY` and optional
+  `os-keychain` support, closing the plaintext PII and projection-key material
+  exposure from `0.11.1`.
+- **`gaze index ingest` defaults residual safety-net hits to redact.** The new
+  `--on-residual redact|strict` mode keeps real-document ingestion usable while
+  preserving the never-leak contract; operators can still opt into strict
+  fail-closed behavior.
+- **The README now leads with the one-command quickstart and the correct product
+  framing:** deterministic reversible PII pseudonymization and outbound DLP, not
+  guardrails, prompt-injection defense, or content-safety filtering.
+
+### Fixed
+
+- **`gaze index` now surfaces real error detail.** Failures that previously
+  collapsed into an opaque `PolicyConfig` error now preserve the actionable
+  underlying error.
+- **Detection NER now loads the Kiji bundle.** The loader accepts optional
+  `config.json` metadata and conditionally supplies `token_type_ids`, matching
+  the shipped Kiji model bundle.
+- **Proxy and structural recognizer hardening.** OpenAI proxy PII surfaces were
+  tightened, email structural TLD matching was corrected, and the new phone and
+  IBAN recognizers avoid the known false-negative shapes fixed in this release.
+
 ## [0.11.1] - 2026-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "chacha20poly1305",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.11.0"
+version = "0.11.2"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
 gaze-audit = { path = "crates/gaze-audit", version = "0.11.0" }
-gaze = { path = "crates/gaze", version = "0.11.0", package = "gaze-pii" }
+gaze = { path = "crates/gaze", version = "0.11.2", package = "gaze-pii" }
 gaze-assembly = { path = "crates/gaze-assembly", version = "0.11.0" }
 gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.11.0" }
 gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.11.0" }
 gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.11.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.11.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.2" }
+gaze-types = { path = "crates/gaze-types", version = "0.11.2" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -47,7 +47,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.11.2", package = "gaze-pii" }
 gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
 gaze-audit = { workspace = true }
 gaze-document = { path = "../gaze-document", version = "0.11.0", optional = true }
@@ -55,8 +55,8 @@ gaze-mcp-bridge = { workspace = true, optional = true }
 gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
 gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
-gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.1", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2" }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.2", optional = true }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -73,7 +73,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.11.1
+$ cargo install gaze-cli --version 0.11.2
 ```
 
 Build from the workspace root:
@@ -110,7 +110,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.11.1 --features mcp
+$ cargo install gaze-cli --version 0.11.2 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -28,7 +28,7 @@ daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.11.2", package = "gaze-pii" }
 gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
 gaze-types = { workspace = true }
 http = "1"
@@ -47,6 +47,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.11.0"
+gaze-proxy = "0.11.2"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.11.0
+cargo install gaze-cli --version 0.11.2
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.0"
-gaze-recognizers = "0.11.0"
+gaze-pii = "0.11.2"
+gaze-recognizers = "0.11.2"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.11.0", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.11.2", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,7 +16,7 @@ categories = ["text-processing"]
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.0" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.2" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chacha20poly1305 = { version = "0.10", features = ["std"] }

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,11 +1,11 @@
 # gaze-token-bridge
 
-> **Status:** experimental and published as `gaze-token-bridge = "0.11.1"`.
+> **Status:** experimental and published as `gaze-token-bridge = "0.11.2"`.
 > API is pre-1.0 and may change.
 
 ```toml
 [dependencies]
-gaze-token-bridge = "0.11.1"
+gaze-token-bridge = "0.11.2"
 ```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.11.0"
+gaze-types = "0.11.2"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.11.0"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.0"
+gaze-pii = "0.11.2"
 gaze-assembly = "0.11.0"
-gaze-recognizers = "0.11.0"
+gaze-recognizers = "0.11.2"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).


### PR DESCRIPTION
## [0.11.2] - 2026-06-23

### Added

- **`gaze setup` provides the one-command onboarding path.** The CLI now installs and SHA-verifies the pinned NER model, writes a working policy, and runs a doctor check so OPF model setup is verified or fails closed.
- **Recognizer coverage expanded for outbound DLP workflows.** EU VAT IDs, ISO-length-gated IBANs, and spaced international E.164 phone numbers are now detected by default recognizers.

### Changed

- **Owner-side TokenBridge indexes are encrypted at rest.** Index files now use ChaCha20-Poly1305 bound to a per-index id, with `GAZE_INDEX_KEY` and optional `os-keychain` support, closing the plaintext PII and projection-key material exposure from `0.11.1`.
- **`gaze index ingest` defaults residual safety-net hits to redact.** The new `--on-residual redact|strict` mode keeps real-document ingestion usable while preserving the never-leak contract; operators can still opt into strict fail-closed behavior.
- **The README now leads with the one-command quickstart and the correct product framing:** deterministic reversible PII pseudonymization and outbound DLP, not guardrails, prompt-injection defense, or content-safety filtering.

### Fixed

- **`gaze index` now surfaces real error detail.** Failures that previously collapsed into an opaque `PolicyConfig` error now preserve the actionable underlying error.
- **Detection NER now loads the Kiji bundle.** The loader accepts optional `config.json` metadata and conditionally supplies `token_type_ids`, matching the shipped Kiji model bundle.
- **Proxy and structural recognizer hardening.** OpenAI proxy PII surfaces were tightened, email structural TLD matching was corrected, and the new phone and IBAN recognizers avoid the known false-negative shapes fixed in this release.

Bumped crates:
- `gaze-pii` (`crates/gaze`) to `0.11.2`
- `gaze-cli` to `0.11.2`
- `gaze-proxy` to `0.11.2`
- `gaze-recognizers` to `0.11.2`
- `gaze-token-bridge` to `0.11.2`
- `gaze-types` to `0.11.2`
