### PR TITLE
[agent] fail closed on numeric JSON-Schema literals in the Anthropic codec

### DIFF
--- a/crates/gaze-proxy/src/codecs/anthropic.rs
+++ b/crates/gaze-proxy/src/codecs/anthropic.rs
@@ -2631,7 +2631,9 @@ fn transform_request_schema(
                     }
                     "const" => transform_schema_literal(&mut member.value, ctx, ledger)?,
                     "enum" => transform_schema_enum(&mut member.value, ctx, ledger)?,
-                    "minimum" | "maximum" => request_number_control(&member.value, ledger)?,
+                    "minimum" | "maximum" => {
+                        request_number_literal_control(&member.value, ctx, ledger)?
+                    }
                     _ => return Err(CodecErrorCode::UnsupportedRequestSurface),
                 }
             }
@@ -2987,7 +2989,7 @@ fn transform_schema_literal(
 ) -> Result<(), CodecErrorCode> {
     match &node.kind {
         JsonKind::String(_) => request_string_control(node, ctx, ledger),
-        JsonKind::Number(_) => request_number_control(node, ledger),
+        JsonKind::Number(_) => request_number_literal_control(node, ctx, ledger),
         JsonKind::Bool(_) | JsonKind::Null => ledger.mark(node.occurrence),
         JsonKind::Object(_) | JsonKind::Array(_) => Err(CodecErrorCode::UnsupportedRequestSurface),
     }
@@ -3020,6 +3022,29 @@ fn request_number_control(
         Ok(())
     } else {
         Err(CodecErrorCode::UnsupportedRequestSurface)
+    }
+}
+
+/// Numeric schema-literal control: the numeric analogue of `request_string_control`
+/// for `const` / `enum` members / `minimum` / `maximum` inside `tools[].input_schema`.
+///
+/// Marks coverage and shape-checks the node via `request_number_control`, then probes
+/// the raw digit text through detection and fails closed if it would be tokenized.
+/// Without this, an N-only (all-digit) recognizer never sees a numeric schema literal
+/// and a real order/customer ID reaches the provider un-tokenized (audit finding 1).
+fn request_number_literal_control(
+    node: &JsonNode,
+    ctx: &mut RequestTransformContext<'_>,
+    ledger: &mut CoverageLedger,
+) -> Result<(), CodecErrorCode> {
+    request_number_control(node, ledger)?;
+    let JsonKind::Number(raw) = &node.kind else {
+        return Err(CodecErrorCode::UnsupportedRequestSurface);
+    };
+    if ctx.probe_without_prefix_cache_write(raw)? == *raw {
+        Ok(())
+    } else {
+        Err(CodecErrorCode::ControlWouldMutate)
     }
 }
 

--- a/crates/gaze-proxy/tests/anthropic_codec.rs
+++ b/crates/gaze-proxy/tests/anthropic_codec.rs
@@ -1312,6 +1312,19 @@ fn numeric_schema_literals_flagged_by_recognizer_fail_closed() {
             "input_schema": {"type": "object", "minimum": 7001234}
         }]
     }));
+    // `maximum` — bounds are carriers too. `minimum`/`maximum` share one match arm,
+    // so this case pins the deliberate decision that a numeric schema BOUND carrying
+    // an ID-shaped value fails closed exactly like `const`/`enum` values. It is not
+    // an accidental over-reach: narrowing the fix to values-only must go red here.
+    assert_numeric_schema_literal_rejected(&serde_json::json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [],
+        "tools": [{
+            "name": "lookup",
+            "input_schema": {"type": "object", "maximum": 7001234}
+        }]
+    }));
 
     // MUTATION PROBE: revert request_number_literal_control back to the old
     // request_number_control (mark-only, no detection) at the `const`/`enum`
