### PR TITLE
[agent] add committed-ID vocabulary exemption and count-not-abort strict rejections

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -75,6 +75,13 @@ This production ONNX pass2 pin is intentionally separate from
 Transformers model matrix and is not the Davlan source of truth for the canonical
 no-OPF runner. Kiji continues to load from its existing `ner_models.toml` entry.
 
+At scorer initialization, stable provenance IDs are loaded from every committed
+`crates/gaze-recognizers/embedded/*.toml` recognizer and from the model IDs in
+`scripts/bench/no_opf_models.toml`. An exact, case-sensitive vocabulary match may
+skip only the protected-content reproduction check; source-ID grammar, ordering,
+non-empty, and uniqueness validation still apply. Missing, unreadable, malformed,
+or empty committed vocabulary inputs abort scoring with a typed error.
+
 ## Outputs and verdicts
 
 Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
@@ -91,11 +98,11 @@ Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
 
 Regression and release readiness are deliberately independent. Regression uses
 integer counts with zero tolerance and fails closed on missing, empty, invalid,
-or population-mismatched candidates. Release readiness checks the production
-candidate cell itself: no leaked labeled bytes, uncovered entities, pipeline
-failures, restore failures, invalid manifests, telemetry disagreement,
-unscanned documents, residual suspects, or redact actions. A full command exits
-nonzero for either correctness failure.
+or population-mismatched candidates. Release readiness requires every candidate
+cell to have no pipeline, restore, manifest, telemetry-agreement, or strict
+rejection failures. The production candidate cell must additionally have no
+leaked labeled bytes, uncovered entities, unscanned documents, residual suspects,
+or redact actions. A full command exits nonzero for either correctness failure.
 
 A quick result is always marked not release-ready because it samples the
 population. Quick exits successfully when that incompleteness is its only
@@ -104,9 +111,12 @@ readiness failure, but any observed correctness failure still exits nonzero.
 Performance compares `timing.clean_ms.p95` with
 `--performance-tolerance-percent` and is informational by default. Add
 `--performance-gating` only for an explicitly reviewed performance gate.
-Warmup count, measured-repetition count, every discarded warmup sample, and
-external process/model cold-start-to-first-validated-response are recorded in
-`runner_provenance`. Cold start is separate from Rust response timing.
+Warmup count, measured-repetition count, every discarded warmup sample and its
+outcome, and external process/model cold-start-to-first-validated-response are
+recorded in `runner_provenance`. Warmups are timing-only: their pipeline and
+correctness outcomes never abort or contribute to the scorecard. Each document is
+counted exactly once in the scored pass. Cold start is separate from Rust response
+timing.
 
 ## Baseline acceptance
 

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -18,6 +18,7 @@ import statistics
 import subprocess
 import sys
 import time
+import tomllib
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -232,6 +233,10 @@ class ResponseValidationError(RuntimeError):
     """The Rust benchmark producer violated its closed schema-v3 wire contract."""
 
 
+class SourceIdVocabularyError(RuntimeError):
+    """A committed source-ID vocabulary input could not be loaded safely."""
+
+
 def _expect_object(value: object, context: str) -> dict[str, object]:
     if not isinstance(value, dict) or not all(
         isinstance(key, str) for key in value
@@ -436,6 +441,97 @@ def _validate_source_id(value: str, context: str) -> None:
         )
 
 
