### PR TITLE
[agent] test(gaze): exclude token-shaped filler from restore proptest

### DIFF
--- a/crates/gaze/tests/prop_manifest_invariants.rs
+++ b/crates/gaze/tests/prop_manifest_invariants.rs
@@ -53,7 +53,7 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
     proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
         .expect("valid filler regex")
         .prop_filter(
-            "filler does not contain tracked PII or restore-token delimiters",
+            "filler contains no tracked PII, restore-token delimiters, or token-shaped literals",
             |text| {
                 !text.contains('@')
                     && !text.contains('<')
@@ -62,6 +62,11 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
                     && !text.contains("+44-7700")
                     && !text.contains("+49 1555")
                     && !text.contains("Dr. Schmidt")
+                    // Random filler can spell a bracketless token shape (e.g. `j_6`),
+                    // which strict restore correctly rejects fail-closed as an
+                    // `UnknownToken`. Exclude anything the product's own token-shape
+                    // DLP net would trap so the round-trip invariant holds.
+                    && !gaze::token_shape::contains_token(text)
             },
         )
         .prop_map(Segment::Filler)


### PR DESCRIPTION
## Problem

The `test` workflow is red on `main` (d7b3e30). Root cause is a **flaky property test**, not a product regression:

`prop_strict_restore_is_idempotent` (`crates/gaze/tests/prop_manifest_invariants.rs`) generates random filler text and asserts the cleaned document round-trips through `restore_strict_text`. But the filler generator could spell a **bracketless token shape** (e.g. `j_6`, `q_1`) that the product's token-shape DLP net (`token_shape.rs`) intentionally traps. Strict restore then correctly rejects it fail-closed as `UnknownToken`, and the test's `.expect("first strict restore")` panics.

It is seed-dependent (green on #362, red on #363) with no committed `proptest-regressions` file to pin the seed, so it flakes per CI run.

## Fix

Filter filler through the product's own token-shape matcher so generated inputs can never collide with the restore grammar:

```rust
&& !gaze::token_shape::contains_token(text)
```

This reuses the exact runtime grammar, so the test cannot drift from it. **No product behavior changes** — this is a test-generator hardening only. The fail-closed `UnknownToken` behavior it was tripping over is correct axis-1/axis-2 protection.

## Verification

- `PROPTEST_CASES=4000` green across repeated runs under the pinned `1.96.0` toolchain (previously failed deterministically at that count).
- `cargo fmt --all -- --check` clean; `clippy -D warnings` clean on the touched target.

Prerequisite for the v0.12.0 release (main must be green to cut the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)