### PR TITLE
[agent] align traced and production fail-closed parity

### DIFF
--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -144,7 +144,7 @@ Support summary mentions Dr. Schmidt after triage.
 }
 
 #[test]
-fn index_ingest_redacts_residual_suspects_by_default_without_raw_persistence() {
+fn index_ingest_default_residual_mode_fails_closed_without_raw_persistence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
     let index = temp.path().join("owner-index");
@@ -167,43 +167,25 @@ Support summary mentions Dr. Schmidt marker after triage.
         .output()
         .expect("run index ingest");
     assert!(
-        ingest.status.success(),
-        "default residual ingest failed: stderr={}",
-        String::from_utf8_lossy(&ingest.stderr)
+        !ingest.status.success(),
+        "default residual ingest unexpectedly succeeded"
     );
-
-    let search = gaze_index_command(&fake_kiji)
-        .args(["index", "search", "alice@example.invalid"])
-        .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
-        .arg(&index)
-        .output()
-        .expect("run index search");
+    let stderr = String::from_utf8_lossy(&ingest.stderr);
+    assert!(stderr.contains("ResidualSuspect"), "stderr={stderr}");
     assert!(
-        search.status.success(),
-        "search failed: stderr={}",
-        String::from_utf8_lossy(&search.stderr)
+        stderr.contains("index safety net failed closed"),
+        "stderr={stderr}"
     );
-
-    let stdout = String::from_utf8(search.stdout).expect("utf8 stdout");
-    assert!(stdout.contains(":Email_"));
     for raw in ["alice@example.invalid", "Dr. Schmidt"] {
         assert!(
-            !stdout.contains(raw),
-            "search stdout leaked raw fixture value {raw}: {stdout}"
+            !stderr.contains(raw),
+            "stderr leaked raw fixture value: {stderr}"
         );
     }
-
-    let sealed = fs::read(index.join("index.json")).expect("read sealed index");
-    assert!(sealed.starts_with(b"GAZEIDX1"));
-    for raw in [
-        b"alice@example.invalid".as_slice(),
-        b"Dr. Schmidt".as_slice(),
-    ] {
-        assert!(
-            !bytes_contain(&sealed, raw),
-            "sealed index bytes contain raw fixture value"
-        );
-    }
+    assert!(
+        !index.join("index.json").exists(),
+        "failed ingest persisted an index"
+    );
 }
 
 #[test]

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -970,6 +970,7 @@ impl Pipeline {
                 protection_trace,
             ),
             SafetyNetMode::Resolve => {
+                let raw_before_resolution = session.restore_strict_text(&clean.text)?;
                 let reason = match self.resolve_safety_net_suspects(
                     session,
                     clean,
@@ -989,8 +990,13 @@ impl Pipeline {
                             field_path,
                             SafetyNetMode::Resolve,
                         )?;
-                        (follow_up.stats.uncovered_count + follow_up.stats.partial_bleed_count > 0)
-                            .then_some(FallbackReason::ResidualSuspect)
+                        self.post_resolution_fallback_reason(
+                            session,
+                            clean,
+                            &follow_up,
+                            document_kind,
+                            field_path,
+                        )?
                     }
                 };
                 if let Some(reason) = reason {
@@ -1004,6 +1010,14 @@ impl Pipeline {
                         reason,
                         protection_trace,
                     )?;
+                } else {
+                    validate_clean_manifest(clean)?;
+                    let restored = session.restore_strict_text(&clean.text)?;
+                    if restored != raw_before_resolution {
+                        return Err(protection_trace_error(
+                            "safety-net resolution broke exact restore",
+                        ));
+                    }
                 }
                 Ok(())
             }
