### PR TITLE
[agent] release: prepare v0.11.3 (publish workflow fix + version bumps)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -75,11 +75,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          while IFS= read -r crate; do
-            [ -n "$crate" ] || continue
-            echo "=== packaging $crate ==="
-            cargo package --no-verify -p "$crate"
-          done < publish-plan.txt
+          # Pre-flight package manifests before publishing.
+          # Per-crate packaging fails multi-crate releases like v0.11.2 by resolving unpublished dependents against the crates.io index.
+          cargo package --no-verify --workspace --exclude xtask
 
       - name: Check crates.io first-publish preconditions
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.check_new_crates }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-07-02
+
+v0.11.2 crates were never published to crates.io; v0.11.3 supersedes it for
+crates.io users.
+
+### Added
+
+- **Restore and manifest property suites now cover round-trip and invariant
+  behavior** (#354), raising confidence that reversible pseudonymization stays
+  stable across generated inputs.
+- **Remote CI now runs the release-critical gates** (#356): MSRV,
+  `cargo-deny`, and the `xtask` gate suite.
+- **Restore token regexes now use a session cache** (#356), reducing repeated
+  parsing work without changing strict-restore behavior.
+
+### Changed
+
+- **The unused daemonization dependency was removed** (#352), narrowing the
+  dependency graph shipped to adopters.
+
+### Fixed
+
+- **Email boundary leak fixes, SafetyNet fail-closed behavior, and locale
+  fallback fixes were ported to main** (#353), restoring axis-1 protections that
+  were absent from v0.10.0 through v0.11.2.
+- **Strict restore no longer treats Unicode-digit token ordinals as valid**
+  (#355), avoiding a false-positive restore path for non-ASCII token numbers.
+- **The crates.io publish workflow now packages the workspace as a unit before
+  publishing.** Per-crate pre-flight packaging resolved unpublished internal
+  dependencies against the registry and caused the v0.11.2 multi-crate publish
+  failure.
+
+### Security
+
+- **The pdfium CI download is pinned and SHA-256 verified** (#352), replacing an
+  unverified network fetch in the document test setup.
+
 ## [0.11.2] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-bridge"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.11.0"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "chacha20poly1305",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ homepage = "https://github.com/CertaMesh/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.11.0" }
-gaze = { path = "crates/gaze", version = "0.11.2", package = "gaze-pii" }
-gaze-assembly = { path = "crates/gaze-assembly", version = "0.11.0" }
-gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.11.0" }
-gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.11.0" }
-gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.11.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.2" }
-gaze-types = { path = "crates/gaze-types", version = "0.11.2" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.11.3" }
+gaze = { path = "crates/gaze", version = "0.11.3", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.11.3" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.11.3" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.11.3" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.11.3" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.3" }
+gaze-types = { path = "crates/gaze-types", version = "0.11.3" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your agent never sees a real email, phone number, or order ID. Your server keeps
 Three commands from zero to redacting real PII:
 
 ```sh
-cargo install gaze-cli                                       # `gaze setup` ships in the default build
+cargo install gaze-cli --version 0.11.3                     # `gaze setup` ships in the default build
 gaze setup                                                   # installs + SHA-verifies the NER model, writes ./gaze.toml, runs a doctor check
 echo "Contact Markus Gottschaue at markus@acme.com" | gaze clean --policy gaze.toml
 ```
@@ -138,7 +138,7 @@ Architecture overview with eight Key Design Decisions: [`ARCHITECTURE.md`](ARCHI
 Install the CLI from crates.io:
 
 ```sh
-cargo install gaze-cli
+cargo install gaze-cli --version 0.11.3
 ```
 
 Or build from source (latest `main`, or to enable extra features):

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
+gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.0"
-gaze-assembly = "0.11.0"
-gaze-recognizers = "0.11.0"
+gaze-pii = "0.11.3"
+gaze-assembly = "0.11.3"
+gaze-recognizers = "0.11.3"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.0"
-gaze-audit = "0.11.0"
+gaze-pii = "0.11.3"
+gaze-audit = "0.11.3"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -47,16 +47,16 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.11.2", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
+gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.11.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.11.3", optional = true }
 gaze-mcp-bridge = { workspace = true, optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.3", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2" }
-gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.2", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.3", optional = true }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -73,7 +73,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.11.2
+$ cargo install gaze-cli --version 0.11.3
 ```
 
 Build from the workspace root:
@@ -110,7 +110,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.11.2 --features mcp
+$ cargo install gaze-cli --version 0.11.3 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
+gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.3" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.11.0"
+gaze-document = "0.11.3"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.11.0 --features document
+cargo install gaze-cli --version 0.11.3 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-bridge"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,6 +1,6 @@
 # gaze-mcp-bridge
 
-`gaze-mcp-bridge = "0.11.0"` is the optional policy-gated MCP bridge for Gaze.
+`gaze-mcp-bridge = "0.11.3"` is the optional policy-gated MCP bridge for Gaze.
 
 The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
 downstream MCP tools receive restored PII only for explicitly allowed argument

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/CertaMesh/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.11.0) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.11.3) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.11.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.11.3" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.11.0"
-gaze-mcp-rmcp = "0.11.0"
+gaze-mcp-core = "0.11.3"
+gaze-mcp-rmcp = "0.11.3"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,8 +27,8 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.11.2", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.0" }
+gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -46,6 +46,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.11.2"
+gaze-proxy = "0.11.3"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.11.2
+cargo install gaze-cli --version 0.11.3
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.2"
-gaze-recognizers = "0.11.2"
+gaze-pii = "0.11.3"
+gaze-recognizers = "0.11.3"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.11.2", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.11.3", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -557,8 +557,8 @@ mod tests {
                 PiiClass::Email,
             ),
             (
-                "Home /Users/alice/project",
-                "/Users/alice/project",
+                "Home /workspace/example/project",
+                "/workspace/example/project",
                 PiiClass::Name,
             ),
             ("Org Workspace", "Workspace", PiiClass::Organization),

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,7 +16,7 @@ categories = ["text-processing"]
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.2" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.3" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chacha20poly1305 = { version = "0.10", features = ["std"] }
@@ -27,7 +27,7 @@ rand = "0.8"
 zeroize = "1"
 # Track C chokepoint integration — optional, OFF by default. Pulled in only by
 # the `chokepoint` feature below; the default build/test graph is byte-identical.
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,11 +1,11 @@
 # gaze-token-bridge
 
-> **Status:** experimental and published as `gaze-token-bridge = "0.11.2"`.
+> **Status:** experimental and published as `gaze-token-bridge = "0.11.3"`.
 > API is pre-1.0 and may change.
 
 ```toml
 [dependencies]
-gaze-token-bridge = "0.11.2"
+gaze-token-bridge = "0.11.3"
 ```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.11.2"
+gaze-types = "0.11.3"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.2", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.2"
-gaze-assembly = "0.11.0"
-gaze-recognizers = "0.11.2"
+gaze-pii = "0.11.3"
+gaze-assembly = "0.11.3"
+gaze-recognizers = "0.11.3"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).


### PR DESCRIPTION
## Summary

- Bumps all publish-plan workspace crates and internal `0.11.x` path-dependency pins to `0.11.3`, including `gaze-token-bridge` because `xtask publish-plan` includes it.
- Replaces the publish workflow's per-crate package pre-flight with workspace packaging: `cargo package --no-verify --workspace --exclude xtask`.
- Adds `CHANGELOG.md` notes for `0.11.3` and updates adopter-facing README install/version refs.
- Removes the tracked `/Users/...` test fixture shape so the path-leak release gate is clean.

## Publish Failure Root Cause

The v0.11.2 crates.io workflow failed before publishing because `Pre-flight package manifests` ran `cargo package --no-verify -p <crate>` for each plan entry. That per-crate package command resolved dependent crate versions through the crates.io index before any new workspace crates were published, so crates such as `gaze-recognizers` could not resolve unpublished internal dependencies like `gaze-types = "^0.11.2"`.

The replacement packages the workspace as one unit so Cargo can resolve unpublished in-workspace dependencies through its local overlay. `xtask` is excluded because it is private tooling with path-only dependencies and is not part of the crates.io publish plan.

`workflow_dispatch` dry-run mode still has dependent-resolution limits in the later publish loop; that is out of scope for this release-prep PR.

## Gate Results

| Gate | Result |
| --- | --- |
| `rustup run 1.96.0 cargo metadata --no-deps --format-version 1` | Pass: publish-plan crates report `0.11.3`; `xtask` remains `0.0.1`. |
| `rustup run 1.96.0 cargo package --no-verify --workspace --exclude xtask` | Pass on clean committed tree. |
| `rustup run 1.96.0 cargo run -p xtask -- readme-version-check` | Pass: 12 published crate READMEs checked. |
| `rustup run 1.96.0 cargo run -p xtask -- ci-feature-matrix` | Allowed local Darwin skew only: failed at known `gaze-mcp-core --test tool_ctx_seal` trybuild wording mismatch (todo #1901) after preceding matrix gates passed. |
| `git grep -E '/Users/[a-z]+'` | Pass: zero tracked-file matches after fixture scrub. |
| `CHANGELOG.md` 0.11.3 dogfood through `gaze clean --rulepack-bundled core` | Pass: `entries = 0`, `stats.detections = 0`. |
| `rustup run 1.96.0 cargo fmt --all -- --check` | Pass. |
| `rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings` | Pass. |
| `rustup run 1.96.0 cargo test --workspace --all-features` | Allowed local Darwin skew only: same `gaze-mcp-core --test tool_ctx_seal` trybuild wording mismatch (todo #1901); no other failures observed before that failure. |

Part of solo todo #1871.
