### PR TITLE
[agent] isolate no-phone-parser fail-closed guard

### DIFF
--- a/crates/gaze-recognizers/tests/no_phone_parser_fail_closed.rs
+++ b/crates/gaze-recognizers/tests/no_phone_parser_fail_closed.rs
@@ -1,8 +1,43 @@
-#![cfg(not(feature = "phone-parser"))]
-
+#[cfg(not(feature = "phone-parser"))]
 use gaze_recognizers::{embedded, ValidatorKind};
+#[cfg(not(feature = "phone-parser"))]
 use gaze_types::ValidatorKindParseError;
+#[cfg(feature = "phone-parser")]
+use std::{fs, path::Path, process::Command, sync::Mutex};
 
+#[cfg(feature = "phone-parser")]
+static ISOLATED_HARNESS_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(feature = "phone-parser")]
+const ISOLATED_HARNESS_MANIFEST: &str = r#"[package]
+name = "gaze-recognizers-no-phone-parser-tests"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+resolver = "2"
+
+[features]
+default = []
+phone-parser = []
+
+[dependencies]
+gaze-recognizers = { path = "../../crates/gaze-recognizers", default-features = false }
+gaze-types = { path = "../../crates/gaze-types", default-features = false }
+
+[[test]]
+name = "no_phone_parser_fail_closed"
+path = "../../crates/gaze-recognizers/tests/no_phone_parser_fail_closed.rs"
+"#;
+
+#[cfg(feature = "phone-parser")]
+#[test]
+fn phone_validators_fail_closed_without_phone_parser() {
+    run_in_isolated_no_phone_parser_harness("phone_validators_fail_closed_without_phone_parser");
+}
+
+#[cfg(not(feature = "phone-parser"))]
 #[test]
 fn phone_validators_fail_closed_without_phone_parser() {
     for validator in [
@@ -14,6 +49,15 @@ fn phone_validators_fail_closed_without_phone_parser() {
     }
 }
 
+#[cfg(feature = "phone-parser")]
+#[test]
+fn embedded_spaced_e164_phone_recognizer_fails_closed_without_phone_parser() {
+    run_in_isolated_no_phone_parser_harness(
+        "embedded_spaced_e164_phone_recognizer_fails_closed_without_phone_parser",
+    );
+}
+
+#[cfg(not(feature = "phone-parser"))]
 #[test]
 fn embedded_spaced_e164_phone_recognizer_fails_closed_without_phone_parser() {
     let raw = embedded("core-extended").expect("core-extended embedded rulepack");
@@ -25,6 +69,7 @@ fn embedded_spaced_e164_phone_recognizer_fails_closed_without_phone_parser() {
     assert_unsupported_phone_validator("e164_phone");
 }
 
+#[cfg(not(feature = "phone-parser"))]
 fn assert_unsupported_phone_validator(validator: &str) {
     let err = ValidatorKind::parse(validator)
         .expect_err("phone validator must fail closed without phone-parser feature");
@@ -35,9 +80,64 @@ fn assert_unsupported_phone_validator(validator: &str) {
     );
 }
 
+#[cfg(not(feature = "phone-parser"))]
 fn recognizer_block<'a>(rulepack: &'a str, id: &str) -> &'a str {
     rulepack
         .split("[[recognizers]]")
         .find(|block| block.contains(&format!("id = \"{id}\"")))
         .unwrap_or_else(|| panic!("missing recognizer {id}"))
+}
+
+#[cfg(feature = "phone-parser")]
+fn run_in_isolated_no_phone_parser_harness(test_name: &str) {
+    let _guard = ISOLATED_HARNESS_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("gaze-recognizers must live under the workspace crates directory");
+    let harness_dir = workspace_root
+        .join("target")
+        .join("no-phone-parser-fail-closed-harness");
+    fs::create_dir_all(&harness_dir).expect("create isolated no-phone-parser harness directory");
+
+    let manifest_path = harness_dir.join("Cargo.toml");
+    fs::write(&manifest_path, ISOLATED_HARNESS_MANIFEST)
+        .expect("write isolated no-phone-parser harness manifest");
+    fs::copy(
+        workspace_root.join("Cargo.lock"),
+        harness_dir.join("Cargo.lock"),
+    )
+    .expect("seed isolated no-phone-parser harness lockfile");
+
+    let output = Command::new(env!("CARGO"))
+        .arg("test")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("--offline")
+        .arg("--test")
+        .arg("no_phone_parser_fail_closed")
+        .arg("--")
+        .arg(test_name)
+        .arg("--exact")
+        .env("CARGO_TARGET_DIR", harness_dir.join("target"))
+        .output()
+        .expect("run isolated no-phone-parser fail-closed test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "isolated no-phone-parser test {test_name} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("running 1 test") || stderr.contains("running 1 test"),
+        "isolated no-phone-parser test {test_name} did not execute exactly one test\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("test result: ok. 1 passed")
+            || stderr.contains("test result: ok. 1 passed"),
+        "isolated no-phone-parser test {test_name} did not pass exactly one test\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
 }


### PR DESCRIPTION
## Root cause

gaze-recognizers has a gaze-assembly dev-dependency for its coverage tooling. During cargo test -p gaze-recognizers --no-default-features, Cargo feature unification follows that dev-dependency back into gaze-recognizers with its default phone-parser feature enabled. The file-level cfg(not(feature = "phone-parser")) therefore removed the entire fail-closed integration target, while the xtask guard correctly rejected the resulting running 0 tests output.

## Fix

Keep the existing guard command and both fail-closed assertions intact. When the outer workspace test graph has unified phone-parser on, the two test entries now run their corresponding original assertion in a detached, generated test harness whose gaze-recognizers dependency has default-features = false.

The wrapper also requires the child run to report exactly one executed and passing test. This prevents either assertion from succeeding through another zero-test build. The harness stays under ignored target/; no root manifest, lockfile, public feature, API, or default runtime behavior changes.

This restores the reliability/trust value of the feature-matrix gate without changing production behavior or weakening reversibility, agentic fit, or adopter ergonomics.

## Gate evidence (rustc/cargo 1.96.0)

- Before: exact guard reported running 0 tests.
- After: cargo test -p gaze-recognizers --no-default-features --test no_phone_parser_fail_closed reports running 2 tests; 2 passed.
- cargo run -p xtask -- ci-feature-matrix passed with final ci_feature_matrix: passed.
- cargo fmt --all -- --check passed.
- cargo clippy --locked --workspace --all-features --all-targets -- -D warnings passed.
- cargo test --locked --workspace --all-features passed.

Resolves solo todo #2251
