### PR TITLE
[agent] stabilize Kiji benchmark session tokens

### DIFF
--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -50,7 +50,7 @@ unicode-normalization = "0.1"
 
 [dev-dependencies]
 criterion = "0.5"
-gaze = { path = "../gaze", package = "gaze-pii", default-features = false }
+gaze = { path = "../gaze", package = "gaze-pii", default-features = false, features = ["test-support"] }
 gaze-assembly = { path = "../gaze-assembly" }
 serial_test = "3"
 tempfile = "3"

--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -11,6 +11,7 @@ use gaze::{
 };
 use gaze_recognizers::embedded;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const BENCHMARK_ACTIVE_LOCALES: &[LocaleTag] = &[
     LocaleTag::EnUs,
@@ -222,8 +223,9 @@ fn handle_request(
         .iter()
         .map(|locale| LocaleTag::parse(locale))
         .collect::<Result<Vec<_>, _>>()?;
+    let session_hex = session_hex_for_fixture(&request.fixture_id);
     let raw_text = request.text;
-    let session = Session::new(Scope::Ephemeral)?;
+    let session = Session::new_with_session_hex_for_tests(Scope::Ephemeral, session_hex)?;
     let clean_start = Instant::now();
     let clean_result = full.clean_text_with_safety_net_policy_detect_context_and_protection_trace(
         &session,
@@ -332,6 +334,11 @@ fn handle_request(
         },
         final_protection_trace,
     }))
+}
+
+fn session_hex_for_fixture(fixture_id: &str) -> [u8; 4] {
+    let digest = Sha256::digest(fixture_id.as_bytes());
+    [digest[0], digest[1], digest[2], digest[3]]
 }
 
 #[derive(Debug, Serialize)]
