### PR TITLE
[agent] correct source-ID reproduction guard to delimiter-boundary matching

### DIFF
--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -523,7 +523,14 @@ def _validate_final_protection_trace(
             "final_protection_trace: tokenize items must agree 1:1 with the final manifest"
         )
     for source_id, context in source_identifiers:
-        if any(raw_value and raw_value in source_id for raw_value in protected_raw_values):
+        if any(
+            raw_value
+            and re.search(
+                rf"(?:^|(?<=[._:/-])){re.escape(raw_value)}(?:$|(?=[._:/-]))",
+                source_id,
+            )
+            for raw_value in protected_raw_values
+        ):
             raise ResponseValidationError(
                 f"{context}: identifier reproduces protected request content"
             )

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -499,17 +499,20 @@ class ResponseValidationTests(unittest.TestCase):
     def test_trace_rejects_source_id_reproducing_protected_request_content(
         self,
     ) -> None:
-        protected_value = "order-1234"
-        document = benchmark.Document(
-            uid="synthetic-response",
-            text=protected_value,
-            language="en",
-            region="US",
-            source_dataset="unit-test",
-            spans=(benchmark.Span(0, len(protected_value), "ORDER"),),
-        )
-        for source_id in (protected_value, f"rule-{protected_value}-source"):
-            with self.subTest(source_id=source_id):
+        for protected_value, source_id in (
+            ("order-1234", "order-1234"),
+            ("order-1234", "rule-order-1234-source"),
+            ("davlan", "ner.davlan"),
+        ):
+            with self.subTest(protected_value=protected_value, source_id=source_id):
+                document = benchmark.Document(
+                    uid="synthetic-response",
+                    text=protected_value,
+                    language="en",
+                    region="US",
+                    source_dataset="unit-test",
+                    spans=(benchmark.Span(0, len(protected_value), "ORDER"),),
+                )
                 response = self.tokenize_response()
                 response["manifest_spans"][0]["raw_end"] = len(protected_value)
                 item = response["final_protection_trace"][0]
@@ -520,6 +523,24 @@ class ResponseValidationTests(unittest.TestCase):
                     "reproduces protected request content",
                 ):
                     benchmark.validate_response(document, response)
+
+    def test_trace_accepts_unbounded_source_id_substring(self) -> None:
+        protected_value = "avl"
+        document = benchmark.Document(
+            uid="synthetic-response",
+            text=protected_value,
+            language="en",
+            region="US",
+            source_dataset="unit-test",
+            spans=(benchmark.Span(0, len(protected_value), "ORDER"),),
+        )
+        response = self.tokenize_response()
+        response["manifest_spans"][0]["raw_end"] = len(protected_value)
+        item = response["final_protection_trace"][0]
+        item["raw_end"] = len(protected_value)
+        item["provenance"]["source_ids"] = ["davlan"]
+
+        benchmark.validate_response(document, response)
 
     def test_all_ratified_trace_combinations_validate(self) -> None:
         combinations = (


### PR DESCRIPTION
## Summary

- match protected request values in provenance source IDs only at source-ID start/end or next to `[._:/-]` delimiters
- keep equality and delimiter-bounded copies fail-closed while accepting coincidental substrings inside legitimate identifier tokens
- preserve the source-ID grammar, non-empty/sorted/duplicate-free checks, and existing validation error context

This deliberately narrows a fail-closed guard. It remains leak-safe under the source-ID contract because equality and every delimiter-separated reproduction still reject; only an occurrence fused into a larger identifier token is accepted. Matching stays case-sensitive, empty protected values remain ignored, and values containing delimiters are judged by the characters adjacent to the full occurrence.

## Five axes

- Reliability: removes false rejections without allowing a bounded protected value through; equality and standalone identifier segments still fail closed.
- Reversibility: manifest validation and restore behavior are unchanged.
- Agentic-first: legitimate recognizer IDs can carry their normal names without coincidental protected substrings invalidating benchmark responses.
- Trust: the escaped, case-sensitive boundary rule is deterministic, auditable, and covered by equality, bounded, and unbounded regressions.
- Adopter ergonomics: benchmark consumers get actionable validation without false failures from ordinary source identifiers; there is no API or wire/schema change.

No north-star axis is weakened.

## Verification

- `uv sync --project scripts/bench --locked` (exit 0; 7 packages resolved, 5 installed)
- `uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py'` (76 tests, exit 0)
- `git diff --check` (exit 0)

Resolves solo todo #2186
