### PR TITLE
docs(policy): document \b-next-to-symbol regex pitfall and workaround (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Policy-authoring docs now cover the `\b`-next-to-symbol regex pitfall**
+  (#361). `\b` adjacent to a non-word character (`€`, `$`, `£`, punctuation)
+  never forms a boundary against whitespace, so currency-style patterns like
+  `\b(...€|$...)\b` silently fail to match — a fail-open leak in redaction
+  policies. Investigated as a suspected 0.5.x → 0.11.x regression and ruled
+  out: outputs are byte-identical across versions (standard Rust `regex`
+  semantics, engine unchanged). `docs/reference/policy.md` documents the
+  failure modes and the explicit-boundary-group rewrite.
+
 ## [0.11.3] - 2026-07-02
 
 v0.11.2 crates were never published to crates.io; v0.11.3 supersedes it for

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -819,12 +819,52 @@ rewriting.
 Common idioms:
 
 - Use `\b` word boundaries to avoid matching inside identifiers
-  (`\bORD-\d{6}\b`, not `ORD-\d{6}`).
+  (`\bORD-\d{6}\b`, not `ORD-\d{6}`) — but see the pitfall below when the
+  pattern edge is not a word character.
 - Use `(?i)` at the start of a pattern for case-insensitive matching. PCRE-style
   inline flags such as `pattern = "(?i)customer-\\d+"` work because they are
   supported by Rust `regex`.
 - TOML literal strings (`'...'`) avoid double-escaping backslashes —
   prefer them over basic strings (`"..."`) for regex patterns.
+
+#### Pitfall: `\b` next to non-word characters (currency symbols, punctuation)
+
+`\b` matches a *word boundary*: a transition between a word character
+(`[0-9A-Za-z_]` plus Unicode letters/digits) and a non-word character. When the
+character adjacent to `\b` inside your pattern is itself a **non-word**
+character — `€`, `$`, `£`, `%`, punctuation — the boundary can only exist if the
+*surrounding* text supplies a word character, which is usually the opposite of
+what you want:
+
+```toml
+# BROKEN: never matches "5000€" or "$3,500.00" in normal prose.
+pattern = '\b(?:[$€£]\s?\d[\d.,]*|\d[\d.,]*\s?(?:€|£|EUR|USD|GBP))\b'
+```
+
+- `Order total 5000€ due today.` — no match: the trailing `\b` sits between `€`
+  (non-word) and a space (non-word) — no transition, no boundary.
+- `Posten: 5000€ 1000€ MwSt` — **mis-span**: the engine finds a sneaky
+  alternative parse (`€ 1000` via the symbol-prefix branch) and tokenizes the
+  wrong span, leaking `5000`.
+- `Betrag 1.500,00 EUR fällig.` — matches fine: `EUR` ends in a word character,
+  so `\b` works as expected.
+
+For a redaction policy this fails **open**: the amount silently stays in the
+clean text. This is standard Rust `regex` (and PCRE, and RE2) `\b` semantics —
+not a Gaze behavior — and it has been stable across every Gaze release
+(verified 0.5.x through 0.11.x, byte-identical outputs; see issue #361).
+Because Rust `regex` has no look-around, you cannot emulate a one-sided
+boundary with `(?<!...)`/`(?!...)`. Instead, apply `\b` only to the edges that
+end in a word character and let the symbol act as its own delimiter:
+
+```toml
+# WORKS: \b only guards the digit edges; €/$/£ delimit themselves.
+pattern = '(?:[$€£]\s?\d[\d.,]*\d|[$€£]\s?\d|\b\d[\d.,]*\d\s?(?:€|£|EUR|USD|GBP)|\b\d\s?(?:€|£|EUR|USD|GBP))'
+```
+
+The same applies to any custom class whose values start or end with a symbol
+(percentages, `#`-prefixed IDs, currency): put `\b` next to `\d`/`\w` edges
+only, never next to the symbol.
 
 The pattern is compiled at `Policy::load` time, so a malformed regex fails
 fast with `PolicyConfig` and never reaches `gaze clean`'s stdin read.


### PR DESCRIPTION
Docs-only fix for #361 (does not close it; triage verdict is commented on the issue).

## Triage verdict: not a regression — `\b` semantics never changed

To settle the "worked on 0.5.x" premise empirically, I rebuilt the v0.5.2 binary from its git tag and ran the issue's exact fixtures through the same `money_amount` policy side-by-side with v0.11.x:

| Input | v0.5.x output | v0.11.x output |
|---|---|---|
| `Order total 5000€ due today.` | no match (leaks) | identical |
| `invoice for $3,500.00 from ACME` | no match (leaks) | identical |
| `Posten: 5000€ 1000€ MwSt` | `Posten: 5000<tok>€ MwSt` (mis-span) | identical |
| `Total $100 €200 GBP300 due.` | `Total $<tok>200 <tok> due.` (mis-span) | identical |
| `Betrag 1.500,00 EUR fällig.` | `Betrag <tok> fällig.` (OK) | identical |

**Byte-identical outputs across versions**, including the failure modes. The engine has been the Rust `regex` crate v1 with a bare `Regex::new(pattern)` since the recognizer-native path landed (v0.4.1); no flags, no engine swap, no `\b` change. The pattern never matched symbol-currency amounts in any Gaze release — the downstream gap existed from day one and was *surfaced* (not caused) by refreshing the gaze-laravel behavior gates against v0.11.3.

Mechanically: `\b` is a word-boundary assertion. `€`/`$`/`£` are non-word characters, so `\b` adjacent to them against whitespace never forms a boundary (standard Rust regex / PCRE / RE2 semantics). Alpha codes (`EUR`, `USD`, `GBP`) end in word characters, which is why those kept matching. The mis-spans come from the engine legally finding a sneaky alternate parse (`€ 1000` via the symbol-prefix branch).

## Change

`docs/reference/policy.md` (Regex detector section) gains a **"Pitfall: `\b` next to non-word characters"** subsection: broken pattern, the three failure modes from the issue table, why look-around can't fix it (unsupported by Rust `regex`), and the canonical rewrite — apply `\b` only to word-character edges and let the symbol delimit itself:

```toml
pattern = '(?:[$€£]\s?\d[\d.,]*\d|[$€£]\s?\d|\b\d[\d.,]*\d\s?(?:€|£|EUR|USD|GBP)|\b\d\s?(?:€|£|EUR|USD|GBP))'
```

Workaround verified against all five fixtures on v0.11.x: every symbol case tokenizes, no mis-spans. CHANGELOG `[Unreleased]` records the investigation outcome so the "did semantics change?" question has a durable answer.

## North-star axes

- **Axis 1 (never leak):** the documented pitfall is a fail-open class — policy authors writing `\b`-wrapped symbol patterns leak silently; the docs now prevent it.
- **Axis 4 (trust):** version-comparison evidence in-tree (this PR + issue comment) rather than a folklore answer.

No code changes; `readme-version-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dVthtTfAGD8e2opbJ85Sj
