### PR TITLE
[agent] consume ratified honest success timing (A3)

### DIFF
--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -352,7 +352,7 @@ MANIFEST_INTEGRITY_FIELDS = frozenset(
     }
 )
 SUCCESS_TIMING_FIELDS = frozenset(
-    {"total_ms", "pass1_ms", "pass2_ms", "pass3_ms", "restore_ms", "post_policy_scan_ms"}
+    {"clean_ms", "restore_ms", "post_policy_scan_ms"}
 )
 SUCCESS_RESPONSE_FIELDS = frozenset(
     {
@@ -415,7 +415,7 @@ def _validate_manifest_integrity(value: object, context: str) -> None:
 def _validate_success_timing(value: object, context: str) -> None:
     timing = _expect_exact_keys(value, SUCCESS_TIMING_FIELDS, context)
     for field in SUCCESS_TIMING_FIELDS:
-        if field == "pass2_ms" and timing[field] is None:
+        if field == "post_policy_scan_ms" and timing[field] is None:
             continue
         _expect_number(timing[field], f"{context}.{field}")
 
@@ -1023,7 +1023,7 @@ def run_config(
     contract = ContractAccumulator()
     pipeline_errors: Counter[str] = Counter()
     pipeline_error_stages: Counter[str] = Counter()
-    timing: defaultdict[str, list[float]] = defaultdict(list)
+    success_timing: defaultdict[str, list[float]] = defaultdict(list)
     first_response_ms: float | None = None
 
     try:
@@ -1047,9 +1047,6 @@ def run_config(
             if "pipeline_error_code" in response:
                 pipeline_errors[str(response["pipeline_error_code"])] += 1
                 pipeline_error_stages[str(response["pipeline_error_stage"])] += 1
-                for key, value in response["timing"].items():
-                    if value is not None:
-                        timing[key].append(float(value))
                 continue
             predictions = final_trace_predictions(document, response)
             overall.add(document, predictions)
@@ -1069,7 +1066,7 @@ def run_config(
                 )
             for key, value in response["timing"].items():
                 if value is not None:
-                    timing[key].append(float(value))
+                    success_timing[key].append(float(value))
             if (index + 1) % 500 == 0:
                 print(
                     f"{config}: scored {index + 1}/{len(documents)} documents",
@@ -1083,6 +1080,13 @@ def run_config(
             raise RuntimeError(f"benchmark runner failed with status {return_code}")
 
     wall_seconds = time.perf_counter() - started
+    clean_ms = success_timing.get("clean_ms", [])
+    measured_clean_seconds = sum(clean_ms) / 1000.0
+    production_documents_per_second = (
+        len(clean_ms) / measured_clean_seconds
+        if clean_ms and measured_clean_seconds > 0.0
+        else None
+    )
     return {
         "config": config,
         "metrics": overall.result(),
@@ -1106,16 +1110,17 @@ def run_config(
             key: value.result() for key, value in sorted(per_label.items())
         },
         "latency_ms": {
-            key: timing_summary(value) for key, value in sorted(timing.items())
+            key: timing_summary(value)
+            for key, value in sorted(success_timing.items())
         },
         "warm_latency_ms": {
             key: timing_summary(value[1:])
-            for key, value in sorted(timing.items())
+            for key, value in sorted(success_timing.items())
             if len(value) > 1
         },
         "process": {
             "wall_seconds": wall_seconds,
-            "documents_per_second": len(documents) / wall_seconds,
+            "documents_per_second": production_documents_per_second,
             "start_to_first_response_ms": first_response_ms,
             "stderr_log": str(stderr_path.relative_to(repo_root)),
             "stderr_bytes": stderr_path.stat().st_size,

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -188,7 +188,8 @@ class ContractTests(unittest.TestCase):
                 "error_stages": {"safety_net": 1},
             },
         )
-        self.assertEqual(result["latency_ms"]["total_ms"]["median"], 1.25)
+        self.assertEqual(result["latency_ms"], {})
+        self.assertIsNone(result["process"]["documents_per_second"])
 
 
 class ResponseValidationTests(unittest.TestCase):
@@ -238,12 +239,9 @@ class ResponseValidationTests(unittest.TestCase):
                 "raw_value_mismatches": 0,
             },
             "timing": {
-                "total_ms": 1.0,
-                "pass1_ms": 0.1,
-                "pass2_ms": None,
-                "pass3_ms": 0.2,
+                "clean_ms": 1.0,
                 "restore_ms": 0.3,
-                "post_policy_scan_ms": 0.4,
+                "post_policy_scan_ms": None,
             },
             "final_protection_trace": [],
         }
@@ -308,6 +306,88 @@ class ResponseValidationTests(unittest.TestCase):
         response["manifest_integrity"]["spans"] = True
         with self.assertRaisesRegex(benchmark.ResponseValidationError, "expected an integer"):
             benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_requires_the_exact_ratified_fields(self) -> None:
+        response = self.success_response()
+        response["timing"]["total_ms"] = 1.0
+        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+            benchmark.validate_response(self.document(), response)
+
+        response = self.success_response()
+        response["timing"].pop("clean_ms")
+        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+            benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_only_allows_null_for_post_policy_scan(self) -> None:
+        benchmark.validate_response(self.document(), self.success_response())
+
+        for field in ("clean_ms", "restore_ms"):
+            with self.subTest(field=field):
+                response = self.success_response()
+                response["timing"][field] = None
+                with self.assertRaisesRegex(
+                    benchmark.ResponseValidationError, "expected a finite number"
+                ):
+                    benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_rejects_non_finite_boolean_and_negative_values(
+        self,
+    ) -> None:
+        for field in ("clean_ms", "restore_ms", "post_policy_scan_ms"):
+            for value in (True, -0.1, float("nan"), float("inf")):
+                with self.subTest(field=field, value=value):
+                    response = self.success_response()
+                    response["timing"][field] = value
+                    with self.assertRaises(benchmark.ResponseValidationError):
+                        benchmark.validate_response(self.document(), response)
+
+    def test_success_latency_and_throughput_use_measured_clean_ms_only(self) -> None:
+        first = self.success_response()
+        first["timing"] = {
+            "clean_ms": 2.0,
+            "restore_ms": 10.0,
+            "post_policy_scan_ms": None,
+        }
+        second = self.success_response()
+        second["timing"] = {
+            "clean_ms": 3.0,
+            "restore_ms": 20.0,
+            "post_policy_scan_ms": 7.0,
+        }
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(
+            "\n".join((json.dumps(first), json.dumps(second))) + "\n"
+        )
+        process.wait.return_value = 0
+        repo_root = Path(benchmark.__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
+            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+                result = benchmark.run_config(
+                    repo_root=repo_root,
+                    binary=Path(temporary) / "synthetic-runner",
+                    config="production-full-stack",
+                    documents=[self.document(), self.document()],
+                    model_dir=Path(temporary),
+                    kiji_model_dir=Path(temporary),
+                    opf_command=None,
+                    opf_checkpoint=None,
+                    opf_daemon_socket=None,
+                    threshold=0.5,
+                    diagnostics_dir=Path(temporary) / "diagnostics",
+                )
+
+        self.assertEqual(result["latency_ms"]["clean_ms"]["mean"], 2.5)
+        self.assertEqual(result["latency_ms"]["restore_ms"]["mean"], 15.0)
+        self.assertEqual(
+            result["latency_ms"]["post_policy_scan_ms"]["mean"], 7.0
+        )
+        self.assertNotIn("total_ms", result["latency_ms"])
+        self.assertNotIn("pass1_ms", result["latency_ms"])
+        self.assertNotIn("pass2_ms", result["latency_ms"])
+        self.assertNotIn("pass3_ms", result["latency_ms"])
+        self.assertEqual(result["process"]["documents_per_second"], 400.0)
 
     def test_unknown_pipeline_error_timing_field_fails_closed(self) -> None:
         response = {

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -313,6 +313,15 @@ class ResponseValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
             benchmark.validate_response(self.document(), response)
 
+        for field in ("pass1_ms", "pass2_ms", "pass3_ms"):
+            with self.subTest(field=field):
+                response = self.success_response()
+                response["timing"][field] = 1.0
+                with self.assertRaisesRegex(
+                    benchmark.ResponseValidationError, "unknown fields"
+                ):
+                    benchmark.validate_response(self.document(), response)
+
         response = self.success_response()
         response["timing"].pop("clean_ms")
         with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):


### PR DESCRIPTION
Summary
- Consumer-only bridge for the honest schema-v3 timing wire.
- Success timing now requires exactly {clean_ms, restore_ms, post_policy_scan_ms}; only post_policy_scan_ms may be null.
- Typed pipeline errors remain exactly {total_ms}.
- Successful latency output excludes error total_ms and legacy inferred pass fields. Production documents_per_second is derived only from measured clean_ms samples.
- Warmup/repetition counts, discarded warmups, and cold-start provenance stay deferred to A5.

Five axes
- Reliability: missing, unknown, boolean, negative, and non-finite success durations fail closed; typed failures cannot enter successful aggregates.
- Reversibility: restore_ms remains a direct measurement and the restore contract is unchanged.
- Agentic-first: producer and consumer now share one exact deterministic success wire.
- Trust: clean throughput comes only from observed clean_ms samples, with skipped scans represented as null instead of measured zero.
- Adopter ergonomics: the success timing object is smaller and names the production clean measurement directly.

No axis is weakened.

Boundary
- Only scripts/bench/gaze_bench_score.py and its active Python tests changed.
- No Rust, Cargo, OPF, CI, or out-of-scope documentation changes.
- This PR targets agent/no-opf-honest-timing-v3 for the master-authorized atomic staging migration.

Verification
- uv sync --project scripts/bench --locked
- uv run --project scripts/bench python -m unittest discover -s scripts/bench (47 tests, OK)

Resolves solo todo #2174