@@ -1329,29 +1342,20 @@ fn numeric_schema_literals_not_flagged_pass_unchanged() {
     // path must not reject numbers no recognizer cares about.
     let codec = AnthropicMessagesCodec;
     let cases = [
-        (
-            serde_json::json!({
-                "model": "claude-test", "max_tokens": 32, "messages": [],
-                "tools": [{"name": "lookup", "input_schema": {"type": "object", "const": 42}}]
-            }),
-            "42",
-        ),
-        (
-            serde_json::json!({
-                "model": "claude-test", "max_tokens": 32, "messages": [],
-                "tools": [{"name": "lookup", "input_schema": {"type": "object", "enum": [111, 222]}}]
-            }),
-            "222",
-        ),
-        (
-            serde_json::json!({
-                "model": "claude-test", "max_tokens": 32, "messages": [],
-                "tools": [{"name": "lookup", "input_schema": {"type": "object", "minimum": 5, "maximum": 900}}]
-            }),
-            "900",
-        ),
+        serde_json::json!({
+            "model": "claude-test", "max_tokens": 32, "messages": [],
+            "tools": [{"name": "lookup", "input_schema": {"type": "object", "const": 42}}]
+        }),
+        serde_json::json!({
+            "model": "claude-test", "max_tokens": 32, "messages": [],
+            "tools": [{"name": "lookup", "input_schema": {"type": "object", "enum": [111, 222]}}]
+        }),
+        serde_json::json!({
+            "model": "claude-test", "max_tokens": 32, "messages": [],
+            "tools": [{"name": "lookup", "input_schema": {"type": "object", "minimum": 5, "maximum": 900}}]
+        }),
     ];
-    for (request, needle) in cases {
+    for request in cases {
         let input = serde_json::to_vec(&request).unwrap();
         // AllDigitOrderIdPseudonymizer only flags ORDER_ID (7001234); every numeric
         // literal here is passed through unchanged, so the request must be accepted.
@@ -1359,10 +1363,14 @@ fn numeric_schema_literals_not_flagged_pass_unchanged() {
         let proved = codec
             .protect_request(&input, &mut request_context(&mut pseudonymizer))
             .expect("un-flagged numeric schema literals must pass unchanged");
-        let output = std::str::from_utf8(proved.bytes()).unwrap();
-        assert!(
-            output.contains(needle),
-            "expected {needle} preserved unchanged in {output}"
+        // Byte identity, not substring containment: the no-over-rejection property is
+        // that the body is forwarded untouched. A containment check would also pass if
+        // an un-flagged literal were rewritten (e.g. 42 -> <Order_42>).
+        assert_eq!(
+            proved.bytes(),
+            input.as_slice(),
+            "un-flagged numeric schema literals must be forwarded byte-identical; got {}",
+            std::str::from_utf8(proved.bytes()).unwrap()
         );
     }
 }

--- a/crates/gaze-proxy/tests/anthropic_codec.rs
+++ b/crates/gaze-proxy/tests/anthropic_codec.rs
@@ -1231,3 +1231,138 @@ fn tiny_json_limits_fail_with_closed_codes() {
         .unwrap_err();
     assert_eq!(error.code(), CodecErrorCode::GrowthLimitExceeded);
 }
+
+// ---- Regression: numeric JSON-Schema literals must be PII-detected (fail closed) ----
+// Audit scratchpad #6161 Finding 1: numeric `const` / `enum` members / `minimum` /
+// `maximum` inside tools[].input_schema were accepted verbatim (marked as covered
+// control numbers by request_number_control, never routed through detection, and
+// dropped from the residual carrier views), so an N-only (all-digit) recognizer never
+// saw them and a real order/customer ID reached the provider un-tokenized. They must
+// now be probed and fail closed exactly like string schema literals
+// (request_string_control), via request_number_literal_control.
+
+const ORDER_ID: &str = "7001234";
+
+/// Mirrors an adopter's all-digit (N-only) recognizer for e.g. 7-digit order IDs:
+/// any occurrence of ORDER_ID is treated as PII and would be tokenized.
+struct AllDigitOrderIdPseudonymizer;
+
+impl RequestPseudonymizer for AllDigitOrderIdPseudonymizer {
+    fn protect(&mut self, input: &str) -> Result<String, CodecErrorCode> {
+        Ok(input.replace(ORDER_ID, "<Order_1>"))
+    }
+
+    fn protect_with_prefix_cache_write_mode(
+        &mut self,
+        input: &str,
+        _mode: PrefixCacheWriteMode,
+    ) -> Result<String, CodecErrorCode> {
+        self.protect(input)
+    }
+
+    fn validate_token_shapes(&mut self, _input: &str) -> Result<(), CodecErrorCode> {
+        Ok(())
+    }
+}
+
+fn assert_numeric_schema_literal_rejected(request: &serde_json::Value) {
+    let codec = AnthropicMessagesCodec;
+    let input = serde_json::to_vec(request).unwrap();
+    let mut pseudonymizer = AllDigitOrderIdPseudonymizer;
+    let error = match codec.protect_request(&input, &mut request_context(&mut pseudonymizer)) {
+        Ok(proved) => panic!(
+            "numeric schema literal leaked un-tokenized: {}",
+            std::str::from_utf8(proved.bytes()).unwrap()
+        ),
+        Err(error) => error,
+    };
+    assert_eq!(error.code(), CodecErrorCode::ControlWouldMutate);
+    assert_eq!(error.phase(), CodecPhase::RequestProtection);
+}
+
+#[test]
+fn numeric_schema_literals_flagged_by_recognizer_fail_closed() {
+    // `const`
+    assert_numeric_schema_literal_rejected(&serde_json::json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [],
+        "tools": [{
+            "name": "lookup",
+            "input_schema": {"type": "object", "const": 7001234}
+        }]
+    }));
+    // `enum` member
+    assert_numeric_schema_literal_rejected(&serde_json::json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [],
+        "tools": [{
+            "name": "lookup",
+            "input_schema": {"type": "object", "enum": [7001234]}
+        }]
+    }));
+    // `minimum`
+    assert_numeric_schema_literal_rejected(&serde_json::json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [],
+        "tools": [{
+            "name": "lookup",
+            "input_schema": {"type": "object", "minimum": 7001234}
+        }]
+    }));
+
+    // MUTATION PROBE: revert request_number_literal_control back to the old
+    // request_number_control (mark-only, no detection) at the `const`/`enum`
+    // (transform_schema_literal Number arm) and `minimum`/`maximum` call sites, and
+    // each request above is accepted with 7001234 forwarded verbatim — every
+    // assert_numeric_schema_literal_rejected then trips its Ok(...) panic
+    // ("numeric schema literal leaked un-tokenized: ..."). That is the coherence
+    // assertion this fix restores.
+}
+
+#[test]
+fn numeric_schema_literals_not_flagged_pass_unchanged() {
+    // A recognizer that flags nothing relevant (the common case) must leave
+    // legitimate numeric schema literals byte-identical — the detect-and-fail-closed
+    // path must not reject numbers no recognizer cares about.
+    let codec = AnthropicMessagesCodec;
+    let cases = [
+        (
+            serde_json::json!({
+                "model": "claude-test", "max_tokens": 32, "messages": [],
+                "tools": [{"name": "lookup", "input_schema": {"type": "object", "const": 42}}]
+            }),
+            "42",
+        ),
+        (
+            serde_json::json!({
+                "model": "claude-test", "max_tokens": 32, "messages": [],
+                "tools": [{"name": "lookup", "input_schema": {"type": "object", "enum": [111, 222]}}]
+            }),
+            "222",
+        ),
+        (
+            serde_json::json!({
+                "model": "claude-test", "max_tokens": 32, "messages": [],
+                "tools": [{"name": "lookup", "input_schema": {"type": "object", "minimum": 5, "maximum": 900}}]
+            }),
+            "900",
+        ),
+    ];
+    for (request, needle) in cases {
+        let input = serde_json::to_vec(&request).unwrap();
+        // AllDigitOrderIdPseudonymizer only flags ORDER_ID (7001234); every numeric
+        // literal here is passed through unchanged, so the request must be accepted.
+        let mut pseudonymizer = AllDigitOrderIdPseudonymizer;
+        let proved = codec
+            .protect_request(&input, &mut request_context(&mut pseudonymizer))
+            .expect("un-flagged numeric schema literals must pass unchanged");
+        let output = std::str::from_utf8(proved.bytes()).unwrap();
+        assert!(
+            output.contains(needle),
+            "expected {needle} preserved unchanged in {output}"
+        );
+    }
+}


