### PR TITLE
[agent] declare built-in source IDs in guard vocabulary

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -77,10 +77,14 @@ no-OPF runner. Kiji continues to load from its existing `ner_models.toml` entry.
 
 At scorer initialization, stable provenance IDs are loaded from every committed
 `crates/gaze-recognizers/embedded/*.toml` recognizer and from the model IDs in
-`scripts/bench/no_opf_models.toml`. An exact, case-sensitive vocabulary match may
-skip only the protected-content reproduction check; source-ID grammar, ordering,
-non-empty, and uniqueness validation still apply. Missing, unreadable, malformed,
-or empty committed vocabulary inputs abort scoring with a typed error.
+`scripts/bench/no_opf_models.toml`. That file's `[builtin_source_ids]` declaration
+adds built-in producer IDs only from committed ground truth; tests require every
+declared ID to appear as a string literal in the read-only `gaze-recognizers`
+sources. Runtime producer assertions never extend this vocabulary. An exact,
+case-sensitive vocabulary match may skip only the protected-content reproduction
+check; source-ID grammar, ordering, non-empty, and uniqueness validation still
+apply. Missing, unreadable, malformed, or empty committed vocabulary inputs abort
+scoring with a typed error.
 
 ## Outputs and verdicts
 

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -468,6 +468,37 @@ def _committed_vocabulary_id(value: object, context: str) -> str:
     return value
 
 
+def _committed_builtin_source_ids(
+    models: dict[str, object], model_path: Path
+) -> tuple[str, ...]:
+    section = models.get("builtin_source_ids")
+    if not isinstance(section, dict):
+        raise SourceIdVocabularyError(
+            f"committed built-in source-ID declaration must contain a "
+            f"[builtin_source_ids] table: {model_path}"
+        )
+    if set(section) != {"ids"}:
+        raise SourceIdVocabularyError(
+            f"{model_path}: [builtin_source_ids] must contain only an ids array"
+        )
+    values = section["ids"]
+    if not isinstance(values, list) or not values:
+        raise SourceIdVocabularyError(
+            f"{model_path}: [builtin_source_ids].ids must be a non-empty array"
+        )
+    identifiers = tuple(
+        _committed_vocabulary_id(
+            value, f"{model_path}: builtin_source_ids.ids[{index}]"
+        )
+        for index, value in enumerate(values)
+    )
+    if len(set(identifiers)) != len(identifiers):
+        raise SourceIdVocabularyError(
+            f"{model_path}: [builtin_source_ids].ids must not contain duplicates"
+        )
+    return identifiers
+
+
 def load_committed_source_id_vocabulary(
     repo_root: Path | None = None,
 ) -> frozenset[str]:
