### PR TITLE
[agent] Port improve-wave axis-1 leak fixes to main

### DIFF
--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -59,13 +59,9 @@ The public surface is re-exported from [`src/lib.rs`](src/lib.rs).
 `RegexDetector` can be constructed directly:
 
 ```rust
-use gaze::PiiClass;
 use gaze_recognizers::RegexDetector;
 
-let recognizer = RegexDetector::new(
-    r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b",
-    PiiClass::Email,
-)?;
+let recognizer = RegexDetector::emails()?;
 ```
 
 Use `RegexDetector::emails()` for the built-in email recognizer. Rulepack

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -17,7 +17,7 @@ locales = ["global"]
 kind = "regex"
 # The structural TLD branch excludes reserved restore/fake-token TLDs (`invalid`,
 # `test`); the explicit branches above keep example.invalid/test.local behavior.
-pattern = '''(?i)([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))'''
+pattern = '''(?i)(?-u:\b)([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))(?-u:\b)'''
 capture_groups = [1]
 
 [recognizers.context]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -17,7 +17,8 @@ locales = ["global"]
 kind = "regex"
 # The structural TLD branch excludes reserved restore/fake-token TLDs (`invalid`,
 # `test`); the explicit branches above keep example.invalid/test.local behavior.
-pattern = '''(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))(?:$|[^a-z0-9_])'''
+pattern = '''(?i)([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))'''
+capture_groups = [1]
 capture_groups = [1]
 
 [recognizers.context]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -17,7 +17,8 @@ locales = ["global"]
 kind = "regex"
 # The structural TLD branch excludes reserved restore/fake-token TLDs (`invalid`,
 # `test`); the explicit branches above keep example.invalid/test.local behavior.
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))\b'''
+pattern = '''(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))(?:$|[^a-z0-9_])'''
+capture_groups = [1]
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -19,7 +19,6 @@ kind = "regex"
 # `test`); the explicit branches above keep example.invalid/test.local behavior.
 pattern = '''(?i)([a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,})))'''
 capture_groups = [1]
-capture_groups = [1]
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -54,6 +54,7 @@ pub struct RegexDetector {
     exclusions: Vec<String>,
     validator_kind: Option<ValidatorKind>,
     normalizer_kind: Option<NormalizerKind>,
+    ascii_email_boundary: bool,
 }
 
 impl RegexDetector {
@@ -104,14 +105,17 @@ impl RegexDetector {
             exclusions,
             validator_kind,
             normalizer_kind,
+            ascii_email_boundary: false,
         })
     }
 
     pub fn emails() -> Result<Self> {
-        Self::new(
-            r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b",
+        let mut detector = Self::new(
+            r"(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}",
             PiiClass::Email,
-        )
+        )?;
+        detector.ascii_email_boundary = true;
+        Ok(detector)
     }
 }
 
@@ -120,6 +124,7 @@ impl Detector for RegexDetector {
         self.regex
             .captures_iter(input)
             .filter_map(|caps| self.span_from_captures(&caps))
+            .filter(|span| self.boundary_accepts(input, span))
             .map(|span| Detection::new(span, self.class.clone(), self.source.clone()))
             .collect()
     }
@@ -144,6 +149,9 @@ impl Recognizer for RegexDetector {
             .captures_iter(input)
             .filter_map(|caps| {
                 let span = self.span_from_captures(&caps)?;
+                if !self.boundary_accepts(input, &span) {
+                    return None;
+                }
                 let matched = &input[span.clone()];
                 (!self.is_excluded(matched)).then_some((span, matched))
             })
@@ -213,6 +221,23 @@ impl RegexDetector {
             caps.get(0).map(|m| m.range())
         }
     }
+
+    fn boundary_accepts(&self, input: &str, span: &std::ops::Range<usize>) -> bool {
+        if !self.ascii_email_boundary {
+            return true;
+        }
+
+        let previous_ok = input[..span.start]
+            .chars()
+            .next_back()
+            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+        let next_ok = input[span.end..]
+            .chars()
+            .next()
+            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+
+        previous_ok && next_ok
+    }
 }
 
 fn iban_canonicalize(input: &str) -> String {
@@ -223,9 +248,49 @@ fn iban_canonicalize(input: &str) -> String {
         .collect()
 }
 
+fn is_ascii_email_continuation(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bundled_email_detector_matches_before_non_ascii_letter() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalidø");
+
+        assert_eq!(detections.len(), 1);
+        assert_eq!(detections[0].span, 0..17);
+    }
+
+    #[test]
+    fn bundled_email_detector_matches_after_non_ascii_letter() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "øa@example.invalid");
+
+        assert_eq!(detections.len(), 1);
+        assert_eq!(detections[0].span, 2..19);
+    }
+
+    #[test]
+    fn bundled_email_detector_matches_comma_separated_addresses() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalid,b@example.invalid");
+
+        assert_eq!(detections.len(), 2);
+        assert_eq!(detections[0].span, 0..17);
+        assert_eq!(detections[1].span, 18..35);
+    }
+
+    #[test]
+    fn bundled_email_detector_rejects_ascii_continuation_suffix() {
+        let detector = RegexDetector::emails().expect("email detector");
+        let detections = Detector::detect(&detector, "a@example.invalid1");
+
+        assert!(detections.is_empty());
+    }
 
     #[test]
     fn email_rfc_validator_kind_populates_canonical_form() {

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -111,7 +111,7 @@ impl RegexDetector {
 
     pub fn emails() -> Result<Self> {
         let mut detector = Self::new(
-            r"(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}",
+            r"(?i)[a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,}",
             PiiClass::Email,
         )?;
         detector.ascii_email_boundary = true;
@@ -230,11 +230,11 @@ impl RegexDetector {
         let previous_ok = input[..span.start]
             .chars()
             .next_back()
-            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+            .is_none_or(|ch| !is_ascii_email_continuation(ch));
         let next_ok = input[span.end..]
             .chars()
             .next()
-            .map_or(true, |ch| !is_ascii_email_continuation(ch));
+            .is_none_or(|ch| !is_ascii_email_continuation(ch));
 
         previous_ok && next_ok
     }
@@ -249,7 +249,7 @@ fn iban_canonicalize(input: &str) -> String {
 }
 
 fn is_ascii_email_continuation(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-')
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 #[cfg(test)]
@@ -282,6 +282,37 @@ mod tests {
         assert_eq!(detections.len(), 2);
         assert_eq!(detections[0].span, 0..17);
         assert_eq!(detections[1].span, 18..35);
+    }
+
+    #[test]
+    fn bundled_email_detector_accepts_ascii_punctuation_suffixes() {
+        let detector = RegexDetector::emails().expect("email detector");
+
+        for (input, span) in [
+            ("Contact a@example.invalid. Thanks", 8..25),
+            ("a@example.invalid- call me", 0..17),
+            ("a@example.invalid+", 0..17),
+            ("a@example.invalid%", 0..17),
+        ] {
+            let detections = Detector::detect(&detector, input);
+            assert_eq!(detections.len(), 1, "{input}");
+            assert_eq!(detections[0].span, span, "{input}");
+        }
+    }
+
+    #[test]
+    fn bundled_email_detector_keeps_leading_delimiters_out_of_span() {
+        let detector = RegexDetector::emails().expect("email detector");
+
+        for input in [
+            ".a@example.invalid",
+            "-a@example.invalid",
+            "+a@example.invalid",
+        ] {
+            let detections = Detector::detect(&detector, input);
+            assert_eq!(detections.len(), 1, "{input}");
+            assert_eq!(detections[0].span, 1..18, "{input}");
+        }
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -93,6 +93,8 @@ impl RegexDetector {
         normalizer_kind: Option<NormalizerKind>,
     ) -> Result<Self> {
         let regex = Regex::new(pattern).map_err(RecognizerError::InvalidRegex)?;
+        let ascii_email_boundary = class == PiiClass::Email && source == "email.global";
+
         Ok(Self {
             regex,
             class,
@@ -105,7 +107,7 @@ impl RegexDetector {
             exclusions,
             validator_kind,
             normalizer_kind,
-            ascii_email_boundary: false,
+            ascii_email_boundary,
         })
     }
 

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/class_map.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/class_map.rs
@@ -41,8 +41,10 @@ pub fn map_openai_label(label: &str) -> Result<OpenAiPrivateLabel, SafetyNetErro
 }
 
 /// Maps an official OPF label into the closed safety-net PII vocabulary.
-pub fn openai_label_to_safety_net_class(label: OpenAiPrivateLabel) -> SafetyNetPiiClass {
-    match label {
+pub fn openai_label_to_safety_net_class(
+    label: OpenAiPrivateLabel,
+) -> Result<SafetyNetPiiClass, SafetyNetError> {
+    Ok(match label {
         OpenAiPrivateLabel::PrivatePerson => SafetyNetPiiClass::Name,
         OpenAiPrivateLabel::PrivateAddress => SafetyNetPiiClass::Location,
         OpenAiPrivateLabel::PrivateEmail => SafetyNetPiiClass::Email,
@@ -51,8 +53,12 @@ pub fn openai_label_to_safety_net_class(label: OpenAiPrivateLabel) -> SafetyNetP
         OpenAiPrivateLabel::PrivateDate => SafetyNetPiiClass::Date,
         OpenAiPrivateLabel::AccountNumber => SafetyNetPiiClass::AccountNumber,
         OpenAiPrivateLabel::Secret => SafetyNetPiiClass::Secret,
-        _ => panic!("unknown OpenAI private label - update class_map.rs"),
-    }
+        _ => {
+            return Err(SafetyNetError::InvalidOutput {
+                message: "opf returned unsupported label".to_string(),
+            })
+        }
+    })
 }
 
 fn invalid_label() -> SafetyNetError {
@@ -84,7 +90,9 @@ mod tests {
             let private_label = map_openai_label(label).expect("official label");
             assert_eq!(private_label.as_str(), label);
             assert_eq!(
-                openai_label_to_safety_net_class(private_label).to_pii_class(),
+                openai_label_to_safety_net_class(private_label)
+                    .expect("official label maps to safety-net class")
+                    .to_pii_class(),
                 expected
             );
         }
@@ -92,11 +100,18 @@ mod tests {
 
     #[test]
     fn unknown_and_invalid_labels_fail_closed() {
-        assert!(map_openai_label("organization").is_err());
-        assert!(map_openai_label("private-email").is_err());
-        assert!(map_openai_label("PRIVATE_EMAIL").is_err());
-        assert!(map_openai_label("private_email_123").is_err());
-        assert!(map_openai_label("").is_err());
-        assert!(map_openai_label("abcdefghijklmnopqrstuvwxyzabcdefg").is_err());
+        for label in [
+            "organization",
+            "private-email",
+            "PRIVATE_EMAIL",
+            "private_email_123",
+            "",
+            "abcdefghijklmnopqrstuvwxyzabcdefg",
+        ] {
+            assert!(matches!(
+                map_openai_label(label),
+                Err(SafetyNetError::InvalidOutput { .. })
+            ));
+        }
     }
 }

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs
@@ -144,7 +144,9 @@ fn raw_span_to_model_span(
 
     let private_label = map_openai_label(&raw.label)
         .map_err(|error| ModelError::InferenceFailed(error.to_string()))?;
-    let class = openai_label_to_safety_net_class(private_label).to_pii_class();
+    let class = openai_label_to_safety_net_class(private_label)
+        .map_err(|error| ModelError::InferenceFailed(error.to_string()))?
+        .to_pii_class();
     let byte_range = raw.start..raw.end;
     let text = input[byte_range.clone()].to_string();
 
@@ -163,7 +165,7 @@ fn raw_span_to_suspect(
     context: SafetyNetContext<'_>,
 ) -> Result<Option<LeakSuspect>, SafetyNetError> {
     let private_label = map_openai_label(&raw.label)?;
-    let class = openai_label_to_safety_net_class(private_label).to_pii_class();
+    let class = openai_label_to_safety_net_class(private_label)?.to_pii_class();
     let span = raw.start..raw.end;
     let Some(kind) = context.manifest.diff_against(&span, &class) else {
         return Ok(None);

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1418,6 +1418,25 @@ fn phase2_iban_and_cards_are_universal_and_solo_classes() {
 }
 
 #[test]
+fn core_email_global_matches_non_ascii_and_punctuation_boundaries() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+
+    for input in [
+        "a@example.invalidø",
+        "a@example.invalid. Thanks",
+        "a@example.invalid- call me",
+        "a@example.invalid+",
+        ".a@example.invalid",
+    ] {
+        assert_eq!(
+            detect_recognizer(&core, "email.global", input, LocaleTag::EnUs),
+            vec!["a@example.invalid".to_string()],
+            "{input}"
+        );
+    }
+}
+
+#[test]
 fn core_and_core_extended_compose_without_counter_collision() {
     let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
     let extended = core_extended();

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1426,11 +1426,32 @@ fn core_email_global_matches_non_ascii_and_punctuation_boundaries() {
         "a@example.invalid. Thanks",
         "a@example.invalid- call me",
         "a@example.invalid+",
+        "a@example.invalid%",
         ".a@example.invalid",
     ] {
         assert_eq!(
             detect_recognizer(&core, "email.global", input, LocaleTag::EnUs),
             vec!["a@example.invalid".to_string()],
+            "{input}"
+        );
+    }
+
+    assert_eq!(
+        detect_recognizer(
+            &core,
+            "email.global",
+            "a@example.invalid,b@example.invalid",
+            LocaleTag::EnUs
+        ),
+        vec![
+            "a@example.invalid".to_string(),
+            "b@example.invalid".to_string()
+        ]
+    );
+
+    for input in ["a@example.invalid1", "a@example.invalid_"] {
+        assert!(
+            detect_recognizer(&core, "email.global", input, LocaleTag::EnUs).is_empty(),
             "{input}"
         );
     }

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -70,7 +70,9 @@ fn all_official_labels_map_exactly_to_gaze_classes() {
     for (raw, expected) in cases {
         let label = map_openai_label(raw).unwrap();
         assert_eq!(
-            openai_label_to_safety_net_class(label).to_pii_class(),
+            openai_label_to_safety_net_class(label)
+                .expect("official label maps to safety-net class")
+                .to_pii_class(),
             expected
         );
     }

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -67,6 +67,12 @@ pub enum Error {
     RedactionLog(#[from] RedactionLogError),
     #[error("safety net fallback failed closed: {0:?}")]
     SafetyNetFallback(FallbackReason),
+    #[error("safety net span invalid: start={start}, end={end}, text_len={text_len}")]
+    SafetyNetSpanInvalid {
+        start: usize,
+        end: usize,
+        text_len: usize,
+    },
     #[error("capitals heuristic gate is unsupported for locale {locale}")]
     UnsupportedCapitalHeuristicLocale { locale: String },
     #[error("unsupported raw document variant")]
@@ -962,9 +968,20 @@ impl Pipeline {
         log_entries: bool,
     ) -> Result<()> {
         for suspect in redaction_suspects(report).into_iter().rev() {
-            let span = suspect_action_span(suspect);
-            if !is_char_boundary_range(&clean.text, &span) {
-                continue;
+            let span =
+                round_span_outward_to_char_boundaries(&clean.text, suspect_action_span(suspect))?;
+            let span = expand_span_to_overlapping_manifest_entries(clean, span);
+            for existing in clean
+                .manifest
+                .iter()
+                .filter(|existing| ranges_overlap(&existing.clean_span, &span))
+            {
+                tracing::warn!(
+                    class = ?existing.class,
+                    clean_span_start = existing.clean_span.start,
+                    clean_span_end = existing.clean_span.end,
+                    "safety net redaction dropping overlapping manifest entry"
+                );
             }
             if log_entries {
                 self.log_safety_net_entry(
@@ -1313,6 +1330,61 @@ fn is_char_boundary_range(text: &str, span: &Range<usize>) -> bool {
         && span.end <= text.len()
         && text.is_char_boundary(span.start)
         && text.is_char_boundary(span.end)
+}
+
+fn round_span_outward_to_char_boundaries(text: &str, span: Range<usize>) -> Result<Range<usize>> {
+    if span.start > span.end || span.end > text.len() {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: text.len(),
+        });
+    }
+
+    let mut start = span.start;
+    while start > 0 && !text.is_char_boundary(start) {
+        start -= 1;
+    }
+
+    let mut end = span.end;
+    while end < text.len() && !text.is_char_boundary(end) {
+        end += 1;
+    }
+
+    if !is_char_boundary_range(text, &(start..end)) {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: text.len(),
+        });
+    }
+
+    Ok(start..end)
+}
+
+fn expand_span_to_overlapping_manifest_entries(
+    clean: &CleanText,
+    span: Range<usize>,
+) -> Range<usize> {
+    let mut expanded = span;
+    loop {
+        let mut changed = false;
+        for existing in &clean.manifest {
+            if ranges_overlap(&existing.clean_span, &expanded) {
+                let start = expanded.start.min(existing.clean_span.start);
+                let end = expanded.end.max(existing.clean_span.end);
+                changed |= start != expanded.start || end != expanded.end;
+                expanded = start..end;
+            }
+        }
+        if !changed {
+            return expanded;
+        }
+    }
+}
+
+fn ranges_overlap(left: &Range<usize>, right: &Range<usize>) -> bool {
+    left.start < right.end && right.start < left.end
 }
 
 fn validate_capitals_gate_locales(locale_chain: &[crate::LocaleTag]) -> Result<()> {

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -344,6 +344,7 @@ impl RecognizerRegistry {
         input: &str,
         ctx: &DetectContext<'_>,
     ) -> Result<(Vec<Candidate>, Vec<crate::validator_veto::VetoedCandidate>), DetectError> {
+        let locale_chain = LocaleChain::from(ctx.locale_chain);
         let classes = self
             .entries
             .iter()
@@ -352,7 +353,7 @@ impl RecognizerRegistry {
         let mut candidates = Vec::new();
 
         for class in classes {
-            for locale in ctx.locale_chain {
+            for locale in locale_chain.as_slice() {
                 let locale_ctx = DetectContext::new(std::slice::from_ref(locale), ctx.dictionaries);
                 locale_ctx.degraded.set(ctx.degraded.get());
                 let mut class_candidates = Vec::new();
@@ -385,7 +386,7 @@ impl RecognizerRegistry {
                 self.family_policy(),
                 &self.anchor_resolver,
                 input,
-                ctx.locale_chain,
+                locale_chain.as_slice(),
             ),
             vetoed,
         ))

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1189,7 +1189,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)\b[a-z0-9._%+\-]+@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))\b'''
+pattern = '''(?i)[a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))'''
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1189,7 +1189,7 @@ locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?i)[a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))'''
+pattern = '''(?i)(?-u:\b)[a-z0-9_][a-z0-9._%+\-]*@(?:(?:[a-z0-9\-]+\.)*example\.invalid|test\.local|(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+(?:[a-z]{2,3}|[a-su-z][a-z]{3}|t[a-df-z][a-z]{2}|te[a-rt-z][a-z]|tes[a-su-z]|[a-z]{5,6}|[a-hj-z][a-z]{6}|i[a-mo-z][a-z]{5}|in[a-uw-z][a-z]{4}|inv[b-z][a-z]{3}|inva[a-km-z][a-z]{2}|inval[a-hj-z][a-z]|invali[a-ce-z]|[a-z]{8,}))(?-u:\b)'''
 
 [recognizers.context]
 exclusions = ["test.local"]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -967,7 +967,10 @@ fn structural_findings(text: &str) -> Vec<StructuralFinding> {
 }
 
 fn collect_email_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
-    for matched in email_pattern().find_iter(text) {
+    for caps in email_pattern().captures_iter(text) {
+        let Some(matched) = caps.get(1) else {
+            continue;
+        };
         let raw = matched.as_str();
         if !is_basic_restore_email(raw) {
             continue;
@@ -1040,7 +1043,7 @@ fn collect_api_key_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
 fn email_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        Regex::new(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
+        Regex::new(r"(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,})(?:$|[^a-z0-9_])")
             .expect("email restore DLP regex compiles")
     })
 }
@@ -1971,6 +1974,24 @@ mod tests {
         assert_ne!(events[0].raw_sha256, "alice@example.invalid");
         assert_eq!(events[1].kind, RestoreEventKind::FreshPiiDetected);
         assert_eq!(events[1].class, PiiClass::Email);
+    }
+
+    #[test]
+    fn restore_dlp_email_boundary_accepts_non_ascii_and_punctuation_delimiters() {
+        for (input, location) in [
+            ("a@example.invalidø", 0..17),
+            ("a@example.invalid. Thanks", 0..17),
+            (".a@example.invalid", 1..18),
+        ] {
+            let findings = structural_findings(input);
+            let finding = findings
+                .iter()
+                .find(|finding| finding.class == PiiClass::Email)
+                .unwrap_or_else(|| panic!("missing email finding for {input}"));
+
+            assert_eq!(finding.raw, "a@example.invalid", "{input}");
+            assert_eq!(finding.location, location, "{input}");
+        }
     }
 
     #[test]

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -967,10 +967,10 @@ fn structural_findings(text: &str) -> Vec<StructuralFinding> {
 }
 
 fn collect_email_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
-    for caps in email_pattern().captures_iter(text) {
-        let Some(matched) = caps.get(1) else {
+    for matched in email_pattern().find_iter(text) {
+        if !restore_email_boundary_accepts(text, &matched.range()) {
             continue;
-        };
+        }
         let raw = matched.as_str();
         if !is_basic_restore_email(raw) {
             continue;
@@ -1043,7 +1043,7 @@ fn collect_api_key_findings(text: &str, findings: &mut Vec<StructuralFinding>) {
 fn email_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        Regex::new(r"(?i)(?:^|[^a-z0-9_])([a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,})(?:$|[^a-z0-9_])")
+        Regex::new(r"(?i)[a-z0-9_][a-z0-9._%+\-]*@[a-z0-9.\-]+\.[a-z]{2,}")
             .expect("email restore DLP regex compiles")
     })
 }
@@ -1090,6 +1090,23 @@ fn is_basic_restore_email(input: &str) -> bool {
         return false;
     };
     !local.is_empty() && domain.contains('.') && !domain.starts_with('.') && !domain.ends_with('.')
+}
+
+fn restore_email_boundary_accepts(input: &str, span: &std::ops::Range<usize>) -> bool {
+    let previous_ok = input[..span.start]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_ascii_email_continuation(ch));
+    let next_ok = input[span.end..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_ascii_email_continuation(ch));
+
+    previous_ok && next_ok
+}
+
+fn is_ascii_email_continuation(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 fn ascii_digits(input: &str) -> String {
@@ -1981,6 +1998,9 @@ mod tests {
         for (input, location) in [
             ("a@example.invalidø", 0..17),
             ("a@example.invalid. Thanks", 0..17),
+            ("a@example.invalid-", 0..17),
+            ("a@example.invalid+", 0..17),
+            ("a@example.invalid%", 0..17),
             (".a@example.invalid", 1..18),
         ] {
             let findings = structural_findings(input);
@@ -1991,6 +2011,28 @@ mod tests {
 
             assert_eq!(finding.raw, "a@example.invalid", "{input}");
             assert_eq!(finding.location, location, "{input}");
+        }
+
+        let adjacent = structural_findings("a@example.invalid,b@example.invalid")
+            .into_iter()
+            .filter(|finding| finding.class == PiiClass::Email)
+            .map(|finding| (finding.raw, finding.location))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            adjacent,
+            vec![
+                ("a@example.invalid".to_string(), 0..17),
+                ("b@example.invalid".to_string(), 18..35)
+            ]
+        );
+
+        for input in ["a@example.invalid1", "a@example.invalid_"] {
+            assert!(
+                structural_findings(input)
+                    .iter()
+                    .all(|finding| finding.class != PiiClass::Email),
+                "{input}"
+            );
         }
     }
 

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -145,6 +145,26 @@ fn normalization_runs_before_detection() {
 }
 
 #[test]
+fn email_tokenization_handles_non_ascii_boundary_suffix() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let pipeline = email_token_pipeline();
+
+    let text = redact_text(&pipeline, &session, "a@example.invalidø");
+
+    assert!(
+        !text.contains("a@example.invalid"),
+        "email substring leaked through clean text: {text}"
+    );
+    assert!(text.starts_with('<') && text.ends_with(":Email_1>ø"));
+
+    let token = text.trim_end_matches('ø');
+    assert_eq!(
+        session.restore_strict(token).expect("restore token"),
+        "a@example.invalid"
+    );
+}
+
+#[test]
 fn longest_span_wins_for_overlaps() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let pipeline = Pipeline::builder()

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -81,6 +81,37 @@ fn distinct_conversation_sessions_produce_distinct_pseudonyms_for_identical_raw_
 }
 
 #[test]
+fn clean_with_safety_net_tokenizes_minimal_email() {
+    let pipeline = Pipeline::builder()
+        .detector(RegexDetector::emails().expect("email detector"))
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let (clean, _manifest, _report) = pipeline
+        .clean_with_safety_net(
+            &session,
+            RawDocument::Text("a@example.invalid".to_string()),
+            &[],
+        )
+        .expect("redact");
+    let CleanDocument::Text(text) = clean else {
+        panic!("expected text document");
+    };
+
+    assert!(
+        !text.contains("a@example.invalid"),
+        "minimal email leaked through clean text: {text:?}"
+    );
+    assert!(text.starts_with('<') && text.ends_with(":Email_1>"));
+    assert_eq!(
+        session.restore_strict(&text).expect("restore"),
+        "a@example.invalid"
+    );
+}
+
+#[test]
 fn two_ephemeral_sessions_are_independent_namespaces() {
     let pipeline = email_token_pipeline();
     let a = Session::new(Scope::Ephemeral).expect("session a");

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -37,6 +37,13 @@ struct MockNet {
     seen: Arc<Mutex<Vec<SeenCheck>>>,
 }
 
+#[derive(Clone)]
+struct InvalidSpanNet {
+    locales: Vec<gaze::LocaleTag>,
+    span: Range<usize>,
+    class: PiiClass,
+}
+
 #[derive(Debug, Clone)]
 struct SeenCheck {
     clean_text: String,
@@ -142,6 +149,9 @@ impl SafetyNet for MockNet {
         let Some(span) = self.span.clone() else {
             return Ok(Vec::new());
         };
+        if span.start > span.end || span.end > clean_text.len() {
+            return Ok(Vec::new());
+        }
         let Some(kind) = context.manifest.diff_against(&span, &self.class) else {
             return Ok(Vec::new());
         };
@@ -153,6 +163,32 @@ impl SafetyNet for MockNet {
             Some(0.99),
             kind,
             self.raw_label,
+            context.field_path.map(str::to_string),
+        )])
+    }
+}
+
+impl SafetyNet for InvalidSpanNet {
+    fn id(&self) -> &str {
+        "invalid-span"
+    }
+
+    fn supported_locales(&self) -> &[gaze::LocaleTag] {
+        &self.locales
+    }
+
+    fn check(
+        &self,
+        _clean_text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        Ok(vec![LeakSuspect::new(
+            self.span.clone(),
+            self.class.clone(),
+            self.id(),
+            Some(0.99),
+            LeakKind::Uncovered,
+            "private_email",
             context.field_path.map(str::to_string),
         )])
     }
@@ -265,6 +301,138 @@ fn safety_net_redact_mode_strips_suspect_without_manifest_entry() {
         .expect("redact");
 
     assert_eq!(text(clean), "Reach ");
+    assert!(manifest.is_empty());
+    assert_eq!(report.stats.uncovered_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_rounds_misaligned_multibyte_suspect_outward() {
+    let raw = "Grüße von Dr. Schmidt".to_string();
+    let multibyte = raw.find('ü').expect("multibyte char");
+    let net = MockNet::new(Some(multibyte + 1..multibyte + "ü".len()), PiiClass::Name);
+    let pipeline = pipeline_with_net(Some(net));
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("misaligned redact rounds outward");
+    let clean_text = text(clean);
+
+    assert_eq!(clean_text, "Grße von Dr. Schmidt");
+    assert!(!clean_text.contains("Grüße"));
+    assert!(manifest.is_empty());
+    assert_eq!(report.stats.uncovered_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_expands_overlap_to_entire_emitted_token() {
+    let session = session();
+    let raw = RawDocument::Text("alice@example.invalid ok".to_string());
+    let baseline = text(
+        tokenizing_pipeline()
+            .redact(&session, raw.clone())
+            .expect("baseline"),
+    );
+    let token_len = baseline.find(" ok").expect("token suffix");
+    let net = MockNet::new(Some(2..token_len - 2), PiiClass::Name);
+
+    let (clean, manifest, report) = tokenizing_pipeline_with_net(net)
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            raw,
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("overlap redact expands to emitted token");
+    let clean_text = text(clean);
+
+    assert_eq!(clean_text, " ok");
+    assert!(!clean_text.contains('<'));
+    assert!(!clean_text.contains("Email"));
+    assert!(manifest.is_empty());
+    assert_eq!(
+        session.restore_strict_text(&clean_text).expect("restore"),
+        " ok"
+    );
+    assert_eq!(report.stats.class_mismatch_count, 1);
+}
+
+#[test]
+fn safety_net_redact_mode_out_of_range_suspect_fails_closed_without_raw_text() {
+    let raw = "Reach alice@example.invalid".to_string();
+    let net = InvalidSpanNet {
+        locales: vec![gaze::LocaleTag::Global],
+        span: 6..raw.len() + 1,
+        class: PiiClass::Email,
+    };
+    let pipeline = Pipeline::builder()
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(net)
+        .build()
+        .expect("pipeline");
+    let session = session();
+
+    let err = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw.clone()),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect_err("out-of-range safety net span fails closed");
+
+    assert!(matches!(
+        err,
+        gaze::Error::SafetyNetSpanInvalid {
+            start: 6,
+            end: _,
+            text_len: _
+        }
+    ));
+    assert!(!err.to_string().contains("alice@example.invalid"));
+    assert!(session.tokens().is_empty());
+}
+
+#[test]
+fn safety_net_redact_mode_keeps_aligned_span_redaction_behavior() {
+    let raw = "Hello Dr. Schmidt".to_string();
+    let suspect = "Dr. Schmidt";
+    let start = raw.find(suspect).expect("suspect");
+    let net = MockNet::new(Some(start..start + suspect.len()), PiiClass::Name);
+    let pipeline = pipeline_with_net(Some(net));
+    let session = session();
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(raw),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Redact,
+                gaze::SafetyNetFallback::Strict,
+            ),
+        )
+        .expect("aligned redact");
+
+    assert_eq!(text(clean), "Hello ");
     assert!(manifest.is_empty());
     assert_eq!(report.stats.uncovered_count, 1);
 }


### PR DESCRIPTION
## Incident

The 2026-06-10 improve-wave fixes merged to `agent/context-json-docs` but never landed on `main`; v0.10/v0.11 shipped without these axis-1 correctness fixes. This PR ports the stranded reliability fixes back to current `main`, including the re-discovered #315 email boundary leak where the exact document `a@example.invalid` could survive cleaning unchanged.

Resolves solo todo #1869
Resolves solo todo #1868

## Axis-1 framing

This is a reliability/fail-closed PR. It preserves the north-star guarantee that no PII byte reaches an LLM outside the manifest contract. The changes prioritize correctness axes 1-4 over performance:

- email boundaries are enforced without swallowing delimiters or missing non-ASCII/punctuation edges;
- safety-net redaction spans fail closed on invalid spans instead of silently skipping;
- unknown OPF labels fail closed instead of panicking;
- empty locale chains resolve through the global fallback.

## Per-commit verdicts

| Commit | Verdict | Notes |
|---|---|---|
| `b4a1dd6` | PORT | Ported as `344455b`; adapted to main expanded TLD branch with follow-up `3ef036d` using ASCII zero-width boundaries so adjacent email matching works without token-shape shadowing. |
| `8560c4c` | PORT | Ported as `430f387`; conflict in `core.toml` resolved by preserving main newer TLD branch and wave capture-group boundary semantics. |
| `a3335e4` | PORT | Ported cleanly as `460146b`; adds regex detector email boundary filter and `a@example.invalidø` pipeline regression. |
| `6c0defb` | SKIP-OBSOLETE | Merge wrapper for locale/cache branches; PR-A locale semantics ported via `3bfbfb1`; cache work is deferred to PR-B. |
| `3bfbfb1` | PORT | Ported as `17d97b6`; `detect_all_resolved` now uses `LocaleChain::from(ctx.locale_chain)` for empty-chain fallback. |
| `47d21a6` | PORT | Ported cleanly as `07c7ff4`; safety-net redaction spans fail closed on invalid/out-of-range spans and expand over existing manifest entries. |
| `767032b` | PORT | Ported cleanly as `0e3e32d`; unknown OPF labels return `InvalidOutput` instead of panicking. |
| `b61430d` | DEFERRED | PR-B duplicate of #313 cache work. |
| `58fc412` | DEFERRED | PR-B cache work; use this instead of the duplicate unless main already contains it. |
| `11af355` | DEFERRED | PR-B docs. |
| `bdb51aa` | DEFERRED | PR-B cargo-deny. |
| `eee8e16` | DEFERRED | PR-B CI gates. |
| `fe0854e` | DEFERRED | PR-B docs/tests. |
| `57713d5` | DEFERRED | PR-B context dictionaries. |
| `28b035c` | DEFERRED | PR-B likely skip-obsolete scratchpad doc. |

## Adaptation commits

| Commit | Purpose |
|---|---|
| `03b6a79` | Removed duplicate `capture_groups = [1]` left by conflict resolution; separate commit because no amend is allowed. |
| `3ef036d` | Adapted final email rulepack regexes to `(?-u:\b)` zero-width ASCII boundaries to preserve #315 behavior while satisfying main token-shape shadow guard. |

## Verification

| Command | Result |
|---|---|
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test contracts clean_with_safety_net_tokenizes_minimal_email` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test contracts email_tokenization_handles_non_ascii_boundary_suffix` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-recognizers --test core_extended core_email_global_matches_non_ascii_and_punctuation_boundaries` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-recognizers bundled_email_detector_matches_comma_separated_addresses` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-recognizers bundled_email_detector_accepts_ascii_punctuation_suffixes` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-recognizers bundled_email_detector_rejects_ascii_continuation_suffix` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test safety_net safety_net_redact_mode_rounds_misaligned_multibyte_suspect_outward` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test safety_net safety_net_redact_mode_expands_overlap_to_entire_emitted_token` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test safety_net safety_net_redact_mode_out_of_range_suspect_fails_closed_without_raw_text` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-pii --test safety_net safety_net_redact_mode_keeps_aligned_span_redaction_behavior` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test -p gaze-recognizers --features safety-net-openai --test openai_filter_subprocess` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo fmt --all -- --check` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo clippy --workspace --all-features --all-targets -- -D warnings` | PASS |
| `/Users/krishankoenig/.cargo/bin/cargo test --workspace --all-features` | Workspace suite green except known darwin-only trybuild phrasing skew in `gaze-mcp-core` `tool_ctx_seal` (solo todo #1901); CI is authoritative for that fixture. |