@@ -870,6 +877,10 @@ mod tests {
     use super::*;
     use gaze::RawDocument;
 
+    const PRODUCER_DETERMINISM_CHILD: &str = "GAZE_BENCH_PRODUCER_DETERMINISM_CHILD";
+    const PRODUCER_DETERMINISM_BEGIN: &str = "GAZE_BENCH_PRODUCER_DETERMINISM_BEGIN";
+    const PRODUCER_DETERMINISM_END: &str = "GAZE_BENCH_PRODUCER_DETERMINISM_END";
+
     fn rule_floor_response(fixture_id: &str, locale: &str, text: &str) -> Response {
         let config = BenchConfig::RuleFloorExtended;
         let full = build_pipeline(config).expect("rule-floor-extended pipeline should build");
@@ -883,6 +894,13 @@ mod tests {
             Outcome::Success(response) => response,
             outcome => panic!("expected a success response, got {outcome:?}"),
         }
+    }
+
+    #[test]
+    fn fixture_session_hex_is_stable_and_varies_by_document() {
+        let first = session_hex_for_fixture("synthetic-document-1");
+        assert_eq!(first, session_hex_for_fixture("synthetic-document-1"));
+        assert_ne!(first, session_hex_for_fixture("synthetic-document-2"));
     }
 
     fn assert_success_timing_contract(response: &Response, expects_post_policy_scan: bool) {
@@ -1293,6 +1311,127 @@ mod tests {
         )
         .expect("error response should be written");
         assert_eq!(output, format!("{serialized}\n").as_bytes());
+    }
+
+    #[cfg(feature = "safety-net-kiji")]
+    #[test]
+    #[ignore = "requires pinned NER and Kiji bundles; verifies fresh-process full-stack producer determinism"]
+    fn full_stack_kiji_producer_is_deterministic_across_fresh_processes() {
+        if std::env::var_os(PRODUCER_DETERMINISM_CHILD).is_some() {
+            run_producer_determinism_child();
+            return;
+        }
+
+        let home = PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
+        let ner_model_dir = std::env::var_os("GAZE_NER_MODEL_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/share/gaze/models/davlan-mbert-ner-hrl"));
+        let kiji_model_dir = std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/share/gaze/models/kiji-distilbert"));
+        assert!(
+            ner_model_dir.is_dir(),
+            "pinned NER bundle is missing at {}",
+            ner_model_dir.display()
+        );
+        assert!(
+            kiji_model_dir.is_dir(),
+            "pinned Kiji bundle is missing at {}",
+            kiji_model_dir.display()
+        );
+
+        let current_exe = std::env::current_exe().expect("resolve example test executable");
+        let mut baseline: Option<Vec<u8>> = None;
+        for run in 1..=3 {
+            let output = std::process::Command::new(&current_exe)
+                .arg("--exact")
+                .arg("tests::full_stack_kiji_producer_is_deterministic_across_fresh_processes")
+                .arg("--ignored")
+                .arg("--nocapture")
+                .env(PRODUCER_DETERMINISM_CHILD, "1")
+                .env("GAZE_NER_MODEL_DIR", &ner_model_dir)
+                .env("GAZE_NER_THRESHOLD", "0.3")
+                .env("GAZE_KIJI_DISTILBERT_MODEL_DIR", &kiji_model_dir)
+                .env("RUST_TEST_THREADS", "1")
+                .output()
+                .unwrap_or_else(|error| panic!("spawn producer child {run}: {error}"));
+            assert!(
+                output.status.success(),
+                "producer child {run} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let canonical = extract_producer_determinism_output(&output.stdout);
+            if let Some(expected) = &baseline {
+                assert_eq!(
+                    canonical, *expected,
+                    "full-stack producer diverged in fresh child process {run}"
+                );
+            } else {
+                baseline = Some(canonical);
+            }
+        }
+
+        println!("full-stack Kiji producer determinism verified across 3 fresh processes");
+    }
+
+    #[cfg(feature = "safety-net-kiji")]
+    fn run_producer_determinism_child() {
+        let config = BenchConfig::FullStackKijiResolve;
+        let full = build_pipeline(config).expect("build full-stack Kiji pipeline");
+        println!("{PRODUCER_DETERMINISM_BEGIN}");
+        for request in [
+            Request {
+                fixture_id: "producer-determinism-en-1".to_string(),
+                locale_chain: vec!["en-US".to_string()],
+                text: "Dr. Schmidt from Example Labs reviews GAZE-1001 in Berlin. Contact alice@example.invalid or +1-555-0101. This synthetic paragraph repeats Example Labs, Dr. Schmidt, Berlin, and GAZE-1001 so the full producer exercises deterministic recognition, Pass 2 NER, Kiji resolution, manifest restoration, and post-policy scanning across a document longer than three hundred bytes.".to_string(),
+            },
+            Request {
+                fixture_id: "producer-determinism-de-2".to_string(),
+                locale_chain: vec!["de-DE".to_string()],
+                text: "Dr. Schmidt prueft fuer Example Labs den synthetischen Vorgang GAZE-1002 in Berlin. Der Testkontakt lautet alice@example.invalid und die Testnummer +49 1555 0112233. Dieser erfundene Absatz wiederholt Example Labs, Dr. Schmidt, Berlin und GAZE-1002, damit der vollstaendige Produzent Erkennung, Pass 2 NER, Kiji-Aufloesung, Manifest-Wiederherstellung und die abschliessende Pruefung ueber mehr als dreihundert Bytes ausfuehrt.".to_string(),
+            },
+        ] {
+            let outcome =
+                handle_request(config, &full, request).expect("handle synthetic Kiji request");
+            let canonical = match outcome {
+                Outcome::Success(response) => {
+                    let mut value =
+                        serde_json::to_value(response).expect("serialize producer response");
+                    value
+                        .as_object_mut()
+                        .expect("producer response object")
+                        .remove("timing");
+                    value
+                }
+                Outcome::PipelineError {
+                    fixture_id,
+                    stage,
+                    code,
+                    ..
+                } => serde_json::json!({
+                    "fixture_id": fixture_id,
+                    "pipeline_error_stage": stage,
+                    "pipeline_error_code": code,
+                }),
+            };
+            println!(
+                "{}",
+                serde_json::to_string(&canonical).expect("serialize canonical producer outcome")
+            );
+        }
+        println!("{PRODUCER_DETERMINISM_END}");
+    }
+
+    #[cfg(feature = "safety-net-kiji")]
+    fn extract_producer_determinism_output(stdout: &[u8]) -> Vec<u8> {
+        let stdout = String::from_utf8(stdout.to_vec()).expect("producer stdout must be UTF-8");
+        let (_, after_begin) = stdout
+            .split_once(&format!("{PRODUCER_DETERMINISM_BEGIN}\n"))
+            .expect("producer child output must include begin sentinel");
+        let (canonical, _) = after_begin
+            .split_once(&format!("{PRODUCER_DETERMINISM_END}\n"))
+            .expect("producer child output must include end sentinel");
+        canonical.as_bytes().to_vec()
     }
 
     #[cfg(feature = "safety-net-kiji")]

--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -236,6 +236,7 @@ fn handle_request(
     let (clean_doc, manifest, report, final_protection_trace) = match clean_result {
         Ok(result) => result,
         Err(error) => {
+            emit_invalid_output_diagnostic("clean", &error);
             return Ok(Outcome::PipelineError {
                 fixture_id: request.fixture_id,
                 stage: "clean",
@@ -270,6 +271,7 @@ fn handle_request(
         let post_policy = match full.scan_safety_nets(&session, &clean_text, &locale_chain) {
             Ok(result) => result,
             Err(error) => {
+                emit_invalid_output_diagnostic("post_policy_scan", &error);
                 return Ok(Outcome::PipelineError {
                     fixture_id: request.fixture_id,
                     stage: "post_policy_scan",
@@ -391,6 +393,31 @@ fn pipeline_error_code(error: &gaze::Error) -> &'static str {
         gaze::Error::SafetyNet(_) => "safety_net_error",
         _ => "pipeline_error",
     }
+}
+
+fn emit_invalid_output_diagnostic(stage: &str, error: &gaze::Error) {
+    if let Some(reason) = invalid_output_reason(error) {
+        eprintln!("gaze_bench_invalid_output stage={stage} reason={reason}");
+    }
+}
+
+fn invalid_output_reason(error: &gaze::Error) -> Option<&'static str> {
+    let gaze::Error::SafetyNet(SafetyNetError::InvalidOutput { message }) = error else {
+        return None;
+    };
+    Some(match message.as_str() {
+        "kiji ort returned invalid logits shape" => "logits_shape",
+        "kiji returned out-of-bounds span" | "kiji returned overlapping spans" => {
+            "raw_span_normalization"
+        }
+        "clean-to-raw start mapping failed"
+        | "clean-to-raw end mapping failed"
+        | "empty clean-to-raw mapping" => "clean_to_raw_mapping",
+        "overlapping protection trace" | "trace-manifest mismatch" | "manifest-trace mismatch" => {
+            "trace_manifest"
+        }
+        _ => "other_invalid_output",
+    })
 }
 
 fn parse_config() -> Result<BenchConfig, Box<dyn std::error::Error>> {
@@ -1201,6 +1228,25 @@ mod tests {
         for (error, expected) in cases {
             assert_eq!(pipeline_error_code(&error), expected);
         }
+    }
+
+    #[test]
+    fn invalid_output_diagnostics_are_non_pii_branch_labels() {
+        let cases = [
+            ("kiji ort returned invalid logits shape", "logits_shape"),
+            ("kiji returned overlapping spans", "raw_span_normalization"),
+            ("clean-to-raw start mapping failed", "clean_to_raw_mapping"),
+            ("trace-manifest mismatch", "trace_manifest"),
+            ("synthetic unknown branch", "other_invalid_output"),
+        ];
+
+        for (message, expected) in cases {
+            let error = gaze::Error::SafetyNet(SafetyNetError::InvalidOutput {
+                message: message.to_string(),
+            });
+            assert_eq!(invalid_output_reason(&error), Some(expected));
+        }
+        assert_eq!(invalid_output_reason(&gaze::Error::ExportForbidden), None);
     }
 
     #[test]

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/ort.rs
@@ -140,10 +140,42 @@ impl OrtKijiBackend {
                     sanitize_error(&err.to_string())
                 ),
             })?;
-        let session = ort::session::Session::builder()
-            .map_err(|err| SafetyNetError::ModelUnavailable {
+        let session_builder =
+            ort::session::Session::builder().map_err(|err| SafetyNetError::ModelUnavailable {
                 reason: format!(
                     "failed to initialize kiji ort session: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let session_builder = session_builder.with_intra_threads(1).map_err(|err| {
+            SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to configure kiji ort intra-op threads: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            }
+        })?;
+        let session_builder = session_builder.with_inter_threads(1).map_err(|err| {
+            SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to configure kiji ort inter-op threads: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            }
+        })?;
+        let session_builder = session_builder
+            .with_parallel_execution(false)
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to configure kiji ort sequential execution: {}",
+                    sanitize_error(&err.to_string())
+                ),
+            })?;
+        let session = session_builder
+            .with_deterministic_compute(true)
+            .map_err(|err| SafetyNetError::ModelUnavailable {
+                reason: format!(
+                    "failed to configure deterministic kiji ort compute: {}",
                     sanitize_error(&err.to_string())
                 ),
             })?

--- a/crates/gaze-recognizers/tests/kiji_ort_determinism.rs
+++ b/crates/gaze-recognizers/tests/kiji_ort_determinism.rs
@@ -1,0 +1,206 @@
+//! Fresh-process determinism regression for the in-process Kiji ORT backend.
+
+#![cfg(feature = "safety-net-kiji")]
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use gaze_recognizers::safety_net::kiji_distilbert::{
+    KijiDistilbertBackend, OrtKijiBackend, OrtKijiConfig, RawSpan, SafetyNetError,
+};
+use serde::Serialize;
+
+const CHILD_MODE: &str = "GAZE_KIJI_ORT_DETERMINISM_CHILD";
+const BEGIN_SENTINEL: &str = "KIJI_ORT_DETERMINISM_BEGIN";
+const END_SENTINEL: &str = "KIJI_ORT_DETERMINISM_END";
+const CHILD_RUNS: usize = 5;
+
+const FIXTURES: &[(&str, &str)] = &[
+    (
+        "mixed-short",
+        "Dr. Schmidt from Example Labs met Alice in Berlin. Contact: alice@example.invalid.",
+    ),
+    (
+        "de-borderline-long",
+        "Dr. Schmidt prueft den synthetischen Vorgang GAZE-0001 fuer Example Labs in Berlin. Die Rueckfrage geht ausschliesslich an alice@example.invalid oder an die dokumentierte Testnummer +49 1555 0112233. Danach vergleicht Dr. Schmidt den Vorgang mit GAZE-0002, notiert Example Labs erneut und bestaetigt, dass alle Namen, Adressen und Nummern in diesem Absatz erfunden und nur fuer den deterministischen Test bestimmt sind.",
+    ),
+    (
+        "en-borderline-long",
+        "Alice from Example Labs asked Dr. Schmidt to review synthetic order GAZE-0101 in Berlin. The only test contact is alice@example.invalid and the only test phone is +1-555-0101. Dr. Schmidt then compared Example Labs with Example Research, moved the fictional meeting from Berlin to Hamburg, and repeated the synthetic identifiers GAZE-0101 and GAZE-0102 so the input crosses several token and entity boundaries without containing any real personal data.",
+    ),
+    (
+        "punctuation-joins",
+        "Example-Labs/Research, Berlin: Dr. Schmidt; alice@example.invalid; GAZE-0201. Example_Labs+Research and Dr.-Schmidt appear beside punctuation so BIO joiner handling is exercised.",
+    ),
+    (
+        "mixed-repetition-long",
+        "Dr. Schmidt arbeitet bei Example Labs in Berlin, waehrend Alice fuer Example Research in Hamburg arbeitet. Alice schreibt an alice@example.invalid, Dr. Schmidt nutzt ebenfalls alice@example.invalid als rein synthetischen Testkontakt. The fictional review mentions Example Labs, Example Research, Berlin, Hamburg, Dr. Schmidt, Alice, GAZE-0301, GAZE-0302, +49 1555 0112233, and +1-555-0102 more than once to create a long mixed-language sequence near multiple BIO boundaries.",
+    ),
+    (
+        "title-and-org-chain",
+        "Dr. Schmidt, Example Labs Berlin, Example Research Hamburg, Alice, Dr. Schmidt, Example-Labs, Example Research, Berlin/Hamburg, alice@example.invalid, GAZE-0401. This is a synthetic chain intended to make adjacent title, person, organization, location, and miscellaneous labels compete without exposing any real person's information.",
+    ),
+];
+
+#[derive(Serialize)]
+struct ChildRecord<'a> {
+    fixture_id: &'a str,
+    outcome: CanonicalOutcome,
+    trace: BackendTrace<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum CanonicalOutcome {
+    Spans { spans: Vec<CanonicalSpan> },
+    Error { variant: &'static str },
+}
+
+#[derive(Serialize)]
+struct CanonicalSpan {
+    start: usize,
+    end: usize,
+    class: String,
+    score_bits: Option<u32>,
+}
+
+impl From<RawSpan> for CanonicalSpan {
+    fn from(span: RawSpan) -> Self {
+        Self {
+            start: span.start,
+            end: span.end,
+            class: span.label,
+            score_bits: span.score.map(f32::to_bits),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct BackendTrace<'a> {
+    backend_id: &'a str,
+    version: &'a str,
+    decoding_params: BTreeMap<&'a str, &'a str>,
+}
+
+#[test]
+#[ignore = "requires the pinned Kiji model bundle; run explicitly to verify fresh-process ORT determinism"]
+fn kiji_ort_outputs_are_identical_across_fresh_processes() {
+    if std::env::var_os(CHILD_MODE).is_some() {
+        run_child();
+        return;
+    }
+
+    let model_dir = model_dir();
+    assert!(
+        model_dir.is_dir(),
+        "Kiji model bundle is missing at {}",
+        model_dir.display()
+    );
+
+    let current_exe = std::env::current_exe().expect("resolve current test executable");
+    let mut baselines: Option<Vec<u8>> = None;
+    for run in 1..=CHILD_RUNS {
+        let output = Command::new(&current_exe)
+            .arg("--exact")
+            .arg("kiji_ort_outputs_are_identical_across_fresh_processes")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env(CHILD_MODE, "1")
+            .env("GAZE_KIJI_DISTILBERT_MODEL_DIR", &model_dir)
+            .env("RUST_TEST_THREADS", "1")
+            .output()
+            .unwrap_or_else(|error| panic!("spawn Kiji determinism child {run}: {error}"));
+        assert!(
+            output.status.success(),
+            "Kiji determinism child {run} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let canonical = extract_canonical_output(&output.stdout);
+        if let Some(expected) = &baselines {
+            assert_eq!(
+                canonical, *expected,
+                "Kiji ORT output diverged in fresh child process {run}"
+            );
+        } else {
+            baselines = Some(canonical);
+        }
+    }
+
+    let canonical_bytes = baselines.as_ref().map_or(0, Vec::len);
+    println!(
+        "Kiji ORT determinism verified: {CHILD_RUNS} fresh processes, {} synthetic fixtures, {canonical_bytes} canonical bytes",
+        FIXTURES.len()
+    );
+}
+
+fn run_child() {
+    let backend = OrtKijiBackend::new(OrtKijiConfig::new(model_dir()))
+        .expect("initialize Kiji ORT backend in child process");
+    println!("{BEGIN_SENTINEL}");
+    for (fixture_id, text) in FIXTURES {
+        let outcome = match backend.infer(text) {
+            Ok(spans) => CanonicalOutcome::Spans {
+                spans: spans.into_iter().map(CanonicalSpan::from).collect(),
+            },
+            Err(error) => CanonicalOutcome::Error {
+                variant: safety_net_error_variant(&error),
+            },
+        };
+        let trace = BackendTrace {
+            backend_id: backend.id(),
+            version: backend.version(),
+            decoding_params: backend
+                .decoding_params()
+                .iter()
+                .map(|(key, value)| (*key, value.as_str()))
+                .collect(),
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&ChildRecord {
+                fixture_id,
+                outcome,
+                trace,
+            })
+            .expect("serialize canonical Kiji output")
+        );
+    }
+    println!("{END_SENTINEL}");
+}
+
+fn extract_canonical_output(stdout: &[u8]) -> Vec<u8> {
+    let stdout = String::from_utf8(stdout.to_vec()).expect("child stdout must be UTF-8");
+    let (_, after_begin) = stdout
+        .split_once(&format!("{BEGIN_SENTINEL}\n"))
+        .expect("child output must include begin sentinel");
+    let (canonical, _) = after_begin
+        .split_once(&format!("{END_SENTINEL}\n"))
+        .expect("child output must include end sentinel");
+    canonical.as_bytes().to_vec()
+}
+
+fn model_dir() -> PathBuf {
+    std::env::var_os("GAZE_KIJI_DISTILBERT_MODEL_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(default_model_dir)
+}
+
+fn default_model_dir() -> PathBuf {
+    let home = std::env::var_os("HOME").unwrap_or_else(|| OsString::from("."));
+    PathBuf::from(home).join(".local/share/gaze/models/kiji-distilbert")
+}
+
+fn safety_net_error_variant(error: &SafetyNetError) -> &'static str {
+    match error {
+        SafetyNetError::Unavailable { .. } => "unavailable",
+        SafetyNetError::WeightsMissing { .. } => "weights_missing",
+        SafetyNetError::ModelUnavailable { .. } => "model_unavailable",
+        SafetyNetError::ModelIntegrityMismatch { .. } => "model_integrity_mismatch",
+        SafetyNetError::InputTooLarge { .. } => "input_too_large",
+        SafetyNetError::Runtime { .. } => "runtime",
+        SafetyNetError::InvalidOutput { .. } => "invalid_output",
+        _ => "unknown",
+    }
+}

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/lib.rs"
 default = ["bundled-recognizers"]
 bundled-recognizers = ["dep:gaze-recognizers"]
 safety-net = ["gaze-recognizers/safety-net"]
+test-support = []
 
 [dependencies]
 anyhow = "1"

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -306,6 +306,26 @@ impl Session {
         })
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    /// Constructs a benchmark/test-only Session with a fixed token prefix.
+    ///
+    /// This constructor is forbidden in production; production callers must use
+    /// [`Session::new`] so session unlinkability continues to use fresh randomness.
+    pub fn new_with_session_hex_for_tests(scope: Scope, session_hex: [u8; 4]) -> Result<Self> {
+        Ok(Self {
+            scope,
+            session_hex,
+            audit_session_id: new_audit_session_id(),
+            next_by_class: DashMap::new(),
+            token_by_value: DashMap::new(),
+            value_by_token: DashMap::new(),
+            prefix_cache: DashMap::new(),
+            restore_regex_cache: RwLock::new(None),
+            signing_key: SessionKey::generate()?,
+        })
+    }
+
     pub fn from_policy(policy: &Policy) -> Result<Self> {
         Self::from_policy_with_ttl_override(policy, None)
     }
@@ -1441,6 +1461,21 @@ fn snapshot_signing_preimage(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_only_constructor_pins_session_hex_without_changing_token_contract() {
+        let session =
+            Session::new_with_session_hex_for_tests(Scope::Ephemeral, [0x01, 0x23, 0x45, 0x67])
+                .expect("fixed-prefix session");
+
+        assert_eq!(session.session_hex(), "01234567");
+        assert_eq!(
+            session
+                .tokenize(&PiiClass::Email, "alice@example.invalid")
+                .expect("synthetic email token"),
+            "<01234567:Email_1>"
+        );
+    }
 
     fn signed_snapshot_v03(payload: SnapshotPayload) -> SensitiveSnapshot {
         let payload_bytes = serde_json::to_vec(&payload).expect("serialize payload");


### PR DESCRIPTION
## Summary

- configure Kiji ORT sessions for deterministic, single-threaded sequential execution
- add branch-only, non-PII InvalidOutput telemetry that identified `clean_to_raw_mapping` as the fail-closed signature
- pin the benchmark Session token prefix to the first four SHA-256 bytes of each fixture ID, so every document is stable across processes while different documents retain distinct token prefixes
- cover both the ORT backend and the end-to-end `clean_for_bench` producer across fresh processes

The root cause was above ORT: `Session::new` generates a random per-session token hex, and those token bytes are present in the clean text passed to Kiji. Fresh producer processes therefore gave the model different input for the same source document. Borderline spans crossed outcome boundaries, with the fail-closed cases consistently surfacing as `clean_to_raw_mapping`. The benchmark now derives a stable prefix from the non-PII fixture ID and uses it uniformly for every cell.

The earlier int8 investigation is not shipped. The final branch has no Track-A, Python, benchmark-pin, model-manifest, or lockfile changes.

## Test-only Session seam

`Session::new_with_session_hex_for_tests` follows the existing hidden test-seam pattern: it is `#[doc(hidden)]`, named `_for_tests`, and compiled only under `cfg(test)` or the explicit empty `test-support` feature. `gaze-recognizers` enables that feature only on its dev dependency so `clean_for_bench` can exercise the seam.

Production `Session::new`, `random_session_hex()`, signing-key generation, audit-session generation, and unlinkability behavior are byte-for-byte unchanged. Normal-feature rustdoc excludes the constructor, so it is absent from adopters' ordinary API surface. The constructor is documented as benchmark/test-only and forbidden in production.

## Outcome stability

| Configuration | Divergent docs across 3 runs | clean | strict | InvalidOutput | pipeline_error |
| --- | ---: | --- | --- | --- | --- |
| A6N pre-fix fp32 | 614 / 2910 | 987–995 | 1311–1331 | 592–603 | 0–1 |
| fp32 + deterministic ORT config, random session hex | 602 / 2910 | 1000 / 993 / 990 | 1284 / 1309 / 1289 | 625 / 608 / 631 | 1 / 0 / 0 |
| int8 experiment, random session hex (dropped) | 616 / 2910 | 941 / 947 / 942 | 1415 / 1394 / 1391 | 554 / 569 / 577 | 0 / 0 / 0 |
| final fp32 + pinned per-fixture hex | **0 / 2910** | **991 / 991 / 991** | **1326 / 1326 / 1326** | **593 / 593 / 593** | **0 / 0 / 0** |

The stable operating point is an expected consequence of removing random benchmark input variation. Detection thresholds, span decoding, scores, timeout semantics, `strict_would_reject`, restore behavior, and fail-closed gates are unchanged.

## Five-axes evaluation

1. **Reliability (never leak):** All fail-closed boundaries remain intact. Stable benchmark input removes random clean/strict/InvalidOutput classification without weakening Kiji or mapping validation.
2. **Reversibility:** Production token generation and restore contracts are unchanged. The benchmark-only constructor creates ordinary restorable tokens with a reproducible prefix.
3. **Agentic-first:** Repeated benchmark runs now measure the same agent-facing document flow rather than a different pseudonymized input on every process.
4. **Trust:** The outcome is auditable and deterministic per fixture across fresh processes. Explicit single-threaded ORT configuration strengthens determinism at a disclosed inference-latency cost; this is the ratified correctness-over-performance tradeoff.
5. **Adopter ergonomics:** The normal public API is unchanged. The seam is hidden and absent unless a crate explicitly opts into `test-support`.

No production north-star axis is weakened.

## Verification

- three fresh full fp32 runs, 2,910 documents each: zero per-document divergence and identical integer totals
- evidence: `target/bench-data/diagnostics/final-fp32-pinned-hex/unpinned-full-summary.json`
- raw producer records/logs: `target/bench-data/diagnostics/final-fp32-pinned-hex/raw/`
- `rustup run 1.96.0 cargo fmt --all -- --check`
- `rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `rustup run 1.96.0 cargo test --workspace --all-features`
- `rustup run 1.96.0 cargo test -p gaze-recognizers --features safety-net-kiji`
- `rustup run 1.96.0 cargo test -p gaze-recognizers --example clean_for_bench --features safety-net-kiji`
- ignored backend regression: identical output across 5 fresh processes and 6 synthetic fixtures
- ignored full producer regression: identical canonical output across 3 fresh processes
- `uv sync --project scripts/bench --locked`
- `uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py'` (87 tests)
- normal-feature rustdoc audit: hidden Session constructor absent

Resolves solo todo #2216
