### PR TITLE
[agent] atomically promote honest timing wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "candle-core",
  "candle-onnx",
  "criterion",
+ "gaze-assembly",
  "gaze-pii",
  "gaze-types",
  "hex",

--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -5,9 +5,9 @@ use std::time::Instant;
 
 use gaze::{
     Action, CleanDocument, Context, EmittedTokenSpan, GazeLocalProtectionTraceItem, LeakKind,
-    LeakReportStats, LocaleChain, LocaleTag, NerPolicy, PiiClass, Pipeline, RawDocument, RuleSpec,
-    Rulepack, RulepackSource, SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
-    Scope, Session,
+    LeakReportStats, LocaleChain, LocaleTag, NerPolicy, PiiClass, Pipeline, RuleSpec, Rulepack,
+    RulepackSource, SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope,
+    Session,
 };
 use gaze_recognizers::embedded;
 use serde::{Deserialize, Serialize};
@@ -133,12 +133,9 @@ struct LeakSuspectSpan {
 
 #[derive(Debug, Serialize)]
 struct Timing {
-    total_ms: f64,
-    pass1_ms: f64,
-    pass2_ms: Option<f64>,
-    pass3_ms: f64,
+    clean_ms: f64,
     restore_ms: f64,
-    post_policy_scan_ms: f64,
+    post_policy_scan_ms: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -188,15 +185,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stdin = io::stdin();
     let mut stdout = io::BufWriter::new(io::stdout().lock());
     let full = build_pipeline(config)?;
-    let floor = build_pipeline(floor_config(config))?;
-    let pre_safety = if matches!(
-        config,
-        BenchConfig::FullStackKijiResolve | BenchConfig::FullStackOpfResolve
-    ) {
-        Some(build_pipeline(BenchConfig::Pass2Ner)?)
-    } else {
-        None
-    };
 
     for line in stdin.lock().lines() {
         let line = line?;
@@ -204,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
         let request: Request = serde_json::from_str(&line)?;
-        match handle_request(config, &full, &floor, pre_safety.as_ref(), request)? {
+        match handle_request(config, &full, request)? {
             Outcome::Success(response) => {
                 serde_json::to_writer(&mut stdout, &response)?;
                 stdout.write_all(b"\n")?;
@@ -227,8 +215,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn handle_request(
     config: BenchConfig,
     full: &Pipeline,
-    floor: &Pipeline,
-    pre_safety: Option<&Pipeline>,
     request: Request,
 ) -> Result<Outcome, Box<dyn std::error::Error>> {
     let locale_chain = request
@@ -238,7 +224,7 @@ fn handle_request(
         .collect::<Result<Vec<_>, _>>()?;
     let raw_text = request.text;
     let session = Session::new(Scope::Ephemeral)?;
-    let full_start = Instant::now();
+    let clean_start = Instant::now();
     let clean_result = full.clean_text_with_safety_net_policy_detect_context_and_protection_trace(
         &session,
         &raw_text,
@@ -246,7 +232,7 @@ fn handle_request(
         &Default::default(),
         safety_net_policy(config),
     );
-    let total_ms = full_start.elapsed().as_secs_f64() * 1000.0;
+    let clean_ms = clean_start.elapsed().as_secs_f64() * 1000.0;
     let (clean_doc, manifest, report, final_protection_trace) = match clean_result {
         Ok(result) => result,
         Err(error) => {
@@ -254,7 +240,7 @@ fn handle_request(
                 fixture_id: request.fixture_id,
                 stage: "clean",
                 code: pipeline_error_code(&error),
-                total_ms,
+                total_ms: clean_ms,
             });
         }
     };
@@ -276,11 +262,11 @@ fn handle_request(
         phase_execution_mask: restore_telemetry.phase_execution_mask,
     };
 
-    let post_policy_scan_start = Instant::now();
-    let post_policy_safety_net_stats = if matches!(
+    let (post_policy_safety_net_stats, post_policy_scan_ms) = if matches!(
         config,
         BenchConfig::FullStackKijiResolve | BenchConfig::FullStackOpfResolve
     ) {
+        let post_policy_scan_start = Instant::now();
         let post_policy = match full.scan_safety_nets(&session, &clean_text, &locale_chain) {
             Ok(result) => result,
             Err(error) => {
@@ -288,51 +274,18 @@ fn handle_request(
                     fixture_id: request.fixture_id,
                     stage: "post_policy_scan",
                     code: pipeline_error_code(&error),
-                    total_ms,
+                    total_ms: clean_ms,
                 });
             }
         };
-        Some(SafetyNetStats::from(&post_policy.report.stats))
+        let post_policy_scan_ms = post_policy_scan_start.elapsed().as_secs_f64() * 1000.0;
+        (
+            Some(SafetyNetStats::from(&post_policy.report.stats)),
+            Some(post_policy_scan_ms),
+        )
     } else {
-        None
+        (None, None)
     };
-    let post_policy_scan_ms = post_policy_scan_start.elapsed().as_secs_f64() * 1000.0;
-
-    let floor_session = Session::new(Scope::Ephemeral)?;
-    let floor_start = Instant::now();
-    let _ = floor.clean_with_safety_net_policy_detect_context(
-        &floor_session,
-        RawDocument::Text(raw_text.clone()),
-        &locale_chain,
-        &Default::default(),
-        SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
-    )?;
-    let pass1_ms = floor_start.elapsed().as_secs_f64() * 1000.0;
-
-    let (pre_safety_text_len, pre_safety_manifest_spans, pre_safety_ms) =
-        if let Some(pre_safety_pipeline) = pre_safety {
-            let pre_safety_session = Session::new(Scope::Ephemeral)?;
-            let pre_safety_start = Instant::now();
-            let (pre_safety_doc, pre_safety_manifest, _) = pre_safety_pipeline
-                .clean_with_safety_net_policy_detect_context(
-                    &pre_safety_session,
-                    RawDocument::Text(raw_text.clone()),
-                    &locale_chain,
-                    &Default::default(),
-                    SafetyNetPolicy::new(SafetyNetMode::Strict, SafetyNetFallback::Redact),
-                )?;
-            let elapsed = pre_safety_start.elapsed().as_secs_f64() * 1000.0;
-            let CleanDocument::Text(pre_safety_text) = pre_safety_doc else {
-                return Err("expected text pre-safety document".into());
-            };
-            (
-                Some(pre_safety_text.len()),
-                Some(serialize_manifest(pre_safety_manifest)),
-                Some(elapsed),
-            )
-        } else {
-            (None, None, None)
-        };
 
     let manifest_spans = serialize_manifest(manifest);
     let final_protection_trace = serialize_final_protection_trace(final_protection_trace);
@@ -361,8 +314,8 @@ fn handle_request(
         fixture_id: request.fixture_id,
         clean_text,
         manifest_spans,
-        pre_safety_text_len,
-        pre_safety_manifest_spans,
+        pre_safety_text_len: None,
+        pre_safety_manifest_spans: None,
         leak_suspects,
         safety_net_mode: safety_net_mode_name(safety_net_policy(config).mode).to_string(),
         strict_would_reject,
@@ -371,29 +324,7 @@ fn handle_request(
         restore,
         manifest_integrity: integrity,
         timing: Timing {
-            total_ms,
-            pass1_ms,
-            pass2_ms: if matches!(
-                config,
-                BenchConfig::FullStackKijiResolve | BenchConfig::FullStackOpfResolve
-            ) {
-                pre_safety_ms.map(|elapsed| (elapsed - pass1_ms).max(0.0))
-            } else {
-                (config == BenchConfig::Pass2Ner).then_some((total_ms - pass1_ms).max(0.0))
-            },
-            pass3_ms: match config {
-                BenchConfig::RuleFloorCore
-                | BenchConfig::RuleFloorExtended
-                | BenchConfig::Pass2Ner => 0.0,
-                BenchConfig::FullStackKijiResolve | BenchConfig::FullStackOpfResolve => {
-                    pre_safety_ms
-                        .map(|elapsed| (total_ms - elapsed).max(0.0))
-                        .unwrap_or(0.0)
-                }
-                BenchConfig::Pass3Kiji | BenchConfig::Pass3Opf | BenchConfig::Pass3LocaleAware => {
-                    (total_ms - pass1_ms).max(0.0)
-                }
-            },
+            clean_ms,
             restore_ms,
             post_policy_scan_ms,
         },
@@ -482,19 +413,6 @@ fn parse_config() -> Result<BenchConfig, Box<dyn std::error::Error>> {
         }
     }
     Ok(config)
-}
-
-fn floor_config(config: BenchConfig) -> BenchConfig {
-    match config {
-        BenchConfig::RuleFloorCore => BenchConfig::RuleFloorCore,
-        BenchConfig::RuleFloorExtended
-        | BenchConfig::Pass2Ner
-        | BenchConfig::FullStackKijiResolve
-        | BenchConfig::FullStackOpfResolve
-        | BenchConfig::Pass3Kiji
-        | BenchConfig::Pass3Opf
-        | BenchConfig::Pass3LocaleAware => BenchConfig::RuleFloorExtended,
-    }
 }
 
 fn build_pipeline(config: BenchConfig) -> Result<Pipeline, BenchmarkBuildError> {
@@ -923,22 +841,51 @@ fn manifest_integrity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gaze::RawDocument;
 
     fn rule_floor_response(fixture_id: &str, locale: &str, text: &str) -> Response {
         let config = BenchConfig::RuleFloorExtended;
         let full = build_pipeline(config).expect("rule-floor-extended pipeline should build");
-        let floor = build_pipeline(floor_config(config)).expect("floor pipeline should build");
         let request = Request {
             fixture_id: fixture_id.to_string(),
             locale_chain: vec![locale.to_string()],
             text: text.to_string(),
         };
 
-        match handle_request(config, &full, &floor, None, request)
-            .expect("synthetic request should be handled")
-        {
+        match handle_request(config, &full, request).expect("synthetic request should be handled") {
             Outcome::Success(response) => response,
             outcome => panic!("expected a success response, got {outcome:?}"),
+        }
+    }
+
+    fn assert_success_timing_contract(response: &Response, expects_post_policy_scan: bool) {
+        let serialized = serde_json::to_value(response).expect("response should serialize");
+        let timing = serialized
+            .get("timing")
+            .and_then(serde_json::Value::as_object)
+            .expect("response should contain a timing object");
+        assert_eq!(timing.len(), 3);
+        for field in ["clean_ms", "restore_ms", "post_policy_scan_ms"] {
+            assert!(timing.contains_key(field), "missing timing field {field}");
+        }
+        for field in ["clean_ms", "restore_ms"] {
+            let value = timing[field]
+                .as_f64()
+                .unwrap_or_else(|| panic!("timing field {field} should be a number"));
+            assert!(value.is_finite(), "timing field {field} should be finite");
+            assert!(value >= 0.0, "timing field {field} should be nonnegative");
+        }
+        if expects_post_policy_scan {
+            let value = timing["post_policy_scan_ms"]
+                .as_f64()
+                .expect("executed post-policy scan timing should be a number");
+            assert!(value.is_finite());
+            assert!(value >= 0.0);
+        } else {
+            assert_eq!(
+                timing.get("post_policy_scan_ms"),
+                Some(&serde_json::Value::Null)
+            );
         }
     }
 
@@ -960,6 +907,8 @@ mod tests {
         assert!(!response.clean_text.contains(clean_protected_value));
         assert!(response.restore.exact);
         assert_eq!(response.safety_net_mode, "strict");
+        assert!(response.pre_safety_text_len.is_none());
+        assert!(response.pre_safety_manifest_spans.is_none());
 
         let integrity = &response.manifest_integrity;
         assert!(integrity.spans >= 1);
@@ -970,22 +919,9 @@ mod tests {
         assert_eq!(integrity.overlapping_clean_spans, 0);
         assert_eq!(integrity.non_monotonic_raw_spans, 0);
 
+        assert_success_timing_contract(response, false);
+
         let serialized = serde_json::to_value(response).expect("response should serialize");
-        let timing = serialized
-            .get("timing")
-            .and_then(serde_json::Value::as_object)
-            .expect("response should contain a timing object");
-        assert_eq!(timing.len(), 6);
-        for field in [
-            "total_ms",
-            "pass1_ms",
-            "pass2_ms",
-            "pass3_ms",
-            "restore_ms",
-            "post_policy_scan_ms",
-        ] {
-            assert!(timing.contains_key(field), "missing timing field {field}");
-        }
 
         let trace_value = serialized
             .get("final_protection_trace")
@@ -1319,21 +1255,20 @@ mod tests {
     fn kiji_response_contract_records_restore_and_manifest_debt() {
         let config = BenchConfig::FullStackKijiResolve;
         let full = build_pipeline(config).expect("full Kiji pipeline should build from model env");
-        let floor = build_pipeline(floor_config(config)).expect("floor pipeline should build");
-        let pre_safety =
-            build_pipeline(BenchConfig::Pass2Ner).expect("pre-safety NER pipeline should build");
         let request = Request {
             fixture_id: "de-kiji-debt-1".to_string(),
             locale_chain: vec!["de".to_string()],
             text: "Bitte an dr.schmidt@example.invalid schreiben, Tel. +49 1555 0112233."
                 .to_string(),
         };
-        let response = match handle_request(config, &full, &floor, Some(&pre_safety), request)
-            .expect("Kiji request should be handled")
-        {
-            Outcome::Success(response) => response,
-            outcome => panic!("expected a Kiji response, got {outcome:?}"),
-        };
+        let response =
+            match handle_request(config, &full, request).expect("Kiji request should be handled") {
+                Outcome::Success(response) => response,
+                outcome => panic!("expected a Kiji response, got {outcome:?}"),
+            };
+        assert_success_timing_contract(&response, true);
+        assert!(response.pre_safety_text_len.is_none());
+        assert!(response.pre_safety_manifest_spans.is_none());
 
         // Recorded baseline debt (~69.46% exact restore, ~36.85% valid manifest): false
         // restore.exact and non-zero integrity violations are debt signals, not expected-good.

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -352,7 +352,7 @@ MANIFEST_INTEGRITY_FIELDS = frozenset(
     }
 )
 SUCCESS_TIMING_FIELDS = frozenset(
-    {"total_ms", "pass1_ms", "pass2_ms", "pass3_ms", "restore_ms", "post_policy_scan_ms"}
+    {"clean_ms", "restore_ms", "post_policy_scan_ms"}
 )
 SUCCESS_RESPONSE_FIELDS = frozenset(
     {
@@ -415,7 +415,7 @@ def _validate_manifest_integrity(value: object, context: str) -> None:
 def _validate_success_timing(value: object, context: str) -> None:
     timing = _expect_exact_keys(value, SUCCESS_TIMING_FIELDS, context)
     for field in SUCCESS_TIMING_FIELDS:
-        if field == "pass2_ms" and timing[field] is None:
+        if field == "post_policy_scan_ms" and timing[field] is None:
             continue
         _expect_number(timing[field], f"{context}.{field}")
 
@@ -1023,7 +1023,7 @@ def run_config(
     contract = ContractAccumulator()
     pipeline_errors: Counter[str] = Counter()
     pipeline_error_stages: Counter[str] = Counter()
-    timing: defaultdict[str, list[float]] = defaultdict(list)
+    success_timing: defaultdict[str, list[float]] = defaultdict(list)
     first_response_ms: float | None = None
 
     try:
@@ -1047,9 +1047,6 @@ def run_config(
             if "pipeline_error_code" in response:
                 pipeline_errors[str(response["pipeline_error_code"])] += 1
                 pipeline_error_stages[str(response["pipeline_error_stage"])] += 1
-                for key, value in response["timing"].items():
-                    if value is not None:
-                        timing[key].append(float(value))
                 continue
             predictions = final_trace_predictions(document, response)
             overall.add(document, predictions)
@@ -1069,7 +1066,7 @@ def run_config(
                 )
             for key, value in response["timing"].items():
                 if value is not None:
-                    timing[key].append(float(value))
+                    success_timing[key].append(float(value))
             if (index + 1) % 500 == 0:
                 print(
                     f"{config}: scored {index + 1}/{len(documents)} documents",
@@ -1083,6 +1080,13 @@ def run_config(
             raise RuntimeError(f"benchmark runner failed with status {return_code}")
 
     wall_seconds = time.perf_counter() - started
+    clean_ms = success_timing.get("clean_ms", [])
+    measured_clean_seconds = sum(clean_ms) / 1000.0
+    production_documents_per_second = (
+        len(clean_ms) / measured_clean_seconds
+        if clean_ms and measured_clean_seconds > 0.0
+        else None
+    )
     return {
         "config": config,
         "metrics": overall.result(),
@@ -1106,16 +1110,17 @@ def run_config(
             key: value.result() for key, value in sorted(per_label.items())
         },
         "latency_ms": {
-            key: timing_summary(value) for key, value in sorted(timing.items())
+            key: timing_summary(value)
+            for key, value in sorted(success_timing.items())
         },
         "warm_latency_ms": {
             key: timing_summary(value[1:])
-            for key, value in sorted(timing.items())
+            for key, value in sorted(success_timing.items())
             if len(value) > 1
         },
         "process": {
             "wall_seconds": wall_seconds,
-            "documents_per_second": len(documents) / wall_seconds,
+            "documents_per_second": production_documents_per_second,
             "start_to_first_response_ms": first_response_ms,
             "stderr_log": str(stderr_path.relative_to(repo_root)),
             "stderr_bytes": stderr_path.stat().st_size,

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -188,7 +188,8 @@ class ContractTests(unittest.TestCase):
                 "error_stages": {"safety_net": 1},
             },
         )
-        self.assertEqual(result["latency_ms"]["total_ms"]["median"], 1.25)
+        self.assertEqual(result["latency_ms"], {})
+        self.assertIsNone(result["process"]["documents_per_second"])
 
 
 class ResponseValidationTests(unittest.TestCase):
@@ -238,12 +239,9 @@ class ResponseValidationTests(unittest.TestCase):
                 "raw_value_mismatches": 0,
             },
             "timing": {
-                "total_ms": 1.0,
-                "pass1_ms": 0.1,
-                "pass2_ms": None,
-                "pass3_ms": 0.2,
+                "clean_ms": 1.0,
                 "restore_ms": 0.3,
-                "post_policy_scan_ms": 0.4,
+                "post_policy_scan_ms": None,
             },
             "final_protection_trace": [],
         }
@@ -308,6 +306,97 @@ class ResponseValidationTests(unittest.TestCase):
         response["manifest_integrity"]["spans"] = True
         with self.assertRaisesRegex(benchmark.ResponseValidationError, "expected an integer"):
             benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_requires_the_exact_ratified_fields(self) -> None:
+        response = self.success_response()
+        response["timing"]["total_ms"] = 1.0
+        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+            benchmark.validate_response(self.document(), response)
+
+        for field in ("pass1_ms", "pass2_ms", "pass3_ms"):
+            with self.subTest(field=field):
+                response = self.success_response()
+                response["timing"][field] = 1.0
+                with self.assertRaisesRegex(
+                    benchmark.ResponseValidationError, "unknown fields"
+                ):
+                    benchmark.validate_response(self.document(), response)
+
+        response = self.success_response()
+        response["timing"].pop("clean_ms")
+        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+            benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_only_allows_null_for_post_policy_scan(self) -> None:
+        benchmark.validate_response(self.document(), self.success_response())
+
+        for field in ("clean_ms", "restore_ms"):
+            with self.subTest(field=field):
+                response = self.success_response()
+                response["timing"][field] = None
+                with self.assertRaisesRegex(
+                    benchmark.ResponseValidationError, "expected a finite number"
+                ):
+                    benchmark.validate_response(self.document(), response)
+
+    def test_success_timing_rejects_non_finite_boolean_and_negative_values(
+        self,
+    ) -> None:
+        for field in ("clean_ms", "restore_ms", "post_policy_scan_ms"):
+            for value in (True, -0.1, float("nan"), float("inf")):
+                with self.subTest(field=field, value=value):
+                    response = self.success_response()
+                    response["timing"][field] = value
+                    with self.assertRaises(benchmark.ResponseValidationError):
+                        benchmark.validate_response(self.document(), response)
+
+    def test_success_latency_and_throughput_use_measured_clean_ms_only(self) -> None:
+        first = self.success_response()
+        first["timing"] = {
+            "clean_ms": 2.0,
+            "restore_ms": 10.0,
+            "post_policy_scan_ms": None,
+        }
+        second = self.success_response()
+        second["timing"] = {
+            "clean_ms": 3.0,
+            "restore_ms": 20.0,
+            "post_policy_scan_ms": 7.0,
+        }
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(
+            "\n".join((json.dumps(first), json.dumps(second))) + "\n"
+        )
+        process.wait.return_value = 0
+        repo_root = Path(benchmark.__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
+            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+                result = benchmark.run_config(
+                    repo_root=repo_root,
+                    binary=Path(temporary) / "synthetic-runner",
+                    config="production-full-stack",
+                    documents=[self.document(), self.document()],
+                    model_dir=Path(temporary),
+                    kiji_model_dir=Path(temporary),
+                    opf_command=None,
+                    opf_checkpoint=None,
+                    opf_daemon_socket=None,
+                    threshold=0.5,
+                    diagnostics_dir=Path(temporary) / "diagnostics",
+                )
+
+        self.assertEqual(result["latency_ms"]["clean_ms"]["mean"], 2.5)
+        self.assertEqual(result["latency_ms"]["restore_ms"]["mean"], 15.0)
+        self.assertEqual(
+            result["latency_ms"]["post_policy_scan_ms"]["mean"], 7.0
+        )
+        self.assertNotIn("total_ms", result["latency_ms"])
+        self.assertNotIn("pass1_ms", result["latency_ms"])
+        self.assertNotIn("pass2_ms", result["latency_ms"])
+        self.assertNotIn("pass3_ms", result["latency_ms"])
+        self.assertEqual(result["process"]["documents_per_second"], 400.0)
 
     def test_unknown_pipeline_error_timing_field_fails_closed(self) -> None:
         response = {


### PR DESCRIPTION
Summary
- Promote the independently reviewed Rust producer (#377) and Python consumer (#378) together, so public integration never contains a half-migrated schema-v3 timing wire.
- Success timing is now exactly {clean_ms, restore_ms, post_policy_scan_ms}; only post_policy_scan_ms may be null.
- Typed pipeline-error timing stays exactly {total_ms}.
- Remove inferred pass timings and the auxiliary floor/pre-safety executions from production request handling. Successful throughput now uses measured clean_ms only.
- Add the one missing Cargo.lock edge for the gaze-recognizers -> gaze-assembly dev-dependency introduced in B2. This was required for the committed workspace to pass cargo --locked.

Five-axis evaluation
- Reliability: producer and consumer move as one change; missing, legacy, boolean, negative, and non-finite success timings fail closed.
- Reversibility: restore behavior and the direct restore_ms measurement are unchanged.
- Agentic-first: each benchmark cell reports the selected production clean call without auxiliary verification work in its throughput sample.
- Trust: inferred pass1/pass2/pass3 values are gone, skipped post-policy scans are null, and the error wire remains separately validated.
- Adopter ergonomics: the success timing object is smaller and names the measured work directly.

No axis is weakened.

Verification
- cargo fmt --all -- --check
- cargo test --locked -p gaze-recognizers --example clean_for_bench
- cargo test --locked -p gaze-pii --test safety_net
- cargo test --locked -p gaze-assembly
- cargo test --locked -p gaze-recognizers --features safety-net-kiji
- cargo clippy --locked --workspace --all-features --all-targets -- -D warnings
- uv sync --project scripts/bench --locked
- uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py' (47 tests, OK)
- Direct exact-key inspection of success and error response validators

Boundary
- Combined diff: clean_for_bench.rs, gaze_bench_score.py, its active tests, and the mechanical Cargo.lock dependency edge.
- No stable public API or shared-type change.
- OPF was neither changed nor run.
- Warmup, repetitions, and external cold-start provenance remain A5 work.

Resolves solo todo #2175
Resolves solo todo #2165