+def _load_committed_toml(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        raise SourceIdVocabularyError(
+            f"committed source-ID vocabulary input is missing: {path}"
+        )
+    try:
+        with path.open("rb") as handle:
+            value = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SourceIdVocabularyError(
+            f"cannot read committed source-ID vocabulary input {path}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise SourceIdVocabularyError(
+            f"committed source-ID vocabulary input must be a TOML table: {path}"
+        )
+    return value
+
+
+def _committed_vocabulary_id(value: object, context: str) -> str:
+    if not isinstance(value, str) or not SOURCE_ID_PATTERN.fullmatch(value):
+        raise SourceIdVocabularyError(
+            f"{context}: expected a metadata-only stable identifier"
+        )
+    return value
+
+
+def load_committed_source_id_vocabulary(
+    repo_root: Path | None = None,
+) -> frozenset[str]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    rulepack_dir = root / "crates/gaze-recognizers/embedded"
+    if not rulepack_dir.is_dir():
+        raise SourceIdVocabularyError(
+            f"committed rulepack directory is missing: {rulepack_dir}"
+        )
+    rulepack_paths = sorted(rulepack_dir.glob("*.toml"))
+    if not rulepack_paths:
+        raise SourceIdVocabularyError(
+            f"committed rulepack directory contains no TOML bundles: {rulepack_dir}"
+        )
+
+    identifiers: set[str] = set()
+    recognizer_count = 0
+    for path in rulepack_paths:
+        rulepack = _load_committed_toml(path)
+        recognizers = rulepack.get("recognizers", [])
+        if not isinstance(recognizers, list):
+            raise SourceIdVocabularyError(
+                f"{path}: recognizers must be an array of tables"
+            )
+        for index, recognizer in enumerate(recognizers):
+            if not isinstance(recognizer, dict) or "id" not in recognizer:
+                raise SourceIdVocabularyError(
+                    f"{path}: recognizers[{index}] must declare an id"
+                )
+            identifiers.add(
+                _committed_vocabulary_id(
+                    recognizer["id"], f"{path}: recognizers[{index}].id"
+                )
+            )
+            recognizer_count += 1
+    if recognizer_count == 0:
+        raise SourceIdVocabularyError(
+            f"committed rulepacks declare no recognizer IDs: {rulepack_dir}"
+        )
+
+    model_path = root / "scripts/bench/no_opf_models.toml"
+    models = _load_committed_toml(model_path)
+    model_count = 0
+    for section_name, section in models.items():
+        if not isinstance(section, dict) or "id" not in section:
+            continue
+        identifiers.add(
+            _committed_vocabulary_id(
+                section["id"], f"{model_path}: {section_name}.id"
+            )
+        )
+        model_count += 1
+    if model_count == 0:
+        raise SourceIdVocabularyError(
+            f"committed model source declares no IDs: {model_path}"
+        )
+    if not identifiers:
+        raise SourceIdVocabularyError("committed source-ID vocabulary is empty")
+    return frozenset(identifiers)
+
+
+COMMITTED_SOURCE_ID_VOCABULARY = load_committed_source_id_vocabulary()
+
+
 def _validate_final_protection_trace(
     document: Document,
     value: object,
@@ -523,7 +619,7 @@ def _validate_final_protection_trace(
             "final_protection_trace: tokenize items must agree 1:1 with the final manifest"
         )
     for source_id, context in source_identifiers:
-        if any(
+        if source_id not in COMMITTED_SOURCE_ID_VOCABULARY and any(
             raw_value
             and re.search(
                 rf"(?:^|(?<=[._:/-])){re.escape(raw_value)}(?:$|(?=[._:/-]))",
@@ -1071,11 +1167,18 @@ def run_config(
             warmup_document = documents[warmup_index % len(documents)]
             response, round_trip_ms = exchange(warmup_document)
             if "pipeline_error_code" in response:
-                raise RuntimeError(
-                    f"{config}: warmup {warmup_index + 1} failed closed with "
-                    f"{response['pipeline_error_code']} at "
-                    f"{response['pipeline_error_stage']}"
+                timing = response["timing"]
+                assert isinstance(timing, dict)
+                discarded_warmup_samples.append(
+                    {
+                        "sample": warmup_index + 1,
+                        "round_trip_ms": round_trip_ms,
+                        "pipeline_error_code": response["pipeline_error_code"],
+                        "pipeline_error_stage": response["pipeline_error_stage"],
+                        "total_ms": timing["total_ms"],
+                    }
                 )
+                continue
             timing = response["timing"]
             assert isinstance(timing, dict)
             warmup_metrics = MetricAccumulator()
@@ -1103,30 +1206,6 @@ def run_config(
                 "residual_suspects": contract_result["post_policy_suspects"],
                 "redact_actions": contract_result["redact_actions"],
             }
-            universal_warmup_gates = (
-                "restore_failures",
-                "manifest_invalid_documents",
-            )
-            production_warmup_gates = (
-                "leaked_labeled_utf8_bytes",
-                "uncovered_entities",
-                "strict_rejections",
-                "residual_suspects",
-                "redact_actions",
-            )
-            gated = universal_warmup_gates + (
-                production_warmup_gates if config == PRODUCTION_CONFIG else ()
-            )
-            failures = {
-                gate: warmup_correctness[gate]
-                for gate in gated
-                if warmup_correctness[gate] != 0
-            }
-            if failures:
-                raise RuntimeError(
-                    f"{config}: discarded warmup {warmup_index + 1} failed "
-                    f"correctness gates: {failures}"
-                )
             discarded_warmup_samples.append(
                 {
                     "sample": warmup_index + 1,
@@ -1587,6 +1666,7 @@ def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, obj
             "restore_decision_failures",
             "manifest_invalid_documents",
             "manifest_integrity_errors",
+            "strict_rejections",
         ):
             if counts[gate] != 0:
                 failures.append(
@@ -1606,7 +1686,6 @@ def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, obj
                 "documents_with_leaks",
                 "leaked_labeled_utf8_bytes",
                 "uncovered_entities",
-                "strict_rejections",
                 "post_policy_unscanned_documents",
                 "residual_suspects",
                 "redact_actions",

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -586,8 +586,8 @@ def markdown_summary(
         f"- Performance: **{performance['disposition']} / {performance['status']}**",
         "",
         "| Config | Attempted | Failed closed | Leaked bytes | Restore failures "
-        "| Residual suspects | clean_ms p95 |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| Strict rejections | Residual suspects | clean_ms p95 |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ]
     for run in scorecard["runs"]:
         counts = score._run_correctness_counts(run)
@@ -597,7 +597,8 @@ def markdown_summary(
             f"| {run['config']} | {counts['attempted_documents']} | "
             f"{counts['failed_closed_documents']} | "
             f"{counts['leaked_labeled_utf8_bytes']} | "
-            f"{counts['restore_failures']} | {counts['residual_suspects']} | "
+            f"{counts['restore_failures']} | {counts['strict_rejections']} | "
+            f"{counts['residual_suspects']} | "
             f"{clean_display} |"
         )
     return "\n".join(lines) + "\n"

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -398,6 +398,75 @@ class ResponseValidationTests(unittest.TestCase):
         self.assertNotIn("pass3_ms", result["latency_ms"])
         self.assertEqual(result["process"]["documents_per_second"], 400.0)
 
+    def test_warmup_correctness_and_pipeline_errors_are_logged_not_counted(
+        self,
+    ) -> None:
+        document = self.document()
+        warmup_error = {
+            "fixture_id": document.uid,
+            "pipeline_error_stage": "safety_net",
+            "pipeline_error_code": "POLICY_REJECTED",
+            "timing": {"total_ms": 1.25},
+        }
+        warmup_rejection = self.success_response()
+        scored_rejection = self.success_response()
+        for response in (warmup_rejection, scored_rejection):
+            response["leak_suspects"] = [
+                {
+                    "clean_start": 0,
+                    "clean_end": 2,
+                    "action_start": 0,
+                    "action_end": 2,
+                    "class": "name",
+                    "safety_net_id": "safety.name",
+                    "kind": "uncovered",
+                }
+            ]
+            response["initial_safety_net_stats"].update(
+                {"suspect_count": 1, "uncovered_count": 1}
+            )
+            response["strict_would_reject"] = True
+        process = mock.Mock()
+        process.stdin = io.StringIO()
+        process.stdout = io.StringIO(
+            "\n".join(
+                json.dumps(response)
+                for response in (warmup_error, warmup_rejection, scored_rejection)
+            )
+            + "\n"
+        )
+        process.wait.return_value = 0
+        repo_root = Path(benchmark.__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
+            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+                result = benchmark.run_config(
+                    repo_root=repo_root,
+                    binary=Path(temporary) / "synthetic-runner",
+                    config="full-stack-kiji-resolve",
+                    documents=[document],
+                    model_dir=Path(temporary),
+                    kiji_model_dir=Path(temporary),
+                    opf_command=None,
+                    opf_checkpoint=None,
+                    opf_daemon_socket=None,
+                    threshold=0.3,
+                    diagnostics_dir=Path(temporary) / "diagnostics",
+                    warmup_count=2,
+                )
+
+        self.assertEqual(result["pipeline_contract"]["documents"], 1)
+        self.assertEqual(
+            result["pipeline_contract"]["strict_would_reject_documents"], 1
+        )
+        self.assertEqual(result["pipeline_contract"]["strict_acceptance_rate"], 0.0)
+        self.assertEqual(result["pipeline_availability"]["failed_closed_documents"], 0)
+        discarded = result["process"]["discarded_warmup_samples"]
+        self.assertEqual(len(discarded), 2)
+        self.assertEqual(discarded[0]["pipeline_error_code"], "POLICY_REJECTED")
+        self.assertEqual(discarded[0]["pipeline_error_stage"], "safety_net")
+        self.assertEqual(discarded[1]["correctness"]["strict_rejections"], 1)
+
     def test_unknown_pipeline_error_timing_field_fails_closed(self) -> None:
         response = {
             "fixture_id": "synthetic-response",
@@ -523,6 +592,48 @@ class ResponseValidationTests(unittest.TestCase):
                     "reproduces protected request content",
                 ):
                     benchmark.validate_response(document, response)
+
+    def test_trace_accepts_committed_id_despite_bounded_protected_segment(
+        self,
+    ) -> None:
+        protected_value = "de"
+        document = benchmark.Document(
+            uid="synthetic-response",
+            text=protected_value,
+            language="de",
+            region="DE",
+            source_dataset="unit-test",
+            spans=(benchmark.Span(0, len(protected_value), "POSTAL"),),
+        )
+        response = self.tokenize_response()
+        response["manifest_spans"][0]["raw_end"] = len(protected_value)
+        item = response["final_protection_trace"][0]
+        item["raw_end"] = len(protected_value)
+        item["provenance"]["source_ids"] = ["postal.de"]
+
+        benchmark.validate_response(document, response)
+
+    def test_trace_rejects_novel_id_with_bounded_protected_segment(self) -> None:
+        protected_value = "de"
+        document = benchmark.Document(
+            uid="synthetic-response",
+            text=protected_value,
+            language="de",
+            region="DE",
+            source_dataset="unit-test",
+            spans=(benchmark.Span(0, len(protected_value), "POSTAL"),),
+        )
+        response = self.tokenize_response()
+        response["manifest_spans"][0]["raw_end"] = len(protected_value)
+        item = response["final_protection_trace"][0]
+        item["raw_end"] = len(protected_value)
+        item["provenance"]["source_ids"] = ["novel.de.source"]
+
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError,
+            "reproduces protected request content",
+        ):
+            benchmark.validate_response(document, response)
 
     def test_trace_accepts_unbounded_source_id_substring(self) -> None:
         protected_value = "avl"
@@ -1071,6 +1182,21 @@ class DataikuSelectionTests(unittest.TestCase):
 
 
 class ConfigTests(unittest.TestCase):
+    def test_committed_source_id_vocabulary_loads_rulepack_and_model_ids(self) -> None:
+        self.assertIn("postal.de", benchmark.COMMITTED_SOURCE_ID_VOCABULARY)
+        self.assertIn(
+            "davlan-mbert-ner-hrl-onnx",
+            benchmark.COMMITTED_SOURCE_ID_VOCABULARY,
+        )
+
+    def test_committed_source_id_vocabulary_load_failure_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaisesRegex(
+                benchmark.SourceIdVocabularyError,
+                "committed rulepack directory is missing",
+            ):
+                benchmark.load_committed_source_id_vocabulary(Path(temporary))
+
     def test_all_no_opf_config_names_are_present_and_spelled_exactly(self) -> None:
         expected = (
             "rule-floor-extended",

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -149,6 +149,30 @@ class IntegerComparatorTests(unittest.TestCase):
         self.assertFalse(comparison["regression"]["passed"])
         self.assertFalse(comparison["release_readiness"]["passed"])
 
+    def test_strict_rejections_are_bucketed_ratcheted_and_release_blocking(
+        self,
+    ) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        candidate["runs"][0]["pipeline_contract"][
+            "strict_would_reject_documents"
+        ] = 1
+
+        counts = score._run_correctness_counts(candidate["runs"][0])
+        comparison = score.compare_scorecards(candidate, baseline)
+
+        self.assertEqual(counts["strict_rejections"], 1)
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertFalse(comparison["release_readiness"]["passed"])
+        for verdict in ("regression", "release_readiness"):
+            self.assertTrue(
+                any(
+                    failure.get("config") == score.DEFAULT_CONFIGS[0]
+                    and failure.get("gate") == "strict_rejections"
+                    for failure in comparison[verdict]["failures"]
+                )
+            )
+
     def test_performance_is_informational_by_default(self) -> None:
         baseline = scorecard()
         candidate = copy.deepcopy(baseline)
@@ -495,6 +519,42 @@ class ProfileIsolationTests(unittest.TestCase):
             [document.uid for document in first],
             [document.uid for document in second],
         )
+
+    def test_repetitions_require_exact_strict_rejection_counts(self) -> None:
+        runs_by_config = {
+            run["config"]: run for run in scorecard()["runs"]
+        }
+        call_count = 0
+
+        def fake_run_config(*args: object, **kwargs: object) -> dict[str, object]:
+            nonlocal call_count
+            config = str(args[2])
+            run = copy.deepcopy(runs_by_config[config])
+            if (
+                call_count >= len(score.DEFAULT_CONFIGS)
+                and config == score.DEFAULT_CONFIGS[0]
+            ):
+                run["pipeline_contract"]["strict_would_reject_documents"] = 1
+            call_count += 1
+            return run
+
+        with mock.patch.object(score, "run_config", side_effect=fake_run_config):
+            with self.assertRaisesRegex(
+                runner.RepetitionMismatchError,
+                "integer correctness counts",
+            ):
+                runner.execute_measurements(
+                    repo_root=Path("/synthetic/repo"),
+                    binary=Path("/synthetic/clean_for_bench"),
+                    documents=[self.document()],
+                    davlan_model=Path("/synthetic/davlan"),
+                    kiji_model=Path("/synthetic/kiji"),
+                    threshold=0.3,
+                    diagnostics_dir=Path("/synthetic/diagnostics"),
+                    warmup_count=0,
+                    measured_repetitions=2,
+                    source_environment={"PATH": "/synthetic/bin"},
+                )
 
 
 class BaselineGuardTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- load the source-ID exemption vocabulary at scorer initialization from committed embedded rulepack recognizer IDs and the committed no-OPF model IDs
- exempt only exact, case-sensitive vocabulary hits from the protected-content reproduction check while retaining every source-ID grammar, non-empty, sorted, and duplicate-free guard
- make warmups timing-only, log both typed pipeline errors and successful correctness outcomes, and count each document only in its scored pass
- enforce strict-rejection counts per cell through strict acceptance, exact repetition comparison, integer regression ratchets, release readiness, and the human-readable summary

## Five-axes evaluation

1. **Reliability (never leak):** This makes two explicit fail-closed semantics changes. First, the reproduction guard is narrowed only for exact IDs loaded from repository-committed TOML; producer-provided values cannot create exemptions, novel IDs retain bounded matching, and a missing, unreadable, malformed, or empty vocabulary aborts with a typed error. Second, document-level warmup correctness and typed pipeline-error outcomes no longer abort the run; they are logged and discarded, while the scored pass validates and counts them. Leak detection is not weakened: telemetry/output agreement remains mandatory for every response, scored failures retain zero-tolerance buckets, and any strict rejection now fails release readiness in its cell.
2. **Reversibility:** Restore-exact and manifest-integrity checks remain unchanged. Warmup restore outcomes are visible in discarded telemetry, and scored restore failures remain counted and release-blocking.
3. **Agentic-first:** Timing warmups can no longer hide the full scored benchmark behind an early document outcome, while per-cell strict-rejection buckets expose producer debt for agentic workflow configurations.
4. **Trust:** The exemption ground truth is deterministic, auditable committed data rather than producer assertions. Exact integer repetition and baseline ratchets include strict rejections, and no wire or scorecard schema changes are introduced.
5. **Adopter ergonomics:** The summary now surfaces strict-rejection counts directly, and typed vocabulary-load errors identify the committed input that prevented safe scoring.

## Verification

- `uv sync --project scripts/bench --locked` — passed (`Resolved 7 packages`; `Checked 5 packages`)
- `uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py'` — passed (`Ran 83 tests`; `OK`)

Resolves solo todo #2195
