### PR TITLE
[agent] pin production Davlan ONNX runtime

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -54,16 +54,26 @@ silently skipped.
 
 | Model | Default location | Pin source | Validation |
 | --- | --- | --- | --- |
-| Davlan multilingual BERT NER | `~/.local/share/gaze/models/davlan-mbert-ner-hrl` | `davlan-bert-multilingual.bundle_sha` in `crates/gaze-recognizers/benches/ner_models.toml` | pinned `SHA256SUMS` digest, exact five-artifact manifest and bundle surface, then every artifact digest |
-| Kiji DistilBERT | `~/.local/share/gaze/models/kiji-distilbert` | `kiji-distilbert.bundle_sha` in the same TOML | pinned `SHA256SUMS` digest, then every listed artifact digest |
+| Davlan multilingual BERT NER (production pass2 ONNX) | `~/.local/share/gaze/models/davlan-mbert-ner-hrl` | `[pass2_ner]` in `scripts/bench/no_opf_models.toml` | pinned `SHA256SUMS` digest, exact seven-artifact manifest and eight-file bundle surface, then every artifact digest |
+| Kiji DistilBERT | `~/.local/share/gaze/models/kiji-distilbert` | `kiji-distilbert.bundle_sha` in `crates/gaze-recognizers/benches/ner_models.toml` | pinned `SHA256SUMS` digest, then every listed artifact digest |
 
 Override locations with `--model-dir` and `--kiji-model-dir`. The runner rejects
 symlinks in validated bundle material. Davlan's canonical bundle contains exactly
-`config.json`, `pytorch_model.bin`, `special_tokens_map.json`,
-`tokenizer_config.json`, `vocab.txt`, and `SHA256SUMS`. Its pin is the SHA-256 of
-that `SHA256SUMS` file. The manifest must list exactly those five runtime
-artifacts, and the directory may contain no other files or directories; missing
-artifacts, alternate weights, cache metadata, and all other extras fail closed.
+`model.onnx`, `tokenizer.json`, `config.json`, `tokenizer_config.json`,
+`special_tokens_map.json`, `vocab.txt`, `labels.json`, and `SHA256SUMS`. Its
+production provenance is repository
+`onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX`, commit
+`cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8`, and canonical manifest digest
+`7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16`.
+The manifest must list exactly the seven runtime artifacts and match that digest;
+the directory may contain no other files, directories, or symlinks. Missing
+artifacts, Transformers or safetensors weights, cache metadata, and all other
+extras fail closed.
+
+This production ONNX pass2 pin is intentionally separate from
+`crates/gaze-recognizers/benches/ner_models.toml`. That file remains the research
+Transformers model matrix and is not the Davlan source of truth for the canonical
+no-OPF runner. Kiji continues to load from its existing `ner_models.toml` entry.
 
 ## Outputs and verdicts
 

--- a/scripts/bench/no_opf_models.toml
+++ b/scripts/bench/no_opf_models.toml
@@ -1,0 +1,9 @@
+[pass2_ner]
+id = "davlan-mbert-ner-hrl-onnx"
+hf_repo = "onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX"
+hf_commit = "cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8"
+bundle_sha = "7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16"   # SHA256 of the canonical SHA256SUMS manifest for these seven ONNX runtime artifacts
+runtime = "onnxruntime"
+model_file = "model.onnx"
+fetch_script = "scripts/fetch/fetch-ner-model.sh"
+required_artifacts = ["model.onnx", "tokenizer.json", "config.json", "tokenizer_config.json", "special_tokens_map.json", "vocab.txt", "labels.json"]

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -27,13 +27,16 @@ NEGATIVE_CORPUS = Path(
     "crates/xtask/fixtures/negative_corpus/en_de_negative.jsonl"
 )
 MODEL_CONFIG = Path("crates/gaze-recognizers/benches/ner_models.toml")