@@ -510,8 +541,11 @@ def load_committed_source_id_vocabulary(
 
     model_path = root / "scripts/bench/no_opf_models.toml"
     models = _load_committed_toml(model_path)
+    identifiers.update(_committed_builtin_source_ids(models, model_path))
     model_count = 0
     for section_name, section in models.items():
+        if section_name == "builtin_source_ids":
+            continue
         if not isinstance(section, dict) or "id" not in section:
             continue
         identifiers.add(

--- a/scripts/bench/no_opf_models.toml
+++ b/scripts/bench/no_opf_models.toml
@@ -7,3 +7,15 @@ runtime = "onnxruntime"
 model_file = "model.onnx"
 fetch_script = "scripts/fetch/fetch-ner-model.sh"
 required_artifacts = ["model.onnx", "tokenizer.json", "config.json", "tokenizer_config.json", "special_tokens_map.json", "vocab.txt", "labels.json"]
+
+[builtin_source_ids]
+ids = [
+    "ner",
+    "kiji-distilbert",
+    "kiji-distilbert-ort",
+    "kiji-distilbert-tract",
+    "kiji-distilbert-candle",
+    "kiji-distilbert-subprocess",
+    "openai-privacy-filter",
+    "openai-privacy-filter-subprocess",
+]

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -7,6 +7,7 @@ import json
 import socket
 import sys
 import tempfile
+import tomllib
 import types
 import unittest
 from pathlib import Path
@@ -18,6 +19,30 @@ import gaze_bench_score as benchmark
 import openpii_gaze_bench as openpii_benchmark
 import dataiku_en_de_gaze_bench as dataiku_benchmark
 import opf_daemon
+
+
+EXPECTED_BUILTIN_SOURCE_IDS = frozenset(
+    {
+        "ner",
+        "kiji-distilbert",
+        "kiji-distilbert-ort",
+        "kiji-distilbert-tract",
+        "kiji-distilbert-candle",
+        "kiji-distilbert-subprocess",
+        "openai-privacy-filter",
+        "openai-privacy-filter-subprocess",
+    }
+)
+BUILTIN_SOURCE_LITERAL_PATHS = (
+    "crates/gaze-recognizers/src/ner/recognizer.rs",
+    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs",
+    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs",
+    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/tract.rs",
+    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/candle.rs",
+    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs",
+    "crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs",
+    "crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs",
+)
 
 
 class OffsetTests(unittest.TestCase):
@@ -613,6 +638,24 @@ class ResponseValidationTests(unittest.TestCase):
 
         benchmark.validate_response(document, response)
 
+    def test_trace_accepts_builtin_id_equal_to_protected_content(self) -> None:
+        protected_value = "ner"
+        document = benchmark.Document(
+            uid="synthetic-response",
+            text=protected_value,
+            language="en",
+            region="US",
+            source_dataset="unit-test",
+            spans=(benchmark.Span(0, len(protected_value), "ORDER"),),
+        )
+        response = self.tokenize_response()
+        response["manifest_spans"][0]["raw_end"] = len(protected_value)
+        item = response["final_protection_trace"][0]
+        item["raw_end"] = len(protected_value)
+        item["provenance"]["source_ids"] = ["ner"]
+
+        benchmark.validate_response(document, response)
+
     def test_trace_rejects_novel_id_with_bounded_protected_segment(self) -> None:
         protected_value = "de"
         document = benchmark.Document(
@@ -1188,6 +1231,40 @@ class ConfigTests(unittest.TestCase):
             "davlan-mbert-ner-hrl-onnx",
             benchmark.COMMITTED_SOURCE_ID_VOCABULARY,
         )
+        self.assertTrue(
+            EXPECTED_BUILTIN_SOURCE_IDS.issubset(
+                benchmark.COMMITTED_SOURCE_ID_VOCABULARY
+            )
+        )
+
+    def test_builtin_source_id_declaration_matches_committed_source_literals(
+        self,
+    ) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        with (repo_root / "scripts/bench/no_opf_models.toml").open("rb") as handle:
+            models = tomllib.load(handle)
+        declared = models["builtin_source_ids"]["ids"]
+        self.assertEqual(len(declared), len(EXPECTED_BUILTIN_SOURCE_IDS))
+        self.assertEqual(frozenset(declared), EXPECTED_BUILTIN_SOURCE_IDS)
+        source_text = "\n".join(
+            (repo_root / relative_path).read_text(encoding="utf-8")
+            for relative_path in BUILTIN_SOURCE_LITERAL_PATHS
+        )
+
+        def assert_committed_literals(source_ids: list[str]) -> None:
+            for source_id in source_ids:
+                self.assertIn(
+                    f'"{source_id}"',
+                    source_text,
+                    f"declared built-in source ID lacks a committed source literal: "
+                    f"{source_id}",
+                )
+
+        assert_committed_literals(declared)
+        with self.assertRaisesRegex(AssertionError, "fabricated-built-in-source"):
+            assert_committed_literals(
+                [*declared, "fabricated-built-in-source"]
+            )
 
     def test_committed_source_id_vocabulary_load_failure_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1196,6 +1273,33 @@ class ConfigTests(unittest.TestCase):
                 "committed rulepack directory is missing",
             ):
                 benchmark.load_committed_source_id_vocabulary(Path(temporary))
+
+    def test_builtin_source_id_declaration_failures_fail_closed(self) -> None:
+        declarations = {
+            "missing": "",
+            "malformed": "builtin_source_ids = []\n",
+            "empty": "[builtin_source_ids]\nids = []\n",
+        }
+        for name, declaration in declarations.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                repo_root = Path(temporary)
+                rulepack_dir = repo_root / "crates/gaze-recognizers/embedded"
+                rulepack_dir.mkdir(parents=True)
+                (rulepack_dir / "synthetic.toml").write_text(
+                    '[[recognizers]]\nid = "synthetic-rule"\n',
+                    encoding="utf-8",
+                )
+                model_path = repo_root / "scripts/bench/no_opf_models.toml"
+                model_path.parent.mkdir(parents=True)
+                model_path.write_text(
+                    f'{declaration}[synthetic_model]\nid = "synthetic-model"\n',
+                    encoding="utf-8",
+                )
+                with self.assertRaisesRegex(
+                    benchmark.SourceIdVocabularyError,
+                    "builtin_source_ids|built-in source-ID declaration",
+                ):
+                    benchmark.load_committed_source_id_vocabulary(repo_root)
 
     def test_all_no_opf_config_names_are_present_and_spelled_exactly(self) -> None:
         expected = (

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -33,16 +33,48 @@ EXPECTED_BUILTIN_SOURCE_IDS = frozenset(
         "openai-privacy-filter-subprocess",
     }
 )
-BUILTIN_SOURCE_LITERAL_PATHS = (
-    "crates/gaze-recognizers/src/ner/recognizer.rs",
-    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs",
-    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs",
-    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/tract.rs",
-    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/candle.rs",
-    "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs",
-    "crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs",
-    "crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs",
-)
+BUILTIN_SOURCE_LITERAL_PATHS = {
+    "ner": "crates/gaze-recognizers/src/ner/recognizer.rs",
+    "kiji-distilbert": (
+        "crates/gaze-recognizers/src/safety_net/kiji_distilbert/mod.rs"
+    ),
+    "kiji-distilbert-ort": (
+        "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs"
+    ),
+    "kiji-distilbert-tract": (
+        "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/tract.rs"
+    ),
+    "kiji-distilbert-candle": (
+        "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/candle.rs"
+    ),
+    "kiji-distilbert-subprocess": (
+        "crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs"
+    ),
+    "openai-privacy-filter": (
+        "crates/gaze-recognizers/src/safety_net/openai_filter/mod.rs"
+    ),
+    "openai-privacy-filter-subprocess": (
+        "crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs"
+    ),
+}
+
+
+def assert_builtin_source_literals(
+    source_ids: list[str], authoritative_source_text: dict[str, str]
+) -> None:
+    for source_id in source_ids:
+        relative_path = BUILTIN_SOURCE_LITERAL_PATHS.get(source_id)
+        if relative_path is None:
+            raise AssertionError(
+                f"declared built-in source ID has no authoritative source mapping: "
+                f"{source_id}"
+            )
+        source_text = authoritative_source_text.get(relative_path)
+        if source_text is None or f'"{source_id}"' not in source_text:
+            raise AssertionError(
+                f"declared built-in source ID lacks a literal in its authoritative "
+                f"source file {relative_path}: {source_id}"
+            )
 
 
 class OffsetTests(unittest.TestCase):
@@ -1246,24 +1278,41 @@ class ConfigTests(unittest.TestCase):
         declared = models["builtin_source_ids"]["ids"]
         self.assertEqual(len(declared), len(EXPECTED_BUILTIN_SOURCE_IDS))
         self.assertEqual(frozenset(declared), EXPECTED_BUILTIN_SOURCE_IDS)
-        source_text = "\n".join(
-            (repo_root / relative_path).read_text(encoding="utf-8")
-            for relative_path in BUILTIN_SOURCE_LITERAL_PATHS
+        self.assertEqual(
+            frozenset(BUILTIN_SOURCE_LITERAL_PATHS),
+            EXPECTED_BUILTIN_SOURCE_IDS,
         )
+        authoritative_source_text = {
+            relative_path: (repo_root / relative_path).read_text(encoding="utf-8")
+            for relative_path in set(BUILTIN_SOURCE_LITERAL_PATHS.values())
+        }
 
-        def assert_committed_literals(source_ids: list[str]) -> None:
-            for source_id in source_ids:
-                self.assertIn(
-                    f'"{source_id}"',
-                    source_text,
-                    f"declared built-in source ID lacks a committed source literal: "
-                    f"{source_id}",
-                )
-
-        assert_committed_literals(declared)
+        assert_builtin_source_literals(declared, authoritative_source_text)
         with self.assertRaisesRegex(AssertionError, "fabricated-built-in-source"):
-            assert_committed_literals(
-                [*declared, "fabricated-built-in-source"]
+            assert_builtin_source_literals(
+                [*declared, "fabricated-built-in-source"],
+                authoritative_source_text,
+            )
+
+    def test_builtin_source_id_coherence_rejects_stripped_authoritative_literal(
+        self,
+    ) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        source_id = "kiji-distilbert"
+        relative_path = BUILTIN_SOURCE_LITERAL_PATHS[source_id]
+        source_text = (repo_root / relative_path).read_text(encoding="utf-8")
+        literal = f'"{source_id}"'
+        self.assertIn(literal, source_text)
+        stripped_source_text = source_text.replace(literal, "")
+        self.assertNotIn(literal, stripped_source_text)
+
+        with self.assertRaisesRegex(AssertionError, source_id):
+            assert_builtin_source_literals(
+                [source_id],
+                {
+                    relative_path: stripped_source_text,
+                    "unrelated/test_fixture.rs": literal,
+                },
             )
 
     def test_committed_source_id_vocabulary_load_failure_fails_closed(self) -> None:


### PR DESCRIPTION
## Summary

- declare the eight built-in recognizer source IDs in `scripts/bench/no_opf_models.toml`
- load the declaration through the existing typed, fail-closed committed vocabulary path
- map each declared ID to one authoritative producer file and test both a fabricated ninth ID and a stripped-authoritative-file mutation
- keep runtime producer assertions outside the trusted vocabulary

The ID-to-path map lives in the Python coherence test rather than the TOML declaration. Source paths are verification metadata, not runtime trust inputs; keeping them test-only leaves the production loader contract limited to the eight IDs while still anchoring every declaration to its producer file. The checker only accepts the quoted literal from that mapped file. The mutation probe strips the literal from the authoritative file and supplies the same literal under an unrelated fixture path, which must still fail.

## Five-axes evaluation

1. **Reliability (never leak):** The exemption remains limited to exact, case-sensitive IDs from committed ground truth. A vocabulary hit skips only the protected-content reproduction check; source-ID grammar, non-empty, sorted, and duplicate-free validation still runs. Unlisted IDs retain full bounded matching, including equality, so `order-1234` and `rule-order-1234-source` still reject. Missing, malformed, empty, invalid, or duplicate declarations abort with `SourceIdVocabularyError`.
2. **Reversibility:** Manifest validation and restore behavior are unchanged. This only classifies committed provenance identifiers for benchmark response validation.
3. **Agentic-first:** Built-in provenance such as `ner` can describe the recognizer without falsely rejecting a protected value that happens to be identical.
4. **Trust:** The declaration is deterministic and reviewable. Each ID maps to one authoritative producer file without hardcoded line numbers, and executable negative probes prove that neither a fabricated ID nor a matching literal elsewhere can satisfy coherence. Runtime producer data cannot create an exemption.
5. **Adopter ergonomics:** The README documents every vocabulary source and the fail-closed contract. Existing producer and wire/schema contracts do not change.

No north-star axis is weakened. Leak detection is preserved by the committed-only exact-match boundary, universal structural checks, and unchanged bounded matching for every non-vocabulary ID.

## Verification

- `uv sync --project scripts/bench --locked` (exit 0; 7 packages resolved, 5 checked)
- `uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py'` (87 tests, exit 0)
- targeted coherence and stripped-authoritative-literal mutation probes (2 tests, `OK`)
- `git diff --check` (exit 0)

Resolves solo todo #2196
