### PR TITLE
[agent] fix(restore): parse token ordinals as ASCII digits only

### DIFF
--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -2864,7 +2864,7 @@ mod tests {
             .strip_prefix("Assigned to ")
             .expect("token prefix")
             .to_string();
-        assert!(regex::Regex::new(r"^<[0-9a-f]{8}:Name_\d+>$")
+        assert!(regex::Regex::new(r"^<[0-9a-f]{8}:Name_[0-9]+>$")
             .unwrap()
             .is_match(&token));
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1236,7 +1236,7 @@ fn parse_restore_token_parts(raw: &str) -> Option<(PiiClass, u32)> {
     if let Some(rest) = raw.strip_prefix("email") {
         let (ordinal, tail) = rest.split_once('.')?;
         if tail.ends_with("@gaze-fake.invalid") || tail.ends_with("@example.test") {
-            return Some((PiiClass::Email, ordinal.parse().ok()?));
+            return Some((PiiClass::Email, parse_ascii_ordinal(ordinal)?));
         }
     }
 
@@ -1248,17 +1248,30 @@ fn parse_restore_token_parts(raw: &str) -> Option<(PiiClass, u32)> {
 
     if let Some(rest) = body.strip_prefix("Custom:") {
         let (name, ordinal) = rest.rsplit_once('_')?;
-        return Some((PiiClass::Custom(name.to_string()), ordinal.parse().ok()?));
+        return Some((
+            PiiClass::Custom(name.to_string()),
+            parse_ascii_ordinal(ordinal)?,
+        ));
     }
     if let Some(rest) = body.strip_prefix("custom:") {
         let (name, ordinal) = rest.rsplit_once('_')?;
-        return Some((PiiClass::Custom(name.to_string()), ordinal.parse().ok()?));
+        return Some((
+            PiiClass::Custom(name.to_string()),
+            parse_ascii_ordinal(ordinal)?,
+        ));
     }
 
     let (class, ordinal) = body.rsplit_once('_')?;
-    let ordinal = ordinal.parse().ok()?;
+    let ordinal = parse_ascii_ordinal(ordinal)?;
     let class = PiiClass::from_canonical_str(class).unwrap_or_else(|| PiiClass::custom(class));
     Some((class, ordinal))
+}
+
+fn parse_ascii_ordinal(raw: &str) -> Option<u32> {
+    if raw.is_empty() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    raw.parse().ok()
 }
 
 fn malformed_restore_token_pattern() -> &'static Regex {
@@ -1343,14 +1356,21 @@ fn parse_token_index(token: &str) -> Option<usize> {
         .strip_prefix("email")
         .and_then(|rest| rest.split_once('.').map(|(index, _)| index))
     {
-        return local.parse().ok();
+        return parse_ascii_index(local);
     }
     let suffix = token
         .rsplit_once('_')?
         .1
         .strip_suffix('>')
         .unwrap_or(token.rsplit_once('_')?.1);
-    suffix.parse().ok()
+    parse_ascii_index(suffix)
+}
+
+fn parse_ascii_index(raw: &str) -> Option<usize> {
+    if raw.is_empty() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    raw.parse().ok()
 }
 
 fn snapshot_signing_preimage(

--- a/crates/gaze/src/token_shape.rs
+++ b/crates/gaze/src/token_shape.rs
@@ -113,7 +113,7 @@ fn build_pattern() -> String {
         .join("|");
 
     format!(
-        r"<[0-9a-f]{{8}}:(?:{builtin_alt})_\d+>|<[0-9a-f]{{8}}:Custom:[a-z0-9_]*_\d+>|\bemail\d+\.[0-9a-f]{{8}}@gaze-fake\.invalid\b|\b[0-9a-f]{{8}}:(?:{builtin_lower_alt})_\d+\b|\b[0-9a-f]{{8}}:custom:[a-z0-9_]*_\d+\b|<(?:{builtin_alt})_\d+>|<Custom:[a-z0-9_]*_\d+>|\b(?:{builtin_lower_alt})_\d+\b|\bcustom:[a-z0-9_]*_\d+\b|\bemail\d+@example\.test\b|\bemail\d+@gaze-fake\.invalid\b|<[A-Z][a-zA-Z0-9]+_\d+>|<[a-z][a-zA-Z0-9_]*_\d+>|\b[A-Z][a-zA-Z0-9]+_\d+\b|\b[a-z][a-zA-Z0-9_]*_\d+\b",
+        r"<[0-9a-f]{{8}}:(?:{builtin_alt})_[0-9]+>|<[0-9a-f]{{8}}:Custom:[a-z0-9_]*_[0-9]+>|\bemail[0-9]+\.[0-9a-f]{{8}}@gaze-fake\.invalid\b|\b[0-9a-f]{{8}}:(?:{builtin_lower_alt})_[0-9]+\b|\b[0-9a-f]{{8}}:custom:[a-z0-9_]*_[0-9]+\b|<(?:{builtin_alt})_[0-9]+>|<Custom:[a-z0-9_]*_[0-9]+>|\b(?:{builtin_lower_alt})_[0-9]+\b|\bcustom:[a-z0-9_]*_[0-9]+\b|\bemail[0-9]+@example\.test\b|\bemail[0-9]+@gaze-fake\.invalid\b|<[A-Z][a-zA-Z0-9]+_[0-9]+>|<[a-z][a-zA-Z0-9_]*_[0-9]+>|\b[A-Z][a-zA-Z0-9]+_[0-9]+\b|\b[a-z][a-zA-Z0-9_]*_[0-9]+\b",
         builtin_alt = builtin_alt,
         builtin_lower_alt = builtin_lower_alt,
     )
@@ -294,6 +294,25 @@ mod tests {
         assert!(!contains_token("See <Email_1bar>."));
         assert!(!contains_token("literal email@example.invalid address"));
         assert!(!contains_token("<Custom:-_1>"));
+    }
+
+    #[test]
+    fn unicode_digits_do_not_match_token_ordinals() {
+        for digit in ["\u{11DA0}", "\u{0966}", "\u{0660}", "\u{FF10}"] {
+            for shape in [
+                format!("a_{digit}"),
+                format!("Email_{digit}"),
+                format!("<Email_{digit}>"),
+                format!("<deadbeef:Email_{digit}>"),
+                format!("email{digit}@example.test"),
+                format!("email{digit}.deadbeef@gaze-fake.invalid"),
+            ] {
+                assert!(
+                    !contains_token(&shape),
+                    "Unicode digit must not match token ordinal: {shape:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -6,9 +6,9 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use gaze::{
-    Action, ClassRule, CleanDocument, ColumnRule, DefaultRule, ExecPolicy, PiiClass, Pipeline,
-    RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, Sandbox, SandboxError,
-    SandboxPlan, Scope, Session, UntrustedExecRequest, ValidatedExecRequest, Value,
+    Action, ClassRule, CleanDocument, ColumnRule, DefaultRule, Error, ExecPolicy, PiiClass,
+    Pipeline, RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, Sandbox,
+    SandboxError, SandboxPlan, Scope, Session, UntrustedExecRequest, ValidatedExecRequest, Value,
 };
 use gaze_audit::SqliteLogger;
 use gaze_recognizers::NormalizerKind;
@@ -34,6 +34,42 @@ fn restore_is_lax_but_restore_strict_fails_closed() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     assert_eq!(session.restore("missing-token"), None);
     assert!(session.restore_strict("missing-token").is_err());
+}
+
+#[test]
+fn restore_text_ignores_unicode_digits_in_innocent_token_like_text() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    for text in ["a_\u{11DA0}%", "a_\u{0966}%", "a_\u{0660}%", "a_\u{FF10}%"] {
+        assert_eq!(
+            session
+                .restore_strict_text(text)
+                .expect("strict restore should pass through innocent text"),
+            text
+        );
+        assert_eq!(restore_lax_text(&session, text), text);
+    }
+}
+
+#[test]
+fn restore_strict_text_still_rejects_ascii_shaped_unknown_token() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let err = session
+        .restore_strict_text("Email_999")
+        .expect_err("strict restore must reject absent ASCII token shapes");
+
+    match err {
+        Error::UnknownToken {
+            class,
+            ordinal,
+            raw,
+        } => {
+            assert_eq!(class, PiiClass::Email);
+            assert_eq!(ordinal, 999);
+            assert_eq!(raw, "Email_999");
+        }
+        other => panic!("expected UnknownToken, got {other:?}"),
+    }
 }
 
 #[test]
@@ -143,6 +179,22 @@ fn redact_text(pipeline: &Pipeline, session: &Session, text: &str) -> String {
         panic!("expected text document");
     };
     text
+}
+
+fn restore_lax_text(session: &Session, text: &str) -> String {
+    let mut restored = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for matched in gaze::token_shape::pattern().find_iter(text) {
+        restored.push_str(&text[cursor..matched.start()]);
+        restored.push_str(
+            &session
+                .restore(matched.as_str())
+                .unwrap_or_else(|| matched.as_str().to_string()),
+        );
+        cursor = matched.end();
+    }
+    restored.push_str(&text[cursor..]);
+    restored
 }
 
 #[test]


### PR DESCRIPTION
Root cause: restore token-shape scanning used regex \d for token ordinals. The Rust regex crate treats \d as Unicode-aware, so innocent text like a_\u{11DA0}% was falsely classified as token-shaped text before ordinal parsing fell back to UnknownToken.

Fix: token-shape ordinal regexes now use [0-9]+, restore ordinal/index parsing explicitly rejects non-ASCII digits, and the emission-side assertion now checks ASCII decimal ordinals. Emission remains ASCII because token constructors format integer counters with format!.

Tests: added contracts coverage for Gunjala Gondi, Devanagari, Arabic-Indic, and fullwidth zero pass-through under strict restore and scanner+lax restore; kept strict fail-closed coverage for absent ASCII token Email_999; added token_shape unit coverage for Unicode digits across wrapped, bare, session-prefixed, and format-preserving shapes.

Gates: rustup run 1.96.0 cargo fmt --all; rustup run 1.96.0 cargo clippy --workspace --all-features -- -D warnings; rustup run 1.96.0 cargo test --workspace --all-features (only allowed darwin trybuild wording failure in gaze-mcp-core tool_ctx_seal); package split follow-up tests passed for all crates outside gaze-mcp-core, including xtask.

Resolves solo todo #1920