### PR TITLE
[agent] add canonical local no-OPF benchmark runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,21 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --all-features --no-fail-fast
 
+  benchmark-model-free:
+    name: benchmark model-free Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: 0.11.16
+          enable-cache: true
+          cache-dependency-glob: scripts/bench/uv.lock
+      - name: Sync locked benchmark environment
+        run: uv sync --project scripts/bench --locked
+      - name: Run benchmark scorer and comparator tests
+        run: uv run --project scripts/bench python -m unittest discover -s scripts/bench
+
   xtask-gates:
     name: xtask gates
     runs-on: ubuntu-latest

--- a/docs/reference/benchmarks/README.md
+++ b/docs/reference/benchmarks/README.md
@@ -46,10 +46,12 @@ Gaze path: deterministic recognizers, Pass 2 NER, Kiji SafetyNet discovery,
 Resolve promotion, fallback, exact restore, manifest integrity, post-policy
 scan, precision, and warm latency.
 
-Runnable path:
+Canonical local paths:
 
 ```bash
-uv run --with pyarrow scripts/bench/dataiku_en_de_gaze_bench.py --no-download
+uv sync --project scripts/bench --locked
+uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py quick --no-download
+uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py full --no-download --compare-baseline target/bench-data/no-opf/baseline.json
 ```
 
 The first run may omit `--no-download`; the runner fetches and verifies the
@@ -62,13 +64,29 @@ Evidence paths:
 | Dataset and scoring contract | `docs/reference/benchmarks/dataiku-en-de-holdout.md` |
 | Current whole-pipeline baseline | `docs/reference/benchmarks/v0.12-en-de-whole-pipeline-baseline.md` |
 | Warm OpenAI Privacy Filter sample | `docs/reference/benchmarks/v0.12-opf-daemon-sample.md` |
-| Benchmark runner | `scripts/bench/dataiku_en_de_gaze_bench.py` |
+| Canonical benchmark runner | `scripts/bench/run_no_opf_benchmark.py` |
+| Runner contract and outputs | `scripts/bench/README.md` |
 | Dataset revision | `DataikuNLP/kiji-pii-training-data@0275550f0b1f1b8f2dc9356fd31ac1c788b8228b` |
 | Test-file SHA256 | `916c63792345bf3c2e0888941b3d14526c43b7c7fe8af60e0d283fed71b1234d` |
 
-The upstream test split is reserved from training. It has no negative-only
-documents, so it remains one layer of the release gate rather than a complete
-PII evaluation.
+The upstream test split is reserved from training. The canonical runner pairs
+its complete English/German selection with the complete committed A4 EN/DE
+negative corpus at
+`crates/xtask/fixtures/negative_corpus/en_de_negative.jsonl`. Quick runs use the
+scorer's seeded stratified sampler; full runs use the complete combined corpus.
+
+The runner writes a schema-v3 scorecard, Markdown summary, per-language,
+per-label, and per-negative-category diagnostics, plus separate machine-readable
+regression and release-readiness verdicts under ignored
+`target/bench-data/no-opf/`. Regression uses zero-tolerance integer-count
+ratchets. Release readiness is an independent candidate-only verdict.
+Performance tolerance is separately configured and informational by default.
+
+Required model bundles are verified before any cell starts. Warmups, measured
+repetitions, discarded warmup samples, and external cold-start to the first
+validated response are Python-runner provenance; response latency consumes the
+producer's honest `clean_ms`. See `scripts/bench/README.md` for model locations,
+planning runtime, output details, and the guarded baseline-acceptance command.
 
 The optional OPF cell is intentionally not part of the default run. It requires
 a verified 2.6 GB checkpoint and a warmed local daemon, and it currently has a

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,127 @@
+# Gaze benchmark scripts
+
+The one canonical local regression entry point is:
+
+```bash
+scripts/bench/run_no_opf_benchmark.py
+```
+
+The other files in this directory are scorer, producer, or specialized research
+components. They are not alternate release-regression entry points.
+
+## Setup and profiles
+
+Create the locked Python environment once:
+
+```bash
+uv sync --project scripts/bench --locked
+```
+
+Use `quick` while developing. It takes a seeded, deterministic stratified
+sample through `gaze_bench_score.stratified_sample`:
+
+```bash
+uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py \
+  quick --seed 20260710 --no-download
+```
+
+Use `full` for a local release candidate. It evaluates every English/German
+document selected from the pinned Dataiku test split and all 1,024 committed A4
+negative fixtures:
+
+```bash
+uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py \
+  full --seed 20260710 --no-download \
+  --compare-baseline target/bench-data/no-opf/baseline.json
+```
+
+Omit `--no-download` on the first run to fetch and SHA-256 verify the pinned
+Dataiku Parquet file. Both profiles use only `rule-floor-extended`, `pass2-ner`,
+and `full-stack-kiji-resolve`. The runner removes OPF environment variables and
+passes no OPF command, checkpoint, or daemon socket, even if the invoking shell
+defines them.
+
+Planning estimates on a modern laptop are roughly 2–10 minutes for the default
+256-document quick profile and 30–120 minutes per measured full repetition.
+Thermals, CPU runtime, and filesystem cache state can move those estimates
+substantially; A6 records the authoritative observed runtime.
+
+## Required local models
+
+The runner validates both model bundles before it builds or starts a benchmark
+cell. Missing or mismatched bytes are typed, actionable failures; no cell is
+silently skipped.
+
+| Model | Default location | Pin source | Validation |
+| --- | --- | --- | --- |
+| Davlan multilingual BERT NER | `~/.local/share/gaze/models/davlan-mbert-ner-hrl` | `davlan-bert-multilingual.bundle_sha` in `crates/gaze-recognizers/benches/ner_models.toml` | SHA-256 over the complete deterministic file tree |
+| Kiji DistilBERT | `~/.local/share/gaze/models/kiji-distilbert` | `kiji-distilbert.bundle_sha` in the same TOML | pinned `SHA256SUMS` digest, then every listed artifact digest |
+
+Override locations with `--model-dir` and `--kiji-model-dir`. The runner rejects
+symlinks in validated bundle material.
+
+## Outputs and verdicts
+
+Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
+
+| Artifact | Purpose |
+| --- | --- |
+| `scorecard-v3.json` | full schema-v3 scorecard and runner provenance |
+| `summary.md` | concise human-readable result |
+| `diagnostics.json` | per-language, per-label, and per-negative-category diagnostics |
+| `regression-status.json` | baseline-relative integer-count ratchet verdict |
+| `release-readiness-status.json` | candidate-only absolute correctness verdict |
+| `performance-status.json` | separately configured p95 `clean_ms` comparison |
+| `logs/` | subprocess stderr by repetition and config |
+
+Regression and release readiness are deliberately independent. Regression uses
+integer counts with zero tolerance and fails closed on missing, empty, invalid,
+or population-mismatched candidates. Release readiness checks the production
+candidate cell itself: no leaked labeled bytes, uncovered entities, pipeline
+failures, restore failures, invalid manifests, telemetry disagreement,
+unscanned documents, residual suspects, or redact actions. A full command exits
+nonzero for either correctness failure.
+
+A quick result is always marked not release-ready because it samples the
+population. Quick exits successfully when that incompleteness is its only
+readiness failure, but any observed correctness failure still exits nonzero.
+
+Performance compares `timing.clean_ms.p95` with
+`--performance-tolerance-percent` and is informational by default. Add
+`--performance-gating` only for an explicitly reviewed performance gate.
+Warmup count, measured-repetition count, every discarded warmup sample, and
+external process/model cold-start-to-first-validated-response are recorded in
+`runner_provenance`. Cold start is separate from Rust response timing.
+
+## Baseline acceptance
+
+Baseline replacement has three guards: a full profile, an exact review
+confirmation, and a release-ready candidate. Replacing an existing file also
+requires a regression-clean comparison against that same file.
+
+```bash
+uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py \
+  full --no-download \
+  --compare-baseline target/bench-data/no-opf/baseline.json \
+  --accept-baseline target/bench-data/no-opf/baseline.json \
+  --accept-baseline-confirm I_HAVE_REVIEWED_FULL_RESULTS
+```
+
+Review `scorecard-v3.json`, all three status files, `diagnostics.json`, and the
+stderr logs before using that command. Quick results and failed candidates can
+never replace a baseline.
+
+To initialize a baseline only when the target does not yet exist, omit
+`--compare-baseline` but keep the full profile and exact confirmation. The
+runner refuses to overwrite an existing file through this initialization path.
+
+## Model-free verification
+
+Normal CI runs only the locked Python tests:
+
+```bash
+uv run --project scripts/bench python -m unittest discover -s scripts/bench
+```
+
+CI does not download models or run either benchmark profile. The authoritative
+full model run and baseline/error-bucket analysis belong to A6.

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -78,6 +78,7 @@ class Document:
     region: str
     source_dataset: str
     spans: tuple[Span, ...]
+    negative_category: str | None = None
 
     @property
     def locale_chain(self) -> list[str]:
@@ -985,8 +986,14 @@ def run_config(
     opf_daemon_socket: Path | None,
     threshold: float,
     diagnostics_dir: Path,
+    base_environment: Mapping[str, str] | None = None,
+    warmup_count: int = 0,
 ) -> dict[str, object]:
