### PR TITLE
[agent] emit ratified final-protection trace (B1)

### DIFF
--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use gaze::{
-    Action, ClassRule, CleanDocument, DefaultRule, EmittedTokenSpan, LeakKind, LeakReportStats,
-    LocaleTag, PiiClass, Pipeline, RawDocument, RawMatch, RecognizerSpec, Rulepack, RulepackSource,
-    SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope, Session,
+    Action, ClassRule, CleanDocument, DefaultRule, EmittedTokenSpan, GazeLocalProtectionTraceItem,
+    LeakKind, LeakReportStats, LocaleTag, PiiClass, Pipeline, RawDocument, RawMatch,
+    RecognizerSpec, Rulepack, RulepackSource, SafetyNetError, SafetyNetFallback, SafetyNetMode,
+    SafetyNetPolicy, Scope, Session,
 };
 use gaze_recognizers::{
     embedded, NerOptions, NerRecognizer, NormalizerKind, RegexDetector, ValidatorKind,
@@ -38,6 +39,22 @@ struct ManifestSpan {
     clean_start: usize,
     clean_end: usize,
     class: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FinalProtectionTraceItem {
+    raw_start: usize,
+    raw_end: usize,
+    class: String,
+    action: String,
+    provenance: FinalProtectionTraceProvenance,
+}
+
+#[derive(Debug, Serialize)]
+struct FinalProtectionTraceProvenance {
+    stage: String,
+    decision: String,
+    source_ids: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -159,15 +176,15 @@ fn handle_request(
     let raw_text = request.text;
     let session = Session::new(Scope::Ephemeral)?;
     let full_start = Instant::now();
-    let clean_result = full.clean_with_safety_net_policy_detect_context(
+    let clean_result = full.clean_text_with_safety_net_policy_detect_context_and_protection_trace(
         &session,
-        RawDocument::Text(raw_text.clone()),
+        &raw_text,
         &locale_chain,
         &Default::default(),
         safety_net_policy(config),
     );
     let total_ms = full_start.elapsed().as_secs_f64() * 1000.0;
-    let (clean_doc, manifest, report) = match clean_result {
+    let (clean_doc, manifest, report, final_protection_trace) = match clean_result {
         Ok(result) => result,
         Err(error) => {
             return Ok(Outcome::PipelineError {
@@ -255,6 +272,7 @@ fn handle_request(
         };
 
     let manifest_spans = serialize_manifest(manifest);
+    let final_protection_trace = serialize_final_protection_trace(final_protection_trace);
     let initial_safety_net_stats = SafetyNetStats::from(&report.stats);
     let strict_would_reject = report.stats.uncovered_count + report.stats.partial_bleed_count > 0;
     let leak_suspects = report
@@ -316,6 +334,7 @@ fn handle_request(
             restore_ms,
             post_policy_scan_ms,
         },
+        final_protection_trace,
     }))
 }
 
@@ -334,6 +353,7 @@ struct Response {
     restore: RestoreResult,
     manifest_integrity: ManifestIntegrity,
     timing: Timing,
+    final_protection_trace: Vec<FinalProtectionTraceItem>,
 }
 
 #[derive(Debug, Serialize)]
@@ -760,6 +780,25 @@ fn serialize_manifest(manifest: Vec<EmittedTokenSpan>) -> Vec<ManifestSpan> {
         .collect()
 }
 
+fn serialize_final_protection_trace(
+    trace: Vec<GazeLocalProtectionTraceItem>,
+) -> Vec<FinalProtectionTraceItem> {
+    trace
+        .into_iter()
+        .map(|item| FinalProtectionTraceItem {
+            raw_start: item.raw_start(),
+            raw_end: item.raw_end(),
+            class: item.class().to_canonical_str(),
+            action: item.action().to_string(),
+            provenance: FinalProtectionTraceProvenance {
+                stage: item.stage().to_string(),
+                decision: item.decision().to_string(),
+                source_ids: item.source_ids().to_vec(),
+            },
+        })
+        .collect()
+}
+
 fn manifest_integrity(
     session: &Session,
     raw_text: &str,
@@ -830,7 +869,13 @@ mod tests {
         }
     }
 
-    fn assert_success_contract(response: &Response, fixture_id: &str, email: &str) {
+    fn assert_success_contract(
+        response: &Response,
+        fixture_id: &str,
+        raw_text: &str,
+        clean_protected_value: &str,
+        trace_forbidden_values: &[&str],
+    ) {
         assert_eq!(response.fixture_id, fixture_id);
         assert!(
             response
@@ -839,7 +884,7 @@ mod tests {
                 .any(|span| span.class == "email"),
             "the deterministic rule floor should tokenize the synthetic email"
         );
-        assert!(!response.clean_text.contains(email));
+        assert!(!response.clean_text.contains(clean_protected_value));
         assert!(response.restore.exact);
         assert_eq!(response.safety_net_mode, "strict");
 
@@ -868,30 +913,141 @@ mod tests {
         ] {
             assert!(timing.contains_key(field), "missing timing field {field}");
         }
+
+        let trace_value = serialized
+            .get("final_protection_trace")
+            .and_then(serde_json::Value::as_array)
+            .expect("success response should contain a protection trace array");
+        assert_eq!(trace_value.len(), response.final_protection_trace.len());
+        assert!(!response.final_protection_trace.is_empty());
+
+        let mut previous_raw_end = 0usize;
+        for (item, serialized_item) in response
+            .final_protection_trace
+            .iter()
+            .zip(trace_value.iter())
+        {
+            assert!(item.raw_start < item.raw_end);
+            assert!(item.raw_end <= raw_text.len());
+            assert!(raw_text.is_char_boundary(item.raw_start));
+            assert!(raw_text.is_char_boundary(item.raw_end));
+            assert!(item.raw_start >= previous_raw_end);
+            previous_raw_end = item.raw_end;
+            assert!(matches!(
+                (
+                    item.provenance.stage.as_str(),
+                    item.provenance.decision.as_str(),
+                    item.action.as_str(),
+                ),
+                ("primary_pipeline", "policy", "tokenize")
+                    | ("safety_net", "resolve", "tokenize")
+                    | ("safety_net", "redact", "redact")
+                    | ("safety_net", "fallback_redact", "redact")
+            ));
+            assert_eq!(item.provenance.stage, "primary_pipeline");
+            assert_eq!(item.provenance.decision, "policy");
+            assert_eq!(item.action, "tokenize");
+            assert!(!item.provenance.source_ids.is_empty());
+            assert!(item
+                .provenance
+                .source_ids
+                .iter()
+                .all(|source_id| !source_id.is_empty()));
+            assert!(item
+                .provenance
+                .source_ids
+                .windows(2)
+                .all(|pair| pair[0] < pair[1]));
+            assert_eq!(
+                response
+                    .manifest_spans
+                    .iter()
+                    .filter(|span| {
+                        span.raw_start == item.raw_start
+                            && span.raw_end == item.raw_end
+                            && span.class == item.class
+                    })
+                    .count(),
+                1
+            );
+
+            let object = serialized_item
+                .as_object()
+                .expect("trace item should be an object");
+            assert_eq!(object.len(), 5);
+            for field in ["raw_start", "raw_end", "class", "action", "provenance"] {
+                assert!(object.contains_key(field), "missing trace field {field}");
+            }
+            let provenance = object["provenance"]
+                .as_object()
+                .expect("trace provenance should be an object");
+            assert_eq!(provenance.len(), 3);
+            for field in ["stage", "decision", "source_ids"] {
+                assert!(
+                    provenance.contains_key(field),
+                    "missing provenance field {field}"
+                );
+            }
+        }
+        for span in &response.manifest_spans {
+            assert_eq!(
+                response
+                    .final_protection_trace
+                    .iter()
+                    .filter(|item| {
+                        item.action == "tokenize"
+                            && item.raw_start == span.raw_start
+                            && item.raw_end == span.raw_end
+                            && item.class == span.class
+                    })
+                    .count(),
+                1
+            );
+        }
+        let serialized_trace = serde_json::to_string(&response.final_protection_trace)
+            .expect("trace should serialize");
+        for protected_value in trace_forbidden_values {
+            assert!(!serialized_trace.contains(protected_value));
+        }
     }
 
     #[test]
     fn en_rule_floor_success_response_contract() {
-        let email = "alice@example.invalid";
-        let response = rule_floor_response(
-            "en-1",
-            "en",
-            "Contact alice@example.invalid or call +1-555-0142.",
-        );
+        let text = "Contact alice@example.invalid or call +1-555-0142.";
+        let response = rule_floor_response("en-1", "en", text);
 
-        assert_success_contract(&response, "en-1", email);
+        assert_success_contract(
+            &response,
+            "en-1",
+            text,
+            "alice@example.invalid",
+            &["alice@example.invalid", "+1-555-0142"],
+        );
     }
 
     #[test]
     fn de_rule_floor_success_response_contract() {
-        let email = "dr.schmidt@example.invalid";
-        let response = rule_floor_response(
-            "de-1",
-            "de",
-            "Bitte an dr.schmidt@example.invalid schreiben, Tel. +49 1555 0112233.",
-        );
+        let text = "Bitte an dr.schmidt@example.invalid schreiben, Tel. +49 1555 0112233.";
+        let response = rule_floor_response("de-1", "de", text);
 
-        assert_success_contract(&response, "de-1", email);
+        assert_success_contract(
+            &response,
+            "de-1",
+            text,
+            "dr.schmidt@example.invalid",
+            &["dr.schmidt@example.invalid", "+49 1555 0112233"],
+        );
+    }
+
+    #[test]
+    fn success_response_keeps_empty_protection_trace_field() {
+        let response = rule_floor_response("empty-1", "en", "nothing sensitive here.");
+        assert!(response.final_protection_trace.is_empty());
+        let serialized = serde_json::to_value(&response).expect("response should serialize");
+        assert_eq!(
+            serialized.get("final_protection_trace"),
+            Some(&serde_json::Value::Array(Vec::new()))
+        );
     }
 
     #[test]
@@ -950,6 +1106,7 @@ mod tests {
         ] {
             assert!(object.contains_key(field), "missing error field {field}");
         }
+        assert!(!object.contains_key("final_protection_trace"));
         let timing = object["timing"]
             .as_object()
             .expect("error timing should be a JSON object");

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -41,8 +41,8 @@ pub use gaze_types::{
 };
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{
-    Error, Pipeline, PipelineBuilder, PipelineOptimizationConfig, Result, SafetyNetFallback,
-    SafetyNetMode, SafetyNetPolicy,
+    Error, GazeLocalProtectionTraceItem, Pipeline, PipelineBuilder, PipelineOptimizationConfig,
+    Result, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
 };
 pub use policy::{
     validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1031,6 +1031,8 @@ impl Pipeline {
             if !is_char_boundary_range(&clean.text, &span) {
                 return Ok(Some(FallbackReason::ResidualSuspect));
             }
+            // Establish the original interval before tokenization mutates the session or any
+            // clean text, manifest, or diagnostic trace state.
             let raw_span = map_clean_span_to_raw(clean, &span)?;
             let raw = clean.text[span.clone()].to_string();
             let replacement = session.tokenize_with_family("safety_net", &suspect.class, &raw)?;
@@ -2756,6 +2758,147 @@ mod tests {
         assert!(manifest.iter().any(|span| {
             span.raw_span == (name_start..text.len()) && span.class == PiiClass::Name
         }));
+    }
+
+    #[test]
+    fn production_safety_resolve_manifest_uses_original_coordinates_after_primary_shift() {
+        let text = "alice@example.invalid met Dr. Schmidt";
+        let name_start = text.find("Dr. Schmidt").expect("synthetic name");
+        let expected_name_span = name_start..text.len();
+        let pipeline = traced_email_pipeline(MarkerSafetyNet {
+            id: "name-safety.fixture",
+            marker: "Dr. Schmidt",
+            class: PiiClass::Name,
+        });
+        let policy = SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact);
+
+        let production_session = Session::new(Scope::Ephemeral).expect("session");
+        let (production_doc, production_manifest, _) = pipeline
+            .clean_with_safety_net_policy_detect_context(
+                &production_session,
+                RawDocument::Text(text.to_string()),
+                &[crate::LocaleTag::Global],
+                &DictionaryBundle::default(),
+                policy,
+            )
+            .expect("production clean");
+        let CleanDocument::Text(production_text) = production_doc else {
+            panic!("expected text output");
+        };
+
+        let primary = production_manifest
+            .iter()
+            .find(|span| span.class == PiiClass::Email)
+            .expect("primary email token");
+        assert_ne!(
+            primary.clean_span.end - primary.clean_span.start,
+            primary.raw_span.end - primary.raw_span.start,
+            "the fixture must exercise a byte-length-changing primary replacement"
+        );
+        let resolved = production_manifest
+            .iter()
+            .find(|span| span.class == PiiClass::Name)
+            .expect("safety-net resolved token");
+        assert_eq!(resolved.raw_span, expected_name_span);
+
+        for emitted in &production_manifest {
+            assert!(emitted.raw_span.start < emitted.raw_span.end);
+            assert!(emitted.raw_span.end <= text.len());
+            assert!(text.is_char_boundary(emitted.raw_span.start));
+            assert!(text.is_char_boundary(emitted.raw_span.end));
+            assert!(emitted.clean_span.start < emitted.clean_span.end);
+            assert!(emitted.clean_span.end <= production_text.len());
+            assert!(production_text.is_char_boundary(emitted.clean_span.start));
+            assert!(production_text.is_char_boundary(emitted.clean_span.end));
+            let token = &production_text[emitted.clean_span.clone()];
+            let restored = production_session
+                .restore(token)
+                .expect("manifest token should restore");
+            assert_eq!(restored, text[emitted.raw_span.clone()]);
+        }
+        assert_eq!(
+            pipeline
+                .restore_strict_text(&production_session, &production_text)
+                .expect("production output should restore exactly"),
+            text
+        );
+
+        let traced_session = Session::new(Scope::Ephemeral).expect("session");
+        let (_, traced_manifest, _, trace) = pipeline
+            .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+                &traced_session,
+                text,
+                &[crate::LocaleTag::Global],
+                &DictionaryBundle::default(),
+                policy,
+            )
+            .expect("traced clean");
+        let production_coordinates = production_manifest
+            .iter()
+            .map(|span| (span.raw_span.clone(), span.class.clone()))
+            .collect::<Vec<_>>();
+        let traced_coordinates = traced_manifest
+            .iter()
+            .map(|span| (span.raw_span.clone(), span.class.clone()))
+            .collect::<Vec<_>>();
+        let trace_coordinates = trace
+            .iter()
+            .map(|item| (item.raw_start()..item.raw_end(), item.class().clone()))
+            .collect::<Vec<_>>();
+        assert_eq!(traced_coordinates, production_coordinates);
+        assert_eq!(trace_coordinates, production_coordinates);
+    }
+
+    #[test]
+    fn ambiguous_safety_resolve_mapping_fails_before_any_emission() {
+        let raw_text = "alice@example.invalid tail";
+        let existing_token = "<Email_1>";
+        let mut clean = CleanText {
+            text: format!("{existing_token} tail"),
+            manifest: vec![EmittedTokenSpan::new(
+                0..existing_token.len(),
+                0.."alice@example.invalid".len(),
+                PiiClass::Email,
+            )],
+        };
+        let report = LeakReport::from_parts(
+            vec![LeakSuspect::new(
+                1..2,
+                PiiClass::Name,
+                "ambiguous.fixture",
+                Some(1.0),
+                LeakKind::Uncovered,
+                PiiClass::Name.to_canonical_str(),
+                None,
+            )],
+            Vec::new(),
+        );
+        let before_text = clean.text.clone();
+        let before_manifest = clean.manifest.clone();
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let mut trace = ProtectionTraceCollector::new(raw_text);
+
+        let error = pipeline
+            .resolve_safety_net_suspects(
+                &session,
+                &mut clean,
+                &report,
+                DocumentKind::Text,
+                None,
+                Some(&mut trace),
+            )
+            .expect_err("an interval inside an existing token is ambiguous");
+
+        assert!(matches!(
+            error,
+            Error::SafetyNet(SafetyNetError::InvalidOutput { message })
+                if message == "clean-to-raw start mapping failed"
+        ));
+        assert_eq!(clean.text, before_text);
+        assert_eq!(clean.manifest, before_manifest);
+        assert!(trace.items.is_empty());
+        assert!(session.snapshot_entries().is_empty());
     }
 
     #[test]

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -206,6 +206,68 @@ pub struct SafetyNetResult {
     pub report: LeakReport,
 }
 
+#[doc(hidden)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GazeLocalProtectionTraceItem {
+    raw_span: Range<usize>,
+    class: PiiClass,
+    kind: GazeLocalProtectionTraceKind,
+    source_ids: Vec<String>,
+}
+
+impl GazeLocalProtectionTraceItem {
+    pub fn raw_start(&self) -> usize {
+        self.raw_span.start
+    }
+
+    pub fn raw_end(&self) -> usize {
+        self.raw_span.end
+    }
+
+    pub fn class(&self) -> &PiiClass {
+        &self.class
+    }
+
+    pub fn stage(&self) -> &'static str {
+        match self.kind {
+            GazeLocalProtectionTraceKind::PrimaryPolicyTokenize => "primary_pipeline",
+            GazeLocalProtectionTraceKind::SafetyNetResolveTokenize
+            | GazeLocalProtectionTraceKind::SafetyNetRedact
+            | GazeLocalProtectionTraceKind::SafetyNetFallbackRedact => "safety_net",
+        }
+    }
+
+    pub fn decision(&self) -> &'static str {
+        match self.kind {
+            GazeLocalProtectionTraceKind::PrimaryPolicyTokenize => "policy",
+            GazeLocalProtectionTraceKind::SafetyNetResolveTokenize => "resolve",
+            GazeLocalProtectionTraceKind::SafetyNetRedact => "redact",
+            GazeLocalProtectionTraceKind::SafetyNetFallbackRedact => "fallback_redact",
+        }
+    }
+
+    pub fn action(&self) -> &'static str {
+        match self.kind {
+            GazeLocalProtectionTraceKind::PrimaryPolicyTokenize
+            | GazeLocalProtectionTraceKind::SafetyNetResolveTokenize => "tokenize",
+            GazeLocalProtectionTraceKind::SafetyNetRedact
+            | GazeLocalProtectionTraceKind::SafetyNetFallbackRedact => "redact",
+        }
+    }
+
+    pub fn source_ids(&self) -> &[String] {
+        &self.source_ids
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GazeLocalProtectionTraceKind {
+    PrimaryPolicyTokenize,
+    SafetyNetResolveTokenize,
+    SafetyNetRedact,
+    SafetyNetFallbackRedact,
+}
+
 impl std::fmt::Debug for Pipeline {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Pipeline").finish_non_exhaustive()
@@ -396,11 +458,65 @@ impl Pipeline {
                     locale_chain,
                     None,
                     policy,
+                    None,
                 )?;
                 Ok((CleanDocument::Text(clean.text), clean.manifest, report))
             }
             _ => Err(Error::UnsupportedRawDocumentVariant),
         }
+    }
+
+    #[doc(hidden)]
+    #[allow(clippy::type_complexity)]
+    pub fn clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+        &self,
+        session: &Session,
+        text: &str,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+        policy: SafetyNetPolicy,
+    ) -> Result<(
+        CleanDocument,
+        Vec<EmittedTokenSpan>,
+        LeakReport,
+        Vec<GazeLocalProtectionTraceItem>,
+    )> {
+        let mut protection_trace = ProtectionTraceCollector::new(text);
+        let mut clean = self.redact_text_with_manifest_uncached(
+            session,
+            text,
+            None,
+            DocumentKind::Text,
+            locale_chain,
+            dictionaries,
+            Some(&mut protection_trace),
+        )?;
+        let report = self.run_safety_nets(
+            session,
+            &clean.text,
+            &Manifest::from_spans(clean.manifest.clone()),
+            DocumentKind::Text,
+            locale_chain,
+            None,
+            policy.mode,
+        )?;
+        self.apply_safety_net_policy(
+            session,
+            &mut clean,
+            &report,
+            DocumentKind::Text,
+            locale_chain,
+            None,
+            policy,
+            Some(&mut protection_trace),
+        )?;
+        let trace = protection_trace.finish(&clean.manifest)?;
+        Ok((
+            CleanDocument::Text(clean.text),
+            clean.manifest,
+            report,
+            trace,
+        ))
     }
 
     pub fn scan_safety_nets(
@@ -519,6 +635,7 @@ impl Pipeline {
                     document_kind,
                     locale_chain,
                     dictionaries,
+                    None,
                 )?;
                 let clean_offset = hit.clean_text.len();
                 let raw_offset = hit.raw_len;
@@ -554,6 +671,7 @@ impl Pipeline {
             document_kind,
             locale_chain,
             dictionaries,
+            None,
         )?;
         if self.optimization_config.prefix_cache {
             session.store_prefix_cache(text, &clean.text, &clean.manifest);
@@ -570,6 +688,7 @@ impl Pipeline {
         document_kind: DocumentKind,
         locale_chain: &[crate::LocaleTag],
         dictionaries: &DictionaryBundle,
+        mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<CleanText> {
         let normalized = normalize(text);
         let spans = &normalized.spans;
@@ -611,6 +730,10 @@ impl Pipeline {
             let raw = text[detection.detection.span.clone()].to_string();
             let context = build_context(field_name);
             let action = self.action_for(&detection.detection, &context);
+            if protection_trace.is_some() && !matches!(action, Action::Tokenize | Action::Preserve)
+            {
+                return Err(Error::UnsupportedActionVariant);
+            }
             self.log_entry(
                 session,
                 &detection,
@@ -643,11 +766,22 @@ impl Pipeline {
                 Some(replacement) => {
                     let clean_start = out.len();
                     out.push_str(&replacement);
+                    let class = detection.detection.class.clone();
                     emitted.push(EmittedTokenSpan::new(
                         clean_start..out.len(),
                         span.clone(),
-                        detection.detection.class,
+                        class.clone(),
                     ));
+                    if action == Action::Tokenize {
+                        if let Some(trace) = protection_trace.as_deref_mut() {
+                            trace.record(
+                                span.clone(),
+                                class,
+                                GazeLocalProtectionTraceKind::PrimaryPolicyTokenize,
+                                detection.trace_source_ids.clone(),
+                            )?;
+                        }
+                    }
                 }
                 None => out.push_str(&text[span.clone()]),
             }
@@ -821,6 +955,7 @@ impl Pipeline {
         locale_chain: &[crate::LocaleTag],
         field_path: Option<&str>,
         policy: SafetyNetPolicy,
+        mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<()> {
         match policy.mode {
             SafetyNetMode::Strict | SafetyNetMode::Tolerant => Ok(()),
@@ -832,6 +967,7 @@ impl Pipeline {
                 field_path,
                 None,
                 true,
+                protection_trace,
             ),
             SafetyNetMode::Resolve => {
                 let reason = match self.resolve_safety_net_suspects(
@@ -840,6 +976,7 @@ impl Pipeline {
                     report,
                     document_kind,
                     field_path,
+                    protection_trace.as_deref_mut(),
                 )? {
                     Some(reason) => Some(reason),
                     None => {
@@ -865,6 +1002,7 @@ impl Pipeline {
                         field_path,
                         policy.fallback,
                         reason,
+                        protection_trace,
                     )?;
                 }
                 Ok(())
@@ -879,6 +1017,7 @@ impl Pipeline {
         report: &LeakReport,
         document_kind: DocumentKind,
         field_path: Option<&str>,
+        mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<Option<FallbackReason>> {
         if report
             .suspects
@@ -892,6 +1031,7 @@ impl Pipeline {
             if !is_char_boundary_range(&clean.text, &span) {
                 return Ok(Some(FallbackReason::ResidualSuspect));
             }
+            let raw_span = map_clean_span_to_raw(clean, &span)?;
             let raw = clean.text[span.clone()].to_string();
             let replacement = session.tokenize_with_family("safety_net", &suspect.class, &raw)?;
             self.log_safety_net_entry(
@@ -910,10 +1050,18 @@ impl Pipeline {
                 &replacement,
                 Some(EmittedTokenSpan::new(
                     span.start..span.start + replacement.len(),
-                    span,
+                    raw_span.clone(),
                     suspect.class.clone(),
                 )),
             );
+            if let Some(trace) = protection_trace.as_deref_mut() {
+                trace.record(
+                    raw_span,
+                    suspect.class.clone(),
+                    GazeLocalProtectionTraceKind::SafetyNetResolveTokenize,
+                    vec![suspect.safety_net_id.clone()],
+                )?;
+            }
         }
         Ok(None)
     }
@@ -928,6 +1076,7 @@ impl Pipeline {
         field_path: Option<&str>,
         fallback: SafetyNetFallback,
         reason: FallbackReason,
+        protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<()> {
         for suspect in redaction_suspects(report) {
             self.log_safety_net_entry(
@@ -952,6 +1101,7 @@ impl Pipeline {
                 field_path,
                 Some(reason),
                 false,
+                protection_trace,
             ),
         }
     }
@@ -966,11 +1116,16 @@ impl Pipeline {
         field_path: Option<&str>,
         fallback_reason: Option<FallbackReason>,
         log_entries: bool,
+        mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<()> {
         for suspect in redaction_suspects(report).into_iter().rev() {
             let span =
                 round_span_outward_to_char_boundaries(&clean.text, suspect_action_span(suspect))?;
             let span = expand_span_to_overlapping_manifest_entries(clean, span);
+            let raw_span = protection_trace
+                .as_ref()
+                .map(|_| map_clean_span_to_raw(clean, &span))
+                .transpose()?;
             for existing in clean
                 .manifest
                 .iter()
@@ -1000,6 +1155,18 @@ impl Pipeline {
                 )?;
             }
             replace_clean_span(clean, span, "", None);
+            if let (Some(trace), Some(raw_span)) = (protection_trace.as_deref_mut(), raw_span) {
+                trace.record(
+                    raw_span,
+                    suspect.class.clone(),
+                    if fallback_reason.is_some() {
+                        GazeLocalProtectionTraceKind::SafetyNetFallbackRedact
+                    } else {
+                        GazeLocalProtectionTraceKind::SafetyNetRedact
+                    },
+                    vec![suspect.safety_net_id.clone()],
+                )?;
+            }
         }
         Ok(())
     }
@@ -1278,6 +1445,7 @@ struct IndexedDetection {
     detection: Detection,
     recognizer_id: Option<String>,
     recognizer_version_id: Option<String>,
+    trace_source_ids: Vec<String>,
     decided_by: ConflictTier,
     family: String,
     ambiguity_record: Option<AmbiguityRecord>,
@@ -1288,6 +1456,167 @@ struct IndexedDetection {
 struct CleanText {
     text: String,
     manifest: Vec<EmittedTokenSpan>,
+}
+
+struct ProtectionTraceCollector<'a> {
+    raw_text: &'a str,
+    items: Vec<GazeLocalProtectionTraceItem>,
+}
+
+impl<'a> ProtectionTraceCollector<'a> {
+    fn new(raw_text: &'a str) -> Self {
+        Self {
+            raw_text,
+            items: Vec::new(),
+        }
+    }
+
+    fn record(
+        &mut self,
+        raw_span: Range<usize>,
+        class: PiiClass,
+        kind: GazeLocalProtectionTraceKind,
+        mut source_ids: Vec<String>,
+    ) -> Result<()> {
+        if raw_span.start >= raw_span.end
+            || raw_span.end > self.raw_text.len()
+            || !self.raw_text.is_char_boundary(raw_span.start)
+            || !self.raw_text.is_char_boundary(raw_span.end)
+        {
+            return Err(protection_trace_error("invalid original-text span"));
+        }
+        if source_ids
+            .iter()
+            .any(|source_id| source_id.trim().is_empty())
+        {
+            return Err(protection_trace_error("empty protection source id"));
+        }
+        source_ids.sort();
+        source_ids.dedup();
+        if source_ids.is_empty() {
+            return Err(protection_trace_error("missing protection source id"));
+        }
+
+        self.items
+            .retain(|existing| !ranges_overlap(&existing.raw_span, &raw_span));
+        self.items.push(GazeLocalProtectionTraceItem {
+            raw_span,
+            class,
+            kind,
+            source_ids,
+        });
+        Ok(())
+    }
+
+    fn finish(
+        mut self,
+        manifest: &[EmittedTokenSpan],
+    ) -> Result<Vec<GazeLocalProtectionTraceItem>> {
+        self.items.sort_by(|left, right| {
+            (
+                left.raw_span.start,
+                left.raw_span.end,
+                left.stage(),
+                left.decision(),
+            )
+                .cmp(&(
+                    right.raw_span.start,
+                    right.raw_span.end,
+                    right.stage(),
+                    right.decision(),
+                ))
+        });
+        if self
+            .items
+            .windows(2)
+            .any(|pair| pair[0].raw_span.end > pair[1].raw_span.start)
+        {
+            return Err(protection_trace_error("overlapping protection trace"));
+        }
+
+        for item in &self.items {
+            let matching_manifest = manifest
+                .iter()
+                .filter(|span| span.raw_span == item.raw_span && span.class == item.class)
+                .count();
+            match item.action() {
+                "tokenize" if matching_manifest == 1 => {}
+                "redact"
+                    if !manifest
+                        .iter()
+                        .any(|span| ranges_overlap(&span.raw_span, &item.raw_span)) => {}
+                _ => return Err(protection_trace_error("trace-manifest mismatch")),
+            }
+        }
+        for span in manifest {
+            let matching_trace = self
+                .items
+                .iter()
+                .filter(|item| {
+                    item.action() == "tokenize"
+                        && item.raw_span == span.raw_span
+                        && item.class == span.class
+                })
+                .count();
+            if matching_trace != 1 {
+                return Err(protection_trace_error("manifest-trace mismatch"));
+            }
+        }
+
+        Ok(self.items)
+    }
+}
+
+fn protection_trace_error(message: &'static str) -> Error {
+    Error::SafetyNet(SafetyNetError::InvalidOutput {
+        message: message.to_string(),
+    })
+}
+
+fn map_clean_span_to_raw(clean: &CleanText, span: &Range<usize>) -> Result<Range<usize>> {
+    if span.start >= span.end || !is_char_boundary_range(&clean.text, span) {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: clean.text.len(),
+        });
+    }
+    let start = map_clean_boundary_to_raw(&clean.manifest, span.start)
+        .ok_or_else(|| protection_trace_error("clean-to-raw start mapping failed"))?;
+    let end = map_clean_boundary_to_raw(&clean.manifest, span.end)
+        .ok_or_else(|| protection_trace_error("clean-to-raw end mapping failed"))?;
+    if start >= end {
+        return Err(protection_trace_error("empty clean-to-raw mapping"));
+    }
+    Ok(start..end)
+}
+
+fn map_clean_boundary_to_raw(manifest: &[EmittedTokenSpan], offset: usize) -> Option<usize> {
+    let mut clean_cursor = 0usize;
+    let mut raw_cursor = 0usize;
+    for emitted in manifest {
+        if emitted.clean_span.start < clean_cursor
+            || emitted.raw_span.start < raw_cursor
+            || emitted.clean_span.start - clean_cursor != emitted.raw_span.start - raw_cursor
+        {
+            return None;
+        }
+        if offset < emitted.clean_span.start {
+            return raw_cursor.checked_add(offset.checked_sub(clean_cursor)?);
+        }
+        if offset == emitted.clean_span.start {
+            return Some(emitted.raw_span.start);
+        }
+        if offset < emitted.clean_span.end {
+            return None;
+        }
+        if offset == emitted.clean_span.end {
+            return Some(emitted.raw_span.end);
+        }
+        clean_cursor = emitted.clean_span.end;
+        raw_cursor = emitted.raw_span.end;
+    }
+    raw_cursor.checked_add(offset.checked_sub(clean_cursor)?)
 }
 
 fn actionable_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
@@ -2018,6 +2347,7 @@ fn merged_losers(resolved: &[Candidate], registry: &RecognizerRegistry) -> Vec<I
                     detection: Detection::new(winner.span.clone(), class, source.clone()),
                     recognizer_id: Some(source.clone()),
                     recognizer_version_id: None,
+                    trace_source_ids: vec![source.clone()],
                     decided_by: if winner.decided_by == ConflictTier::Merged {
                         ConflictTier::Merged
                     } else {
@@ -2037,6 +2367,8 @@ fn indexed_detection_from_candidate(
     candidate: Candidate,
     registry: &RecognizerRegistry,
 ) -> IndexedDetection {
+    let mut trace_source_ids = candidate.merged_sources.clone();
+    trace_source_ids.push(candidate.recognizer_id.clone());
     let membership = registry
         .family_policy()
         .membership(&candidate.recognizer_id);
@@ -2060,6 +2392,7 @@ fn indexed_detection_from_candidate(
         detection: Detection::new(candidate.span, candidate.class, candidate.source),
         recognizer_id: Some(candidate.recognizer_id),
         recognizer_version_id: candidate.recognizer_version_id,
+        trace_source_ids,
         decided_by: candidate.decided_by,
         family: candidate.token_family,
         ambiguity_record,
@@ -2279,6 +2612,81 @@ mod tests {
         calls: Arc<AtomicUsize>,
     }
 
+    struct MarkerSafetyNet {
+        id: &'static str,
+        marker: &'static str,
+        class: PiiClass,
+    }
+
+    impl SafetyNet for MarkerSafetyNet {
+        fn id(&self) -> &str {
+            self.id
+        }
+
+        fn supported_locales(&self) -> &[crate::LocaleTag] {
+            &[crate::LocaleTag::Global]
+        }
+
+        fn check(
+            &self,
+            clean_text: &str,
+            context: SafetyNetContext<'_>,
+        ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+            let Some(start) = clean_text.find(self.marker) else {
+                return Ok(Vec::new());
+            };
+            let span = start..start + self.marker.len();
+            let Some(kind) = context.manifest.diff_against(&span, &self.class) else {
+                return Ok(Vec::new());
+            };
+            Ok(vec![LeakSuspect::new(
+                span,
+                self.class.clone(),
+                self.id,
+                Some(1.0),
+                kind,
+                self.class.to_canonical_str(),
+                None,
+            )])
+        }
+    }
+
+    struct ManifestMismatchSafetyNet;
+
+    impl SafetyNet for ManifestMismatchSafetyNet {
+        fn id(&self) -> &str {
+            "manifest-mismatch.fixture"
+        }
+
+        fn supported_locales(&self) -> &[crate::LocaleTag] {
+            &[crate::LocaleTag::Global]
+        }
+
+        fn check(
+            &self,
+            _clean_text: &str,
+            context: SafetyNetContext<'_>,
+        ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+            let Some(emitted) = context.manifest.spans.first() else {
+                return Ok(Vec::new());
+            };
+            let class = PiiClass::Name;
+            let span = emitted.clean_span.clone();
+            let Some(kind) = context.manifest.diff_against(&span, &class) else {
+                return Ok(Vec::new());
+            };
+            Ok(vec![LeakSuspect::new(
+                span,
+                class.clone(),
+                self.id(),
+                Some(1.0),
+                kind,
+                class.to_canonical_str(),
+                None,
+            )])
+        }
+    }
+
     impl SafetyNet for CountingSafetyNet {
         fn id(&self) -> &str {
             "counting"
@@ -2294,6 +2702,114 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Vec::new())
         }
+    }
+
+    fn traced_email_pipeline(safety_net: impl SafetyNet + 'static) -> Pipeline {
+        Pipeline::builder()
+            .detector(detector_with_detections(
+                "email.fixture",
+                vec![Detection::new(0..21, PiiClass::Email, "email.fixture")],
+            ))
+            .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .register_safety_net(safety_net)
+            .build()
+            .expect("pipeline")
+    }
+
+    #[test]
+    fn protection_trace_captures_primary_and_safety_resolve_at_application() {
+        let text = "alice@example.invalid met Dr. Schmidt";
+        let name_start = text.find("Dr. Schmidt").expect("synthetic name");
+        let pipeline = traced_email_pipeline(MarkerSafetyNet {
+            id: "name-safety.fixture",
+            marker: "Dr. Schmidt",
+            class: PiiClass::Name,
+        });
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        let (_, manifest, _, trace) = pipeline
+            .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+                &session,
+                text,
+                &[crate::LocaleTag::Global],
+                &DictionaryBundle::default(),
+                SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact),
+            )
+            .expect("traced clean");
+
+        assert_eq!(trace.len(), 2);
+        assert_eq!(trace[0].raw_start(), 0);
+        assert_eq!(trace[0].raw_end(), 21);
+        assert_eq!(trace[0].class(), &PiiClass::Email);
+        assert_eq!(trace[0].stage(), "primary_pipeline");
+        assert_eq!(trace[0].decision(), "policy");
+        assert_eq!(trace[0].action(), "tokenize");
+        assert_eq!(trace[0].source_ids(), &["email.fixture".to_string()]);
+        assert_eq!(trace[1].raw_start(), name_start);
+        assert_eq!(trace[1].raw_end(), text.len());
+        assert_eq!(trace[1].class(), &PiiClass::Name);
+        assert_eq!(trace[1].stage(), "safety_net");
+        assert_eq!(trace[1].decision(), "resolve");
+        assert_eq!(trace[1].action(), "tokenize");
+        assert_eq!(trace[1].source_ids(), &["name-safety.fixture".to_string()]);
+        assert!(manifest.iter().any(|span| {
+            span.raw_span == (name_start..text.len()) && span.class == PiiClass::Name
+        }));
+    }
+
+    #[test]
+    fn protection_trace_captures_safety_redact_and_fallback_supersede() {
+        let text = "alice@example.invalid met Dr. Schmidt";
+        let name_start = text.find("Dr. Schmidt").expect("synthetic name");
+        let redact_pipeline = traced_email_pipeline(MarkerSafetyNet {
+            id: "name-safety.fixture",
+            marker: "Dr. Schmidt",
+            class: PiiClass::Name,
+        });
+        let redact_session = Session::new(Scope::Ephemeral).expect("session");
+        let (_, redact_manifest, _, redact_trace) = redact_pipeline
+            .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+                &redact_session,
+                text,
+                &[crate::LocaleTag::Global],
+                &DictionaryBundle::default(),
+                SafetyNetPolicy::new(SafetyNetMode::Redact, SafetyNetFallback::Redact),
+            )
+            .expect("redact trace");
+        assert_eq!(redact_trace.len(), 2);
+        assert_eq!(redact_trace[1].raw_start(), name_start);
+        assert_eq!(redact_trace[1].raw_end(), text.len());
+        assert_eq!(redact_trace[1].stage(), "safety_net");
+        assert_eq!(redact_trace[1].decision(), "redact");
+        assert_eq!(redact_trace[1].action(), "redact");
+        assert!(redact_manifest
+            .iter()
+            .all(|span| span.raw_span.end <= name_start));
+
+        let fallback_pipeline = traced_email_pipeline(ManifestMismatchSafetyNet);
+        let fallback_session = Session::new(Scope::Ephemeral).expect("session");
+        let (_, fallback_manifest, _, fallback_trace) = fallback_pipeline
+            .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+                &fallback_session,
+                "alice@example.invalid",
+                &[crate::LocaleTag::Global],
+                &DictionaryBundle::default(),
+                SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact),
+            )
+            .expect("fallback trace");
+        assert!(fallback_manifest.is_empty());
+        assert_eq!(fallback_trace.len(), 1);
+        assert_eq!(fallback_trace[0].raw_start(), 0);
+        assert_eq!(fallback_trace[0].raw_end(), 21);
+        assert_eq!(fallback_trace[0].class(), &PiiClass::Name);
+        assert_eq!(fallback_trace[0].stage(), "safety_net");
+        assert_eq!(fallback_trace[0].decision(), "fallback_redact");
+        assert_eq!(fallback_trace[0].action(), "redact");
+        assert_eq!(
+            fallback_trace[0].source_ids(),
+            &["manifest-mismatch.fixture".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Add a gaze-local action-time protection trace collector with deterministic supersede, ordering, span, provenance, and final-manifest validation.
- Emit the required schema-v3 final_protection_trace array from clean_for_bench on every success response while leaving PipelineErrorResponse unchanged.
- Cover primary policy tokenization plus no-model safety-net resolve, redact, and fallback-redact provenance.

Intentional production semantic correction (OPT-1)
- Safety-net RESOLVE now stores the original-request UTF-8 byte interval in EmittedTokenSpan.raw_span for both ordinary clean_with_safety_net_policy_detect_context calls and traced diagnostic calls.
- Previously, a later safety-net token stored a clean-text coordinate after an earlier byte-length-changing primary replacement, violating the documented raw-text meaning of raw_span.
- The live manifest maps the clean action interval before tokenization or any clean text, manifest, or trace mutation.
- Ambiguous mapping fails closed through the existing typed SafetyNetError::InvalidOutput path before token, manifest, or trace emission; it never falls back to clean coordinates.
- Direct production regression coverage proves original raw coordinates, UTF-8 boundaries, manifest value validity, exact restore round-trip, and traced/non-traced coordinate agreement.

Test plan
- cargo test -p gaze-recognizers --example clean_for_bench
- cargo test -p gaze-pii
- cargo test -p gaze-recognizers --example clean_for_bench --features safety-net-kiji
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings

Five-axis evaluation
- Reliability: ambiguous clean-to-original mapping fails closed before session or output mutation, and malformed, overlapping, empty-source, or manifest-inconsistent traces are rejected before success.
- Reversibility: production and traced safety-resolve manifests now use the actual original source interval, exact restore is regression-tested, and tokenize traces remain one-to-one with the surviving manifest.
- Agentic-first: the benchmark wire always carries deterministic final action provenance in original request byte coordinates without diverging from production behavior.
- Trust: action provenance is captured at application time, metadata-only, closed-value, deterministic, and backed by the documented EmittedTokenSpan raw-coordinate semantics.
- Adopter ergonomics: the existing production method keeps its signature while returning corrected manifest coordinates, and the benchmark success schema always includes final_protection_trace, including an empty array.

Boundary
- Public surface changed only through a #[doc(hidden)] internal diagnostic and its gaze-local item type.
- No new gaze::Error variant was introduced; OPT-1 reuses the existing typed SafetyNetError::InvalidOutput path.
- No gaze-types or shared-type changes.
- No existing stable public function signature or return-type changes.
- Root Cargo.toml and Cargo.lock are untouched, and no dependency was added.
- Trace data is captured at action application and is metadata-only; it is not reconstructed from leak suspects, pre-safety manifest spans, or manifest absence.
- No OPF, Python, docs, CI, or xtask changes.

Resolves solo todo #2170