### PR TITLE
[agent] Supply-chain hygiene: pin pdfium, drop dead daemonize dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           large-packages: false
           docker-images: true
           swap-storage: false
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
         with:
           toolchain: 1.96.0
@@ -34,14 +34,19 @@ jobs:
       - name: Install pdfium dynamic library (gaze-document PDF input)
         run: |
           set -eu
+          # Pinned release: https://github.com/bblanchon/pdfium-binaries/releases/tag/chromium%2F7920
+          # Update by resolving the latest tag, downloading pdfium-linux-x64.tgz, and refreshing PDFIUM_SHA256.
+          PDFIUM_RELEASE="chromium/7920"
+          PDFIUM_SHA256="49ab3afbd4e6c1e284b5f2898129c8bb8a10fd785c1c5392c8c1fc70242f9ced"
           curl -sSL -o /tmp/pdfium.tgz \
-            https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz
+            "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_RELEASE}/pdfium-linux-x64.tgz"
+          echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c -
           mkdir -p /tmp/pdfium-extract
           tar -xzf /tmp/pdfium.tgz -C /tmp/pdfium-extract
           sudo install -m 0755 /tmp/pdfium-extract/lib/libpdfium.so /usr/local/lib/libpdfium.so
           sudo ldconfig
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,15 +815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,7 +1566,6 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
- "daemonize",
  "dirs",
  "fs2",
  "futures-util",

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`
+   |                         ^^^ function or associated item not found in `ToolCtx<'_>`

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -9,8 +9,8 @@ error[E0624]: associated function `new` is private
    |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
    |     ---------------------------------------------------- private associated function defined here
 
-error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
+error[E0599]: no associated function or constant named `new` found for struct `ToolCtx<'a>` in the current scope
   --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
    |
 12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ function or associated item not found in `ToolCtx<'_>`
+   |                         ^^^ associated function or constant not found in `ToolCtx<'_>`

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -17,14 +17,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["proxy-daemon"]
-proxy-daemon = ["dep:chrono", "dep:dirs", "dep:fs2", "dep:daemonize", "dep:tracing-appender"]
+proxy-daemon = ["dep:chrono", "dep:dirs", "dep:fs2", "dep:tracing-appender"]
 
 [dependencies]
 async-trait = "0.1"
 axum = "0.8"
 bytes = "1"
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock", "std"] }
-daemonize = { version = "0.5", optional = true }
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"


### PR DESCRIPTION
## What changed

- Removed the unused optional `daemonize` dependency from `gaze-proxy` and regenerated `Cargo.lock`, eliminating the unmaintained advisory from the graph.
- Pinned the pdfium CI download to `chromium/7920` and added SHA-256 verification before extraction/install.
- Pinned `actions/checkout@v6` and `actions/cache@v4` to their resolved commit SHAs.
- Updated one Rust 1.96.0 trybuild stderr fixture for diagnostic wording drift uncovered by the required full-suite gate.

## Verification

- `grep -rn "daemonize" crates/ --include="*.rs"`: no hits
- `grep -rn daemonize crates/gaze-proxy/build.rs 2>/dev/null`: no build script present
- `cargo check -p gaze-proxy --features proxy-daemon`: pass
- `cargo check -p gaze-proxy --all-features`: pass
- `grep -c 'name = "daemonize"' Cargo.lock`: 0
- `grep -n pdfium .github/workflows/*.yml`: only `.github/workflows/test.yml`
- Re-downloaded `https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7920/pdfium-linux-x64.tgz`; SHA-256 matched `49ab3afbd4e6c1e284b5f2898129c8bb8a10fd785c1c5392c8c1fc70242f9ced`
- Parsed `.github/workflows/test.yml` with PyYAML
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: pass
- `cargo test --workspace --all-features`: pass

## Axis tradeoffs

No north-star axis is weakened. This strengthens reliability and trust by removing an advisory-bearing dead dependency and making the CI binary input deterministic and checksum-verified.

Resolves solo todo #1863