### PR DESCRIPTION
# Fail closed on numeric JSON-Schema literals in the Anthropic codec

Closes item 1 (Finding 1) of Solo todo #2400 — the public-codec zero-leak push. #2400 stays open for the OpenAI/Gemini legacy-adapter work and the numeric residuals noted below.

## The leak

Numeric JSON-Schema literals inside `tools[].input_schema` — `const`, `enum` members, `minimum`, and `maximum` — were accepted verbatim by the Anthropic request codec. They were routed to `request_number_control`, which marks the node in the ledger and range/shape-checks it but never sends the value to detection, and they were also excluded from the residual carrier views, so the `prove_request_logical_domains` re-scan never looked at them either.

The result: an adopter recognizer that matches all-digit values — an order ID, a customer number — never saw those literals, and the raw number reached `api.anthropic.com` un-tokenized. That is a north-star axis-1 defect: a byte of PII crossing to the provider outside the manifest contract.

Evidence on the pre-fix code (`crates/gaze-proxy/src/codecs/anthropic.rs`):

- `:2632-2634` — the `"minimum" | "maximum"` schema arm routed straight to `request_number_control`.
- `:2983-2994` — `transform_schema_literal`'s `JsonKind::Number(_)` arm did the same, covering `const` directly and `enum` members via `transform_schema_enum`.
- `:1702-1715` — `classify_schema_literal` no-ops on `Number`, so numeric literals never became carriers.
- `:1649-1658` — the `minimum`/`maximum` classify arm is empty, same effect.

