### PR TITLE
[agent] serialize global-panic-hook tests in gaze-proxy (#2401)

### DIFF
--- a/crates/gaze-proxy/src/principal.rs
+++ b/crates/gaze-proxy/src/principal.rs
@@ -318,6 +318,40 @@ impl PrincipalResolver for ProcessLocalLoopbackResolver {
     }
 }
 
+/// Test-only serialization for the process-global panic hook.
+///
+/// [`invoke_resolver`] swaps the global panic hook for the duration of the trusted
+/// resolver call, so *every* caller of it is a global-hook writer. A test that
+/// installs its own hook and then observes whether it fires therefore races any
+/// concurrent `invoke_resolver` in the same test binary: the concurrent boundary
+/// window can mask the installed hook (observed hit count too low) or restore a
+/// stale hook over it.
+///
+/// [`RESOLVER_PANIC_HOOK_BOUNDARY`] cannot be reused for this -- `invoke_resolver`
+/// takes it internally and [`Mutex`] is not reentrant. This second lock is always
+/// acquired strictly *outside* that boundary and is never taken by production code,
+/// so the ordering cannot deadlock.
+///
+/// Every test that touches [`std::panic::set_hook`] / [`std::panic::take_hook`],
+/// directly or through [`invoke_resolver`], MUST hold this guard across its whole
+/// hook window. That includes tests in `tests/session_registry.rs`, which
+/// `#[path]`-includes this module and so shares this exact lock.
+///
+/// `#[cfg(test)]` keeps this out of every non-test build; production behavior is
+/// unchanged.
+#[cfg(test)]
+pub(crate) static PANIC_HOOK_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquires [`PANIC_HOOK_TEST_LOCK`], tolerating poisoning from an unrelated
+/// failing test so the real assertion failure is what gets reported.
+#[cfg(test)]
+pub(crate) fn lock_panic_hook_for_test() -> MutexGuard<'static, ()> {
+    match PANIC_HOOK_TEST_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -340,6 +374,7 @@ mod tests {
 
     #[test]
     fn loopback_identity_is_stable_for_one_resolver() -> Result<(), PrincipalResolveError> {
+        let _panic_hook_guard = lock_panic_hook_for_test();
         let resolver = ProcessLocalLoopbackResolver::new()?;
         let context =
             || PrincipalContext::new(ListenerScope::Loopback, PeerScope::Loopback, None, None);

--- a/crates/gaze-proxy/tests/session_registry.rs
+++ b/crates/gaze-proxy/tests/session_registry.rs
@@ -24,8 +24,8 @@ mod principal;
 mod session_registry;
 
 use principal::{
-    invoke_resolver, AuthenticatedPrincipal, ListenerScope, PeerScope, PrincipalContext,
-    PrincipalResolveError, PrincipalResolver, ProcessLocalLoopbackResolver,
+    invoke_resolver, lock_panic_hook_for_test, AuthenticatedPrincipal, ListenerScope, PeerScope,
+    PrincipalContext, PrincipalResolveError, PrincipalResolver, ProcessLocalLoopbackResolver,
     MAX_AUTHENTICATED_PRINCIPAL_BYTES, MAX_LOCAL_AUTH_CREDENTIAL_BYTES,
 };
 use session_registry::{
@@ -164,6 +164,9 @@ impl PrincipalResolver for ContextResolver {
 
 #[test]
 fn resolver_boundary_handles_success_empty_oversized_and_panic_without_raw_sources() {
+    // Held across the whole test: the counting hook installed below is only
+    // observable if no concurrent `invoke_resolver` swaps the global hook.
+    let _panic_hook_guard = lock_panic_hook_for_test();
     let resolved = invoke_resolver(
         &StaticResolver(b"tenant-a".to_vec()),
         loopback_context(None, None).unwrap(),
@@ -215,6 +218,7 @@ fn resolver_boundary_handles_success_empty_oversized_and_panic_without_raw_sourc
 
 #[test]
 fn context_exposes_only_closed_scopes_and_optional_nonprinting_borrowed_inputs() {
+    let _panic_hook_guard = lock_panic_hook_for_test();
     let certificate_hash = [0x42; 32];
     let local_auth = b"synthetic-local-auth";
     let resolved = invoke_resolver(
@@ -244,6 +248,7 @@ fn context_exposes_only_closed_scopes_and_optional_nonprinting_borrowed_inputs()
 
 #[test]
 fn process_local_loopback_resolver_is_stable_per_launch_and_rejects_remote_scope() {
+    let _panic_hook_guard = lock_panic_hook_for_test();
     let first = ProcessLocalLoopbackResolver::new().unwrap();
     let second = ProcessLocalLoopbackResolver::new().unwrap();
     let first_a = invoke_resolver(&first, loopback_context(None, None).unwrap()).unwrap();


### PR DESCRIPTION
## What

Fixes the intermittent `ci-feature-matrix` failure at `crates/gaze-proxy/tests/session_registry.rs:204` (`assert_eq!(hook_hits, 1)` failing with `left: 0, right: 1`).

## Root cause

`invoke_resolver` swaps the process-global panic hook for the duration of the trusted resolver call, so **every one of its callers is itself a global-hook writer**. The `session_registry` test binary contains four such writers — including `principal::tests::loopback_identity_is_stable_for_one_resolver`, which enters that binary via `#[path = "../src/principal.rs"]`. Any of them running concurrently with the one test that installs a counting hook can mask that hook (observed hit count too low) or restore a stale hook over it.

## Fix

A `#[cfg(test)]`-only `PANIC_HOOK_TEST_LOCK` in `principal.rs`, plus a poison-tolerant `lock_panic_hook_for_test()` helper. Every test that touches `std::panic::set_hook` / `take_hook` — directly or through `invoke_resolver` — now holds it across its whole hook window.

Two design notes:

- The existing `RESOLVER_PANIC_HOOK_BOUNDARY` could not be reused: `invoke_resolver` takes it internally and `Mutex` is not reentrant. The new lock is always acquired strictly *outside* that boundary and is never taken by production code, so the ordering cannot deadlock.
- The helper tolerates lock poisoning, so an unrelated failing test reports its own assertion failure rather than turning one red test into a poisoning cascade.

## Evidence

- Negative control: **pre-fix 15/3000** failures under load, **post-fix 0/3000**.
- `cargo run -p xtask -- ci-feature-matrix` -> exit 0
- `cargo test --workspace --all-features` x4 -> all exit 0 (120 ok-result-lines each)
- Post-fix hammer 1500x `--test-threads=16` -> 0 failures
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean

## North-star axes

No axis weakened. This is test-infrastructure only:

- **Production delta is 0** — every added item is `#[cfg(test)]`-gated and does not exist in a non-test build.
- **No public API change** — the added items are `pub(crate)`.
- **Assertions unchanged** — the panic path, `ResolverPanicked`, `source().is_none()`, and the no-raw-source-leak assertion all still run exactly as before. The fix adds guard acquisitions and weakens nothing.

Axis 4 (trust: auditable + deterministic) improves: the feature matrix stops emitting false reds that would otherwise mask a real regression.

Resolves Solo todo #2401.
