### PR TITLE
[agent] test(mcp-core): stabilize ToolCtx seal diagnostic

### DIFF
--- a/crates/gaze-mcp-core/tests/tool_ctx_seal.rs
+++ b/crates/gaze-mcp-core/tests/tool_ctx_seal.rs
@@ -1,6 +1,6 @@
 //! Compile-fail fixtures verifying the [`gaze_mcp_core::ToolCtx`] seal:
 //! external crates must NOT be able to construct a `ToolCtx` via either
-//! [`gaze_mcp_core::ctx::ToolCtx::new`] (private constructor) or a struct
+//! [`gaze_mcp_core::ctx::ToolCtx::new_with_resources`] (private constructor) or a struct
 //! literal (private fields + `#[non_exhaustive]`).
 //!
 //! The fixtures live in `tests/ui/`; this driver runs them via trybuild.

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.rs
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.rs
@@ -1,15 +1,25 @@
-// Verifies that `ToolCtx::new` is `pub(crate)` — external crates cannot call
-// it. This is the primary chokepoint guarantee: no fabrication of contexts
-// from outside the dispatcher.
+// Verifies that `ToolCtx::new_with_resources` is `pub(crate)` — external
+// crates cannot call it. This is the primary chokepoint guarantee: no
+// fabrication of contexts from outside the dispatcher.
 
 use serde_json::Value;
 use ulid::Ulid;
 
-use gaze_mcp_core::ctx::{SessionHandle, ToolCtx};
+use gaze_mcp_core::ctx::ToolCtx;
+
+fn unavailable<T>() -> T {
+    panic!("compile-fail fixture")
+}
 
 fn try_to_fabricate() {
-    let _session = SessionHandle::new("audit-id");
-    let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
+    let _ctx = ToolCtx::new_with_resources(
+        unavailable(),
+        unavailable(),
+        Value::Null,
+        Ulid::new(),
+        "tool",
+        "principal",
+    );
 }
 
 fn main() {}

--- a/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
+++ b/crates/gaze-mcp-core/tests/ui/tool_ctx_no_external_constructor.stderr
@@ -1,16 +1,16 @@
-error[E0624]: associated function `new` is private
-  --> tests/ui/tool_ctx_no_external_constructor.rs:11:35
+error[E0624]: associated function `new_with_resources` is private
+  --> tests/ui/tool_ctx_no_external_constructor.rs:15:25
    |
-11 |     let _session = SessionHandle::new("audit-id");
-   |                                   ^^^ private associated function
+15 |       let _ctx = ToolCtx::new_with_resources(
+   |                           ^^^^^^^^^^^^^^^^^^ private associated function
    |
   ::: src/ctx.rs
    |
-   |     pub(crate) fn new(audit_session_id: &'a str) -> Self {
-   |     ---------------------------------------------------- private associated function defined here
-
-error[E0599]: no function or associated item named `new` found for struct `ToolCtx<'a>` in the current scope
-  --> tests/ui/tool_ctx_no_external_constructor.rs:12:25
-   |
-12 |     let _ctx = ToolCtx::new(_session, Value::Null, Ulid::new(), "tool", "principal");
-   |                         ^^^ function or associated item not found in `ToolCtx<'_>`
+   | /     pub(crate) fn new_with_resources(
+   | |         session: SessionHandle<'a>,
+   | |         resources: ToolResources<'a>,
+   | |         redacted_args: serde_json::Value,
+...  |
+   | |         principal_id: &'a str,
+   | |     ) -> Self {
+   | |_____________- private associated function defined here


### PR DESCRIPTION
Summary

- Exercise the actual private ToolCtx::new_with_resources constructor in the compile-fail fixture.
- Replace platform-variable E0599 missing-item wording with stable E0624 privacy diagnostics.
- Preserve the external-construction seal without changing production code or public API.

Verification

- rustup run 1.96.0 cargo fmt --all -- --check
- rustup run 1.96.0 cargo test -p gaze-mcp-core --test tool_ctx_seal
- rustup run 1.96.0 cargo test -p gaze-mcp-core --all-features

Five-axis evaluation

- Reliability: no production behavior change.
- Reversibility: no manifest or restore change.
- Agentic fit: no runtime contract change.
- Trust: removes a platform-dependent false CI failure while retaining the compile-fail seal.
- Adopter ergonomics: no public API or dependency change.

Resolves solo todo #1901