Free-form numbers in the message body were already fail-closed (`transform_request_mutable`'s Number arm returns `UnsupportedRequestSurface`); the gap was schema-shaped positions only. Narrow trigger, critical class.

## The fix

A new crate-private `request_number_literal_control` — the exact numeric analogue of the existing `request_string_control`. It delegates to `request_number_control` for the ledger mark and shape check, then probes the raw literal through `ctx.probe_without_prefix_cache_write` (the same isolated detect-without-mutate primitive the `$defs` key guard and the string control use) and returns `ControlWouldMutate` if detection would rewrite it. Both call sites — the `"minimum" | "maximum"` arm and the `transform_schema_literal` Number arm — now route through it.

No public API change; the new function and both new tests are private. bare-`pub` delta vs base is 0.

Tests added in `crates/gaze-proxy/tests/anthropic_codec.rs`:

- `numeric_schema_literals_flagged_by_recognizer_fail_closed` — `const`, an `enum` member, `minimum`, and `maximum` each carrying an ID-shaped synthetic value must be rejected with `ControlWouldMutate` in `RequestProtection`. This was the RED test; on base-equivalent code it fails with the leaked body printed.
- `numeric_schema_literals_not_flagged_pass_unchanged` — legitimate numeric literals no recognizer cares about must be forwarded **byte-identical**, so the new probe cannot silently turn into an over-rejection or a rewrite.

Both call sites were verified individually load-bearing: reverting either one alone to `request_number_control` turns the fail-closed test red with the raw value on the wire.

## MAJOR — behavior change: a new hard-reject class for 5-digit numeric literals

**Adopters should read this before upgrading.** This change makes numeric schema literals detection-visible, which means locale-active naked-digit recognizers now fire on them. Concretely, `postal.us` (`\b\d{5}(-\d{4})?\b`, `en-US`) and `postal.de` (`\b\d{5}\b`, `de-DE`) in the `core` rulepack match any bare 5-digit number. So on an `en-US` or `de-DE` locale chain, a tool schema containing `"maximum": 65535`, `"minimum": 10000`, or `"const": 32768` now fails the **entire request** closed with `ControlWouldMutate`, where it previously went through.

This is exactly the behavior string literals already had — the numeric path was the anomaly — but it is a real, user-visible rejection class that did not exist before.

Mitigations for adopters who legitimately ship 5-digit numeric schema literals:

- pass `--locale=global`, which takes the postal recognizers out of the active chain, or
- supply a policy that narrows or disables `postal.us` / `postal.de`.

## Axis justification (AGENTS.md universal rule 1)

This change **weakens axis 5 (adopter ergonomics)** to **strengthen axis 1 (never leak)**, and that trade is deliberate.

Correctness axes 1–4 always beat ergonomics. A numeric ID reaching the provider un-tokenized is a critical defect with no recovery — the byte is gone, and the whole point of the runtime is that this cannot happen. A false reject is a recoverable annoyance: it is loud, deterministic, surfaced as a typed `ControlWouldMutate` error at the chokepoint, and has two documented one-line mitigations. Fail-closed is the repo's standing posture, and accepting a known leak to avoid a known false positive would invert the axis order.

Note also that the fix rejects on **all** numeric schema literals including the bounds `minimum`/`maximum`, not only the values `const`/`enum`. That is intentional and pinned by a dedicated test case: a `minimum`/`maximum` pair is a real, if contrived, exfiltration channel for an ID-shaped value, and answering differently for the same value depending on which schema keyword carries it would be an axis-4 determinism regression. Whether to narrow this to values-only is an open decision recorded in #2400, to be settled once across both the codec and the proxy paths — it is not an oversight here.

## Known residuals (out of scope, tracked)

Both are pre-existing on `main` and independent of this change; they are recorded in Solo todo #2400:

- **MINOR-3** — non-schema numeric control positions (`max_tokens`, `top_k`, `thinking.budget_tokens` via `request_integer_control`; `temperature`/`top_p` via `request_unit_interval_control`) are marked and range-checked but never probed, so raw digits still egress there. These are sampling-control fields rather than data carriers, but they are the last un-probed provider-visible numerics in the request.
- **MINOR-4** — context-gated recognizers still cannot see numeric literals, because numbers remain excluded from the classify/carrier views that feed the cross-carrier re-scan. A cue-gated recognizer will reject `{"description": "order id of the customer", "const": "7001234"}` (string) but accept the same request with the value as a number. This fix closes the isolated-detection case; the composite/context-gated case is the natural successor work.

## Verification

All under the repo-pinned rustc 1.96.0. Fixtures are synthetic throughout — no real PII.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — exit 0
- `cargo test -p gaze-proxy --all-features --test anthropic_codec` — 22 passed, 0 failed
- `cargo test --workspace --all-features` — **exit 101 locally**, from a pre-existing environmental flake only, not from this change. `gaze-cli` safety-net tests intermittently time out their OPF subprocess (`{"error":"SafetyNet","exit":3,"variant":"Timeout"}`) when the machine is under heavy parallel load. Re-run in isolation on the same tree, `safety_net_cli` passes 10/10 and `cli_pipe::t_safety_net_registry_selects_locale_backend` passes. The failure also reproduces at the merge base with this change absent, and this change touches only `crates/gaze-proxy`. CI runs on a quieter machine; if it reproduces there, that is a separate pre-existing issue rather than a defect in this PR.

Signed-off-by: Krishan Koenig <krishan.koenig@googlemail.com>