+NO_OPF_MODEL_CONFIG = Path("scripts/bench/no_opf_models.toml")
 DEFAULT_DAVLAN_MODEL = Path("~/.local/share/gaze/models/davlan-mbert-ner-hrl")
 DEFAULT_KIJI_MODEL = Path("~/.local/share/gaze/models/kiji-distilbert")
 DAVLAN_RUNTIME_ARTIFACTS = frozenset(
     {
         "config.json",
-        "pytorch_model.bin",
+        "labels.json",
+        "model.onnx",
         "special_tokens_map.json",
+        "tokenizer.json",
         "tokenizer_config.json",
         "vocab.txt",
     }
@@ -71,6 +74,9 @@ class ModelPin:
     path: Path
     digest_kind: str
     expected_sha256: str
+    hf_repo: str | None = None
+    hf_commit: str | None = None
+    runtime: str | None = None
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -136,25 +142,51 @@ def load_model_pins(
     config_path = repo_root / MODEL_CONFIG
     raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
     models = {item["id"]: item for item in raw.get("model", [])}
+    no_opf_config_path = repo_root / NO_OPF_MODEL_CONFIG
+    no_opf_raw = tomllib.loads(no_opf_config_path.read_text(encoding="utf-8"))
     try:
-        davlan_sha = str(models["davlan-bert-multilingual"]["bundle_sha"])
+        pass2_ner = no_opf_raw["pass2_ner"]
+        davlan_id = str(pass2_ner["id"])
+        davlan_repo = str(pass2_ner["hf_repo"])
+        davlan_commit = str(pass2_ner["hf_commit"])
+        davlan_sha = str(pass2_ner["bundle_sha"])
+        davlan_runtime = str(pass2_ner["runtime"])
+        davlan_model_file = str(pass2_ner["model_file"])
+        davlan_fetch_script = str(pass2_ner["fetch_script"])
+        davlan_artifacts = frozenset(
+            str(item) for item in pass2_ner["required_artifacts"]
+        )
         kiji_sha = str(models["kiji-distilbert"]["bundle_sha"])
-    except KeyError as error:
+    except (KeyError, TypeError) as error:
         raise ModelBundleError(
-            f"required model pin is missing from {config_path}: {error}"
+            "required model pin is missing or invalid in "
+            f"{no_opf_config_path} or {config_path}: {error}"
         ) from error
+    if (
+        davlan_id != "davlan-mbert-ner-hrl-onnx"
+        or davlan_runtime != "onnxruntime"
+        or davlan_model_file != "model.onnx"
+        or davlan_fetch_script != "scripts/fetch/fetch-ner-model.sh"
+        or davlan_artifacts != DAVLAN_RUNTIME_ARTIFACTS
+    ):
+        raise ModelBundleError(
+            f"production pass2 NER contract is invalid in {no_opf_config_path}"
+        )
     return (
         ModelPin(
-            "davlan-bert-multilingual",
+            davlan_id,
             davlan_path,
             "SHA256SUMS",
             davlan_sha,
+            hf_repo=davlan_repo,
+            hf_commit=davlan_commit,
+            runtime=davlan_runtime,
         ),
         ModelPin("kiji-distilbert", kiji_path, "SHA256SUMS", kiji_sha),
     )
 
 
-def _validate_davlan_manifest_surface(pin: ModelPin) -> None:
+def _validate_davlan_manifest_surface(pin: ModelPin) -> dict[str, object]:
     manifest = pin.path / "SHA256SUMS"
     if not manifest.is_file() or manifest.is_symlink():
         raise ModelBundleError(
@@ -187,32 +219,61 @@ def _validate_davlan_manifest_surface(pin: ModelPin) -> None:
                 f"{pin.model_id}: unexpected bundle surface entry: {entry}"
             )
 
-    listed_artifacts: list[str] = []
-    for line_number, line in enumerate(
-        manifest.read_text(encoding="utf-8").splitlines(), start=1
-    ):
-        if not line:
-            continue
+    try:
+        manifest_lines = manifest.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ModelBundleError(
+            f"{pin.model_id}: cannot read checksum manifest {manifest}: {error}"
+        ) from error
+    listed_artifacts: list[tuple[str, str]] = []
+    for line_number, line in enumerate(manifest_lines, start=1):
         fields = line.split()
-        if len(fields) != 2 or len(fields[0]) != 64:
+        if (
+            len(fields) != 2
+            or len(fields[0]) != 64
+            or any(character not in "0123456789abcdef" for character in fields[0])
+        ):
             raise ModelBundleError(
                 f"{pin.model_id}: malformed {manifest.name} line {line_number}"
             )
-        relative_raw = fields[1]
+        expected, relative_raw = fields
         relative = Path(relative_raw)
         if relative.is_absolute() or ".." in relative.parts:
             raise ModelBundleError(
                 f"{pin.model_id}: unsafe path in {manifest.name} line {line_number}"
             )
-        listed_artifacts.append(relative.as_posix())
+        listed_artifacts.append((relative_raw, expected))
     if (
         len(listed_artifacts) != len(DAVLAN_RUNTIME_ARTIFACTS)
-        or set(listed_artifacts) != DAVLAN_RUNTIME_ARTIFACTS
+        or {name for name, _ in listed_artifacts} != DAVLAN_RUNTIME_ARTIFACTS
     ):
         raise ModelBundleError(
             f"{pin.model_id}: {manifest.name} must list exactly the canonical "
-            "five runtime artifacts"
+            "seven ONNX runtime artifacts"
         )
+    for relative_raw, expected in listed_artifacts:
+        artifact = pin.path / relative_raw
+        if not artifact.is_file() or artifact.is_symlink():
+            raise ModelBundleError(
+                f"{pin.model_id}: required artifact is missing or unsafe: {artifact}"
+            )
+        actual = score.sha256_file(artifact)
+        if actual != expected:
+            raise ModelBundleError(
+                f"{pin.model_id}: artifact digest mismatch for {artifact}; "
+                f"expected {expected}, got {actual}"
+            )
+    return {
+        "model_id": pin.model_id,
+        "hf_repo": pin.hf_repo,
+        "hf_commit": pin.hf_commit,
+        "runtime": pin.runtime,
+        "digest_kind": pin.digest_kind,
+        "bundle_sha": pin.expected_sha256,
+        "expected_sha256": pin.expected_sha256,
+        "observed_sha256": actual_manifest_sha,
+        "verified_artifacts": len(listed_artifacts),
+    }
 
 
 def _validate_checksum_manifest(pin: ModelPin) -> dict[str, object]:
@@ -274,8 +335,12 @@ def validate_model_bundle(pin: ModelPin) -> dict[str, object]:
             f"{pin.model_id}: model directory does not exist: {pin.path}; "
             "install the pinned local model bundle before running"
         )
-    if pin.model_id == "davlan-bert-multilingual":
-        _validate_davlan_manifest_surface(pin)
+    if pin.model_id == "davlan-mbert-ner-hrl-onnx":
+        if pin.path.is_symlink():
+            raise ModelBundleError(
+                f"{pin.model_id}: model directory is a symlink: {pin.path}"
+            )
+        return _validate_davlan_manifest_surface(pin)
     return _validate_checksum_manifest(pin)
 
 

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -18,10 +18,17 @@ import run_no_opf_benchmark as runner
 
 DAVLAN_ARTIFACTS = (
     "config.json",
-    "pytorch_model.bin",
+    "labels.json",
+    "model.onnx",
     "special_tokens_map.json",
+    "tokenizer.json",
     "tokenizer_config.json",
     "vocab.txt",
+)
+DAVLAN_HF_REPO = "onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX"
+DAVLAN_HF_COMMIT = "cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8"
+DAVLAN_BUNDLE_SHA = (
+    "7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16"
 )
 
 
@@ -165,11 +172,28 @@ class ModelValidationTests(unittest.TestCase):
         manifest = bundle / "SHA256SUMS"
         manifest.write_text("".join(manifest_lines), encoding="utf-8")
         return runner.ModelPin(
-            "davlan-bert-multilingual",
+            "davlan-mbert-ner-hrl-onnx",
             bundle,
             "SHA256SUMS",
             score.sha256_file(manifest),
+            hf_repo=DAVLAN_HF_REPO,
+            hf_commit=DAVLAN_HF_COMMIT,
+            runtime="onnxruntime",
         )
+
+    def test_production_davlan_pin_is_separate_and_onnx_specific(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        davlan, kiji = runner.load_model_pins(
+            repo_root,
+            Path("/synthetic/davlan"),
+            Path("/synthetic/kiji"),
+        )
+        self.assertEqual(davlan.model_id, "davlan-mbert-ner-hrl-onnx")
+        self.assertEqual(davlan.hf_repo, DAVLAN_HF_REPO)
+        self.assertEqual(davlan.hf_commit, DAVLAN_HF_COMMIT)
+        self.assertEqual(davlan.expected_sha256, DAVLAN_BUNDLE_SHA)
+        self.assertEqual(davlan.runtime, "onnxruntime")
+        self.assertEqual(kiji.model_id, "kiji-distilbert")
 
     def test_missing_model_is_an_actionable_typed_error(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
@@ -187,9 +211,37 @@ class ModelValidationTests(unittest.TestCase):
         self.assertEqual(result["digest_kind"], "SHA256SUMS")
         self.assertEqual(result["observed_sha256"], pin.expected_sha256)
         self.assertEqual(result["verified_artifacts"], len(DAVLAN_ARTIFACTS))
+        self.assertEqual(result["hf_repo"], DAVLAN_HF_REPO)
+        self.assertEqual(result["hf_commit"], DAVLAN_HF_COMMIT)
+        self.assertEqual(result["bundle_sha"], pin.expected_sha256)
+
+    def test_davlan_transformers_bundle_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            (bundle / "model.onnx").unlink()
+            (bundle / "pytorch_model.bin").write_bytes(
+                b"synthetic transformers weights"
+            )
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "unexpected bundle surface"
+            ):
+                runner.validate_model_bundle(pin)
+
+    def test_davlan_safetensors_bundle_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            (bundle / "model.safetensors").write_bytes(
+                b"synthetic alternate weights"
+            )
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "unexpected bundle surface"
+            ):
+                runner.validate_model_bundle(pin)
 
     def test_davlan_extra_bundle_material_fails_closed(self) -> None:
-        for extra in ("model.safetensors", "model.onnx", "README.md", "cache/tree"):
+        for extra in ("pytorch_model.bin", "README.md"):
             with self.subTest(extra=extra), tempfile.TemporaryDirectory() as tmp:
                 bundle = Path(tmp) / "davlan"
                 pin = self.write_davlan_bundle(bundle)
@@ -200,6 +252,16 @@ class ModelValidationTests(unittest.TestCase):
                     runner.ModelBundleError, "unexpected bundle surface"
                 ):
                     runner.validate_model_bundle(pin)
