### PR TITLE
[agent] release: prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-06
+
 ### Added
 
 - **Policy-authoring docs now cover the `\b`-next-to-symbol regex pitfall**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-bridge"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chacha20poly1305",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ homepage = "https://github.com/CertaMesh/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.11.3" }
-gaze = { path = "crates/gaze", version = "0.11.3", package = "gaze-pii" }
-gaze-assembly = { path = "crates/gaze-assembly", version = "0.11.3" }
-gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.11.3" }
-gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.11.3" }
-gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.11.3" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.11.3" }
-gaze-types = { path = "crates/gaze-types", version = "0.11.3" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.12.0" }
+gaze = { path = "crates/gaze", version = "0.12.0", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.12.0" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.12.0" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.12.0" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.12.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.12.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.12.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your agent never sees a real email, phone number, or order ID. Your server keeps
 Three commands from zero to redacting real PII:
 
 ```sh
-cargo install gaze-cli --version 0.11.3                     # `gaze setup` ships in the default build
+cargo install gaze-cli --version 0.12.0                     # `gaze setup` ships in the default build
 gaze setup                                                   # installs + SHA-verifies the NER model, writes ./gaze.toml, runs a doctor check
 echo "Contact Markus Gottschaue at markus@acme.com" | gaze clean --policy gaze.toml
 ```
@@ -138,7 +138,7 @@ Architecture overview with eight Key Design Decisions: [`ARCHITECTURE.md`](ARCHI
 Install the CLI from crates.io:
 
 ```sh
-cargo install gaze-cli --version 0.11.3
+cargo install gaze-cli --version 0.12.0
 ```
 
 Or build from source (latest `main`, or to enable extra features):

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.3"
-gaze-assembly = "0.11.3"
-gaze-recognizers = "0.11.3"
+gaze-pii = "0.12.0"
+gaze-assembly = "0.12.0"
+gaze-recognizers = "0.12.0"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.3"
-gaze-audit = "0.11.3"
+gaze-pii = "0.12.0"
+gaze-audit = "0.12.0"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -47,16 +47,16 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.11.3", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.12.0", optional = true }
 gaze-mcp-bridge = { workspace = true, optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.3", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.12.0", optional = true }
 gaze-proxy = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
-gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.11.3", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.12.0", optional = true }
 gaze-types = { workspace = true }
 pdfium-render = { version = "0.9", optional = true }
 regex = "1"
@@ -73,7 +73,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 tempfile = "3"

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.11.3
+$ cargo install gaze-cli --version 0.12.0
 ```
 
 Build from the workspace root:
@@ -110,7 +110,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.11.3 --features mcp
+$ cargo install gaze-cli --version 0.12.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -44,7 +44,7 @@ render-image = []
 
 [dev-dependencies]
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.11.3" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.12.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.11.3"
+gaze-document = "0.12.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.11.3 --features document
+cargo install gaze-cli --version 0.12.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-bridge"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,6 +1,6 @@
 # gaze-mcp-bridge
 
-`gaze-mcp-bridge = "0.11.3"` is the optional policy-gated MCP bridge for Gaze.
+`gaze-mcp-bridge = "0.12.0"` is the optional policy-gated MCP bridge for Gaze.
 
 The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
 downstream MCP tools receive restored PII only for explicitly allowed argument

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/CertaMesh/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.11.3) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.12.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -22,7 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.11.3" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.12.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.11.3"
-gaze-mcp-rmcp = "0.11.3"
+gaze-mcp-core = "0.12.0"
+gaze-mcp-rmcp = "0.12.0"
 ```
 
 ```rust

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,8 +27,8 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.11.3", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.11.3" }
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
 gaze-types = { workspace = true }
 http = "1"
 libc = "0.2"
@@ -46,6 +46,6 @@ url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.11.3"
+gaze-proxy = "0.12.0"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.11.3
+cargo install gaze-cli --version 0.12.0
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.3"
-gaze-recognizers = "0.11.3"
+gaze-pii = "0.12.0"
+gaze-recognizers = "0.12.0"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.11.3", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.12.0", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,7 +16,7 @@ categories = ["text-processing"]
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii", version = "0.11.3" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.12.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chacha20poly1305 = { version = "0.10", features = ["std"] }
@@ -27,7 +27,7 @@ rand = "0.8"
 zeroize = "1"
 # Track C chokepoint integration — optional, OFF by default. Pulled in only by
 # the `chokepoint` feature below; the default build/test graph is byte-identical.
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.11.3", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,11 +1,11 @@
 # gaze-token-bridge
 
-> **Status:** experimental and published as `gaze-token-bridge = "0.11.3"`.
+> **Status:** experimental and published as `gaze-token-bridge = "0.12.0"`.
 > API is pre-1.0 and may change.
 
 ```toml
 [dependencies]
-gaze-token-bridge = "0.11.3"
+gaze-token-bridge = "0.12.0"
 ```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.11.3"
+gaze-types = "0.12.0"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.11.3", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.11.3"
-gaze-assembly = "0.11.3"
-gaze-recognizers = "0.11.3"
+gaze-pii = "0.12.0"
+gaze-assembly = "0.12.0"
+gaze-recognizers = "0.12.0"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).


### PR DESCRIPTION
## v0.12.0 release preparation

Mirrors the #357 (v0.11.3) release-prep structure. Additive changes since v0.11.3 (new public API + new CLI warning) ⇒ **MINOR** bump.

### Changes
- Bump workspace + all 12 published crates `0.11.3` → `0.12.0` (per-crate `version`, internal path-dep pins, `Cargo.lock`, README install/version references).
- `CHANGELOG.md`: promote `[Unreleased]` → `## [0.12.0] - 2026-07-06`.

### Shipped in 0.12.0
- `gaze clean` warns when a collision-family fallback class would silently leak; new `gaze_assembly::uncovered_collision_family_classes` (#360 / #362).
- CI runs `bundle-tokenization-drift --verify-ack` (#360).
- Documented collision-family fallback class contract so `preserve`-default policies stop leaking IBANs (#360).
- Policy-authoring docs cover the `\b`-next-to-symbol regex pitfall (#361 / #363).

### Pre-flight (local, mirrors CI)
- `cargo fmt --all --check` ✓
- `cargo clippy --workspace --all-features --all-targets -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (base now green after #364 fixed a flaky restore proptest)
- `xtask readme-version-check` ✓ (12 published crates)
- `xtask publish-plan` ✓ (12 crates, order unchanged)
- `xtask scrub-public-text` on the `[0.12.0]` CHANGELOG section ✓ (dogfooded, zero detections)
- path-leak grep `/Users/…` ✓ (none)

After merge: tag `v0.12.0` on the merge commit → `release.yml` (binaries + GitHub Release) and `publish-crates.yml` (OIDC crates.io publish) fire from the tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)