-    environment = os.environ.copy()
+    if not documents:
+        raise ValueError(f"{config}: cannot run an empty document cell")
+    if warmup_count < 0:
+        raise ValueError("warmup_count must be non-negative")
+    environment = dict(base_environment) if base_environment is not None else os.environ.copy()
     environment["GAZE_NER_MODEL_DIR"] = str(model_dir)
     environment["GAZE_NER_THRESHOLD"] = str(threshold)
     environment["GAZE_KIJI_DISTILBERT_MODEL_DIR"] = str(kiji_model_dir)
@@ -1018,6 +1025,9 @@ def run_config(
     overall = MetricAccumulator()
     per_language: defaultdict[str, MetricAccumulator] = defaultdict(MetricAccumulator)
     per_label: defaultdict[str, RecallAccumulator] = defaultdict(RecallAccumulator)
+    per_negative_category: defaultdict[str, MetricAccumulator] = defaultdict(
+        MetricAccumulator
+    )
     direct = RecallAccumulator()
     contextual = RecallAccumulator()
     contract = ContractAccumulator()
@@ -1025,25 +1035,103 @@ def run_config(
     pipeline_error_stages: Counter[str] = Counter()
     success_timing: defaultdict[str, list[float]] = defaultdict(list)
     first_response_ms: float | None = None
+    discarded_warmup_samples: list[dict[str, object]] = []
+
+    def exchange(document: Document) -> tuple[dict[str, object], float]:
+        nonlocal first_response_ms
+        request = {
+            "fixture_id": document.uid,
+            "locale_chain": document.locale_chain,
+            "text": document.text,
+        }
+        request_started = time.perf_counter()
+        process.stdin.write(json.dumps(request, ensure_ascii=False) + "\n")
+        process.stdin.flush()
+        response_line = process.stdout.readline()
+        if not response_line:
+            return_code = process.poll()
+            raise RuntimeError(
+                f"benchmark runner exited before {document.uid}; status={return_code}"
+            )
+        response = validate_response(document, json.loads(response_line))
+        validated_at = time.perf_counter()
+        if first_response_ms is None:
+            first_response_ms = (validated_at - started) * 1000.0
+        return response, (validated_at - request_started) * 1000.0
 
     try:
-        for index, document in enumerate(documents):
-            request = {
-                "fixture_id": document.uid,
-                "locale_chain": document.locale_chain,
-                "text": document.text,
-            }
-            process.stdin.write(json.dumps(request, ensure_ascii=False) + "\n")
-            process.stdin.flush()
-            response_line = process.stdout.readline()
-            if not response_line:
-                return_code = process.poll()
+        for warmup_index in range(warmup_count):
+            warmup_document = documents[warmup_index % len(documents)]
+            response, round_trip_ms = exchange(warmup_document)
+            if "pipeline_error_code" in response:
                 raise RuntimeError(
-                    f"benchmark runner exited before {document.uid}; status={return_code}"
+                    f"{config}: warmup {warmup_index + 1} failed closed with "
+                    f"{response['pipeline_error_code']} at "
+                    f"{response['pipeline_error_stage']}"
                 )
-            if first_response_ms is None:
-                first_response_ms = (time.perf_counter() - started) * 1000.0
-            response = validate_response(document, json.loads(response_line))
+            timing = response["timing"]
+            assert isinstance(timing, dict)
+            warmup_metrics = MetricAccumulator()
+            warmup_metrics.add(
+                warmup_document,
+                final_trace_predictions(warmup_document, response),
+            )
+            warmup_contract = ContractAccumulator()
+            warmup_contract.add(response)
+            metric_result = warmup_metrics.result()
+            contract_result = warmup_contract.result()
+            warmup_correctness = {
+                "leaked_labeled_utf8_bytes": metric_result["utf8_bytes"]["leaked"],
+                "uncovered_entities": (
+                    metric_result["entities"]["gold"]
+                    - metric_result["entities"]["fully_covered"]
+                ),
+                "restore_failures": 1
+                - contract_result["restore_exact_documents"],
+                "manifest_invalid_documents": 1
+                - contract_result["manifest_valid_documents"],
+                "strict_rejections": contract_result[
+                    "strict_would_reject_documents"
+                ],
+                "residual_suspects": contract_result["post_policy_suspects"],
+                "redact_actions": contract_result["redact_actions"],
+            }
+            universal_warmup_gates = (
+                "restore_failures",
+                "manifest_invalid_documents",
+            )
+            production_warmup_gates = (
+                "leaked_labeled_utf8_bytes",
+                "uncovered_entities",
+                "strict_rejections",
+                "residual_suspects",
+                "redact_actions",
+            )
+            gated = universal_warmup_gates + (
+                production_warmup_gates if config == PRODUCTION_CONFIG else ()
+            )
+            failures = {
+                gate: warmup_correctness[gate]
+                for gate in gated
+                if warmup_correctness[gate] != 0
+            }
+            if failures:
+                raise RuntimeError(
+                    f"{config}: discarded warmup {warmup_index + 1} failed "
+                    f"correctness gates: {failures}"
+                )
+            discarded_warmup_samples.append(
+                {
+                    "sample": warmup_index + 1,
+                    "round_trip_ms": round_trip_ms,
+                    "clean_ms": timing["clean_ms"],
+                    "restore_ms": timing["restore_ms"],
+                    "post_policy_scan_ms": timing["post_policy_scan_ms"],
+                    "correctness": warmup_correctness,
+                }
+            )
+        for index, document in enumerate(documents):
+            response, _ = exchange(document)
             if "pipeline_error_code" in response:
                 pipeline_errors[str(response["pipeline_error_code"])] += 1
                 pipeline_error_stages[str(response["pipeline_error_stage"])] += 1
@@ -1051,6 +1139,10 @@ def run_config(
             predictions = final_trace_predictions(document, response)
             overall.add(document, predictions)
             per_language[document.language].add(document, predictions)
+            if document.negative_category is not None:
+                per_negative_category[document.negative_category].add(
+                    document, predictions
+                )
             direct_spans = [
                 span for span in document.spans if span.label in DIRECT_IDENTIFIER_LABELS
             ]
@@ -1109,6 +1201,10 @@ def run_config(
         "per_label_recall": {
             key: value.result() for key, value in sorted(per_label.items())
         },
+        "per_negative_category": {
+            key: value.result()
+            for key, value in sorted(per_negative_category.items())
+        },
         "latency_ms": {
             key: timing_summary(value)
             for key, value in sorted(success_timing.items())
@@ -1122,6 +1218,9 @@ def run_config(
             "wall_seconds": wall_seconds,
             "documents_per_second": production_documents_per_second,
             "start_to_first_response_ms": first_response_ms,
+            "cold_start_to_first_validated_response_ms": first_response_ms,
+            "warmup_count": warmup_count,
+            "discarded_warmup_samples": discarded_warmup_samples,
             "stderr_log": str(stderr_path.relative_to(repo_root)),
             "stderr_bytes": stderr_path.stat().st_size,
         },
@@ -1168,17 +1267,16 @@ SCORING_METADATA: dict[str, object] = {
         "Latency is considered only after correctness gates pass.",
     ],
     "comparison_gates": {
-        "pipeline_completion_rate": "must equal 1.0 for release readiness; no regression",
-        "leaked_labeled_utf8_bytes": "must equal 0 for release readiness; no regression",
-        "full_entity_coverage_recall": "must equal 1.0 for release readiness; no regression",
-        "zero_leak_document_rate": "must equal 1.0 for release readiness; no regression",
-        "restore_exact_rate": "must equal 1.0 for release readiness; no regression",
-        "manifest_valid_document_rate": "must equal 1.0 for release readiness; no regression",
-        "strict_rejections": "must equal 0 for release readiness; no regression",
-        "residual_suspects": "must equal 0 for release readiness; no regression",
-        "redact_actions": "must equal 0 for exact-reversibility readiness; no regression",
-        "byte_precision": "no regression without explicit review",
-        "p95_latency_ms": "lower only after every correctness gate passes",
+        "correctness": "zero-tolerance integer-count ratchets; ratios are diagnostics only",
+        "release_readiness": "production cell must have zero correctness failures",
+        "population": (
+            "candidate and baseline evaluated-population provenance and invariant "
+            "counts must match"
+        ),
+        "performance": (
+            "clean_ms p95 uses a separately configured tolerance and is "
+            "informational by default"
+        ),
     },
 }
 
@@ -1310,7 +1408,21 @@ def _evaluated_population_provenance(
     }
 
 
-def _run_correctness_values(run: Mapping[str, object]) -> dict[str, int | float]:
+def _count(value: object, context: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{context} must be a non-negative integer")
+    return value
+
+
+def _count_map(value: object, context: str) -> dict[str, int]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{context} must be an object")
+    return {
+        str(key): _count(item, f"{context}.{key}") for key, item in value.items()
+    }
+
+
+def _run_correctness_counts(run: Mapping[str, object]) -> dict[str, int]:
     metrics = run["metrics"]
     contract = run["pipeline_contract"]
     availability = run["pipeline_availability"]
@@ -1320,72 +1432,242 @@ def _run_correctness_values(run: Mapping[str, object]) -> dict[str, int | float]
     entities = metrics["entities"]
     if not isinstance(utf8_bytes, dict) or not isinstance(entities, dict):
         raise ValueError("scorecard metric sections must be objects")
+    attempted = _count(availability["attempted_documents"], "attempted_documents")
+    completed = _count(availability["completed_documents"], "completed_documents")
+    failed = _count(
+        availability["failed_closed_documents"], "failed_closed_documents"
+    )
+    errors = _count_map(availability.get("errors", {}), "pipeline errors")
+    error_stages = _count_map(
+        availability.get("error_stages", {}), "pipeline error stages"
+    )
+    if completed + failed != attempted:
+        raise ValueError("pipeline attempted/completed/failed counts disagree")
+    if sum(errors.values()) != failed or sum(error_stages.values()) != failed:
+        raise ValueError("pipeline error telemetry disagrees with failed count")
+
+    documents = _count(metrics["documents"], "metrics.documents")
+    without_leaks = _count(
+        metrics["documents_without_leaks"], "documents_without_leaks"
+    )
+    if documents != completed or without_leaks > documents:
+        raise ValueError("metric document counts disagree with pipeline completion")
+    contract_documents = _count(contract["documents"], "contract.documents")
+    if contract_documents != completed:
+        raise ValueError("contract document count disagrees with pipeline completion")
+
+    gold_entities = _count(entities["gold"], "entities.gold")
+    fully_covered = _count(entities["fully_covered"], "entities.fully_covered")
+    if fully_covered > gold_entities:
+        raise ValueError("fully covered entities exceed gold entities")
+    pii_bytes = _count(utf8_bytes["pii"], "utf8_bytes.pii")
+    leaked_bytes = _count(utf8_bytes["leaked"], "utf8_bytes.leaked")
+    if leaked_bytes > pii_bytes:
+        raise ValueError("leaked bytes exceed labeled PII bytes")
+
+    restore_exact = _count(
+        contract["restore_exact_documents"], "restore_exact_documents"
+    )
+    restore_success = _count(
+        contract["restore_success_decisions"], "restore_success_decisions"
+    )
+    manifest_valid = _count(
+        contract["manifest_valid_documents"], "manifest_valid_documents"
+    )
+    post_policy_scanned = _count(
+        contract.get("post_policy_scanned_documents", 0),
+        "post_policy_scanned_documents",
+    )
+    for name, value in (
+        ("restore_exact_documents", restore_exact),
+        ("restore_success_decisions", restore_success),
+        ("manifest_valid_documents", manifest_valid),
+        ("post_policy_scanned_documents", post_policy_scanned),
+    ):
+        if value > contract_documents:
+            raise ValueError(f"{name} exceeds contract documents")
+    integrity_errors = sum(
+        _count_map(
+            contract.get("manifest_integrity_errors", {}),
+            "manifest_integrity_errors",
+        ).values()
+    )
+
     return {
-        "pipeline_completion_rate": float(availability["completion_rate"]),
-        "leaked_labeled_utf8_bytes": int(utf8_bytes["leaked"]),
-        "pii_byte_recall": float(utf8_bytes["recall"]),
-        "full_entity_coverage_recall": float(entities["full_coverage_recall"]),
-        "zero_leak_document_rate": float(metrics["zero_leak_document_rate"]),
-        "restore_exact_rate": float(contract["restore_exact_rate"]),
-        "manifest_valid_document_rate": float(
-            contract["manifest_valid_document_rate"]
+        "attempted_documents": attempted,
+        "completed_documents": completed,
+        "failed_closed_documents": failed,
+        "scored_documents": documents,
+        "documents_without_leaks": without_leaks,
+        "documents_with_leaks": documents - without_leaks,
+        "pii_utf8_bytes": pii_bytes,
+        "leaked_labeled_utf8_bytes": leaked_bytes,
+        "gold_entities": gold_entities,
+        "fully_covered_entities": fully_covered,
+        "uncovered_entities": gold_entities - fully_covered,
+        "false_positive_utf8_bytes": _count(
+            utf8_bytes["false_positive"], "utf8_bytes.false_positive"
         ),
-        "strict_rejections": int(contract["strict_would_reject_documents"]),
-        "residual_suspects": int(contract.get("post_policy_suspects", 0)),
-        "redact_actions": int(contract.get("redact_actions", 0)),
-        "byte_precision": float(utf8_bytes["precision"]),
+        "documents_with_false_positives": _count(
+            metrics["documents_with_false_positives"],
+            "documents_with_false_positives",
+        ),
+        "contract_documents": contract_documents,
+        "restore_exact_documents": restore_exact,
+        "restore_failures": contract_documents - restore_exact,
+        "restore_success_decisions": restore_success,
+        "restore_decision_failures": contract_documents - restore_success,
+        "manifest_valid_documents": manifest_valid,
+        "manifest_invalid_documents": contract_documents - manifest_valid,
+        "manifest_integrity_errors": integrity_errors,
+        "strict_rejections": _count(
+            contract["strict_would_reject_documents"],
+            "strict_would_reject_documents",
+        ),
+        "post_policy_scanned_documents": post_policy_scanned,
+        "post_policy_unscanned_documents": contract_documents - post_policy_scanned,
+        "residual_suspects": _count(
+            contract.get("post_policy_suspects", 0), "post_policy_suspects"
+        ),
+        "redact_actions": _count(contract.get("redact_actions", 0), "redact_actions"),
     }
+
+
+def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, object]:
+    failures: list[dict[str, object]] = []
+    try:
+        candidate_runs = _scorecard_runs(candidate)
+    except (KeyError, TypeError, ValueError) as error:
+        return {
+            "passed": False,
+            "failures": [{"gate": "candidate_runs", "reason": str(error)}],
+        }
+    expected_configs = frozenset(DEFAULT_CONFIGS)
+    if frozenset(candidate_runs) != expected_configs:
+        failures.append(
+            {
+                "gate": "candidate_config_set",
+                "expected": sorted(expected_configs),
+                "actual": sorted(candidate_runs),
+            }
+        )
+    try:
+        _evaluated_population_provenance(candidate)
+    except (KeyError, TypeError, ValueError) as error:
+        failures.append(
+            {
+                "gate": "candidate_evaluated_population_provenance",
+                "reason": str(error),
+            }
+        )
+    cell_counts: dict[str, dict[str, int]] = {}
+    for config in sorted(expected_configs.intersection(candidate_runs)):
+        try:
+            counts = _run_correctness_counts(candidate_runs[config])
+        except (KeyError, TypeError, ValueError) as error:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": "candidate_integer_counts",
+                    "reason": str(error),
+                }
+            )
+            continue
+        cell_counts[config] = counts
+        for gate in (
+            "failed_closed_documents",
+            "restore_failures",
+            "restore_decision_failures",
+            "manifest_invalid_documents",
+            "manifest_integrity_errors",
+        ):
+            if counts[gate] != 0:
+                failures.append(
+                    {
+                        "config": config,
+                        "gate": gate,
+                        "actual": counts[gate],
+                        "required": 0,
+                    }
+                )
+        if counts["attempted_documents"] <= 0:
+            failures.append({"config": config, "gate": "non_empty_run"})
+    if PRODUCTION_CONFIG in candidate_runs:
+        counts = cell_counts.get(PRODUCTION_CONFIG)
+        if counts is not None:
+            zero_targets = (
+                "documents_with_leaks",
+                "leaked_labeled_utf8_bytes",
+                "uncovered_entities",
+                "strict_rejections",
+                "post_policy_unscanned_documents",
+                "residual_suspects",
+                "redact_actions",
+            )
+            for gate in zero_targets:
+                if counts[gate] != 0:
+                    failures.append(
+                        {
+                            "config": PRODUCTION_CONFIG,
+                            "gate": gate,
+                            "actual": counts[gate],
+                            "required": 0,
+                        }
+                    )
+    return {"passed": not failures, "failures": failures}
 
 
 def compare_scorecards(
     candidate: Mapping[str, object], baseline: Mapping[str, object]
 ) -> dict[str, object]:
     regression_failures: list[dict[str, object]] = []
-    readiness_failures: list[dict[str, object]] = []
+    release_readiness = evaluate_release_readiness(candidate)
     try:
         candidate_runs = _scorecard_runs(candidate)
-    except ValueError as error:
+    except (KeyError, TypeError, ValueError) as error:
         candidate_runs = {}
         failure = {"gate": "candidate_runs", "reason": str(error)}
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
     try:
         baseline_runs = _scorecard_runs(baseline)
-    except ValueError as error:
+    except (KeyError, TypeError, ValueError) as error:
         baseline_runs = {}
         failure = {"gate": "baseline_runs", "reason": str(error)}
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
     expected_configs = frozenset(DEFAULT_CONFIGS)
     candidate_configs = frozenset(candidate_runs)
     baseline_configs = frozenset(baseline_runs)
+    invariant_counts = (
+        "attempted_documents",
+        "pii_utf8_bytes",
+        "gold_entities",
+    )
     higher_is_better = (
-        "pipeline_completion_rate",
-        "pii_byte_recall",
-        "full_entity_coverage_recall",
-        "zero_leak_document_rate",
-        "restore_exact_rate",
-        "manifest_valid_document_rate",
-        "byte_precision",
+        "completed_documents",
+        "scored_documents",
+        "documents_without_leaks",
+        "fully_covered_entities",
+        "restore_exact_documents",
+        "restore_success_decisions",
+        "manifest_valid_documents",
+        "post_policy_scanned_documents",
     )
     lower_is_better = (
+        "failed_closed_documents",
+        "documents_with_leaks",
         "leaked_labeled_utf8_bytes",
+        "uncovered_entities",
+        "false_positive_utf8_bytes",
+        "documents_with_false_positives",
+        "restore_failures",
+        "restore_decision_failures",
+        "manifest_invalid_documents",
+        "manifest_integrity_errors",
         "strict_rejections",
+        "post_policy_unscanned_documents",
         "residual_suspects",
         "redact_actions",
     )
-    readiness_targets: dict[str, int | float] = {
-        "pipeline_completion_rate": 1.0,
-        "leaked_labeled_utf8_bytes": 0,
-        "pii_byte_recall": 1.0,
-        "full_entity_coverage_recall": 1.0,
-        "zero_leak_document_rate": 1.0,
-        "restore_exact_rate": 1.0,
-        "manifest_valid_document_rate": 1.0,
-        "strict_rejections": 0,
-        "residual_suspects": 0,
-        "redact_actions": 0,
-    }
 
     if candidate_configs != expected_configs:
         failure = {
@@ -1394,7 +1676,6 @@ def compare_scorecards(
             "actual": sorted(candidate_configs),
         }
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
     if baseline_configs != expected_configs:
         failure = {
             "gate": "baseline_config_set",
@@ -1402,28 +1683,25 @@ def compare_scorecards(
             "actual": sorted(baseline_configs),
         }
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
 
     candidate_provenance: dict[str, object] | None = None
     baseline_provenance: dict[str, object] | None = None
     try:
         candidate_provenance = _evaluated_population_provenance(candidate)
-    except ValueError as error:
+    except (KeyError, TypeError, ValueError) as error:
         failure = {
             "gate": "candidate_evaluated_population_provenance",
             "reason": str(error),
         }
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
     try:
         baseline_provenance = _evaluated_population_provenance(baseline)
-    except ValueError as error:
+    except (KeyError, TypeError, ValueError) as error:
         failure = {
             "gate": "baseline_evaluated_population_provenance",
             "reason": str(error),
         }
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
     if (
         candidate_provenance is not None
         and baseline_provenance is not None
@@ -1434,7 +1712,6 @@ def compare_scorecards(
             "reason": "candidate and baseline provenance differ",
         }
         regression_failures.append(failure)
-        readiness_failures.append(copy.deepcopy(failure))
 
     prerequisites_match = (
         candidate_configs == expected_configs
@@ -1444,8 +1721,28 @@ def compare_scorecards(
     )
     if prerequisites_match:
         for config in sorted(expected_configs):
-            candidate_values = _run_correctness_values(candidate_runs[config])
-            baseline_values = _run_correctness_values(baseline_runs[config])
+            try:
+                candidate_values = _run_correctness_counts(candidate_runs[config])
+                baseline_values = _run_correctness_counts(baseline_runs[config])
+            except (KeyError, TypeError, ValueError) as error:
+                regression_failures.append(
+                    {
+                        "config": config,
+                        "gate": "integer_counts",
+                        "reason": str(error),
+                    }
+                )
+                continue
+            for gate in invariant_counts:
+                if candidate_values[gate] != baseline_values[gate]:
+                    regression_failures.append(
+                        {
+                            "config": config,
+                            "gate": f"{gate}_match",
+                            "candidate": candidate_values[gate],
+                            "baseline": baseline_values[gate],
+                        }
+                    )
             for gate in higher_is_better:
                 if candidate_values[gate] < baseline_values[gate]:
                     regression_failures.append(
@@ -1467,27 +1764,51 @@ def compare_scorecards(
                         }
                     )
 
-    if prerequisites_match:
-        production_values = _run_correctness_values(candidate_runs[PRODUCTION_CONFIG])
-        for gate, target in readiness_targets.items():
-            if production_values[gate] != target:
-                readiness_failures.append(
-                    {
-                        "config": PRODUCTION_CONFIG,
-                        "gate": gate,
-                        "actual": production_values[gate],
-                        "required": target,
-                    }
-                )
-
     return {
         "schema_version": SCORECARD_SCHEMA_VERSION,
         "regression": {
             "passed": not regression_failures,
             "failures": regression_failures,
         },
-        "release_readiness": {
-            "passed": not readiness_failures,
-            "failures": readiness_failures,
-        },
+        "release_readiness": release_readiness,
+    }
+
+
+def compare_performance(
+    candidate: Mapping[str, object],
+    baseline: Mapping[str, object],
+    *,
+    tolerance_percent: float,
+    gating: bool = False,
+) -> dict[str, object]:
+    if tolerance_percent < 0.0:
+        raise ValueError("performance tolerance must be non-negative")
+    failures: list[dict[str, object]] = []
+    comparisons: list[dict[str, object]] = []
+    try:
+        candidate_runs = _scorecard_runs(candidate)
+        baseline_runs = _scorecard_runs(baseline)
+        for config in sorted(DEFAULT_CONFIGS):
+            candidate_p95 = float(candidate_runs[config]["latency_ms"]["clean_ms"]["p95"])
+            baseline_p95 = float(baseline_runs[config]["latency_ms"]["clean_ms"]["p95"])
+            limit = baseline_p95 * (1.0 + tolerance_percent / 100.0)
+            comparison = {
+                "config": config,
+                "metric": "clean_ms.p95",
+                "candidate": candidate_p95,
+                "baseline": baseline_p95,
+                "limit": limit,
+            }
+            comparisons.append(comparison)
+            if candidate_p95 > limit:
+                failures.append(copy.deepcopy(comparison))
+    except (KeyError, TypeError, ValueError) as error:
+        failures.append({"gate": "performance_data", "reason": str(error)})
+    return {
+        "passed": not failures,
+        "gating": gating,
+        "disposition": "gating" if gating else "informational",
+        "tolerance_percent": tolerance_percent,
+        "comparisons": comparisons,
+        "failures": failures,
     }

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""Canonical local Dataiku EN/DE plus A4 negative-corpus benchmark runner."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import dataiku_en_de_gaze_bench as dataiku
+import gaze_bench_score as score
+
+
+QUICK_DOCUMENTS = 256
+DEFAULT_WARMUPS = 1
+DEFAULT_MEASURED_REPETITIONS = 1
+DEFAULT_PERFORMANCE_TOLERANCE_PERCENT = 20.0
+BASELINE_CONFIRMATION = "I_HAVE_REVIEWED_FULL_RESULTS"
+NEGATIVE_CORPUS = Path(
+    "crates/xtask/fixtures/negative_corpus/en_de_negative.jsonl"
+)
+MODEL_CONFIG = Path("crates/gaze-recognizers/benches/ner_models.toml")
+DEFAULT_DAVLAN_MODEL = Path("~/.local/share/gaze/models/davlan-mbert-ner-hrl")
+DEFAULT_KIJI_MODEL = Path("~/.local/share/gaze/models/kiji-distilbert")
+
+
+class RunnerError(RuntimeError):
+    code = "runner_error"
+
+
+class ModelBundleError(RunnerError):
+    code = "model_bundle_error"
+
+
+class CandidateError(RunnerError):
+    code = "candidate_error"
+
+
+class BaselineError(RunnerError):
+    code = "baseline_error"
+
+
+class BaselineAcceptanceError(RunnerError):
+    code = "baseline_acceptance_error"
+
+
+class RepetitionMismatchError(RunnerError):
+    code = "repetition_mismatch"
+
+
+@dataclass(frozen=True)
+class ModelPin:
+    model_id: str
+    path: Path
+    digest_kind: str
+    expected_sha256: str
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", choices=("quick", "full"))
+    parser.add_argument("--seed", type=int, default=score.DEFAULT_SAMPLE_SEED)
+    parser.add_argument("--quick-documents", type=int, default=QUICK_DOCUMENTS)
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path("target/bench-data/dataiku-en-de/test.parquet"),
+    )
+    parser.add_argument("--negative-corpus", type=Path, default=NEGATIVE_CORPUS)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("target/bench-data/no-opf"),
+    )
+    parser.add_argument(
+        "--model-dir",
+        type=Path,
+        default=Path(
+            os.environ.get("GAZE_NER_MODEL_DIR", str(DEFAULT_DAVLAN_MODEL))
+        ).expanduser(),
+    )
+    parser.add_argument(
+        "--kiji-model-dir",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "GAZE_KIJI_DISTILBERT_MODEL_DIR", str(DEFAULT_KIJI_MODEL)
+            )
+        ).expanduser(),
+    )
+    parser.add_argument("--threshold", type=float, default=0.3)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument(
+        "--measured-repetitions",
+        type=int,
+        default=DEFAULT_MEASURED_REPETITIONS,
+    )
+    parser.add_argument("--compare-baseline", type=Path)
+    parser.add_argument("--accept-baseline", type=Path)
+    parser.add_argument("--accept-baseline-confirm")
+    parser.add_argument(
+        "--performance-tolerance-percent",
+        type=float,
+        default=DEFAULT_PERFORMANCE_TOLERANCE_PERCENT,
+    )
+    parser.add_argument("--performance-gating", action="store_true")
+    parser.add_argument("--no-download", action="store_true")
+    parser.add_argument("--skip-build", action="store_true")
+    return parser.parse_args(argv)
+
+
+def repo_path(repo_root: Path, path: Path) -> Path:
+    return path if path.is_absolute() else repo_root / path
+
+
+def sha256_tree(path: Path) -> str:
+    digest = hashlib.sha256()
+    for child in sorted(path.rglob("*")):
+        if child.is_symlink():
+            raise ModelBundleError(
+                f"model bundle {path} contains a symlink: {child.relative_to(path)}"
+            )
+        if child.is_file():
+            relative = child.relative_to(path).as_posix().encode("utf-8")
+            digest.update(relative)
+            digest.update(b"\0")
+            digest.update(score.sha256_file(child).encode("ascii"))
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def load_model_pins(
+    repo_root: Path, davlan_path: Path, kiji_path: Path
+) -> tuple[ModelPin, ModelPin]:
+    config_path = repo_root / MODEL_CONFIG
+    raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    models = {item["id"]: item for item in raw.get("model", [])}
+    try:
+        davlan_sha = str(models["davlan-bert-multilingual"]["bundle_sha"])
+        kiji_sha = str(models["kiji-distilbert"]["bundle_sha"])
+    except KeyError as error:
+        raise ModelBundleError(
+            f"required model pin is missing from {config_path}: {error}"
+        ) from error
+    return (
+        ModelPin("davlan-bert-multilingual", davlan_path, "tree", davlan_sha),
+        ModelPin("kiji-distilbert", kiji_path, "SHA256SUMS", kiji_sha),
+    )
+
+
+def _validate_checksum_manifest(pin: ModelPin) -> dict[str, object]:
+    manifest = pin.path / pin.digest_kind
+    if not manifest.is_file():
+        raise ModelBundleError(
+            f"{pin.model_id}: required checksum manifest is missing: {manifest}; "
+            "install the pinned local model bundle before running"
+        )
+    actual_manifest_sha = score.sha256_file(manifest)
+    if actual_manifest_sha != pin.expected_sha256:
+        raise ModelBundleError(
+            f"{pin.model_id}: checksum manifest digest mismatch at {manifest}; "
+            f"expected {pin.expected_sha256}, got {actual_manifest_sha}"
+        )
+    checked = 0
+    for line_number, line in enumerate(
+        manifest.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) != 2 or len(fields[0]) != 64:
+            raise ModelBundleError(
+                f"{pin.model_id}: malformed {manifest.name} line {line_number}"
+            )
+        expected, relative_raw = fields
+        relative = Path(relative_raw)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ModelBundleError(
+                f"{pin.model_id}: unsafe path in {manifest.name} line {line_number}"
+            )
+        artifact = pin.path / relative
+        if not artifact.is_file() or artifact.is_symlink():
+            raise ModelBundleError(
+                f"{pin.model_id}: required artifact is missing or unsafe: {artifact}"
+            )
+        actual = score.sha256_file(artifact)
+        if actual != expected:
+            raise ModelBundleError(
+                f"{pin.model_id}: artifact digest mismatch for {artifact}; "
+                f"expected {expected}, got {actual}"
+            )
+        checked += 1
+    if checked == 0:
+        raise ModelBundleError(f"{pin.model_id}: checksum manifest is empty")
+    return {
+        "model_id": pin.model_id,
+        "digest_kind": pin.digest_kind,
+        "expected_sha256": pin.expected_sha256,
+        "observed_sha256": actual_manifest_sha,
+        "verified_artifacts": checked,
+    }
+
+
+def validate_model_bundle(pin: ModelPin) -> dict[str, object]:
+    if not pin.path.is_dir():
+        raise ModelBundleError(
+            f"{pin.model_id}: model directory does not exist: {pin.path}; "
+            "install the pinned local model bundle before running"
+        )
+    if pin.digest_kind != "tree":
+        return _validate_checksum_manifest(pin)
+    actual = sha256_tree(pin.path)
+    if actual != pin.expected_sha256:
+        raise ModelBundleError(
+            f"{pin.model_id}: model bundle digest mismatch at {pin.path}; "
+            f"expected {pin.expected_sha256}, got {actual}"
+        )
+    return {
+        "model_id": pin.model_id,
+        "digest_kind": "tree",
+        "expected_sha256": pin.expected_sha256,
+        "observed_sha256": actual,
+        "verified_artifacts": sum(1 for item in pin.path.rglob("*") if item.is_file()),
+    }
+
+
+def validate_required_models(
+    repo_root: Path, davlan_path: Path, kiji_path: Path
+) -> list[dict[str, object]]:
+    return [
+        validate_model_bundle(pin)
+        for pin in load_model_pins(repo_root, davlan_path, kiji_path)
+    ]
+
+
+def load_negative_documents(
+    path: Path,
+) -> tuple[list[score.Document], dict[str, object]]:
+    if not path.is_file():
+        raise CandidateError(f"negative corpus is missing: {path}")
+    documents: list[score.Document] = []
+    languages: dict[str, int] = {}
+    categories: dict[str, int] = {}
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise CandidateError(
+                f"negative corpus JSON is invalid at line {line_number}: {error}"
+            ) from error
+        if not isinstance(row, dict):
+            raise CandidateError(f"negative corpus line {line_number} is not an object")
+        uid = row.get("id")
+        language = row.get("language")
+        category = row.get("category")
+        text = row.get("text")
+        if not all(isinstance(value, str) and value for value in (uid, category, text)):
+            raise CandidateError(
+                f"negative corpus line {line_number} has invalid id/category/text"
+            )
+        if language not in {"en", "de"}:
+            raise CandidateError(
+                f"negative corpus line {line_number} has unsupported language {language!r}"
+            )
+        if row.get("oracle_spans") != []:
+            raise CandidateError(
+                f"negative corpus line {line_number} is not a negative-only fixture"
+            )
+        documents.append(
+            score.Document(
+                uid=uid,
+                text=text,
+                language=language,
+                region="",
+                source_dataset="gaze-a4-negative-corpus",
+                spans=(),
+                negative_category=category,
+            )
+        )
+        languages[language] = languages.get(language, 0) + 1
+        categories[category] = categories.get(category, 0) + 1
+    if not documents:
+        raise CandidateError("negative corpus contains no documents")
+    return documents, {
+        "documents": len(documents),
+        "languages": dict(sorted(languages.items())),
+        "categories": dict(sorted(categories.items())),
+        "sha256": score.sha256_file(path),
+    }
+
+
+def composite_dataset_report(
+    dataiku_report: Mapping[str, object], negative_report: Mapping[str, object]
+) -> tuple[dict[str, object], dict[str, object]]:
+    dataiku_integrity = dataiku_report["integrity"]
+    assert isinstance(dataiku_integrity, dict)
+    component_digests = {
+        "dataiku": str(dataiku_integrity["sha256"]),
+        "negative_corpus": str(negative_report["sha256"]),
+    }
+    composite_digest = hashlib.sha256(
+        json.dumps(component_digests, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    metadata = {
+        "repository": f"{dataiku.DATASET_REPO}+gaze",
+        "revision": f"{dataiku.DATASET_REVISION}+a4-negative-v1",
+        "file": f"{dataiku.DATASET_FILE}+{NEGATIVE_CORPUS.as_posix()}",
+        "license": "Apache-2.0 + CC0-1.0 synthetic",
+        "synthetic_only": True,
+        "reserved_from_training": True,
+        "selection_policy": "complete EN/DE holdout plus complete committed A4 negatives",
+    }
+    report = {
+        "integrity": {
+            "sha256": composite_digest,
+            "component_sha256": component_digests,
+        },
+        "components": {
+            "dataiku": copy.deepcopy(dict(dataiku_report)),
+            "negative_corpus": copy.deepcopy(dict(negative_report)),
+        },
+    }
+    return metadata, report
+
+
+def build_no_opf_environment(source: Mapping[str, str]) -> dict[str, str]:
+    def is_opf_key(key: str) -> bool:
+        upper = key.upper()
+        return (
+            upper.startswith("OPF_")
+            or upper.startswith("GAZE_OPF_")
+            or "OPENAI_FILTER" in upper
+        )
+
+    return {key: value for key, value in source.items() if not is_opf_key(key)}
+
+
+def execute_measurements(
+    *,
+    repo_root: Path,
+    binary: Path,
+    documents: Sequence[score.Document],
+    davlan_model: Path,
+    kiji_model: Path,
+    threshold: float,
+    diagnostics_dir: Path,
+    warmup_count: int,
+    measured_repetitions: int,
+    source_environment: Mapping[str, str] | None = None,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    if measured_repetitions <= 0:
+        raise CandidateError("measured repetitions must be positive")
+    if warmup_count < 0:
+        raise CandidateError("warmup count must be non-negative")
+    configs = tuple(score.DEFAULT_CONFIGS)
+    if any("opf" in config.lower() for config in configs):
+        raise CandidateError("canonical no-OPF config set unexpectedly contains OPF")
+    environment = build_no_opf_environment(source_environment or os.environ)
+    repetition_runs: list[list[dict[str, object]]] = []
+    provenance: list[dict[str, object]] = []
+    for repetition in range(1, measured_repetitions + 1):
+        current: list[dict[str, object]] = []
+        for config in configs:
+            run = score.run_config(
+                repo_root,
+                binary,
+                config,
+                documents,
+                davlan_model,
+                kiji_model,
+                None,
+                None,
+                None,
+                threshold,
+                diagnostics_dir / f"repetition-{repetition}",
+                base_environment=environment,
+                warmup_count=warmup_count,
+            )
+            current.append(run)
+        repetition_runs.append(current)
+        provenance.append(
+            {
+                "repetition": repetition,
+                "runs": [
+                    {
+                        "config": run["config"],
+                        "cold_start_to_first_validated_response_ms": run["process"][
+                            "cold_start_to_first_validated_response_ms"
+                        ],
+                        "warmup_count": run["process"]["warmup_count"],
+                        "discarded_warmup_samples": run["process"][
+                            "discarded_warmup_samples"
+                        ],
+                        "clean_ms": run["latency_ms"].get("clean_ms"),
+                    }
+                    for run in current
+                ],
+            }
+        )
+    canonical = repetition_runs[0]
+    canonical_counts = {
+        str(run["config"]): score._run_correctness_counts(run) for run in canonical
+    }
+    for repetition, runs in enumerate(repetition_runs[1:], start=2):
+        counts = {
+            str(run["config"]): score._run_correctness_counts(run) for run in runs
+        }
+        if counts != canonical_counts:
+            raise RepetitionMismatchError(
+                f"measured repetition {repetition} disagrees with repetition 1 "
+                "on integer correctness counts"
+            )
+    return canonical, provenance
+
+
+def load_scorecard(path: Path, label: str) -> dict[str, object]:
+    if not path.is_file():
+        raise BaselineError(f"{label} scorecard is missing: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise BaselineError(f"cannot read {label} scorecard {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise BaselineError(f"{label} scorecard must be a JSON object")
+    return value
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def diagnostics(scorecard: Mapping[str, object]) -> dict[str, object]:
+    runs = scorecard.get("runs")
+    if not isinstance(runs, list) or not runs:
+        raise CandidateError("candidate scorecard has no diagnostic runs")
+    return {
+        "schema_version": score.SCORECARD_SCHEMA_VERSION,
+        "runs": [
+            {
+                "config": run["config"],
+                "per_language": run["per_language"],
+                "per_label": run["per_label_recall"],
+                "per_negative_category": run["per_negative_category"],
+                "pipeline_availability": run["pipeline_availability"],
+                "pipeline_contract": run["pipeline_contract"],
+            }
+            for run in runs
+        ],
+    }
+
+
+def markdown_summary(
+    scorecard: Mapping[str, object],
+    regression: Mapping[str, object],
+    readiness: Mapping[str, object],
+    performance: Mapping[str, object],
+) -> str:
+    lines = [
+        "# Gaze canonical no-OPF benchmark",
+        "",
+        f"- Regression: **{regression['status']}**",
+        f"- Release readiness: **{readiness['status']}**",
+        f"- Performance: **{performance['disposition']} / {performance['status']}**",
+        "",
+        "| Config | Attempted | Failed closed | Leaked bytes | Restore failures "
+        "| Residual suspects | clean_ms p95 |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for run in scorecard["runs"]:
+        counts = score._run_correctness_counts(run)
+        clean_p95 = run["latency_ms"].get("clean_ms", {}).get("p95")
+        clean_display = f"{float(clean_p95):.3f}" if clean_p95 is not None else "n/a"
+        lines.append(
+            f"| {run['config']} | {counts['attempted_documents']} | "
+            f"{counts['failed_closed_documents']} | "
+            f"{counts['leaked_labeled_utf8_bytes']} | "
+            f"{counts['restore_failures']} | {counts['residual_suspects']} | "
+            f"{clean_display} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _status_document(kind: str, result: Mapping[str, object]) -> dict[str, object]:
+    passed = bool(result["passed"])
+    return {
+        "schema_version": 1,
+        "kind": kind,
+        "status": "passed" if passed else "failed",
+        "passed": passed,
+        "failures": copy.deepcopy(result.get("failures", [])),
+    }
+
+
+def accept_baseline(
+    args: argparse.Namespace,
+    candidate: Mapping[str, object],
+    regression: Mapping[str, object],
+    readiness: Mapping[str, object],
+) -> None:
+    if args.accept_baseline is None:
+        if args.accept_baseline_confirm is not None:
+            raise BaselineAcceptanceError(
+                "--accept-baseline-confirm requires --accept-baseline"
+            )
+        return
+    if args.profile != "full":
+        raise BaselineAcceptanceError("only a full-profile result may become a baseline")
+    if args.accept_baseline_confirm != BASELINE_CONFIRMATION:
+        raise BaselineAcceptanceError(
+            "baseline acceptance requires --accept-baseline-confirm "
+            f"{BASELINE_CONFIRMATION}"
+        )
+    initializing = args.compare_baseline is None
+    if initializing and args.accept_baseline.exists():
+        raise BaselineAcceptanceError(
+            "refusing to overwrite an existing baseline without --compare-baseline"
+        )
+    if not initializing and (
+        args.compare_baseline.resolve() != args.accept_baseline.resolve()
+    ):
+        raise BaselineAcceptanceError(
+            "--compare-baseline and --accept-baseline must name the same reviewed file"
+        )
+    regression_failed = not initializing and regression.get("passed") is not True
+    if regression_failed or readiness.get("passed") is not True:
+        raise BaselineAcceptanceError(
+            "refusing to accept a regressing or not-release-ready candidate"
+        )
+    write_json(args.accept_baseline, candidate)
+
+
+def validate_cli_guards(args: argparse.Namespace) -> None:
+    if args.performance_gating and args.compare_baseline is None:
+        raise BaselineError("--performance-gating requires --compare-baseline")
+    if args.accept_baseline is None:
+        if args.accept_baseline_confirm is not None:
+            raise BaselineAcceptanceError(
+                "--accept-baseline-confirm requires --accept-baseline"
+            )
+        return
+    if args.profile != "full":
+        raise BaselineAcceptanceError("only a full-profile result may become a baseline")
+    if args.accept_baseline_confirm != BASELINE_CONFIRMATION:
+        raise BaselineAcceptanceError(
+            "baseline acceptance requires --accept-baseline-confirm "
+            f"{BASELINE_CONFIRMATION}"
+        )
+    if args.compare_baseline is None and args.accept_baseline.exists():
+        raise BaselineAcceptanceError(
+            "refusing to overwrite an existing baseline without --compare-baseline"
+        )
+    if args.compare_baseline is not None and (
+        args.compare_baseline.resolve() != args.accept_baseline.resolve()
+    ):
+        raise BaselineAcceptanceError(
+            "--compare-baseline and --accept-baseline must name the same reviewed file"
+        )
+
+
+def run(args: argparse.Namespace) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    if args.compare_baseline is not None:
+        args.compare_baseline = repo_path(repo_root, args.compare_baseline)
+    if args.accept_baseline is not None:
+        args.accept_baseline = repo_path(repo_root, args.accept_baseline)
+    validate_cli_guards(args)
+    output_dir = repo_path(repo_root, args.output_dir) / args.profile
+    dataset_path = repo_path(repo_root, args.dataset)
+    negative_path = repo_path(repo_root, args.negative_corpus)
+    davlan_model = args.model_dir.expanduser().resolve()
+    kiji_model = args.kiji_model_dir.expanduser().resolve()
+
+    model_provenance = validate_required_models(
+        repo_root, davlan_model, kiji_model
+    )
+    if dataset_path.is_file():
+        dataiku.verify_dataset(dataset_path)
+    elif args.no_download:
+        raise CandidateError(f"Dataiku dataset is missing: {dataset_path}")
+    else:
+        dataiku.fetch_dataset(dataset_path)
+    positive_documents, dataiku_report = dataiku.load_documents(dataset_path)
+    negative_documents, negative_report = load_negative_documents(negative_path)
+    available_documents = positive_documents + negative_documents
+    max_documents = args.quick_documents if args.profile == "quick" else None
+    if max_documents is not None and max_documents <= 0:
+        raise CandidateError("quick document count must be positive")
+    documents, sampling_report = score.stratified_sample(
+        available_documents, max_documents, seed=args.seed
+    )
+    if args.profile == "full" and len(documents) != len(available_documents):
+        raise CandidateError("full profile did not select the complete corpus")
+
+    binary = (
+        repo_root / "target/debug/examples/clean_for_bench"
+        if args.skip_build
+        else dataiku.build_binary(repo_root, tuple(score.DEFAULT_CONFIGS))
+    )
+    if not binary.is_file():
+        raise CandidateError(f"benchmark binary is missing: {binary}")
+    runs, repetition_provenance = execute_measurements(
+        repo_root=repo_root,
+        binary=binary,
+        documents=documents,
+        davlan_model=davlan_model,
+        kiji_model=kiji_model,
+        threshold=args.threshold,
+        diagnostics_dir=output_dir / "logs",
+        warmup_count=args.warmups,
+        measured_repetitions=args.measured_repetitions,
+    )
+    metadata, dataset_report = composite_dataset_report(
+        dataiku_report, negative_report
+    )
+    candidate = score.assemble_scorecard(
+        repo_root=repo_root,
+        dataset_metadata=metadata,
+        dataset_report=dataset_report,
+        sampling_report=sampling_report,
+        parameters={
+            "profile": args.profile,
+            "configs": list(score.DEFAULT_CONFIGS),
+            "max_documents": max_documents,
+            "sampling_seed": args.seed,
+            "ner_threshold": args.threshold,
+            "warmup_count": args.warmups,
+            "measured_repetitions": args.measured_repetitions,
+            "opf": False,
+        },
+        runs=runs,
+    )
+    candidate["runner_provenance"] = {
+        "entry_point": "scripts/bench/run_no_opf_benchmark.py",
+        "profile": args.profile,
+        "model_bundles": model_provenance,
+        "warmup_count": args.warmups,
+        "measured_repetitions": args.measured_repetitions,
+        "repetitions": repetition_provenance,
+        "latency_source": "validated response timing.clean_ms",
+        "cold_start_metric": "external process start to first validated response",
+    }
+
+    readiness_result = score.evaluate_release_readiness(candidate)
+    readiness_correctness_failed = not readiness_result["passed"]
+    if args.profile != "full":
+        readiness_result = copy.deepcopy(readiness_result)
+        readiness_result["passed"] = False
+        readiness_result["failures"].append(
+            {
+                "gate": "full_profile_required",
+                "reason": "a sampled quick run cannot establish release readiness",
+            }
+        )
+    readiness = _status_document("release_readiness", readiness_result)
+    if args.compare_baseline is None:
+        regression: dict[str, object] = {
+            "schema_version": 1,
+            "kind": "regression",
+            "status": "not_compared",
+            "passed": None,
+            "failures": [],
+        }
+        performance: dict[str, object] = {
+            "schema_version": 1,
+            "kind": "performance",
+            "status": "not_compared",
+            "passed": None,
+            "gating": args.performance_gating,
+            "disposition": "gating" if args.performance_gating else "informational",
+            "tolerance_percent": args.performance_tolerance_percent,
+            "comparisons": [],
+            "failures": [],
+        }
+    else:
+        baseline = load_scorecard(args.compare_baseline, "baseline")
+        comparison = score.compare_scorecards(candidate, baseline)
+        regression = _status_document("regression", comparison["regression"])
+        performance_result = score.compare_performance(
+            candidate,
+            baseline,
+            tolerance_percent=args.performance_tolerance_percent,
+            gating=args.performance_gating,
+        )
+        performance = {
+            "schema_version": 1,
+            "kind": "performance",
+            "status": "passed" if performance_result["passed"] else "failed",
+            **performance_result,
+        }
+
+    write_json(output_dir / "scorecard-v3.json", candidate)
+    write_json(output_dir / "diagnostics.json", diagnostics(candidate))
+    write_json(output_dir / "regression-status.json", regression)
+    write_json(output_dir / "release-readiness-status.json", readiness)
+    write_json(output_dir / "performance-status.json", performance)
+    (output_dir / "summary.md").write_text(
+        markdown_summary(candidate, regression, readiness, performance),
+        encoding="utf-8",
+    )
+
+    accept_baseline(args, candidate, regression, readiness)
+    if regression["passed"] is False:
+        return 3
+    if args.profile == "full" and readiness["passed"] is False:
+        return 4
+    if args.profile == "quick" and readiness_correctness_failed:
+        return 4
+    if args.performance_gating and performance["passed"] is False:
+        return 5
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        return run(parse_args(argv))
+    except RunnerError as error:
+        print(f"ERROR [{error.code}]: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -807,6 +807,8 @@ class ScorecardComparisonTests(unittest.TestCase):
     ) -> dict[str, object]:
         recall = 1.0 if leaked == 0 else 0.5
         ids = evaluated_ids or ["synthetic-comparison-1"]
+        documents = len(ids)
+        fully_covered = documents if leaked == 0 else documents - 1
         digest = hashlib.sha256(
             json.dumps(ids, ensure_ascii=False, separators=(",", ":")).encode(
                 "utf-8"
@@ -814,20 +816,45 @@ class ScorecardComparisonTests(unittest.TestCase):
         ).hexdigest()
         run = {
             "metrics": {
+                "documents": documents,
                 "zero_leak_document_rate": recall,
+                "documents_without_leaks": fully_covered,
+                "documents_with_false_positives": 0,
                 "utf8_bytes": {
+                    "pii": documents * 2,
                     "leaked": leaked,
+                    "false_positive": 0,
                     "recall": recall,
                     "precision": 1.0,
                 },
-                "entities": {"full_coverage_recall": recall},
+                "entities": {
+                    "gold": documents,
+                    "fully_covered": fully_covered,
+                    "full_coverage_recall": recall,
+                },
             },
             "pipeline_contract": {
+                "documents": documents,
+                "restore_exact_documents": documents,
                 "restore_exact_rate": 1.0,
+                "restore_success_decisions": documents,
+                "manifest_valid_documents": documents,
                 "manifest_valid_document_rate": 1.0,
+                "manifest_integrity_errors": {},
                 "strict_would_reject_documents": 0,
+                "post_policy_scanned_documents": documents,
+                "post_policy_suspects": 0,
+                "redact_actions": 0,
             },
-            "pipeline_availability": {"completion_rate": 1.0},
+            "pipeline_availability": {
+                "attempted_documents": documents,
+                "completed_documents": documents,
+                "failed_closed_documents": 0,
+                "errors": {},
+                "error_stages": {},
+                "completion_rate": 1.0,
+            },
+            "latency_ms": {"clean_ms": {"p95": 1.0}},
         }
         return {
             "schema_version": 3,
@@ -875,12 +902,12 @@ class ScorecardComparisonTests(unittest.TestCase):
         self.assertFalse(comparison["regression"]["passed"])
         self.assertFalse(comparison["release_readiness"]["passed"])
 
-    def test_mismatched_evaluated_population_provenance_fails_closed(self) -> None:
+    def test_mismatched_population_fails_regression_not_candidate_readiness(self) -> None:
         baseline = self.scorecard(leaked=0)
         candidate = self.scorecard(leaked=0, evaluated_ids=["synthetic-other-1"])
         comparison = benchmark.compare_scorecards(candidate, baseline)
         self.assertFalse(comparison["regression"]["passed"])
-        self.assertFalse(comparison["release_readiness"]["passed"])
+        self.assertTrue(comparison["release_readiness"]["passed"])
 
     def test_release_readiness_uses_the_production_candidate_cell(self) -> None:
         candidate = self.scorecard(leaked=0)

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -155,6 +155,51 @@ class ModelValidationTests(unittest.TestCase):
             ):
                 runner.validate_required_models(repo_root, missing, missing)
 
+    def test_present_model_with_mismatched_manifest_digest_fails_closed(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "present-model"
+            bundle.mkdir()
+            artifact = bundle / "model.onnx"
+            artifact.write_bytes(b"synthetic model bytes")
+            manifest = bundle / "SHA256SUMS"
+            manifest.write_text(
+                f"{score.sha256_file(artifact)}  model.onnx\n",
+                encoding="utf-8",
+            )
+            pin = runner.ModelPin(
+                "synthetic-present-model",
+                bundle,
+                "SHA256SUMS",
+                "0" * 64,
+            )
+            with mock.patch.object(runner, "load_model_pins", return_value=(pin,)):
+                with self.assertRaisesRegex(
+                    runner.ModelBundleError, "checksum manifest digest mismatch"
+                ):
+                    runner.validate_required_models(repo_root, bundle, bundle)
+
+    def test_present_model_with_mismatched_artifact_digest_fails_closed(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "present-model"
+            bundle.mkdir()
+            artifact = bundle / "model.onnx"
+            artifact.write_bytes(b"synthetic corrupted model bytes")
+            manifest = bundle / "SHA256SUMS"
+            manifest.write_text(f"{'0' * 64}  model.onnx\n", encoding="utf-8")
+            pin = runner.ModelPin(
+                "synthetic-present-model",
+                bundle,
+                "SHA256SUMS",
+                score.sha256_file(manifest),
+            )
+            with mock.patch.object(runner, "load_model_pins", return_value=(pin,)):
+                with self.assertRaisesRegex(
+                    runner.ModelBundleError, "artifact digest mismatch"
+                ):
+                    runner.validate_required_models(repo_root, bundle, bundle)
+
 
 class ProfileIsolationTests(unittest.TestCase):
     def document(self) -> score.Document:

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+import copy
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gaze_bench_score as score
+import run_no_opf_benchmark as runner
+
+
+def scorecard(leaked: int = 0) -> dict[str, object]:
+    uid = "synthetic-runner-1"
+    digest = hashlib.sha256(
+        json.dumps([uid], separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    fully_covered = 1 if leaked == 0 else 0
+    run = {
+        "metrics": {
+            "documents": 1,
+            "documents_without_leaks": fully_covered,
+            "documents_with_false_positives": 0,
+            "utf8_bytes": {
+                "pii": 2,
+                "leaked": leaked,
+                "false_positive": 0,
+            },
+            "entities": {"gold": 1, "fully_covered": fully_covered},
+        },
+        "pipeline_contract": {
+            "documents": 1,
+            "restore_exact_documents": 1,
+            "restore_success_decisions": 1,
+            "manifest_valid_documents": 1,
+            "manifest_integrity_errors": {},
+            "strict_would_reject_documents": 0,
+            "post_policy_scanned_documents": 1,
+            "post_policy_suspects": 0,
+            "redact_actions": 0,
+        },
+        "pipeline_availability": {
+            "attempted_documents": 1,
+            "completed_documents": 1,
+            "failed_closed_documents": 0,
+            "errors": {},
+            "error_stages": {},
+        },
+        "per_language": {},
+        "per_label_recall": {},
+        "per_negative_category": {},
+        "latency_ms": {"clean_ms": {"p95": 1.0}},
+        "process": {
+            "cold_start_to_first_validated_response_ms": 2.0,
+            "warmup_count": 1,
+            "discarded_warmup_samples": [{"sample": 1, "clean_ms": 0.5}],
+        },
+    }
+    return {
+        "schema_version": 3,
+        "dataset": {
+            "repository": "synthetic/runner",
+            "revision": "synthetic-v1",
+            "file": "synthetic.jsonl",
+            "integrity": {"sha256": "0" * 64},
+            "evaluated_population": {"documents": 1},
+            "sampling": {
+                "strategy": score.SAMPLING_STRATEGY,
+                "seed": 7,
+                "evaluated_document_ids": [uid],
+                "evaluated_document_ids_digest": {
+                    "algorithm": "sha256",
+                    "value": digest,
+                },
+            },
+        },
+        "runs": [
+            {"config": config, **copy.deepcopy(run)}
+            for config in score.DEFAULT_CONFIGS
+        ],
+    }
+
+
+class IntegerComparatorTests(unittest.TestCase):
+    def test_empty_and_missing_candidates_fail_closed(self) -> None:
+        baseline = scorecard()
+        for candidate in ({}, {"schema_version": 3, "runs": []}):
+            comparison = score.compare_scorecards(candidate, baseline)
+            self.assertFalse(comparison["regression"]["passed"])
+            self.assertFalse(comparison["release_readiness"]["passed"])
+
+    def test_integer_leak_ratchet_catches_change_even_if_rate_is_unchanged(self) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        candidate["runs"][0]["metrics"]["utf8_bytes"]["leaked"] = 1
+        comparison = score.compare_scorecards(candidate, baseline)
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertTrue(
+            any(
+                failure.get("gate") == "leaked_labeled_utf8_bytes"
+                for failure in comparison["regression"]["failures"]
+            )
+        )
+
+    def test_success_count_decrease_is_a_zero_tolerance_regression(self) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        candidate["runs"][0]["metrics"]["documents_without_leaks"] = 0
+        comparison = score.compare_scorecards(candidate, baseline)
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertTrue(
+            any(
+                failure.get("gate") == "documents_without_leaks"
+                for failure in comparison["regression"]["failures"]
+            )
+        )
+
+    def test_pipeline_telemetry_disagreement_fails_both_verdicts(self) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        production = candidate["runs"][-1]["pipeline_availability"]
+        production["failed_closed_documents"] = 1
+        production["completed_documents"] = 0
+        production["errors"] = {}
+        production["error_stages"] = {}
+        comparison = score.compare_scorecards(candidate, baseline)
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertFalse(comparison["release_readiness"]["passed"])
+
+    def test_performance_is_informational_by_default(self) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        candidate["runs"][0]["latency_ms"]["clean_ms"]["p95"] = 2.0
+        result = score.compare_performance(
+            candidate, baseline, tolerance_percent=10.0
+        )
+        self.assertFalse(result["passed"])
+        self.assertFalse(result["gating"])
+        self.assertEqual(result["disposition"], "informational")
+
+
+class ModelValidationTests(unittest.TestCase):
+    def test_missing_model_is_an_actionable_typed_error(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "missing-model"
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "model directory does not exist"
+            ):
+                runner.validate_required_models(repo_root, missing, missing)
+
+
+class ProfileIsolationTests(unittest.TestCase):
+    def document(self) -> score.Document:
+        return score.Document(
+            uid="synthetic-no-opf-1",
+            text="synthetic text",
+            language="en",
+            region="US",
+            source_dataset="unit-test",
+            spans=(),
+        )
+
+    def test_full_profile_never_passes_opf_even_when_environment_is_set(self) -> None:
+        fake_environment = {
+            "PATH": "/synthetic/bin",
+            "GAZE_OPENAI_FILTER_OPF": "/tmp/fake-opf",
+            "OPF_CHECKPOINT": "/tmp/fake-checkpoint",
+            "GAZE_OPF_DAEMON_SOCKET": "/tmp/fake.sock",
+        }
+        fake_run = scorecard()["runs"][0]
+        with mock.patch.object(score, "run_config", return_value=fake_run) as run_config:
+            _, provenance = runner.execute_measurements(
+                repo_root=Path("/synthetic/repo"),
+                binary=Path("/synthetic/clean_for_bench"),
+                documents=[self.document()],
+                davlan_model=Path("/synthetic/davlan"),
+                kiji_model=Path("/synthetic/kiji"),
+                threshold=0.3,
+                diagnostics_dir=Path("/synthetic/diagnostics"),
+                warmup_count=1,
+                measured_repetitions=1,
+                source_environment=fake_environment,
+            )
+        self.assertEqual(run_config.call_count, len(score.DEFAULT_CONFIGS))
+        for call in run_config.call_args_list:
+            self.assertEqual(call.args[6:9], (None, None, None))
+            passed_environment = call.kwargs["base_environment"]
+            self.assertEqual(passed_environment, {"PATH": "/synthetic/bin"})
+        serialized = json.loads(json.dumps(provenance))
+        first = serialized[0]["runs"][0]
+        self.assertEqual(first["warmup_count"], 1)
+        self.assertEqual(len(first["discarded_warmup_samples"]), 1)
+        self.assertEqual(first["cold_start_to_first_validated_response_ms"], 2.0)
+
+    def test_quick_sampling_is_reproducible(self) -> None:
+        documents = [
+            score.Document(
+                uid=f"synthetic-sample-{index}",
+                text="synthetic text",
+                language="en" if index % 2 else "de",
+                region="US" if index % 2 else "DE",
+                source_dataset="unit-test",
+                spans=(),
+            )
+            for index in range(20)
+        ]
+        first, _ = score.stratified_sample(documents, 7, seed=41)
+        second, _ = score.stratified_sample(list(reversed(documents)), 7, seed=41)
+        self.assertEqual(
+            [document.uid for document in first],
+            [document.uid for document in second],
+        )
+
+
+class BaselineGuardTests(unittest.TestCase):
+    def args(self, **overrides: object) -> Namespace:
+        values = {
+            "profile": "full",
+            "accept_baseline": Path("/tmp/synthetic-baseline.json"),
+            "compare_baseline": Path("/tmp/synthetic-baseline.json"),
+            "accept_baseline_confirm": None,
+        }
+        values.update(overrides)
+        return Namespace(**values)
+
+    def test_accept_baseline_requires_exact_review_confirmation(self) -> None:
+        result = {"passed": True}
+        with self.assertRaisesRegex(
+            runner.BaselineAcceptanceError, "requires --accept-baseline-confirm"
+        ):
+            runner.accept_baseline(self.args(), scorecard(), result, result)
+
+    def test_quick_profile_can_never_replace_baseline(self) -> None:
+        result = {"passed": True}
+        with self.assertRaisesRegex(
+            runner.BaselineAcceptanceError, "only a full-profile"
+        ):
+            runner.accept_baseline(
+                self.args(
+                    profile="quick",
+                    accept_baseline_confirm=runner.BASELINE_CONFIRMATION,
+                ),
+                scorecard(),
+                result,
+                result,
+            )
+
+    def test_initialization_cannot_overwrite_an_existing_baseline(self) -> None:
+        result = {"passed": True}
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "baseline.json"
+            baseline.write_text("{}\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                runner.BaselineAcceptanceError, "refusing to overwrite"
+            ):
+                runner.accept_baseline(
+                    self.args(
+                        accept_baseline=baseline,
+                        compare_baseline=None,
+                        accept_baseline_confirm=runner.BASELINE_CONFIRMATION,
+                    ),
+                    scorecard(),
+                    {"passed": None},
+                    result,
+                )
+
+    def test_reviewed_release_ready_initialization_writes_new_baseline(self) -> None:
+        result = {"passed": True}
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline = Path(tmp) / "baseline.json"
+            runner.accept_baseline(
+                self.args(
+                    accept_baseline=baseline,
+                    compare_baseline=None,
+                    accept_baseline_confirm=runner.BASELINE_CONFIRMATION,
+                ),
+                scorecard(),
+                {"passed": None},
+                result,
+            )
+            self.assertEqual(json.loads(baseline.read_text()), scorecard())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- Add scripts/bench/run_no_opf_benchmark.py as the one canonical local entry point. quick uses the scorer seeded stratified sampler; full uses the complete Dataiku EN/DE selection plus all 1,024 committed A4 negatives.
- Validate pinned Davlan and Kiji model bytes before build or cell execution. Missing, mismatched, unsafe, or incomplete bundles fail with typed errors.
- Compare zero-tolerance integer correctness counts, keep regression and release readiness as separate machine-readable verdicts, and keep clean_ms p95 tolerance separate and informational by default.
- Add guarded full-only baseline initialization/replacement, explicit no-OPF environment isolation, per-language/per-label/per-negative-category diagnostics, and runner-owned warmup/repetition/cold-start provenance.
- Run the locked model-free scorer/comparator suite in normal CI. No model benchmark is added to GitHub Actions.

Five axes
- Reliability: empty or malformed candidates, population drift, pipeline failures, leaks, restore/manifest failures, residual suspects, and telemetry disagreement fail closed. Warmups are discarded from latency but still pass correctness gates.
- Reversibility: exact restore and valid-manifest integer counts cannot regress; release readiness requires zero restore or manifest failures.
- Agentic-first: the scorecard covers the production-shaped no-OPF cells, stable JSON artifacts, repeatable sampling, and negative categories used by agent workflows.
- Trust: model digests, evaluated IDs, warmups, measured repetitions, cold start, and honest clean_ms provenance are explicit. Ratios cannot hide an integer-count regression.
- Adopter ergonomics: one documented command owns quick/full runs, outputs, model locations, and the reviewed baseline procedure.

No axis is weakened.

Verification
- uv sync --project scripts/bench --locked
- uv run --project scripts/bench python -m unittest discover -s scripts/bench (59 tests, OK)
- git diff --check
- workflow YAML parsed with yq

Boundary
- Only scripts/bench/**, docs/reference/benchmarks/README.md, and model-free wiring in .github/workflows/test.yml changed.
- No Rust, Cargo.toml, Cargo.lock, or OPF behavior changed.
- Both profiles pass no OPF command/checkpoint/socket and strip OPF environment variables; a fake-OPF model-free test covers the full-profile path.
- A6 remains responsible for running the full local model benchmark twice and producing the authoritative baseline/error buckets.

Resolves solo todo #2166
