### PR TITLE
[agent] characterize no-OPF benchmark contract

### DIFF
--- a/docs/reference/benchmarks/dataiku-en-de-holdout.md
+++ b/docs/reference/benchmarks/dataiku-en-de-holdout.md
@@ -38,6 +38,7 @@ model directories independently.
 | Selected German rows | `853` |
 | Selected annotations | `14,719` |
 | Observed selected labels | `29` |
+| Selection seed | Not applicable; the complete pinned EN/DE selection is used without sampling or shuffling |
 
 The runner refuses any file whose byte size or digest differs. It also verifies
 the full row count, validates every selected annotation boundary and annotated
@@ -79,12 +80,16 @@ a separately installed verified checkpoint and warmed daemon. See
 Run the pinned benchmark:
 
 ```bash
+cd <repo-root>
 uv run --with pyarrow scripts/bench/dataiku_en_de_gaze_bench.py
 ```
 
 The first run downloads the pinned 2 MB Parquet file into ignored
 `target/bench-data/`. Later runs can add `--no-download`. Generated result JSON
 is written to `target/bench-data/dataiku-en-de/gaze-scorecard.json` by default.
+The checked-in baseline normalizes local paths as `<repo-root>` and
+`<model-cache>`; do not promote a generated absolute home-directory path into
+benchmark evidence.
 
 ## Limits and contamination rule
 

--- a/docs/reference/benchmarks/v0.12-en-de-whole-pipeline-baseline.md
+++ b/docs/reference/benchmarks/v0.12-en-de-whole-pipeline-baseline.md
@@ -24,9 +24,16 @@ pipeline matched the revision above.
 | Hardware | Apple M5 Max, 18 cores, 64 GB RAM |
 | OS / architecture | macOS 26.5 build 25F71 / arm64 |
 | Rust / Python | rustc 1.95.0 / Python 3.14.5 |
+| Runtime dependencies | `ort` 2.0.0-rc.12, `tokenizers` 0.22.2, `regex` 1.12.3, `serde_json` 1.0.149 (the `Cargo.lock` graph at the Gaze revision above) |
+| Python loader dependency | `pyarrow`; the historical run did not capture its package version |
 | Pass 2 | Davlan multilingual BERT NER, threshold 0.3 |
 | Pass 3 | Kiji DistilBERT SafetyNet, in-process ORT |
 | Full policy | `Resolve` with `Redact` fallback |
+| Selection seed | Not applicable: the complete pinned EN/DE selection was evaluated without sampling or shuffling |
+| Repository root | `<repo-root>` |
+| Dataset file | `<repo-root>/target/bench-data/dataiku-en-de/test.parquet` |
+| Result artifact | `<repo-root>/target/bench-data/dataiku-en-de/gaze-scorecard.json` |
+| Model cache | `<model-cache>/davlan-mbert-ner-hrl` and `<model-cache>/kiji-distilbert` |
 
 Full provenance and selection rules are in
 [`dataiku-en-de-holdout.md`](dataiku-en-de-holdout.md).

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 
-import sys
+import io
+import json
 import socket
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import openpii_gaze_bench as benchmark
+import dataiku_en_de_gaze_bench as dataiku_benchmark
 import opf_daemon
 
 
@@ -97,6 +102,31 @@ class MetricTests(unittest.TestCase):
         self.assertEqual(result["entities"]["full_coverage_recall"], 1.0)
         self.assertEqual(result["zero_leak_document_rate"], 1.0)
 
+    def test_prediction_covering_the_full_entity_is_fully_covered(self) -> None:
+        document = self.document()
+        email_end = document.spans[0].end
+        metrics = benchmark.MetricAccumulator()
+        metrics.add(document, [benchmark.Span(0, email_end + 1, "name")])
+        result = metrics.result()
+
+        self.assertEqual(result["entities"]["fully_covered"], 1)
+        self.assertEqual(result["entities"]["overlapped"], 1)
+        self.assertEqual(result["entities"]["exact_boundary"], 0)
+        self.assertEqual(result["documents_without_leaks"], 1)
+
+    def test_adjacent_prediction_does_not_protect_or_overlap_entity(self) -> None:
+        document = self.document()
+        email_end = document.spans[0].end
+        metrics = benchmark.MetricAccumulator()
+        metrics.add(document, [benchmark.Span(email_end, email_end + 1, "email")])
+        result = metrics.result()
+
+        self.assertEqual(result["utf8_bytes"]["true_positive"], 0)
+        self.assertEqual(result["entities"]["fully_covered"], 0)
+        self.assertEqual(result["entities"]["overlapped"], 0)
+        self.assertEqual(result["prediction_spans"]["overlapped_gold"], 0)
+        self.assertEqual(result["documents_without_leaks"], 0)
+
 
 class ContractTests(unittest.TestCase):
     def test_contract_score_does_not_compensate_restore_failure(self) -> None:
@@ -132,6 +162,209 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(result["manifest_valid_document_rate"], 0.0)
         self.assertEqual(result["strict_acceptance_rate"], 0.0)
         self.assertEqual(result["post_policy_zero_suspect_rate"], 1.0)
+
+    def test_typed_pipeline_error_only_counts_as_failed_closed_availability(
+        self,
+    ) -> None:
+        """A typed failure bypasses score/contract accumulation in the current scorer."""
+        document = benchmark.Document(
+            uid="synthetic-failure",
+            text="alice@example.invalid",
+            language="en",
+            region="US",
+            source_dataset="unit-test",
+            spans=(benchmark.Span(0, len("alice@example.invalid"), "EMAIL"),),
+        )
+        response = {
+            "fixture_id": document.uid,
+            "pipeline_error_code": "POLICY_REJECTED",
+            "pipeline_error_stage": "safety_net",
+            "timing": {"total_ms": 1.25, "pass_2_ms": None},
+        }
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(json.dumps(response) + "\n")
+        process.wait.return_value = 0
+        repo_root = Path(benchmark.__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
+            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+                result = benchmark.run_config(
+                    repo_root=repo_root,
+                    binary=Path(temporary) / "synthetic-runner",
+                    config="rule-floor-extended",
+                    documents=[document],
+                    model_dir=Path(temporary),
+                    kiji_model_dir=Path(temporary),
+                    opf_command=None,
+                    opf_checkpoint=None,
+                    opf_daemon_socket=None,
+                    threshold=0.3,
+                    diagnostics_dir=Path(temporary),
+                )
+
+        self.assertEqual(result["metrics"]["documents"], 0)
+        self.assertEqual(result["pipeline_contract"]["documents"], 0)
+        self.assertEqual(result["pipeline_contract"]["restore_exact_rate"], 1.0)
+        self.assertEqual(
+            result["pipeline_contract"]["manifest_valid_document_rate"], 1.0
+        )
+        self.assertEqual(result["pipeline_contract"]["strict_acceptance_rate"], 0.0)
+        self.assertEqual(
+            result["pipeline_availability"],
+            {
+                "attempted_documents": 1,
+                "completed_documents": 0,
+                "completion_rate": 0.0,
+                "failed_closed_documents": 1,
+                "errors": {"POLICY_REJECTED": 1},
+                "error_stages": {"safety_net": 1},
+            },
+        )
+        self.assertEqual(result["latency_ms"]["total_ms"]["median"], 1.25)
+
+
+class DataikuSelectionTests(unittest.TestCase):
+    def test_load_documents_counts_selected_english_and_german_rows(self) -> None:
+        rows = [
+            {
+                "language": "English",
+                "country": "United States",
+                "text": "alice@example.invalid",
+                "privacy_mask": [
+                    {
+                        "start": 0,
+                        "end": len("alice@example.invalid"),
+                        "value": "alice@example.invalid",
+                        "label": "EMAIL",
+                    }
+                ],
+            },
+            {
+                "language": "German",
+                "country": "Germany",
+                "text": "Dr. Schmidt",
+                "privacy_mask": [
+                    {
+                        "start": 0,
+                        "end": len("Dr. Schmidt"),
+                        "value": "Dr. Schmidt",
+                        "label": "GIVENNAME",
+                    }
+                ],
+            },
+            {
+                "language": "French",
+                "country": "France",
+                "text": "synthetic row",
+                "privacy_mask": [],
+            },
+        ]
+        table = types.SimpleNamespace(to_pylist=lambda: rows)
+        parquet = types.ModuleType("pyarrow.parquet")
+        parquet.read_table = mock.Mock(return_value=table)
+        pyarrow = types.ModuleType("pyarrow")
+        pyarrow.__path__ = []
+        pyarrow.parquet = parquet
+
+        with mock.patch.dict(
+            sys.modules,
+            {"pyarrow": pyarrow, "pyarrow.parquet": parquet},
+        ):
+            with mock.patch.object(dataiku_benchmark, "verify_dataset"):
+                with mock.patch.object(dataiku_benchmark, "DATASET_ROWS", len(rows)):
+                    documents, report = dataiku_benchmark.load_documents(
+                        Path("synthetic.parquet")
+                    )
+
+        self.assertEqual(len(documents), 2)
+        self.assertEqual([document.language for document in documents], ["en", "de"])
+        self.assertEqual(report["integrity"]["rows"], 3)
+        self.assertEqual(report["selection"]["documents"], 2)
+        self.assertEqual(report["selection"]["languages"], {"de": 1, "en": 1})
+
+    def test_max_documents_truncates_after_frozen_selection_report(self) -> None:
+        """Baseline debt to fix later: sampled runs report the full selection."""
+        documents = [
+            benchmark.Document(
+                uid=f"synthetic-{index}",
+                text="alice@example.invalid",
+                language=language,
+                region=region,
+                source_dataset="unit-test",
+                spans=(benchmark.Span(0, len("alice@example.invalid"), "EMAIL"),),
+            )
+            for index, (language, region) in enumerate(
+                (("en", "US"), ("de", "DE")), start=1
+            )
+        ]
+        dataset_report = {
+            "integrity": {"rows": 2},
+            "selection": {"documents": 2, "languages": {"de": 1, "en": 1}},
+        }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            model_dir = temporary_path / "model"
+            model_dir.mkdir()
+            output_path = temporary_path / "scorecard.json"
+            args = types.SimpleNamespace(
+                dataset=temporary_path / "synthetic.parquet",
+                output=output_path,
+                model_dir=model_dir,
+                kiji_model_dir=temporary_path / "kiji-model",
+                threshold=0.3,
+                max_documents=1,
+                opf_command=None,
+                opf_checkpoint=None,
+                opf_daemon_socket=None,
+                config=["rule-floor-extended"],
+                no_download=True,
+                skip_build=True,
+            )
+            with mock.patch.object(dataiku_benchmark, "parse_args", return_value=args):
+                with mock.patch.object(dataiku_benchmark, "verify_dataset"):
+                    with mock.patch.object(
+                        dataiku_benchmark,
+                        "load_documents",
+                        return_value=(documents, dataset_report),
+                    ):
+                        with mock.patch.object(
+                            benchmark,
+                            "run_config",
+                            return_value={"config": "rule-floor-extended"},
+                        ) as run_config:
+                            with mock.patch.object(
+                                benchmark,
+                                "git_metadata",
+                                return_value={"revision": "synthetic", "dirty": False},
+                            ):
+                                self.assertEqual(dataiku_benchmark.main(), 0)
+
+            result = json.loads(output_path.read_text(encoding="utf-8"))
+
+        evaluated_documents = run_config.call_args.args[3]
+        self.assertEqual(len(evaluated_documents), 1)
+        self.assertEqual(result["parameters"]["max_documents"], 1)
+        self.assertEqual(result["dataset"]["selection"]["documents"], 2)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_all_no_opf_config_names_are_present_and_spelled_exactly(self) -> None:
+        expected = (
+            "rule-floor-extended",
+            "pass2-ner",
+            "full-stack-kiji-resolve",
+        )
+        self.assertEqual(benchmark.DEFAULT_CONFIGS, expected)
+        self.assertTrue(set(expected).issubset(dataiku_benchmark.CONFIG_CHOICES))
+
+        argv = ["benchmark"]
+        for config in expected:
+            argv.extend(("--config", config))
+        for module in (benchmark, dataiku_benchmark):
+            with mock.patch.object(sys, "argv", argv):
+                self.assertEqual(tuple(module.parse_args().config), expected)
 
 
 class OpfDaemonTests(unittest.TestCase):


### PR DESCRIPTION
## What & why

Freeze the current Python benchmark scorer behavior before the no-OPF benchmark work changes it. This is characterization-only: no production or scorer behavior changes.

Resolves solo todo #2164

## Characterized behavior

- typed pipeline errors count as failed-closed availability and bypass metric/contract accumulation
- synthetic Dataiku EN/DE selection totals and language counts
- current max-documents baseline debt: the Dataiku wrapper evaluates a truncated list while retaining the full selection report
- exact no-OPF config names: rule-floor-extended, pass2-ner, full-stack-kiji-resolve
- full entity coverage and adjacent non-overlap metric boundaries
- portable Dataiku baseline provenance with unchanged recorded metrics

## Five axes

- Reliability: locks failure accounting and leak-sensitive span boundaries; runtime reliability is unchanged.
- Reversibility: preserves the existing exact-restore and manifest-integrity contract characterization; runtime restore behavior is unchanged.
- Agentic fit: freezes the three production-parity no-OPF cells and the sampled-run reporting behavior used by benchmark automation.
- Trust: makes typed errors, dataset counts, selection debt, dependency pins, and portable provenance auditable.
- Adopter ergonomics: uses stdlib-only unit-test seams for parquet behavior and removes machine-specific evidence paths.

No axis is weakened. The known max-documents reporting mismatch remains explicit baseline debt for a later phase.

## Local gates

- [x] python3 -m unittest discover -s scripts/bench -p test_*.py (15 tests, OK)
- [x] git diff --check
- [x] grep -rn /Users/ docs/reference/benchmarks (no matches)
- [x] Diff limited to Python tests and benchmark docs; no Rust, Cargo, or OPF behavior changes

## Fixtures & PII hygiene

- [x] Synthetic-only fixtures use repository-approved alice@example.invalid and Dr. Schmidt shapes.
- [x] No real PII added.

## DCO and commit discipline

- [x] Commit is signed off.
- [x] Commit has the [agent] prefix and files were staged by exact path.