@@ -1019,23 +1033,62 @@ impl Pipeline {
         field_path: Option<&str>,
         mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<Option<FallbackReason>> {
-        if report
-            .suspects
-            .iter()
-            .any(|suspect| matches!(suspect.kind, LeakKind::ClassMismatch { .. }))
-        {
-            return Ok(Some(FallbackReason::OverlapConflict));
+        validate_clean_manifest(clean)?;
+        let mut protected = Vec::new();
+        let mut actionable = Vec::new();
+        for suspect in &report.suspects {
+            if suspect_is_inside_live_token(session, clean, suspect) {
+                protected.push(suspect);
+            } else if matches!(suspect.kind, LeakKind::ClassMismatch { .. }) {
+                return Ok(Some(FallbackReason::OverlapConflict));
+            } else {
+                actionable.push(suspect);
+            }
         }
-        for suspect in actionable_suspects(report).into_iter().rev() {
+        sort_safety_net_suspects(&mut protected);
+        sort_safety_net_suspects(&mut actionable);
+
+        let mut plans = Vec::with_capacity(actionable.len());
+        for suspect in actionable {
             let span = suspect_action_span(suspect);
             if !is_char_boundary_range(&clean.text, &span) {
                 return Ok(Some(FallbackReason::ResidualSuspect));
             }
-            // Establish the original interval before tokenization mutates the session or any
-            // clean text, manifest, or diagnostic trace state.
+            if !suspect_action_span_matches_manifest(clean, suspect) {
+                return Ok(Some(FallbackReason::OverlapConflict));
+            }
             let raw_span = map_clean_span_to_raw(clean, &span)?;
             let raw = clean.text[span.clone()].to_string();
-            let replacement = session.tokenize_with_family("safety_net", &suspect.class, &raw)?;
+            plans.push(PlannedSafetyNetResolution {
+                suspect,
+                clean_span: span,
+                raw_span,
+                raw,
+            });
+        }
+        if plans
+            .windows(2)
+            .any(|pair| ranges_overlap(&pair[0].clean_span, &pair[1].clean_span))
+        {
+            return Ok(Some(FallbackReason::OverlapConflict));
+        }
+
+        for suspect in protected {
+            self.log_safety_net_entry(
+                session,
+                suspect,
+                document_kind,
+                field_path,
+                Action::Preserve,
+                true,
+                ConflictTier::Resolve,
+                None,
+            )?;
+        }
+        for plan in plans.into_iter().rev() {
+            let suspect = plan.suspect;
+            let replacement =
+                session.tokenize_with_family("safety_net", &suspect.class, &plan.raw)?;
             self.log_safety_net_entry(
                 session,
                 suspect,
@@ -1048,17 +1101,17 @@ impl Pipeline {
             )?;
             replace_clean_span(
                 clean,
-                span.clone(),
+                plan.clean_span.clone(),
                 &replacement,
                 Some(EmittedTokenSpan::new(
-                    span.start..span.start + replacement.len(),
-                    raw_span.clone(),
+                    plan.clean_span.start..plan.clean_span.start + replacement.len(),
+                    plan.raw_span.clone(),
                     suspect.class.clone(),
                 )),
             );
             if let Some(trace) = protection_trace.as_deref_mut() {
                 trace.record(
-                    raw_span,
+                    plan.raw_span,
                     suspect.class.clone(),
                     GazeLocalProtectionTraceKind::SafetyNetResolveTokenize,
                     vec![suspect.safety_net_id.clone()],
@@ -1068,17 +1121,55 @@ impl Pipeline {
         Ok(None)
     }
 
+    fn post_resolution_fallback_reason(
+        &self,
+        session: &Session,
+        clean: &CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+    ) -> Result<Option<FallbackReason>> {
+        validate_clean_manifest(clean)?;
+        let mut protected = Vec::new();
+        for suspect in &report.suspects {
+            if suspect_is_inside_live_token(session, clean, suspect) {
+                protected.push(suspect);
+                continue;
+            }
+            let reason = if matches!(suspect.kind, LeakKind::ClassMismatch { .. }) {
+                FallbackReason::OverlapConflict
+            } else {
+                FallbackReason::ResidualSuspect
+            };
+            return Ok(Some(reason));
+        }
+        sort_safety_net_suspects(&mut protected);
+        for suspect in protected {
+            self.log_safety_net_entry(
+                session,
+                suspect,
+                document_kind,
+                field_path,
+                Action::Preserve,
+                true,
+                ConflictTier::Resolve,
+                None,
+            )?;
+        }
+        Ok(None)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn apply_safety_net_fallback(
         &self,
         session: &Session,
-        clean: &mut CleanText,
+        _clean: &mut CleanText,
         report: &LeakReport,
         document_kind: DocumentKind,
         field_path: Option<&str>,
         fallback: SafetyNetFallback,
         reason: FallbackReason,
-        protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
+        _protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<()> {
         for suspect in redaction_suspects(report) {
             self.log_safety_net_entry(
@@ -1095,16 +1186,7 @@ impl Pipeline {
         match fallback {
             SafetyNetFallback::Strict => Err(Error::SafetyNetFallback(reason)),
             SafetyNetFallback::Tolerant => Ok(()),
-            SafetyNetFallback::Redact => self.redact_safety_net_suspects(
-                session,
-                clean,
-                report,
-                document_kind,
-                field_path,
-                Some(reason),
-                false,
-                protection_trace,
-            ),
+            SafetyNetFallback::Redact => Err(Error::SafetyNetFallback(reason)),
         }
     }
 
@@ -1120,18 +1202,33 @@ impl Pipeline {
         log_entries: bool,
         mut protection_trace: Option<&mut ProtectionTraceCollector<'_>>,
     ) -> Result<()> {
-        for suspect in redaction_suspects(report).into_iter().rev() {
+        validate_clean_manifest(clean)?;
+        let mut plans = Vec::new();
+        for suspect in redaction_suspects(report) {
             let span =
                 round_span_outward_to_char_boundaries(&clean.text, suspect_action_span(suspect))?;
             let span = expand_span_to_overlapping_manifest_entries(clean, span);
-            let raw_span = protection_trace
-                .as_ref()
-                .map(|_| map_clean_span_to_raw(clean, &span))
-                .transpose()?;
+            let raw_span = map_clean_span_to_raw(clean, &span)?;
+            plans.push(PlannedSafetyNetRedaction {
+                suspect,
+                clean_span: span,
+                raw_span,
+            });
+        }
+        if plans
+            .windows(2)
+            .any(|pair| ranges_overlap(&pair[0].clean_span, &pair[1].clean_span))
+        {
+            return Err(protection_trace_error(
+                "overlapping safety-net redaction spans",
+            ));
+        }
+        for plan in plans.into_iter().rev() {
+            let suspect = plan.suspect;
             for existing in clean
                 .manifest
                 .iter()
-                .filter(|existing| ranges_overlap(&existing.clean_span, &span))
+                .filter(|existing| ranges_overlap(&existing.clean_span, &plan.clean_span))
             {
                 tracing::warn!(
                     class = ?existing.class,
@@ -1156,10 +1253,10 @@ impl Pipeline {
                     fallback_reason,
                 )?;
             }
-            replace_clean_span(clean, span, "", None);
-            if let (Some(trace), Some(raw_span)) = (protection_trace.as_deref_mut(), raw_span) {
+            replace_clean_span(clean, plan.clean_span, "", None);
+            if let Some(trace) = protection_trace.as_deref_mut() {
                 trace.record(
-                    raw_span,
+                    plan.raw_span,
                     suspect.class.clone(),
                     if fallback_reason.is_some() {
                         GazeLocalProtectionTraceKind::SafetyNetFallbackRedact
@@ -1460,6 +1557,19 @@ struct CleanText {
     manifest: Vec<EmittedTokenSpan>,
 }
 
+struct PlannedSafetyNetResolution<'a> {
+    suspect: &'a LeakSuspect,
+    clean_span: Range<usize>,
+    raw_span: Range<usize>,
+    raw: String,
+}
+
+struct PlannedSafetyNetRedaction<'a> {
+    suspect: &'a LeakSuspect,
+    clean_span: Range<usize>,
+    raw_span: Range<usize>,
+}
+
 struct ProtectionTraceCollector<'a> {
     raw_text: &'a str,
     items: Vec<GazeLocalProtectionTraceItem>,
@@ -1593,6 +1703,106 @@ fn map_clean_span_to_raw(clean: &CleanText, span: &Range<usize>) -> Result<Range
     Ok(start..end)
 }
 
+fn validate_clean_manifest(clean: &CleanText) -> Result<()> {
+    for emitted in &clean.manifest {
+        let mapped = map_clean_span_to_raw(clean, &emitted.clean_span)?;
+        if mapped != emitted.raw_span {
+            return Err(protection_trace_error(
+                "manifest clean-to-raw mapping mismatch",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn suspect_is_inside_live_token(
+    session: &Session,
+    clean: &CleanText,
+    suspect: &LeakSuspect,
+) -> bool {
+    let span = &suspect.span;
+    if span.start >= span.end || !is_char_boundary_range(&clean.text, span) {
+        return false;
+    }
+    let mut containing = clean.manifest.iter().filter(|emitted| {
+        emitted.clean_span.start <= span.start && span.end <= emitted.clean_span.end
+    });
+    let Some(emitted) = containing.next() else {
+        return false;
+    };
+    if containing.next().is_some() {
+        return false;
+    }
+    let Some(token) = clean.text.get(emitted.clean_span.clone()) else {
+        return false;
+    };
+    let Some(restored) = session.restore(token) else {
+        return false;
+    };
+    session.contains_token(token)
+        && emitted.raw_span.start < emitted.raw_span.end
+        && restored.len() == emitted.raw_span.end - emitted.raw_span.start
+}
+
+fn suspect_action_span_matches_manifest(clean: &CleanText, suspect: &LeakSuspect) -> bool {
+    if suspect.span.start >= suspect.span.end || !is_char_boundary_range(&clean.text, &suspect.span)
+    {
+        return false;
+    }
+    match &suspect.kind {
+        LeakKind::Uncovered => !clean
+            .manifest
+            .iter()
+            .any(|emitted| ranges_overlap(&emitted.clean_span, &suspect.span)),
+        LeakKind::PartialBleed { uncovered } => {
+            if uncovered.start >= uncovered.end
+                || !is_char_boundary_range(&clean.text, uncovered)
+                || uncovered.start < suspect.span.start
+                || uncovered.end > suspect.span.end
+            {
+                return false;
+            }
+            let mut cursor = suspect.span.start;
+            let mut gaps = Vec::new();
+            for emitted in clean
+                .manifest
+                .iter()
+                .filter(|emitted| ranges_overlap(&emitted.clean_span, &suspect.span))
+            {
+                let covered_start = emitted.clean_span.start.max(suspect.span.start);
+                let covered_end = emitted.clean_span.end.min(suspect.span.end);
+                if cursor < covered_start {
+                    gaps.push(cursor..covered_start);
+                }
+                cursor = cursor.max(covered_end);
+            }
+            if cursor < suspect.span.end {
+                gaps.push(cursor..suspect.span.end);
+            }
+            gaps.as_slice() == [uncovered.clone()]
+        }
+        LeakKind::ClassMismatch { .. } => false,
+        _ => false,
+    }
+}
+
+fn sort_safety_net_suspects(suspects: &mut Vec<&LeakSuspect>) {
+    suspects.sort_by(|left, right| {
+        (
+            left.span.start,
+            left.span.end,
+            left.class.to_canonical_str(),
+            left.safety_net_id.as_str(),
+        )
+            .cmp(&(
+                right.span.start,
+                right.span.end,
+                right.class.to_canonical_str(),
+                right.safety_net_id.as_str(),
+            ))
+    });
+}
+
 fn map_clean_boundary_to_raw(manifest: &[EmittedTokenSpan], offset: usize) -> Option<usize> {
     let mut clean_cursor = 0usize;
     let mut raw_cursor = 0usize;
@@ -1619,21 +1829,6 @@ fn map_clean_boundary_to_raw(manifest: &[EmittedTokenSpan], offset: usize) -> Op
         raw_cursor = emitted.raw_span.end;
     }
     raw_cursor.checked_add(offset.checked_sub(clean_cursor)?)
-}
-
-fn actionable_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
-    let mut suspects = report
-        .suspects
-        .iter()
-        .filter(|suspect| {
-            matches!(
-                suspect.kind,
-                LeakKind::Uncovered | LeakKind::PartialBleed { .. }
-            )
-        })
-        .collect::<Vec<_>>();
-    suspects.sort_by_key(|suspect| suspect_action_span(suspect).start);
-    suspects
 }
 
 fn redaction_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
@@ -2849,8 +3044,437 @@ mod tests {
         assert_eq!(trace_coordinates, production_coordinates);
     }
 
+    fn fallback_redact_parity_fixture() -> (Session, CleanText, LeakReport, String) {
+        let email_raw = "alice@example.invalid";
+        let phone_raw = "+1-555-0101";
+        let raw_text = format!("{email_raw} A B {phone_raw}");
+        let session =
+            Session::new_with_session_hex_for_tests(Scope::Ephemeral, [0x01, 0x23, 0x45, 0x67])
+                .expect("session");
+        let email_token = session
+            .tokenize_with_family("counter", &PiiClass::Email, email_raw)
+            .expect("email token");
+        let phone_class = PiiClass::custom("phone");
+        let phone_token = session
+            .tokenize_with_family("counter", &phone_class, phone_raw)
+            .expect("phone token");
+        let clean_text = format!("{email_token} A B {phone_token}");
+        let phone_clean_start = clean_text.find(&phone_token).expect("phone token offset");
+        let phone_raw_start = raw_text.find(phone_raw).expect("phone raw offset");
+        let a_start = clean_text.find("A B").expect("synthetic gap");
+        let b_start = a_start + "A ".len();
+        let clean = CleanText {
+            text: clean_text,
+            manifest: vec![
+                EmittedTokenSpan::new(0..email_token.len(), 0..email_raw.len(), PiiClass::Email),
+                EmittedTokenSpan::new(
+                    phone_clean_start..phone_clean_start + phone_token.len(),
+                    phone_raw_start..phone_raw_start + phone_raw.len(),
+                    phone_class,
+                ),
+            ],
+        };
+        let report = LeakReport::from_parts(
+            vec![
+                LeakSuspect::new(
+                    1..2,
+                    PiiClass::Name,
+                    "parity.fixture",
+                    Some(1.0),
+                    LeakKind::ClassMismatch {
+                        pipeline_class: PiiClass::Email,
+                        safety_net_class: PiiClass::Name,
+                    },
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                ),
+                LeakSuspect::new(
+                    a_start..a_start + 1,
+                    PiiClass::Name,
+                    "parity.fixture",
+                    Some(1.0),
+                    LeakKind::Uncovered,
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                ),
+                LeakSuspect::new(
+                    b_start..b_start + 1,
+                    PiiClass::Name,
+                    "parity.fixture",
+                    Some(1.0),
+                    LeakKind::Uncovered,
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                ),
+            ],
+            Vec::new(),
+        );
+        (session, clean, report, raw_text)
+    }
+
     #[test]
-    fn ambiguous_safety_resolve_mapping_fails_before_any_emission() {
+    fn fallback_redact_manifest_desync_has_traced_untraced_parity() {
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+        let policy = SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact);
+
+        let (traced_session, mut traced_clean, traced_report, raw_text) =
+            fallback_redact_parity_fixture();
+        let mut trace = ProtectionTraceCollector::new(&raw_text);
+        let traced_result = pipeline.apply_safety_net_policy(
+            &traced_session,
+            &mut traced_clean,
+            &traced_report,
+            DocumentKind::Text,
+            &[crate::LocaleTag::Global],
+            None,
+            policy,
+            Some(&mut trace),
+        );
+
+        let (untraced_session, mut untraced_clean, untraced_report, _) =
+            fallback_redact_parity_fixture();
+        let untraced_result = pipeline.apply_safety_net_policy(
+            &untraced_session,
+            &mut untraced_clean,
+            &untraced_report,
+            DocumentKind::Text,
+            &[crate::LocaleTag::Global],
+            None,
+            policy,
+            None,
+        );
+
+        assert!(traced_result.is_ok());
+        assert!(untraced_result.is_ok());
+        assert_eq!(traced_clean.text, untraced_clean.text);
+        assert_eq!(traced_clean.manifest, untraced_clean.manifest);
+        assert_eq!(
+            traced_session
+                .restore_strict_text(&traced_clean.text)
+                .expect("traced output restores"),
+            raw_text
+        );
+        assert_eq!(
+            untraced_session
+                .restore_strict_text(&untraced_clean.text)
+                .expect("untraced output restores"),
+            raw_text
+        );
+    }
+
+    #[test]
+    fn genuine_residual_fails_closed_with_traced_untraced_parity() {
+        fn fixture() -> (Session, CleanText, LeakReport) {
+            let raw = "Dr. Schmidt tail";
+            let session =
+                Session::new_with_session_hex_for_tests(Scope::Ephemeral, [0x01, 0x23, 0x45, 0x67])
+                    .expect("session");
+            let clean = CleanText {
+                text: raw.to_string(),
+                manifest: Vec::new(),
+            };
+            let report = LeakReport::from_parts(
+                vec![LeakSuspect::new(
+                    0.."Dr. Schmidt".len(),
+                    PiiClass::Name,
+                    "initial.fixture",
+                    Some(1.0),
+                    LeakKind::Uncovered,
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                )],
+                Vec::new(),
+            );
+            (session, clean, report)
+        }
+
+        let pipeline = Pipeline::builder()
+            .register_safety_net(MarkerSafetyNet {
+                id: "residual.fixture",
+                marker: "tail",
+                class: PiiClass::Name,
+            })
+            .build()
+            .expect("pipeline");
+        let policy = SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact);
+        let raw = "Dr. Schmidt tail";
+
+        let (traced_session, mut traced_clean, traced_report) = fixture();
+        let mut trace = ProtectionTraceCollector::new(raw);
+        let traced_error = pipeline
+            .apply_safety_net_policy(
+                &traced_session,
+                &mut traced_clean,
+                &traced_report,
+                DocumentKind::Text,
+                &[crate::LocaleTag::Global],
+                None,
+                policy,
+                Some(&mut trace),
+            )
+            .expect_err("genuine traced residual must fail closed");
+
+        let (untraced_session, mut untraced_clean, untraced_report) = fixture();
+        let untraced_error = pipeline
+            .apply_safety_net_policy(
+                &untraced_session,
+                &mut untraced_clean,
+                &untraced_report,
+                DocumentKind::Text,
+                &[crate::LocaleTag::Global],
+                None,
+                policy,
+                None,
+            )
+            .expect_err("genuine untraced residual must fail closed");
+
+        assert!(matches!(
+            traced_error,
+            Error::SafetyNetFallback(FallbackReason::ResidualSuspect)
+        ));
+        assert!(matches!(
+            untraced_error,
+            Error::SafetyNetFallback(FallbackReason::ResidualSuspect)
+        ));
+        assert_eq!(traced_clean.text, untraced_clean.text);
+        assert_eq!(traced_clean.manifest, untraced_clean.manifest);
+        assert_eq!(
+            traced_session
+                .restore_strict_text(&traced_clean.text)
+                .expect("traced failed output remains reversible"),
+            raw
+        );
+        assert_eq!(
+            untraced_session
+                .restore_strict_text(&untraced_clean.text)
+                .expect("untraced failed output remains reversible"),
+            raw
+        );
+    }
+
+    #[test]
+    fn non_affine_manifest_fails_before_mutation_with_traced_untraced_parity() {
+        fn fixture() -> (Session, CleanText, LeakReport, String) {
+            let (session, mut clean, _, raw) = fallback_redact_parity_fixture();
+            let b_start = clean.text.find('B').expect("synthetic gap byte");
+            replace_clean_span(&mut clean, b_start..b_start + 1, "", None);
+            let a_start = clean.text.find('A').expect("remaining synthetic gap byte");
+            let report = LeakReport::from_parts(
+                vec![LeakSuspect::new(
+                    a_start..a_start + 1,
+                    PiiClass::Name,
+                    "non-affine.fixture",
+                    Some(1.0),
+                    LeakKind::Uncovered,
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                )],
+                Vec::new(),
+            );
+            (session, clean, report, raw)
+        }
+
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+        let policy = SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact);
+        let (traced_session, mut traced_clean, traced_report, raw) = fixture();
+        let traced_before = (traced_clean.text.clone(), traced_clean.manifest.clone());
+        let mut trace = ProtectionTraceCollector::new(&raw);
+        let traced_error = pipeline
+            .apply_safety_net_policy(
+                &traced_session,
+                &mut traced_clean,
+                &traced_report,
+                DocumentKind::Text,
+                &[crate::LocaleTag::Global],
+                None,
+                policy,
+                Some(&mut trace),
+            )
+            .expect_err("traced non-affine manifest must fail closed");
+
+        let (untraced_session, mut untraced_clean, untraced_report, _) = fixture();
+        let untraced_before = (untraced_clean.text.clone(), untraced_clean.manifest.clone());
+        let untraced_error = pipeline
+            .apply_safety_net_policy(
+                &untraced_session,
+                &mut untraced_clean,
+                &untraced_report,
+                DocumentKind::Text,
+                &[crate::LocaleTag::Global],
+                None,
+                policy,
+                None,
+            )
+            .expect_err("untraced non-affine manifest must fail closed");
+
+        for error in [traced_error, untraced_error] {
+            assert!(matches!(
+                error,
+                Error::SafetyNet(SafetyNetError::InvalidOutput { message })
+                    if message == "clean-to-raw start mapping failed"
+            ));
+        }
+        assert_eq!((traced_clean.text, traced_clean.manifest), traced_before);
+        assert_eq!(
+            (untraced_clean.text, untraced_clean.manifest),
+            untraced_before
+        );
+        assert!(trace.items.is_empty());
+    }
+
+    #[test]
+    fn resolve_straddles_both_live_tokens_without_retokenizing_them() {
+        let (session, mut clean, _, raw) = fallback_redact_parity_fixture();
+        let email_end = clean.manifest[0].clean_span.end;
+        let phone_start = clean.manifest[1].clean_span.start;
+        let report = LeakReport::from_parts(
+            vec![
+                LeakSuspect::new(
+                    email_end - 1..email_end + 2,
+                    PiiClass::Name,
+                    "left-straddle.fixture",
+                    Some(1.0),
+                    LeakKind::PartialBleed {
+                        uncovered: email_end..email_end + 2,
+                    },
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                ),
+                LeakSuspect::new(
+                    phone_start - 2..phone_start + 1,
+                    PiiClass::Name,
+                    "right-straddle.fixture",
+                    Some(1.0),
+                    LeakKind::PartialBleed {
+                        uncovered: phone_start - 2..phone_start,
+                    },
+                    PiiClass::Name.to_canonical_str(),
+                    None,
+                ),
+            ],
+            Vec::new(),
+        );
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+        let mut trace = ProtectionTraceCollector::new(&raw);
+
+        let reason = pipeline
+            .resolve_safety_net_suspects(
+                &session,
+                &mut clean,
+                &report,
+                DocumentKind::Text,
+                None,
+                Some(&mut trace),
+            )
+            .expect("straddles resolve");
+
+        assert_eq!(reason, None);
+        validate_clean_manifest(&clean).expect("manifest remains affine");
+        assert_eq!(clean.manifest.len(), 4);
+        assert_eq!(trace.items.len(), 2);
+        assert_eq!(
+            session
+                .restore_strict_text(&clean.text)
+                .expect("straddles restore"),
+            raw
+        );
+    }
+
+    #[test]
+    fn resolve_token_gap_token_protects_only_the_single_uncovered_gap() {
+        let (session, mut clean, _, raw) = fallback_redact_parity_fixture();
+        let email_end = clean.manifest[0].clean_span.end;
+        let phone_start = clean.manifest[1].clean_span.start;
+        let report = LeakReport::from_parts(
+            vec![LeakSuspect::new(
+                email_end - 1..phone_start + 1,
+                PiiClass::Name,
+                "token-gap-token.fixture",
+                Some(1.0),
+                LeakKind::PartialBleed {
+                    uncovered: email_end..phone_start,
+                },
+                PiiClass::Name.to_canonical_str(),
+                None,
+            )],
+            Vec::new(),
+        );
+        let pipeline = Pipeline::builder().build().expect("pipeline");
+
+        let reason = pipeline
+            .resolve_safety_net_suspects(
+                &session,
+                &mut clean,
+                &report,
+                DocumentKind::Text,
+                None,
+                None,
+            )
+            .expect("single gap resolves");
+
+        assert_eq!(reason, None);
+        validate_clean_manifest(&clean).expect("manifest remains affine");
+        assert_eq!(clean.manifest.len(), 3);
+        assert_eq!(
+            session
+                .restore_strict_text(&clean.text)
+                .expect("token-gap-token restores"),
+            raw
+        );
+    }
+
+    #[test]
+    fn overlapping_and_nested_resolve_suspects_fail_before_emission() {
+        let raw = "Dr. Schmidt tail";
+        for spans in [[0..11, 3..11], [3..11, 0..11]] {
+            let session =
+                Session::new_with_session_hex_for_tests(Scope::Ephemeral, [0x01, 0x23, 0x45, 0x67])
+                    .expect("session");
+            let mut clean = CleanText {
+                text: raw.to_string(),
+                manifest: Vec::new(),
+            };
+            let report = LeakReport::from_parts(
+                spans
+                    .into_iter()
+                    .map(|span| {
+                        LeakSuspect::new(
+                            span,
+                            PiiClass::Name,
+                            "overlap.fixture",
+                            Some(1.0),
+                            LeakKind::Uncovered,
+                            PiiClass::Name.to_canonical_str(),
+                            None,
+                        )
+                    })
+                    .collect(),
+                Vec::new(),
+            );
+            let pipeline = Pipeline::builder().build().expect("pipeline");
+            let mut trace = ProtectionTraceCollector::new(raw);
+
+            let reason = pipeline
+                .resolve_safety_net_suspects(
+                    &session,
+                    &mut clean,
+                    &report,
+                    DocumentKind::Text,
+                    None,
+                    Some(&mut trace),
+                )
+                .expect("overlap classification succeeds");
+
+            assert_eq!(reason, Some(FallbackReason::OverlapConflict));
+            assert_eq!(clean.text, raw);
+            assert!(clean.manifest.is_empty());
+            assert!(trace.items.is_empty());
+            assert!(session.snapshot_entries().is_empty());
+        }
+    }
+
+    #[test]
+    fn unknown_token_shaped_safety_suspect_falls_back_before_any_emission() {
         let raw_text = "alice@example.invalid tail";
         let existing_token = "<Email_1>";
         let mut clean = CleanText {
@@ -2879,7 +3503,7 @@ mod tests {
         let session = Session::new(Scope::Ephemeral).expect("session");
         let mut trace = ProtectionTraceCollector::new(raw_text);
 
-        let error = pipeline
+        let reason = pipeline
             .resolve_safety_net_suspects(
                 &session,
                 &mut clean,
@@ -2888,13 +3512,9 @@ mod tests {
                 None,
                 Some(&mut trace),
             )
-            .expect_err("an interval inside an existing token is ambiguous");
+            .expect("classification succeeds");
 
-        assert!(matches!(
-            error,
-            Error::SafetyNet(SafetyNetError::InvalidOutput { message })
-                if message == "clean-to-raw start mapping failed"
-        ));
+        assert_eq!(reason, Some(FallbackReason::OverlapConflict));
         assert_eq!(clean.text, before_text);
         assert_eq!(clean.manifest, before_manifest);
         assert!(trace.items.is_empty());
@@ -2941,17 +3561,17 @@ mod tests {
                 SafetyNetPolicy::new(SafetyNetMode::Resolve, SafetyNetFallback::Redact),
             )
             .expect("fallback trace");
-        assert!(fallback_manifest.is_empty());
+        assert_eq!(fallback_manifest.len(), 1);
         assert_eq!(fallback_trace.len(), 1);
         assert_eq!(fallback_trace[0].raw_start(), 0);
         assert_eq!(fallback_trace[0].raw_end(), 21);
-        assert_eq!(fallback_trace[0].class(), &PiiClass::Name);
-        assert_eq!(fallback_trace[0].stage(), "safety_net");
-        assert_eq!(fallback_trace[0].decision(), "fallback_redact");
-        assert_eq!(fallback_trace[0].action(), "redact");
+        assert_eq!(fallback_trace[0].class(), &PiiClass::Email);
+        assert_eq!(fallback_trace[0].stage(), "primary_pipeline");
+        assert_eq!(fallback_trace[0].decision(), "policy");
+        assert_eq!(fallback_trace[0].action(), "tokenize");
         assert_eq!(
             fallback_trace[0].source_ids(),
-            &["manifest-mismatch.fixture".to_string()]
+            &["email.fixture".to_string()]
         );
     }
 

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -432,7 +432,7 @@ fn safety_net_trace_partial_bleed_tokenizes_only_uncovered_subspan() {
 }
 
 #[test]
-fn safety_net_trace_class_mismatch_overlap_falls_back_to_non_reversible_redaction() {
+fn safety_net_trace_class_mismatch_inside_live_token_is_reversible_noop() {
     let raw = "alice@example.invalid ok";
     let baseline_session = session();
     let baseline = text(
@@ -456,51 +456,68 @@ fn safety_net_trace_class_mismatch_overlap_falls_back_to_non_reversible_redactio
     );
 
     assert_eq!(report.stats.class_mismatch_count, 1);
-    assert_eq!(clean, " ok");
-    assert!(manifest.is_empty());
+    assert!(clean.ends_with(" ok"));
+    assert_eq!(manifest.len(), 1);
     assert_eq!(trace.len(), 1);
     assert_eq!(trace[0].raw_start(), 0);
     assert_eq!(trace[0].raw_end(), "alice@example.invalid".len());
-    assert_eq!(trace[0].class(), &PiiClass::Name);
-    assert_eq!(trace[0].stage(), "safety_net");
-    assert_eq!(trace[0].decision(), "fallback_redact");
-    assert_eq!(trace[0].action(), "redact");
-    assert_eq!(trace[0].source_ids(), &["mock".to_string()]);
+    assert_eq!(trace[0].class(), &PiiClass::Email);
+    assert_eq!(trace[0].stage(), "primary_pipeline");
+    assert_eq!(trace[0].decision(), "policy");
+    assert_eq!(trace[0].action(), "tokenize");
+    assert_eq!(trace[0].source_ids(), &["fixed".to_string()]);
     assert_trace_manifest_contract(raw, &clean, &manifest, &trace, &session);
-    assert_successful_redaction_is_not_reversible(raw, &clean, &session);
+    assert_eq!(
+        session
+            .restore_strict_text(&clean)
+            .expect("protected mismatch restores"),
+        raw
+    );
 }
 
 #[test]
-fn safety_net_trace_residual_utf8_suspect_falls_back_with_original_char_boundaries() {
+fn safety_net_trace_residual_utf8_suspect_fails_closed() {
     let raw = "Grüße von Dr. Schmidt";
     let multibyte = raw.find('ü').expect("multibyte character");
     let net = MockNet::new(Some(multibyte + 1..multibyte + "ü".len()), PiiClass::Name);
     let pipeline = pipeline_with_net(Some(net));
-    let session = session();
+    let traced_session = session();
 
-    let (clean, manifest, report, trace) = traced_clean(
-        &pipeline,
-        &session,
-        raw,
-        gaze::SafetyNetPolicy::new(
-            gaze::SafetyNetMode::Resolve,
-            gaze::SafetyNetFallback::Redact,
-        ),
-    );
+    let error = pipeline
+        .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+            &traced_session,
+            raw,
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Resolve,
+                gaze::SafetyNetFallback::Redact,
+            ),
+        )
+        .expect_err("invalid UTF-8 residual must fail closed");
 
-    assert_eq!(report.stats.uncovered_count, 1);
-    assert_eq!(clean, "Grße von Dr. Schmidt");
-    assert!(manifest.is_empty());
-    assert_eq!(trace.len(), 1);
-    assert_eq!(trace[0].raw_start(), multibyte);
-    assert_eq!(trace[0].raw_end(), multibyte + "ü".len());
-    assert_eq!(trace[0].class(), &PiiClass::Name);
-    assert_eq!(trace[0].stage(), "safety_net");
-    assert_eq!(trace[0].decision(), "fallback_redact");
-    assert_eq!(trace[0].action(), "redact");
-    assert_eq!(trace[0].source_ids(), &["mock".to_string()]);
-    assert_trace_manifest_contract(raw, &clean, &manifest, &trace, &session);
-    assert_successful_redaction_is_not_reversible(raw, &clean, &session);
+    assert!(matches!(
+        error,
+        gaze::Error::SafetyNetFallback(FallbackReason::ResidualSuspect)
+    ));
+
+    let untraced_session = session();
+    let untraced_error = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &untraced_session,
+            RawDocument::Text(raw.to_string()),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Resolve,
+                gaze::SafetyNetFallback::Redact,
+            ),
+        )
+        .expect_err("invalid UTF-8 residual must also fail closed without tracing");
+    assert!(matches!(
+        untraced_error,
+        gaze::Error::SafetyNetFallback(FallbackReason::ResidualSuspect)
+    ));
 }
 
 #[test]
@@ -732,7 +749,7 @@ fn safety_net_redact_mode_keeps_aligned_span_redaction_behavior() {
 }
 
 #[test]
-fn safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit() {
+fn safety_net_resolve_live_token_mismatch_is_audited_noop() {
     let session = session();
     let raw = RawDocument::Text("alice@example.invalid ok".to_string());
     let baseline = text(
@@ -763,13 +780,21 @@ fn safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit() {
             &gaze::DictionaryBundle::default(),
             gaze::SafetyNetPolicy::default(),
         )
-        .expect("fallback redact");
+        .expect("protected mismatch");
 
     assert_eq!(report.stats.class_mismatch_count, 1);
-    assert_eq!(text(clean), " ok");
+    let clean = text(clean);
+    assert!(clean.ends_with(" ok"));
+    assert_eq!(
+        session
+            .restore_strict_text(&clean)
+            .expect("protected mismatch restores"),
+        "alice@example.invalid ok"
+    );
     assert!(logger.entries().iter().any(|entry| {
-        entry.decided_by == ConflictTier::Fallback
-            && entry.fallback_triggered == Some(FallbackReason::OverlapConflict)
+        entry.decided_by == ConflictTier::Resolve
+            && entry.conflict_loser
+            && entry.fallback_triggered.is_none()
     }));
 }
 


### PR DESCRIPTION
## Summary

The traced benchmark path already failed closed when safety-net output had genuine residuals or a non-affine clean-to-raw mapping. The non-traced production path could skip part of that integrity work and complete the same input. This PR closes that parity hole, validates safety-net resolve/fallback results before completion, and adds focused traced/non-traced regressions through the pipeline and CLI index path.

This is an intentional production fail-closed behavior correction. Under the user-ratified B' tradeoff, reliability and reversibility take priority over completion: hard documents now return typed failures instead of silently completing with weaker safety evidence. There is no public API, shared type, schema-v3, comparator, release-verdict, root Cargo, OPF, collision-family, or detector/model change.

## Full scorecard

Both fresh full runs used seed `20260710`, the pinned Dataiku EN/DE dataset, the digest-gated Davlan and Kiji bundles, and commit `803eb6c70b18744f1ad72d934615cade0ea65e2b` with `gaze.dirty=false`. Both commands exited 4, which is the expected unchanged release-readiness failure.

R1 and R2 have zero differing integer leaves across every run subtree: 375 for `rule-floor-extended`, 375 for `pass2-ner`, and 370 for `full-stack-kiji-resolve`. The first two cells also reproduce the committed `7395e7a` baseline with zero integer differences.

The full-stack Kiji cell reproduces exactly between R1 and R2:

| Metric | `7395e7a` | R1 | R2 | Candidate delta |
| --- | ---: | ---: | ---: | ---: |
| Failed-closed documents | 593 | 660 | 660 | +67 |
| Completed documents | 2,317 | 2,250 | 2,250 | -67 |
| Zero-leak completed documents | 910 | 908 | 908 | -2 |
| Leaked labeled UTF-8 bytes | 31,737 | 30,693 | 30,693 | -1,044 |
| Documents with leaks | 1,407 | 1,342 | 1,342 | -65 |
| False-positive bytes | 98,857 | 92,106 | 92,106 | -6,751 |
| Documents with false positives | 1,921 | 1,857 | 1,857 | -64 |
| Restore failures | 112 | 0 | 0 | -112 |
| Exact-restorable completed docs | 2,205 | 2,250 | 2,250 | +45 |
| Redact actions | 195 | 0 | 0 | -195 |
| Strict rejections | 1,326 | 1,268 | 1,268 | -58 |
| Residual suspects | 21 | 170 | 170 | +149 |

All 2,250 completed candidate documents are manifest-valid and exact-restorable. Final trace agreement also holds: 23,376 trace items equal 23,376 manifest spans plus zero redact actions.

The higher failed-closed count and lower completion are deliberate and user-reviewed. The canonical regression comparator still fails, as it should: it reports 11 ratchet failures, including failed-closed 593 -> 660, completion 2,317 -> 2,250, residual suspects 21 -> 170, and the availability-dependent scored/gold counts. Nothing was suppressed or weakened to make the result look green. Release-readiness remains `failed` in both runs (`passed=false`, eight failures).

## Residual-suspect classification

The 170 candidate post-policy suspects were classified before this commit with geometry-only telemetry (Solo diagnostic scratchpad 4315). All 170/170 are Kiji re-detections wholly inside Gaze's own live session pseudonym tokens:

- inside-token: 170
- overlap-token: 0
- uncovered: 0
- other: 0

Every affected successful output is manifest-valid and exact-restorable. These are re-detections of already protected, reversible tokens, not uncovered PII in successful output. The increase is consistent with redact actions dropping from 195 to zero and those regions remaining as live tokens.

## Five axes

- Reliability: traced and non-traced calls now fail closed consistently on genuine residuals and ambiguous/non-affine mappings. Leaked labeled bytes fall by 1,044 and documents with leaks fall by 65.
- Reversibility: restore failures fall from 112 to zero, redact actions fall from 195 to zero, and every completed document restores exactly.
- Agentic-first: production-equivalent calls no longer silently complete cases that the traced agent benchmark rejects. The cost is 67 additional typed failures and 67 fewer completions.
- Trust: parity is covered directly, manifests and traces agree, both full runs reproduce every integer, and the residual increase has a geometry-only benign proof.
- Adopter ergonomics: completion regresses from 2,317 to 2,250. That is the explicit B' tradeoff; typed fail-closed behavior is preferable to returning unsafe or non-restorable output. Public integration surfaces are unchanged.

## Verification

- `rustup run 1.96.0 cargo fmt --all -- --check`
- `rustup run 1.96.0 cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`
- `rustup run 1.96.0 cargo test --locked --workspace --all-features`
- `uv sync --project scripts/bench --locked`
- `uv run --project scripts/bench python -m unittest discover -s scripts/bench -p 'test_*.py'` (87 tests)
- full scorecard R1 and R2, seed `20260710` (both expected exit 4)
- dataset aggregate SHA-256 `11614c80f6d0fe78feb4c592fc9674efac08d73fe5549ad1bed8dd057b7592d2`
- Davlan observed/expected digest `7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16`
- Kiji observed/expected digest `c129e135d86698e67c4836456212666f94a56ceaf995acd60532f557b3120d2f`

Resolves solo todo #2229.
