### PR TITLE
[agent] fix(xtask): publish-plan must order versioned dev-dependency edges

### DIFF
--- a/crates/xtask/src/publish_plan.rs
+++ b/crates/xtask/src/publish_plan.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -53,6 +53,8 @@ fn build_publish_plan(metadata: &Metadata) -> Result<Vec<PublishPackage>> {
         .map(|id| (id, 0_usize))
         .collect();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+    let mut dependency_edges_by_package: HashMap<String, BTreeMap<String, PublishDependencyKind>> =
+        HashMap::new();
 
     for id in &metadata.workspace_members {
         let Some(package) = packages_by_id.get(id).copied() else {
@@ -62,26 +64,33 @@ fn build_publish_plan(metadata: &Metadata) -> Result<Vec<PublishPackage>> {
             continue;
         }
 
-        let mut deps = BTreeSet::new();
+        let mut deps: BTreeMap<String, PublishDependencyKind> = BTreeMap::new();
         for dependency in publish_dependencies(package, &package_ids_by_dir) {
             let dependency = dependency?;
-            if dependency == package.id.as_str() {
+            if dependency.package_id == package.id.as_str() {
                 continue;
             }
-            let dependency_package = packages_by_id
-                .get(&dependency)
-                .with_context(|| format!("publish-plan: dependency {dependency} missing"))?;
-            if !publishable_ids.contains(&dependency) {
+            let dependency_package =
+                packages_by_id
+                    .get(&dependency.package_id)
+                    .with_context(|| {
+                        format!("publish-plan: dependency {} missing", dependency.package_id)
+                    })?;
+            if !publishable_ids.contains(&dependency.package_id) {
                 bail!(
                     "publish-plan: published crate {} depends on workspace member {} with publish = false",
                     package.name,
                     dependency_package.name
                 );
             }
-            deps.insert(dependency);
+            deps.entry(dependency.package_id)
+                .and_modify(|kind| *kind = kind.merge(dependency.kind))
+                .or_insert(dependency.kind);
         }
 
-        for dependency in deps {
+        dependency_edges_by_package.insert(package.id.clone(), deps.clone());
+
+        for dependency in deps.into_keys() {
             dependents
                 .entry(dependency)
                 .or_default()
@@ -134,10 +143,26 @@ fn build_publish_plan(metadata: &Metadata) -> Result<Vec<PublishPackage>> {
     }
 
     if ordered.len() != publishable_ids.len() {
-        let unresolved = indegree
+        let unresolved_ids = indegree
+            .iter()
+            .filter(|(_, degree)| **degree > 0)
+            .map(|(id, _)| id.clone())
+            .collect::<HashSet<_>>();
+        if let Some(cycle) = find_dependency_cycle(&dependency_edges_by_package, &unresolved_ids) {
+            let description = format_dependency_cycle(&cycle, &packages_by_id);
+            if cycle
+                .iter()
+                .any(|edge| edge.kind == PublishDependencyKind::VersionedDev)
+            {
+                bail!(
+                    "publish-plan: versioned dev-dependency cycle blocks crates.io publish order: {description}. Break the test-only dependency cycle or publish one crate manually first."
+                );
+            }
+            bail!("publish-plan: workspace publish dependencies contain a cycle: {description}");
+        }
+
+        let unresolved = unresolved_ids
             .into_iter()
-            .filter(|(_, degree)| *degree > 0)
-            .map(|(id, _)| id)
             .filter_map(|id| packages_by_id.get(&id).map(|package| package.name.as_str()))
             .collect::<Vec<_>>()
             .join(", ");
@@ -162,24 +187,41 @@ fn package_ids_by_dir(metadata: &Metadata) -> Result<HashMap<PathBuf, String>> {
 fn publish_dependencies<'a>(
     package: &'a Package,
     package_ids_by_dir: &'a HashMap<PathBuf, String>,
-) -> impl Iterator<Item = Result<String>> + 'a {
+) -> impl Iterator<Item = Result<PublishDependency>> + 'a {
     package
         .dependencies
         .iter()
-        .filter(|dependency| dependency.kind.as_deref() != Some("dev"))
-        .filter(|dependency| dependency.source.is_none())
-        .filter_map(|dependency| {
-            dependency.path.as_ref().map(|path| {
-                package_ids_by_dir.get(path).cloned().with_context(|| {
-                    format!(
-                        "publish-plan: {} has local dependency {} at {}, but no package was found there",
-                        package.name,
-                        dependency.name,
-                        path.display()
-                    )
-                })
-            })
+        .filter_map(|dependency| match publish_dependency_kind(dependency) {
+            Some(kind) => dependency.path.as_ref().map(|path| {
+                package_ids_by_dir
+                    .get(path)
+                    .cloned()
+                    .map(|package_id| PublishDependency { package_id, kind })
+                    .with_context(|| {
+                        format!(
+                            "publish-plan: {} has local dependency {} at {}, but no package was found there",
+                            package.name,
+                            dependency.name,
+                            path.display()
+                        )
+                    })
+            }),
+            None => None,
         })
+}
+
+fn publish_dependency_kind(dependency: &Dependency) -> Option<PublishDependencyKind> {
+    if dependency.source.is_some() || dependency.path.is_none() {
+        return None;
+    }
+    if dependency.kind.as_deref() == Some("dev") {
+        return versioned_dev_dependency(dependency).then_some(PublishDependencyKind::VersionedDev);
+    }
+    Some(PublishDependencyKind::Normal)
+}
+
+fn versioned_dev_dependency(dependency: &Dependency) -> bool {
+    dependency.req.trim() != "*"
 }
 
 fn is_publishable(package: &Package) -> bool {
@@ -192,6 +234,148 @@ fn is_publishable(package: &Package) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PublishPackage {
     name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PublishDependency {
+    package_id: String,
+    kind: PublishDependencyKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublishDependencyKind {
+    Normal,
+    VersionedDev,
+}
+
+impl PublishDependencyKind {
+    fn merge(self, other: Self) -> Self {
+        if self == Self::Normal || other == Self::Normal {
+            Self::Normal
+        } else {
+            Self::VersionedDev
+        }
+    }
+
+    fn cycle_label(self) -> &'static str {
+        match self {
+            Self::Normal => "dependency",
+            Self::VersionedDev => "versioned dev-dependency",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DependencyCycleEdge {
+    from: String,
+    to: String,
+    kind: PublishDependencyKind,
+}
+
+fn find_dependency_cycle(
+    edges_by_package: &HashMap<String, BTreeMap<String, PublishDependencyKind>>,
+    unresolved_ids: &HashSet<String>,
+) -> Option<Vec<DependencyCycleEdge>> {
+    let mut visited = HashSet::new();
+    let mut stack = Vec::new();
+    let mut in_stack = HashMap::new();
+
+    let mut sorted_unresolved_ids = unresolved_ids.iter().collect::<Vec<_>>();
+    sorted_unresolved_ids.sort();
+
+    for id in sorted_unresolved_ids {
+        if visited.contains(id) {
+            continue;
+        }
+        if let Some(cycle) = visit_dependency_cycle(
+            id,
+            edges_by_package,
+            unresolved_ids,
+            &mut visited,
+            &mut stack,
+            &mut in_stack,
+        ) {
+            return Some(cycle);
+        }
+    }
+
+    None
+}
+
+fn visit_dependency_cycle(
+    id: &str,
+    edges_by_package: &HashMap<String, BTreeMap<String, PublishDependencyKind>>,
+    unresolved_ids: &HashSet<String>,
+    visited: &mut HashSet<String>,
+    stack: &mut Vec<String>,
+    in_stack: &mut HashMap<String, usize>,
+) -> Option<Vec<DependencyCycleEdge>> {
+    visited.insert(id.to_string());
+    in_stack.insert(id.to_string(), stack.len());
+    stack.push(id.to_string());
+
+    if let Some(edges) = edges_by_package.get(id) {
+        for (dependency, kind) in edges {
+            if !unresolved_ids.contains(dependency) {
+                continue;
+            }
+            if let Some(start) = in_stack.get(dependency).copied() {
+                let mut cycle = Vec::new();
+                for pair in stack[start..].windows(2) {
+                    let from = pair[0].clone();
+                    let to = pair[1].clone();
+                    let kind = edges_by_package[&from][&to];
+                    cycle.push(DependencyCycleEdge { from, to, kind });
+                }
+                cycle.push(DependencyCycleEdge {
+                    from: stack.last().expect("cycle stack is non-empty").clone(),
+                    to: dependency.clone(),
+                    kind: *kind,
+                });
+                return Some(cycle);
+            }
+            if !visited.contains(dependency) {
+                if let Some(cycle) = visit_dependency_cycle(
+                    dependency,
+                    edges_by_package,
+                    unresolved_ids,
+                    visited,
+                    stack,
+                    in_stack,
+                ) {
+                    return Some(cycle);
+                }
+            }
+        }
+    }
+
+    let removed = stack.pop().expect("cycle stack is non-empty");
+    in_stack.remove(&removed);
+    None
+}
+
+fn format_dependency_cycle(
+    cycle: &[DependencyCycleEdge],
+    packages_by_id: &HashMap<String, &Package>,
+) -> String {
+    let Some(first) = cycle.first() else {
+        return "<empty cycle>".to_string();
+    };
+    let mut description = package_name(&first.from, packages_by_id).to_string();
+    for edge in cycle {
+        description.push_str(" --");
+        description.push_str(edge.kind.cycle_label());
+        description.push_str("--> ");
+        description.push_str(package_name(&edge.to, packages_by_id));
+    }
+    description
+}
+
+fn package_name<'a>(id: &'a str, packages_by_id: &'a HashMap<String, &Package>) -> &'a str {
+    packages_by_id
+        .get(id)
+        .map(|package| package.name.as_str())
+        .unwrap_or(id)
 }
 
 #[derive(Debug, Deserialize)]
@@ -213,6 +397,7 @@ struct Package {
 struct Dependency {
     name: String,
     kind: Option<String>,
+    req: String,
     path: Option<PathBuf>,
     source: Option<String>,
 }
@@ -239,6 +424,7 @@ mod tests {
         assert!(positions.contains_key("gaze-token-bridge"));
 
         assert_before(&positions, "gaze-pii", "gaze-cli");
+        assert_before(&positions, "gaze-audit", "gaze-pii");
         assert_before(&positions, "gaze-mcp-bridge", "gaze-cli");
         assert_before(&positions, "gaze-token-bridge", "gaze-cli");
 
@@ -263,7 +449,7 @@ mod tests {
 
         for id in &publishable_ids {
             let package = packages_by_id[id];
-            for dependency in publish_dependencies(package, &package_ids_by_dir) {
+            for dependency in metadata_publish_order_dependencies(package, &package_ids_by_dir) {
                 let dependency = dependency?;
                 if dependency == package.id.as_str()
                     || !publishable_ids.contains(dependency.as_str())
@@ -278,10 +464,107 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn unversioned_dev_dependency_does_not_force_publish_order() -> Result<()> {
+        let metadata = synthetic_metadata([
+            synthetic_package(
+                "crate-a",
+                [synthetic_dependency("crate-b", Some("dev"), "*")],
+            ),
+            synthetic_package("crate-b", []),
+        ]);
+
+        let plan = build_publish_plan(&metadata)?;
+
+        assert_eq!(
+            plan.iter()
+                .map(|package| package.name.as_str())
+                .collect::<Vec<_>>(),
+            ["crate-a", "crate-b"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn versioned_dev_dependency_cycle_names_the_cycle() {
+        let metadata = synthetic_metadata([
+            synthetic_package(
+                "crate-a",
+                [synthetic_dependency("crate-b", Some("dev"), "^1.0.0")],
+            ),
+            synthetic_package("crate-b", [synthetic_dependency("crate-a", None, "^1.0.0")]),
+        ]);
+
+        let error = build_publish_plan(&metadata).unwrap_err().to_string();
+
+        assert!(error.contains("versioned dev-dependency cycle"));
+        assert!(
+            error.contains("crate-a --versioned dev-dependency--> crate-b --dependency--> crate-a")
+        );
+    }
+
     fn assert_before(positions: &HashMap<&str, usize>, before: &str, after: &str) {
         assert!(
             positions[before] < positions[after],
             "{before} should publish before {after}"
         );
+    }
+
+    fn metadata_publish_order_dependencies<'a>(
+        package: &'a Package,
+        package_ids_by_dir: &'a HashMap<PathBuf, String>,
+    ) -> impl Iterator<Item = Result<String>> + 'a {
+        package.dependencies.iter().filter_map(|dependency| {
+            if dependency.source.is_some() {
+                return None;
+            }
+            if dependency.kind.as_deref() == Some("dev") && dependency.req.trim() == "*" {
+                return None;
+            }
+            dependency.path.as_ref().map(|path| {
+                package_ids_by_dir.get(path).cloned().with_context(|| {
+                    format!(
+                        "test metadata dependency {} at {} did not resolve",
+                        dependency.name,
+                        path.display()
+                    )
+                })
+            })
+        })
+    }
+
+    fn synthetic_metadata<const N: usize>(packages: [Package; N]) -> Metadata {
+        Metadata {
+            workspace_members: packages.iter().map(|package| package.id.clone()).collect(),
+            packages: packages.into(),
+        }
+    }
+
+    fn synthetic_package<const N: usize>(name: &str, dependencies: [Dependency; N]) -> Package {
+        Package {
+            id: synthetic_package_id(name),
+            name: name.to_string(),
+            manifest_path: synthetic_package_dir(name).join("Cargo.toml"),
+            publish: None,
+            dependencies: dependencies.into(),
+        }
+    }
+
+    fn synthetic_dependency(name: &str, kind: Option<&str>, req: &str) -> Dependency {
+        Dependency {
+            name: name.to_string(),
+            kind: kind.map(str::to_string),
+            req: req.to_string(),
+            path: Some(synthetic_package_dir(name)),
+            source: None,
+        }
+    }
+
+    fn synthetic_package_id(name: &str) -> String {
+        format!("path+file:///workspace/{name}#{name}@1.0.0")
+    }
+
+    fn synthetic_package_dir(name: &str) -> PathBuf {
+        PathBuf::from(format!("/workspace/{name}"))
     }
 }


### PR DESCRIPTION
Root cause

`xtask publish-plan` built its graph from local normal/build dependencies only and filtered out all `kind = "dev"` dependencies. `cargo publish` keeps versioned dev-dependencies in the uploaded manifest, so `gaze-pii` still required `gaze-audit = "^0.11.3"` on the crates.io index even though the plan placed `gaze-pii` before `gaze-audit`.

Fix

- Include local versioned dev-dependencies (`req != "*"`) as publish-order edges while continuing to ignore unversioned path-only dev-dependencies.
- Keep normal/build local workspace dependencies as ordering edges.
- Detect publish-order cycles and name the dependency cycle; cycles involving versioned dev-dependency edges fail with an actionable crates.io publish message.
- Add behavioral tests for the whole workspace ordering property, the specific `gaze-audit` before `gaze-pii` regression, unversioned dev-deps, and versioned-dev cycle reporting.

Plan before

```text
1. gaze-types
2. gaze-recognizers
3. gaze-pii
4. gaze-audit
5. gaze-assembly
6. gaze-mcp-core
7. gaze-document
8. gaze-mcp-rmcp
9. gaze-mcp-bridge
10. gaze-proxy
11. gaze-token-bridge
12. gaze-cli
```

Plan after

```text
1. gaze-types
2. gaze-recognizers
3. gaze-audit
4. gaze-pii
5. gaze-assembly
6. gaze-mcp-core
7. gaze-mcp-rmcp
8. gaze-document
9. gaze-mcp-bridge
10. gaze-proxy
11. gaze-token-bridge
12. gaze-cli
```

Dependency-edge audit

Derived from `cargo metadata --no-deps --format-version 1` plus the final `cargo run -p xtask --quiet -- publish-plan`. Unversioned path-only dev-dependencies are omitted because they do not carry a crates.io version requirement in the published manifest.

| Pos | Crate | In-workspace publish-order dependency | Kind | Dependency pos | Valid |
|---:|---|---|---|---:|---|
| 1 | gaze-types | none | none | - | PASS |
| 2 | gaze-recognizers | gaze-types | normal | 1 | PASS |
| 3 | gaze-audit | gaze-types | normal | 1 | PASS |
| 4 | gaze-pii | gaze-types | normal | 1 | PASS |
| 4 | gaze-pii | gaze-recognizers | normal | 2 | PASS |
| 4 | gaze-pii | gaze-audit | dev-with-version (^0.11.3) | 3 | PASS |
| 5 | gaze-assembly | gaze-recognizers | normal | 2 | PASS |
| 5 | gaze-assembly | gaze-pii | normal | 4 | PASS |
| 6 | gaze-mcp-core | gaze-types | normal | 1 | PASS |
| 6 | gaze-mcp-core | gaze-recognizers | normal | 2 | PASS |
| 6 | gaze-mcp-core | gaze-pii | normal | 4 | PASS |
| 6 | gaze-mcp-core | gaze-assembly | normal | 5 | PASS |
| 7 | gaze-mcp-rmcp | gaze-pii | dev-with-version (^0.11.3) | 4 | PASS |
| 7 | gaze-mcp-rmcp | gaze-mcp-core | normal | 6 | PASS |
| 8 | gaze-document | gaze-types | normal | 1 | PASS |
| 8 | gaze-document | gaze-recognizers | normal | 2 | PASS |
| 8 | gaze-document | gaze-pii | normal | 4 | PASS |
| 8 | gaze-document | gaze-mcp-core | normal | 6 | PASS |
| 8 | gaze-document | gaze-mcp-rmcp | dev-with-version (^0.11.3) | 7 | PASS |
| 9 | gaze-mcp-bridge | gaze-types | normal | 1 | PASS |
| 9 | gaze-mcp-bridge | gaze-pii | normal | 4 | PASS |
| 9 | gaze-mcp-bridge | gaze-assembly | normal | 5 | PASS |
| 9 | gaze-mcp-bridge | gaze-mcp-core | normal | 6 | PASS |
| 9 | gaze-mcp-bridge | gaze-mcp-rmcp | normal | 7 | PASS |
| 10 | gaze-proxy | gaze-types | normal | 1 | PASS |
| 10 | gaze-proxy | gaze-recognizers | dev-with-version (^0.11.3) | 2 | PASS |
| 10 | gaze-proxy | gaze-pii | normal | 4 | PASS |
| 10 | gaze-proxy | gaze-assembly | normal | 5 | PASS |
| 11 | gaze-token-bridge | gaze-pii | normal | 4 | PASS |
| 11 | gaze-token-bridge | gaze-mcp-core | normal | 6 | PASS |
| 12 | gaze-cli | gaze-types | normal | 1 | PASS |
| 12 | gaze-cli | gaze-recognizers | dev-with-version (^0.11.3) | 2 | PASS |
| 12 | gaze-cli | gaze-recognizers | normal | 2 | PASS |
| 12 | gaze-cli | gaze-audit | dev-with-version (^0.11.3) | 3 | PASS |
| 12 | gaze-cli | gaze-audit | normal | 3 | PASS |
| 12 | gaze-cli | gaze-pii | normal | 4 | PASS |
| 12 | gaze-cli | gaze-assembly | normal | 5 | PASS |
| 12 | gaze-cli | gaze-mcp-core | normal | 6 | PASS |
| 12 | gaze-cli | gaze-mcp-rmcp | normal | 7 | PASS |
| 12 | gaze-cli | gaze-document | normal | 8 | PASS |
| 12 | gaze-cli | gaze-mcp-bridge | normal | 9 | PASS |
| 12 | gaze-cli | gaze-proxy | normal | 10 | PASS |
| 12 | gaze-cli | gaze-token-bridge | normal | 11 | PASS |

Gates

- PASS: `cargo fmt --check`
- PASS: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- PASS: `cargo test -p xtask`
- ALLOWED KNOWN FAILURE: `cargo test --workspace --all-features` exits at `gaze-mcp-core --test tool_ctx_seal` with the Darwin trybuild wording skew tracked by todo #1901 (`no associated function or constant named` vs `no function or associated item named`). No other failure was observed before that allowed abort.

Part of solo todo #1871