+
+    def test_davlan_subdirectory_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            (bundle / "cache").mkdir()
+            with self.assertRaisesRegex(
+                runner.ModelBundleError, "unexpected bundle surface"
+            ):
+                runner.validate_model_bundle(pin)
 
     def test_davlan_missing_runtime_artifact_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -259,6 +321,42 @@ class ModelValidationTests(unittest.TestCase):
                 runner.ModelBundleError, "must list exactly"
             ):
                 runner.validate_model_bundle(updated_pin)
+
+    def test_davlan_malformed_manifest_line_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = Path(tmp) / "davlan"
+            pin = self.write_davlan_bundle(bundle)
+            manifest = bundle / "SHA256SUMS"
+            lines = manifest.read_text(encoding="utf-8").splitlines()
+            lines[0] = "not-a-sha  config.json"
+            manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            updated_pin = runner.ModelPin(
+                pin.model_id,
+                pin.path,
+                pin.digest_kind,
+                score.sha256_file(manifest),
+            )
+            with self.assertRaisesRegex(runner.ModelBundleError, "malformed"):
+                runner.validate_model_bundle(updated_pin)
+
+    def test_davlan_unsafe_manifest_path_fails_closed(self) -> None:
+        for unsafe in ("../config.json", "/config.json"):
+            with self.subTest(unsafe=unsafe), tempfile.TemporaryDirectory() as tmp:
+                bundle = Path(tmp) / "davlan"
+                pin = self.write_davlan_bundle(bundle)
+                manifest = bundle / "SHA256SUMS"
+                lines = manifest.read_text(encoding="utf-8").splitlines()
+                digest = lines[0].split()[0]
+                lines[0] = f"{digest}  {unsafe}"
+                manifest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                updated_pin = runner.ModelPin(
+                    pin.model_id,
+                    pin.path,
+                    pin.digest_kind,
+                    score.sha256_file(manifest),
+                )
+                with self.assertRaisesRegex(runner.ModelBundleError, "unsafe path"):
+                    runner.validate_model_bundle(updated_pin)
 
     def test_davlan_artifact_digest_mismatch_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary\n\nProduction pass2 Davlan now reads its ONNX pin from `scripts/bench/no_opf_models.toml`, separate from the research Transformers entry in `ner_models.toml`. The pin records `onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX` at commit `cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8` with canonical SHA256SUMS digest `7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16`.\n\nDavlan validation requires exactly seven ONNX runtime artifacts plus `SHA256SUMS`. Transformers weights, safetensors, extras, missing files, subdirectories, symlinks, malformed or unsafe manifest entries, manifest-digest drift, and artifact-digest drift fail closed with `ModelBundleError`. Runner scorecard provenance includes the repo, commit, runtime, and digest.\n\nKiji loading and validation are unchanged. `ner_models.toml` is untouched. This PR targets the staging branch `agent/no-opf-davlan-onnx-contract-v1` and completes only todo 2184.\n\n## Five axes\n\n- Reliability: exact-surface and per-artifact validation prevents the A6 runtime mismatch and all unpinned bundle material from passing.\n- Reversibility: pseudonymization and restore behavior are unchanged; the benchmark gate now verifies the intended recognizer bytes before evaluation.\n- Agentic-first: the canonical no-OPF production path is pinned to its actual ONNX runtime artifacts.\n- Trust: repository, commit, manifest digest, exact membership, and typed failures are deterministic and auditable.\n- Adopter ergonomics: the README separates production ONNX setup from the research Transformers matrix and documents actionable failures.\n\nNo axis is weakened.\n\n## Verification\n\n- `uv sync --project scripts/bench --locked`\n- `uv run --project scripts/bench python -m unittest discover -s scripts/bench` (75 tests, OK)\n- `git diff --check`\n\nResolves solo todo #2184