### PR TITLE
[agent] consume canonical Davlan manifest contract

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -54,11 +54,16 @@ silently skipped.
 
 | Model | Default location | Pin source | Validation |
 | --- | --- | --- | --- |
-| Davlan multilingual BERT NER | `~/.local/share/gaze/models/davlan-mbert-ner-hrl` | `davlan-bert-multilingual.bundle_sha` in `crates/gaze-recognizers/benches/ner_models.toml` | SHA-256 over the complete deterministic file tree |
+| Davlan multilingual BERT NER | `~/.local/share/gaze/models/davlan-mbert-ner-hrl` | `davlan-bert-multilingual.bundle_sha` in `crates/gaze-recognizers/benches/ner_models.toml` | pinned `SHA256SUMS` digest, exact five-artifact manifest and bundle surface, then every artifact digest |
 | Kiji DistilBERT | `~/.local/share/gaze/models/kiji-distilbert` | `kiji-distilbert.bundle_sha` in the same TOML | pinned `SHA256SUMS` digest, then every listed artifact digest |
 
 Override locations with `--model-dir` and `--kiji-model-dir`. The runner rejects
-symlinks in validated bundle material.
+symlinks in validated bundle material. Davlan's canonical bundle contains exactly
+`config.json`, `pytorch_model.bin`, `special_tokens_map.json`,
+`tokenizer_config.json`, `vocab.txt`, and `SHA256SUMS`. Its pin is the SHA-256 of
+that `SHA256SUMS` file. The manifest must list exactly those five runtime
+artifacts, and the directory may contain no other files or directories; missing
+artifacts, alternate weights, cache metadata, and all other extras fail closed.
 
 ## Outputs and verdicts
 

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -29,6 +29,16 @@ NEGATIVE_CORPUS = Path(
 MODEL_CONFIG = Path("crates/gaze-recognizers/benches/ner_models.toml")
 DEFAULT_DAVLAN_MODEL = Path("~/.local/share/gaze/models/davlan-mbert-ner-hrl")
 DEFAULT_KIJI_MODEL = Path("~/.local/share/gaze/models/kiji-distilbert")
+DAVLAN_RUNTIME_ARTIFACTS = frozenset(
+    {
+        "config.json",
+        "pytorch_model.bin",
+        "special_tokens_map.json",
+        "tokenizer_config.json",
+        "vocab.txt",
+    }
+)
+DAVLAN_BUNDLE_SURFACE = DAVLAN_RUNTIME_ARTIFACTS | {"SHA256SUMS"}
 
 
 class RunnerError(RuntimeError):
@@ -120,22 +130,6 @@ def repo_path(repo_root: Path, path: Path) -> Path:
     return path if path.is_absolute() else repo_root / path
 
 
-def sha256_tree(path: Path) -> str:
-    digest = hashlib.sha256()
-    for child in sorted(path.rglob("*")):
-        if child.is_symlink():
-            raise ModelBundleError(
-                f"model bundle {path} contains a symlink: {child.relative_to(path)}"
-            )
-        if child.is_file():
-            relative = child.relative_to(path).as_posix().encode("utf-8")
-            digest.update(relative)
-            digest.update(b"\0")
-            digest.update(score.sha256_file(child).encode("ascii"))
-            digest.update(b"\0")
-    return digest.hexdigest()
-
-
 def load_model_pins(
     repo_root: Path, davlan_path: Path, kiji_path: Path
 ) -> tuple[ModelPin, ModelPin]:
@@ -150,9 +144,75 @@ def load_model_pins(
             f"required model pin is missing from {config_path}: {error}"
         ) from error
     return (
-        ModelPin("davlan-bert-multilingual", davlan_path, "tree", davlan_sha),
+        ModelPin(
+            "davlan-bert-multilingual",
+            davlan_path,
+            "SHA256SUMS",
+            davlan_sha,
+        ),
         ModelPin("kiji-distilbert", kiji_path, "SHA256SUMS", kiji_sha),
     )
+
+
+def _validate_davlan_manifest_surface(pin: ModelPin) -> None:
+    manifest = pin.path / "SHA256SUMS"
+    if not manifest.is_file() or manifest.is_symlink():
+        raise ModelBundleError(
+            f"{pin.model_id}: required checksum manifest is missing or unsafe: "
+            f"{manifest}; install the pinned local model bundle before running"
+        )
+    actual_manifest_sha = score.sha256_file(manifest)
+    if actual_manifest_sha != pin.expected_sha256:
+        raise ModelBundleError(
+            f"{pin.model_id}: checksum manifest digest mismatch at {manifest}; "
+            f"expected {pin.expected_sha256}, got {actual_manifest_sha}"
+        )
+
+    entries = list(pin.path.iterdir())
+    actual_surface = {entry.name for entry in entries}
+    if actual_surface != DAVLAN_BUNDLE_SURFACE:
+        missing = sorted(DAVLAN_BUNDLE_SURFACE - actual_surface)
+        unexpected = sorted(actual_surface - DAVLAN_BUNDLE_SURFACE)
+        raise ModelBundleError(
+            f"{pin.model_id}: unexpected bundle surface at {pin.path}; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    for entry in entries:
+        if entry.is_symlink():
+            raise ModelBundleError(
+                f"{pin.model_id}: bundle surface contains a symlink: {entry}"
+            )
+        if not entry.is_file():
+            raise ModelBundleError(
+                f"{pin.model_id}: unexpected bundle surface entry: {entry}"
+            )
+
+    listed_artifacts: list[str] = []
+    for line_number, line in enumerate(
+        manifest.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) != 2 or len(fields[0]) != 64:
+            raise ModelBundleError(
+                f"{pin.model_id}: malformed {manifest.name} line {line_number}"
+            )
+        relative_raw = fields[1]
+        relative = Path(relative_raw)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ModelBundleError(
+                f"{pin.model_id}: unsafe path in {manifest.name} line {line_number}"
+            )
+        listed_artifacts.append(relative.as_posix())
+    if (
+        len(listed_artifacts) != len(DAVLAN_RUNTIME_ARTIFACTS)
+        or set(listed_artifacts) != DAVLAN_RUNTIME_ARTIFACTS
+    ):
+        raise ModelBundleError(
+            f"{pin.model_id}: {manifest.name} must list exactly the canonical "
+            "five runtime artifacts"
+        )
 
 
 def _validate_checksum_manifest(pin: ModelPin) -> dict[str, object]:
@@ -214,21 +274,9 @@ def validate_model_bundle(pin: ModelPin) -> dict[str, object]:
             f"{pin.model_id}: model directory does not exist: {pin.path}; "
             "install the pinned local model bundle before running"
         )
-    if pin.digest_kind != "tree":
-        return _validate_checksum_manifest(pin)
-    actual = sha256_tree(pin.path)
-    if actual != pin.expected_sha256:
-        raise ModelBundleError(
-            f"{pin.model_id}: model bundle digest mismatch at {pin.path}; "
-            f"expected {pin.expected_sha256}, got {actual}"
-        )
-    return {
-        "model_id": pin.model_id,
-        "digest_kind": "tree",
-        "expected_sha256": pin.expected_sha256,
-        "observed_sha256": actual,
-        "verified_artifacts": sum(1 for item in pin.path.rglob("*") if item.is_file()),
-    }
+    if pin.model_id == "davlan-bert-multilingual":
+        _validate_davlan_manifest_surface(pin)
+    return _validate_checksum_manifest(pin)
 
 
 def validate_required_models(

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -16,6 +16,15 @@ import gaze_bench_score as score
 import run_no_opf_benchmark as runner
 
 
+DAVLAN_ARTIFACTS = (
+    "config.json",
+    "pytorch_model.bin",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+    "vocab.txt",
+)
+
+
 def scorecard(leaked: int = 0) -> dict[str, object]:
     uid = "synthetic-runner-1"
     digest = hashlib.sha256(
@@ -146,6 +155,22 @@ class IntegerComparatorTests(unittest.TestCase):
 
 
 class ModelValidationTests(unittest.TestCase):
+    def write_davlan_bundle(self, bundle: Path) -> runner.ModelPin:
+        bundle.mkdir()
+        manifest_lines = []
+        for name in DAVLAN_ARTIFACTS:
+            artifact = bundle / name
+            artifact.write_bytes(f"synthetic {name} bytes".encode("utf-8"))
+            manifest_lines.append(f"{score.sha256_file(artifact)}  {name}\n")
+        manifest = bundle / "SHA256SUMS"
+        manifest.write_text("".join(manifest_lines), encoding="utf-8")
+        return runner.ModelPin(
+            "davlan-bert-multilingual",
+            bundle,
+            "SHA256SUMS",
+            score.sha256_file(manifest),
+        )
+
     def test_missing_model_is_an_actionable_typed_error(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         with tempfile.TemporaryDirectory() as tmp:
@@ -154,6 +179,116 @@ class ModelValidationTests(unittest.TestCase):
                 runner.ModelBundleError, "model directory does not exist"
             ):
                 runner.validate_required_models(repo_root, missing, missing)
+
+    def test_davlan_exact_surface_manifest_validates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pin = self.write_davlan_bundle(Path(tmp) / "davlan")
+            result = runner.validate_model_bundle(pin)
+        self.assertEqual(result["digest_kind"], "SHA256SUMS")
+        self.assertEqual(result["observed_sha256"], pin.expected_sha256)
+        self.assertEqual(result["verified_artifacts"], len(DAVLAN_ARTIFACTS))
+
+    def test_davlan_extra_bundle_material_fails_closed(self) -> None:
+        for extra in ("model.safetensors", "model.onnx", "README.md", "cache/tree"):
+            with self.subTest(extra=extra), tempfile.TemporaryDirectory() as tmp:
+                bundle = Path(tmp) / "davlan"
+                pin = self.write_davlan_bundle(bundle)
+                unexpected = bundle / extra
+                unexpected.parent.mkdir(parents=True, exist_ok=True)
+                unexpected.write_bytes(b"synthetic unexpected bytes")
+                with self.assertRaisesRegex(
+                    runner.ModelBundleError, "unexpected bundle surface"
+                ):
+                    runner.validate_model_bundle(pin)
+
+    def test_davlan_missing_runtime_artifact_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            (bundle / "vocab.txt").unlink()
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "unexpected bundle surface"
+            ):
+                runner.validate_model_bundle(pin)
+
+    def test_davlan_symlinked_artifact_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bundle = root / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            artifact = bundle / "vocab.txt"
+            artifact.unlink()
+            target = root / "synthetic-vocab-target.txt"
+            target.write_bytes(b"synthetic vocab.txt bytes")
+            artifact.symlink_to(target)
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "symlink"
+            ):
+                runner.validate_model_bundle(pin)
+
+    def test_davlan_manifest_digest_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            wrong_pin = runner.ModelPin(
+                pin.model_id,
+                pin.path,
+                pin.digest_kind,
+                "0" * 64,
+            )
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "checksum manifest digest mismatch"
+            ):
+                runner.validate_model_bundle(wrong_pin)
+
+    def test_davlan_manifest_must_list_exact_runtime_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            manifest = bundle / "SHA256SUMS"
+            lines = manifest.read_text(encoding="utf-8").splitlines()
+            lines[-1] = lines[0]
+            manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            updated_pin = runner.ModelPin(
+                pin.model_id,
+                pin.path,
+                pin.digest_kind,
+                score.sha256_file(manifest),
+            )
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "must list exactly"
+            ):
+                runner.validate_model_bundle(updated_pin)
+
+    def test_davlan_artifact_digest_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            (bundle / "config.json").write_bytes(b"synthetic corrupted config")
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "artifact digest mismatch"
+            ):
+                runner.validate_model_bundle(pin)
+
+    def test_kiji_manifest_validation_remains_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "kiji"
+            bundle.mkdir()
+            artifact = bundle / "model.onnx"
+            artifact.write_bytes(b"synthetic kiji model bytes")
+            manifest = bundle / "SHA256SUMS"
+            manifest.write_text(
+                f"{score.sha256_file(artifact)}  model.onnx\n",
+                encoding="utf-8",
+            )
+            pin = runner.ModelPin(
+                "kiji-distilbert",
+                bundle,
+                "SHA256SUMS",
+                score.sha256_file(manifest),
+            )
+            result = runner.validate_model_bundle(pin)
+        self.assertEqual(result["verified_artifacts"], 1)
 
     def test_present_model_with_mismatched_manifest_digest_fails_closed(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Davlan now validates the master-ratified canonical bundle through the SHA256SUMS digest pin 7a3a0ba1f42a2ad171c80dbf6f247c59e4a9c92ca848c9f5cf0655ffa26cb3da, an exact five-artifact manifest, an exact five-artifact-plus-manifest directory surface, and per-artifact digests. Extras, alternate weights, missing artifacts, and symlinks fail closed with ModelBundleError. Kiji validation is unchanged.

No ner_models.toml, Rust, Cargo, or OPF files changed. This PR targets the authorized staging branch agent/no-opf-davlan-manifest-v1.

## Five axes

- Reliability: fail-closed exact-surface validation prevents cache drift, alternate weights, missing artifacts, and symlinks from silently passing.
- Reversibility: no pseudonymization or restore contract changes; the benchmark gate now guarantees the intended recognizer model bytes before evaluation.
- Agentic-first: benchmark cells cannot silently skip or run against an unratified Davlan bundle.
- Trust: the deterministic SHA256SUMS pin, exact manifest membership, artifact digests, and typed ModelBundleError failures are auditable.
- Adopter ergonomics: the benchmark README documents the distinct Davlan and Kiji validation conventions and actionable failure behavior.

No axis is weakened.

## Verification

- uv sync --project scripts/bench --locked
- uv run --project scripts/bench python -m unittest discover -s scripts/bench (69 tests, OK)

Resolves solo todo #2181