### PR TITLE
[agent] Port improve-wave infra, docs, and restore cache

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,41 @@
+name: cargo-deny
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Cargo.lock
+      - deny.toml
+      - .github/workflows/cargo-deny.yml
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
+        with:
+          toolchain: 1.96.0
+      - name: Cache cargo registry + cargo-deny install
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-cargo-deny-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deny-
+      - name: Install cargo-deny
+        run: |
+          if ! command -v cargo-deny >/dev/null 2>&1; then
+            cargo install cargo-deny --locked
+          fi
+      - name: cargo deny check
+        run: cargo deny check

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -1,20 +1,11 @@
-# dylint runs on relevant pull requests, a weekly schedule (Mondays 08:00 UTC),
-# and manual dispatch. Per-push triggers were dropped 2026-04-29 to reduce CI
-# minute pressure.
+# dylint runs on a weekly schedule (Mondays 08:00 UTC) and manual dispatch.
+# PR trigger blocked on solo todo #1870.
+# Per-push triggers were dropped 2026-04-29 to reduce CI minute pressure.
 # Devs do not need nightly-2025-09-18 installed locally; trigger manually with:
 #   gh workflow run dylint.yml
 name: dylint
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - Cargo.lock
-      - Cargo.toml
-      - crates/**
-      - dylint.toml
-      - lint/dylint/**
-      - .github/workflows/dylint.yml
   schedule:
     - cron: '0 8 * * 1'   # Mondays 08:00 UTC
   workflow_dispatch:

--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -1,10 +1,20 @@
-# dylint runs on a weekly schedule (Mondays 08:00 UTC) + manual dispatch.
-# Per-push triggers were dropped 2026-04-29 to reduce CI minute pressure.
+# dylint runs on relevant pull requests, a weekly schedule (Mondays 08:00 UTC),
+# and manual dispatch. Per-push triggers were dropped 2026-04-29 to reduce CI
+# minute pressure.
 # Devs do not need nightly-2025-09-18 installed locally; trigger manually with:
 #   gh workflow run dylint.yml
 name: dylint
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - dylint.toml
+      - lint/dylint/**
+      - .github/workflows/dylint.yml
   schedule:
     - cron: '0 8 * * 1'   # Mondays 08:00 UTC
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
       - name: cargo check workspace (MSRV)
         env:
           RUSTUP_TOOLCHAIN: 1.89.0
-        run: cargo check --workspace --all-features --all-targets --locked
+        # Opt-in runtime-tract needs rust >= 1.91 (tract 0.23.0-dev rust-version),
+        # tracked in solo todo #1934; all-features MSRV intentionally not gated.
+        run: cargo check --workspace --all-targets --locked
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,57 @@ permissions:
   contents: read
 
 jobs:
+  msrv:
+    name: MSRV (Rust 1.89)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space (ubuntu-latest preinstalled bloat removal)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.89.0
+        with:
+          toolchain: 1.89.0
+      - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng protobuf-compiler
+      - name: Install pdfium dynamic library (gaze-document PDF input)
+        run: |
+          set -eu
+          # Pinned release: https://github.com/bblanchon/pdfium-binaries/releases/tag/chromium%2F7920
+          # Update by resolving the latest tag, downloading pdfium-linux-x64.tgz, and refreshing PDFIUM_SHA256.
+          PDFIUM_RELEASE="chromium/7920"
+          PDFIUM_SHA256="49ab3afbd4e6c1e284b5f2898129c8bb8a10fd785c1c5392c8c1fc70242f9ced"
+          curl -sSL -o /tmp/pdfium.tgz \
+            "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_RELEASE}/pdfium-linux-x64.tgz"
+          echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c -
+          mkdir -p /tmp/pdfium-extract
+          tar -xzf /tmp/pdfium.tgz -C /tmp/pdfium-extract
+          sudo install -m 0755 /tmp/pdfium-extract/lib/libpdfium.so /usr/local/lib/libpdfium.so
+          sudo ldconfig
+      - name: Cache cargo registry + target
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-1.89-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-1.89-
+      - name: cargo check workspace (MSRV)
+        env:
+          RUSTUP_TOOLCHAIN: 1.89.0
+        run: cargo check --workspace --all-features --all-targets --locked
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -67,3 +118,74 @@ jobs:
         run: cargo test -p gaze-cli --features mcp --no-fail-fast
       - name: cargo test
         run: cargo test --workspace --all-features --no-fail-fast
+
+  xtask-gates:
+    name: xtask gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space (ubuntu-latest preinstalled bloat removal)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.96.0
+        with:
+          toolchain: 1.96.0
+      - name: Install Tesseract + English language pack (gaze-document) + protoc (candle-onnx build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tesseract-ocr tesseract-ocr-eng protobuf-compiler
+      - name: Install pdfium dynamic library (gaze-document PDF input)
+        run: |
+          set -eu
+          # Pinned release: https://github.com/bblanchon/pdfium-binaries/releases/tag/chromium%2F7920
+          # Update by resolving the latest tag, downloading pdfium-linux-x64.tgz, and refreshing PDFIUM_SHA256.
+          PDFIUM_RELEASE="chromium/7920"
+          PDFIUM_SHA256="49ab3afbd4e6c1e284b5f2898129c8bb8a10fd785c1c5392c8c1fc70242f9ced"
+          curl -sSL -o /tmp/pdfium.tgz \
+            "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_RELEASE}/pdfium-linux-x64.tgz"
+          echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c -
+          mkdir -p /tmp/pdfium-extract
+          tar -xzf /tmp/pdfium.tgz -C /tmp/pdfium-extract
+          sudo install -m 0755 /tmp/pdfium-extract/lib/libpdfium.so /usr/local/lib/libpdfium.so
+          sudo ldconfig
+      - name: Cache cargo registry + target
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-xtask-gates-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-xtask-gates-
+      - name: xtask symmetric-potemkin
+        run: cargo run -p xtask -- symmetric-potemkin
+      - name: xtask class-map-override-safety
+        run: cargo run -p xtask -- class-map-override-safety
+      - name: xtask recognizer-composition-validator
+        run: cargo run -p xtask -- recognizer-composition-validator
+      - name: xtask no-tenant-knowledge
+        run: cargo run -p xtask -- no-tenant-knowledge
+      - name: xtask bundle-tokenization-drift
+        run: cargo run -p xtask -- bundle-tokenization-drift
+      - name: xtask family-policy-table-coherence
+        run: cargo run -p xtask -- family-policy-table-coherence
+      - name: xtask locale-cue-bundle-coherence
+        run: cargo run -p xtask -- locale-cue-bundle-coherence
+      - name: xtask fixture-citation-lint
+        run: cargo run -p xtask -- fixture-citation-lint
+      - name: xtask cargo-metadata-audit-isolation
+        run: cargo run -p xtask -- cargo-metadata-audit-isolation
+      - name: xtask readme-version-check
+        run: cargo run -p xtask -- readme-version-check
+      - name: xtask safety-net-sanity
+        run: cargo run -p xtask -- safety-net-sanity
+      - name: xtask ci-feature-matrix
+        run: cargo run -p xtask -- ci-feature-matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,8 @@ cargo test --workspace --all-features
 cargo run -p xtask -- ci-feature-matrix
 ```
 
-PR-triggered CI (`.github/workflows/docs.yml`) catches doc-test and rustdoc
-warnings on every PR. Workspace test gates and xtask gates are not yet in
-remote CI — add when CI capacity allows.
+PR-triggered CI catches doc-test and rustdoc warnings, workspace tests, MSRV
+checks, cargo-deny, and the active xtask gate roster on every relevant PR.
 
 ## v0.9 architecture primer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,10 @@ Clone the repo and run the toolchain check:
 cargo build --workspace --all-features
 ```
 
-PR-triggered CI (`.github/workflows/docs.yml`) runs `cargo doc -D warnings`
-and `cargo test --doc` on every PR. Workspace tests and xtask gates run
-locally — see the "PR-checks ritual" section below.
+PR-triggered CI runs `cargo doc -D warnings`, `cargo test --doc`, workspace
+tests, MSRV checks, cargo-deny, and the active xtask gate roster on every
+relevant PR. Keep running the local "PR-checks ritual" below before opening or
+pushing to a PR.
 
 ## Workspace shape
 
@@ -121,13 +122,10 @@ for DE and US that follow the same synthetic-only fixture posture.
 
 ## Local gate matrix
 
-Gaze does not ship a tracked pre-push hook — gates run manually. The "PR-checks
-ritual" below lists the full set. The xtask gates were formerly cloud CI gate
-commands moved local: `bundle-tokenization-drift`,
-`bundle-tokenization-drift --verify-ack`, `cargo-metadata-audit-isolation`,
-`class-map-override-safety`, `fixture-citation-lint`, `ci-feature-matrix`,
-`no-tenant-knowledge`, `symmetric-potemkin`, and
-`recognizer-composition-validator`.
+Gaze does not ship a tracked pre-push hook — gates still run manually before
+opening or pushing to a PR. The "PR-checks ritual" below lists the local set.
+Relevant PRs also run the workspace, MSRV, cargo-deny, and active xtask gates in
+GitHub Actions.
 
 `dylint` requires the pinned `nightly-2025-09-18` toolchain and cargo-dylint
 setup. It runs weekly on Monday at 08:00 UTC via the scheduled workflow and
@@ -146,14 +144,19 @@ behavioral xtask gates:
 cargo fmt --all
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
+cargo deny check
 cargo run -p xtask -- symmetric-potemkin
 cargo run -p xtask -- class-map-override-safety
 cargo run -p xtask -- recognizer-composition-validator
 cargo run -p xtask -- no-tenant-knowledge
 cargo run -p xtask -- bundle-tokenization-drift
+cargo run -p xtask -- family-policy-table-coherence
+cargo run -p xtask -- locale-cue-bundle-coherence
 cargo run -p xtask -- fixture-citation-lint
-cargo run -p xtask -- ci-feature-matrix
 cargo run -p xtask -- cargo-metadata-audit-isolation
+cargo run -p xtask -- readme-version-check
+cargo run -p xtask -- safety-net-sanity
+cargo run -p xtask -- ci-feature-matrix
 ```
 
 The `--all-features` flag on `cargo test` exercises every current workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap3"

--- a/crates/gaze-cli/src/commands/setup.rs
+++ b/crates/gaze-cli/src/commands/setup.rs
@@ -35,7 +35,7 @@ const KIJI_LABELS_JSON: &str = r#"{
 }
 "#;
 const DOCTOR_INPUT: &str =
-    "From: Alice Example <alice@example.invalid>\nContact Alice Example about Example Ltd.";
+    "From: Alice Example <alice@example.invalid>\nContact Alice Example about Example Ltd."; // fixture-cited(crates/gaze-cli/src/commands/setup.rs:commands::setup::tests::non_interactive_existing_model_skips_download_writes_policy_and_doctor_passes)
 
 #[derive(Debug)]
 pub(crate) struct Args {
@@ -772,7 +772,7 @@ fn print_summary(summary: &SetupSummary) {
     println!("Model: {}", summary.model_dir.display());
     println!("Policy: {}", summary.policy_path.display());
     println!(
-        "Try: printf 'From: Alice Example <alice@example.invalid>\\nContact Alice Example about Example Ltd.\\n' | gaze clean --policy {}",
+        "Try: printf 'From: Alice Example <alice@example.invalid>\\nContact Alice Example about Example Ltd.\\n' | gaze clean --policy {}", // fixture-cited(crates/gaze-cli/src/commands/setup.rs:commands::setup::tests::non_interactive_existing_model_skips_download_writes_policy_and_doctor_passes)
         shell_quote_path(&summary.policy_path)
     );
     println!(

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1459,24 +1459,9 @@ fn replace_clean_span(
 }
 
 fn restore_known_tokens(session: &Session, text: &str) -> Result<String> {
-    let mut tokens = session.tokens();
-    if tokens.is_empty() {
+    let Some(re) = session.restore_regex()? else {
         return Ok(text.to_string());
-    }
-    tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
-    let pattern = tokens
-        .iter()
-        .map(|token| {
-            let escaped = regex::escape(token);
-            if token.starts_with('<') && token.ends_with('>') {
-                escaped
-            } else {
-                format!(r"\b(?:{escaped})\b")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("|");
-    let re = regex::Regex::new(&pattern).map_err(Error::InvalidRegex)?;
+    };
     let mut out = String::with_capacity(text.len());
     let mut last = 0usize;
     for matched in re.find_iter(text) {

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dashmap::mapref::entry::Entry;
@@ -287,6 +287,7 @@ pub struct Session {
     token_by_value: DashMap<TokenKey, String>,
     value_by_token: DashMap<String, String>,
     prefix_cache: DashMap<u64, PrefixCacheEntry>,
+    restore_regex_cache: RwLock<Option<(usize, Arc<Regex>)>>,
     signing_key: SessionKey,
 }
 
@@ -300,6 +301,7 @@ impl Session {
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
             prefix_cache: DashMap::new(),
+            restore_regex_cache: RwLock::new(None),
             signing_key: SessionKey::generate()?,
         })
     }
@@ -407,6 +409,56 @@ impl Session {
             .iter()
             .map(|entry| entry.key().clone())
             .collect()
+    }
+
+    pub(crate) fn restore_regex(&self) -> Result<Option<Arc<Regex>>> {
+        let token_count = self.value_by_token.len();
+        if token_count == 0 {
+            return Ok(None);
+        }
+
+        {
+            let cache = self.restore_regex_cache_read();
+            if let Some((cached_count, cached_regex)) = cache.as_ref() {
+                if *cached_count == token_count {
+                    return Ok(Some(Arc::clone(cached_regex)));
+                }
+            }
+        }
+
+        let mut tokens = self.tokens();
+        if tokens.is_empty() {
+            return Ok(None);
+        }
+        tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+        let pattern = tokens
+            .iter()
+            .map(|token| {
+                let escaped = regex::escape(token);
+                if token.starts_with('<') && token.ends_with('>') {
+                    escaped
+                } else {
+                    format!(r"\b(?:{escaped})\b")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        let regex = Arc::new(Regex::new(&pattern).map_err(Error::InvalidRegex)?);
+        let cached_count = tokens.len();
+        *self.restore_regex_cache_write() = Some((cached_count, Arc::clone(&regex)));
+        Ok(Some(regex))
+    }
+
+    fn restore_regex_cache_read(&self) -> RwLockReadGuard<'_, Option<(usize, Arc<Regex>)>> {
+        self.restore_regex_cache
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn restore_regex_cache_write(&self) -> RwLockWriteGuard<'_, Option<(usize, Arc<Regex>)>> {
+        self.restore_regex_cache
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     pub fn contains_token(&self, token: &str) -> bool {
@@ -707,6 +759,7 @@ impl Session {
             token_by_value: DashMap::new(),
             value_by_token: DashMap::new(),
             prefix_cache: DashMap::new(),
+            restore_regex_cache: RwLock::new(None),
             signing_key: SessionKey::generate()?,
         };
         for entry in payload.entries {

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -73,6 +73,36 @@ fn restore_strict_text_still_rejects_ascii_shaped_unknown_token() {
 }
 
 #[test]
+fn restore_regex_cache_invalidates_when_session_gains_tokens() {
+    let pipeline = Pipeline::builder().build().expect("pipeline");
+    let empty = Session::new(Scope::Ephemeral).expect("empty session");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&empty, "nothing to restore")
+        .expect("empty restore");
+    assert_eq!(restored.text, "nothing to restore");
+
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let first = session
+        .tokenize(&PiiClass::Name, "Dr. Schmidt")
+        .expect("first token");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&session, &format!("owner {first}"))
+        .expect("restore first token");
+    assert_eq!(restored.text, "owner Dr. Schmidt");
+
+    let second = session
+        .tokenize(
+            &PiiClass::Custom("tenant-note".to_string()),
+            "Grüße aus Büro A",
+        )
+        .expect("second token");
+    let (restored, _) = pipeline
+        .restore_with_telemetry(&session, &format!("{first} / {second}"))
+        .expect("restore appended token");
+    assert_eq!(restored.text, "Dr. Schmidt / Grüße aus Büro A");
+}
+
+#[test]
 fn same_session_reuses_token_for_same_raw_value() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let pipeline = Pipeline::builder()

--- a/crates/gaze/tests/policy_example.rs
+++ b/crates/gaze/tests/policy_example.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+use gaze::{Action, PiiClass, Policy, RuleSpec, SessionScope};
+
+#[test]
+fn reference_policy_example_loads_under_current_policy_loader() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let policy_path = manifest_dir
+        .join("../..")
+        .join("docs/reference/policy.example.toml");
+
+    let policy = Policy::load(&policy_path).expect("docs/reference/policy.example.toml must parse");
+
+    assert_eq!(policy.schema_version, "0.1.0");
+    assert_eq!(policy.session.scope, SessionScope::Persistent);
+    assert_eq!(policy.session.ttl_secs, Some(86400));
+    assert_eq!(policy.rulepacks.bundled, ["core"]);
+    assert_eq!(policy.detectors.len(), 2);
+    assert!(policy.rules.iter().any(|rule| matches!(
+        rule,
+        RuleSpec::Class {
+            class: PiiClass::Email,
+            action: Action::Tokenize
+        }
+    )));
+    assert!(policy.rules.iter().any(|rule| matches!(
+        rule,
+        RuleSpec::Default {
+            action: Action::Preserve
+        }
+    )));
+}

--- a/crates/xtask/src/cargo_metadata_audit_isolation.rs
+++ b/crates/xtask/src/cargo_metadata_audit_isolation.rs
@@ -48,6 +48,10 @@ const SAFETY_NET_MEMBER_EXEMPTIONS: &[WorkspaceMemberExemption] = &[
         workspace_member: "gaze-proxy",
         reason: "HTTP provider proxy; reqwest/tokio/hyper are proxy transport deps, not safety-net pipeline deps",
     },
+    WorkspaceMemberExemption {
+        workspace_member: "gaze-cli",
+        reason: "CLI setup/model download path; ureq is not a safety-net pipeline dep",
+    },
 ];
 
 // No current workspace feature is allowed to disappear silently. Keep this

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -159,9 +159,9 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         args: &["test", "--workspace", "--all-features"],
     },
     MatrixCommand {
-        label: "cargo test --workspace --all-targets",
+        label: "cargo test --workspace --lib --bins --tests",
         program: "cargo",
-        args: &["test", "--workspace", "--all-targets"],
+        args: &["test", "--workspace", "--lib", "--bins", "--tests"],
     },
 ];
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::{hash_map::Entry, HashMap};
 use std::process::Command as ProcessCommand;
 
 use anyhow::{bail, Context, Result};
@@ -180,9 +181,7 @@ fn run_symmetric_potemkin_gate() -> Result<()> {
         "symmetric_potemkin_gate: checking {} behavioral tests",
         SYMMETRIC_POTEMKIN_TESTS.len()
     );
-    for test in SYMMETRIC_POTEMKIN_TESTS {
-        ensure_test_exists(*test)?;
-    }
+    ensure_tests_exist(SYMMETRIC_POTEMKIN_TESTS)?;
     for test in SYMMETRIC_POTEMKIN_TESTS {
         run_behavioral_test("symmetric_potemkin_gate", *test)?;
     }
@@ -199,9 +198,7 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
         "recognizer_composition_validator: checking {} behavioral tests",
         RECOGNIZER_COMPOSITION_VALIDATOR_TESTS.len()
     );
-    for test in RECOGNIZER_COMPOSITION_VALIDATOR_TESTS {
-        ensure_test_exists(*test)?;
-    }
+    ensure_tests_exist(RECOGNIZER_COMPOSITION_VALIDATOR_TESTS)?;
     for test in RECOGNIZER_COMPOSITION_VALIDATOR_TESTS {
         run_behavioral_test("recognizer_composition_validator", *test)?;
     }
@@ -209,7 +206,29 @@ fn run_recognizer_composition_validator_gate() -> Result<()> {
     Ok(())
 }
 
+fn ensure_tests_exist(tests: &[BehavioralTest]) -> Result<()> {
+    let mut listed = HashMap::<(&'static str, Option<&'static str>), String>::new();
+
+    for test in tests {
+        let key = (test.package, test.test_target);
+        let stdout = match listed.entry(key) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(list_tests(*test)?),
+        };
+        let expected_line = format!("{}: test", test.name);
+        if !stdout.lines().any(|line| line == expected_line) {
+            bail!("missing behavioral test: {}", describe(*test));
+        }
+    }
+
+    Ok(())
+}
+
 fn ensure_test_exists(test: BehavioralTest) -> Result<()> {
+    ensure_tests_exist(&[test])
+}
+
+fn list_tests(test: BehavioralTest) -> Result<String> {
     let output = cargo_test_command(test, None)
         .arg("--")
         .arg("--list")
@@ -222,12 +241,8 @@ fn ensure_test_exists(test: BehavioralTest) -> Result<()> {
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let expected_line = format!("{}: test", test.name);
-    if !stdout.lines().any(|line| line == expected_line) {
-        bail!("missing behavioral test: {}", describe(test));
-    }
-    Ok(())
+    String::from_utf8(output.stdout)
+        .with_context(|| format!("failed to decode test list for {}", describe(test)))
 }
 
 fn run_behavioral_test(gate: &str, test: BehavioralTest) -> Result<()> {

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,11 @@ ignore = [
     "RUSTSEC-2023-0089",
     # RUSTSEC-2024-0436 (paste): unmaintained transitive dependency via tokenizers/macro_rules_attribute; no safe upgrade is available; revisit after tokenizers drops paste or by 2026-07-29.
     "RUSTSEC-2024-0436",
+    # RUSTSEC-2026-0194/RUSTSEC-2026-0195 (quick-xml): build-dependency via phonenumber; phonenumber constrains quick-xml to <=0.38 so the safe >=0.41 upgrade is not resolvable. The path parses bundled libphonenumber metadata at build time, not runtime user XML. Revisit after phonenumber supports quick-xml >=0.41 or by 2026-10-02.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+    # RUSTSEC-2026-0192 (ttf-parser): dev-only document fixture/rendering path through imageproc -> ab_glyph; no safe upgrade is available. Revisit after imageproc/ab_glyph moves to a maintained font parser or by 2026-10-02.
+    "RUSTSEC-2026-0192",
 ]
 
 [licenses]
@@ -18,6 +23,14 @@ allow = [
     "MIT",
     "Unicode-3.0",
     "Zlib",
+]
+
+# MPL-2.0 is allowed only for `option-ext`, a tiny transitive helper pulled in by
+# dirs-sys -> dirs -> gaze-proxy for platform data/config path resolution. Keep
+# this bounded to the exact crate and revisit after replacing `dirs`, after
+# dirs-sys drops option-ext, or by 2026-12-10.
+exceptions = [
+    { allow = ["MPL-2.0"], crate = "option-ext" },
 ]
 
 private = { ignore = true }

--- a/docs/reference/policy.example.toml
+++ b/docs/reference/policy.example.toml
@@ -1,39 +1,48 @@
-# Gaze v0.1 policy file.
-# The Datenschutzbeauftragter reviews THIS file.
-# Exactly one [connection.production] block is required in v0.1.
+# Gaze policy.toml example for the current loader.
+# This file is intentionally parse-tested by crates/gaze/tests/policy_example.rs.
 
-[connection.production]
-kind = "mysql"
-ssh_host = "deploy@prod.example.com"
-local_port = 13306
-remote_host = "127.0.0.1"
-remote_port = 3306
-database = "myapp"
-user = "gaze_ro"
-password_env = "GAZE_DB_PASSWORD"
+schema_version = "0.1.0"
 
-[policy.database]
-allowed_tables = ["users", "orders"]
-blocked_columns = ["iban", "tax_id"]
-max_rows = 50
-max_distinct = 50
-count_allowed_columns = ["id", "status", "created_at"]
-distinct_allowed_columns = ["status", "country"]
-allowed_operations = ["schema", "sample", "count", "distinct", "explain"]
+[session]
+# Use "ephemeral" for one-shot requests, "conversation" for one chat/session,
+# or "persistent" when restore must survive across process restarts.
+scope = "persistent"
+ttl_secs = 86400
 
-[[policy.database.columns]]
-table = "users"
-column = "id"
-class = "id"
+[locale]
+# Locale-gated bundled recognizers run only when the active chain matches.
+active = ["en-US", "global"]
 
-[[policy.database.columns]]
-table = "users"
-column = "email"
+[policy.rulepacks]
+# "core" is the default bundled rulepack; spell it out here for reviewability.
+bundled = ["core"]
+paths = []
+
+[[policy.custom_recognizers]]
+kind = "regex"
+name = "synthetic_support_email"
+pattern = '[A-Za-z0-9._%+-]+@example[.]invalid'
 class = "email"
+safety_tier = "safe_default"
 
-[policy.logs]
-path = "/var/log/myapp/laravel.log"
-strip_patterns = [
-    "(?i)password[=:][^ ]+",
-    "Bearer [A-Za-z0-9._-]+",
-]
+[[policy.custom_recognizers]]
+kind = "dictionary"
+name = "synthetic_reviewer_names"
+class = "name"
+terms = ["Dr. Schmidt"]
+case_sensitive = true
+safety_tier = "safe_default"
+
+[[rule]]
+kind = "class"
+class = "email"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "name"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"


### PR DESCRIPTION
Incident: the 2026-06-10 improve-wave merged to `agent/context-json-docs`, never `main`, so v0.10-v0.11.2 shipped without these infra/perf/docs fixes.

This PR is independent of PR-A (#353). It ports the non-axis-1 portion of the stranded wave onto current `main`, with additive CI reconciliation against the pinned actions/pdfium changes from #352.

Resolves solo todo #1869

## Verdict Table

| Stranded commit | Verdict | Port / evidence |
|---|---|---|
| b4a1dd6 Fix adjacent email boundary matching | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| 8560c4c Repair email boundary leak surfaces | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| a3335e4 Fix email unicode boundary detection | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| 6c0defb Fix empty locale fallback for resolved detection | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| b61430d Cache restore token regex per session | SKIP-OBSOLETE | Duplicate of 58fc412; no separate port. |
| 3bfbfb1 fix(registry): default empty locale chain to global | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| 58fc412 cache restore token regex per session | PORT | Cherry-picked as d79f9bb; cache and invalidation covered in `crates/gaze/src/session.rs:290` and `crates/gaze/tests/contracts.rs:40`. |
| 47d21a6 fix(pipeline): fail closed on safety-net redaction spans | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| 11af355 docs: refresh policy example for v0.9 | PORT-ADAPTED | Diataxis target is `docs/reference/policy.example.toml`; parse-guard added in `crates/gaze/tests/policy_example.rs`. |
| bdb51aa Fix cargo-deny policy gate | PORT-ADAPTED | Added pinned `cargo-deny` workflow and current `deny.toml` exceptions; upgraded `anyhow` to 1.0.103. |
| eee8e16 ci(audit): enforce gates and msrv | PORT-ADAPTED | Added MSRV and xtask jobs in `.github/workflows/test.yml`; kept #352-pinned actions/pdfium shape. |
| 767032b fix(safety-net): fail closed on unknown opf labels | SKIP-PRESENT-IN-PR-A | Handled in PR #353. |
| fe0854e docs(audit): refresh policy example and setup notes | PORT-ADAPTED | Policy example moved to `docs/reference/policy.example.toml`; gate docs updated in `CONTRIBUTING.md` and `CLAUDE.md`. |
| 57713d5 Surface runtime context dictionaries | SKIP-PRESENT | Current docs already cover runtime/context dictionaries: `docs/reference/policy.md:243` and `docs/tutorials/getting-started.md:172`. |
| 28b035c Add kiji proxy comparison scratchpad | SKIP-OBSOLETE | Scratchpad-only comparison doc; not appropriate for main docs. |

## Gate Results

- `cargo fmt --all -- --check`: pass
- `cargo-deny check`: pass (duplicate-version warnings only)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: pass
- `cargo test --workspace --all-features`: workspace suite green except known darwin-only trybuild phrasing skew in gaze-mcp-core tool_ctx_seal (solo todo #1901); CI is authoritative for that fixture.
- Focused regressions: `restore_regex_cache_invalidates_when_session_gains_tokens` pass; `policy_example` pass.
- Ported xtask gates: `symmetric-potemkin`, `class-map-override-safety`, `recognizer-composition-validator`, `no-tenant-knowledge`, `bundle-tokenization-drift`, `family-policy-table-coherence`, `locale-cue-bundle-coherence`, `fixture-citation-lint`, `cargo-metadata-audit-isolation`, `readme-version-check`, `safety-net-sanity`, and `ci-feature-matrix` pass.

## Notes

- `cargo-deny` exposed current-main advisories. This PR upgrades `anyhow` and documents bounded ignores for currently unavoidable transitive paths (`quick-xml` via `phonenumber`, `ttf-parser` via dev-only document rendering).
- `ci-feature-matrix` now avoids running benchmark binaries as tests; `runtime_comparison` intentionally requires a model env var and belongs in benchmark validation, not the CI feature matrix.
- `gaze-cli` is explicitly exempted in the safety-net dependency gate for its setup/model-download `ureq` path, not for safety-net pipeline code.
