### PR TITLE
[agent] close the legacy OpenAI/Gemini adapter leak path (fail closed on unsurfaced PII)

### DIFF
--- a/crates/gaze-proxy/src/adapters/gemini.rs
+++ b/crates/gaze-proxy/src/adapters/gemini.rs
@@ -1,8 +1,38 @@
+use std::borrow::Cow;
+
 use http::Method;
 use serde_json::Value;
 use url::Url;
 
 use crate::adapter::{walk_all_strings, PiiSurface, ProviderAdapter, SseEvent};
+
+/// Canonicalizes a protobuf-JSON field name to its lowerCamelCase spelling.
+///
+/// The Generative Language API is a protobuf-JSON surface, and protobuf JSON parsers accept
+/// BOTH the lowerCamelCase name and the original snake_case field name for every field. Matching
+/// the camelCase spelling literally therefore left `system_instruction` — the same field, spelled
+/// the other legal way — with no detection at all, while `systemInstruction` was covered.
+///
+/// Callers match on the canonical form but keep the caller's ORIGINAL key in field paths, so a
+/// path still names the bytes actually on the wire.
+fn canonical_field_name(key: &str) -> Cow<'_, str> {
+    if !key.contains('_') {
+        return Cow::Borrowed(key);
+    }
+    let mut canonical = String::with_capacity(key.len());
+    let mut capitalize_next = false;
+    for character in key.chars() {
+        if character == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            canonical.extend(character.to_uppercase());
+            capitalize_next = false;
+        } else {
+            canonical.push(character);
+        }
+    }
+    Cow::Owned(canonical)
+}
 
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -52,20 +82,16 @@ fn collect_gemini_surfaces(body: &mut Value, request: bool) -> Vec<PiiSurface<'_
     if let Value::Object(root) = body {
         if request {
             for (key, value) in root {
-                match key.as_str() {
+                match canonical_field_name(key).as_ref() {
                     "contents" => {
                         if let Value::Array(contents) = value {
                             for (index, content) in contents.iter_mut().enumerate() {
-                                collect_content(
-                                    &mut surfaces,
-                                    format!("contents[{index}]"),
-                                    content,
-                                );
+                                collect_content(&mut surfaces, format!("{key}[{index}]"), content);
                             }
                         }
                     }
                     "systemInstruction" => {
-                        collect_content(&mut surfaces, "systemInstruction".to_string(), value);
+                        collect_content(&mut surfaces, key.clone(), value);
                     }
                     _ => {}
                 }
@@ -91,46 +117,49 @@ fn collect_content<'a>(surfaces: &mut Vec<PiiSurface<'a>>, prefix: String, value
     let Value::Object(content) = value else {
         return;
     };
-    if let Some(Value::Array(parts)) = content.get_mut("parts") {
-        for (index, part) in parts.iter_mut().enumerate() {
-            let Value::Object(part) = part else {
-                continue;
-            };
-            for (key, value) in part {
-                match key.as_str() {
-                    "text" => {
-                        if let Value::String(text) = value {
-                            surfaces.push(PiiSurface {
-                                field_path: format!("{prefix}.parts[{index}].text"),
-                                text,
-                            });
-                        }
+    let Some((parts_key, Value::Array(parts))) = content
+        .iter_mut()
+        .find(|(key, _)| canonical_field_name(key) == "parts")
+    else {
+        return;
+    };
+    let parts_prefix = format!("{prefix}.{parts_key}");
+    for (index, part) in parts.iter_mut().enumerate() {
+        let Value::Object(part) = part else {
+            continue;
+        };
+        for (key, value) in part {
+            let part_prefix = format!("{parts_prefix}[{index}].{key}");
+            match canonical_field_name(key).as_ref() {
+                "text" => {
+                    if let Value::String(text) = value {
+                        surfaces.push(PiiSurface {
+                            field_path: part_prefix,
+                            text,
+                        });
                     }
-                    "functionCall" => {
-                        if let Some(args) =
-                            value.as_object_mut().and_then(|call| call.get_mut("args"))
-                        {
-                            walk_all_strings(
-                                surfaces,
-                                format!("{prefix}.parts[{index}].functionCall.args"),
-                                args,
-                            );
-                        }
-                    }
-                    "functionResponse" => {
-                        if let Some(response) = value
-                            .as_object_mut()
-                            .and_then(|call| call.get_mut("response"))
-                        {
-                            walk_all_strings(
-                                surfaces,
-                                format!("{prefix}.parts[{index}].functionResponse.response"),
-                                response,
-                            );
-                        }
-                    }
-                    _ => {}
                 }
+                "functionCall" => {
+                    if let Some((args_key, args)) = value
+                        .as_object_mut()
+                        .and_then(|call| call.iter_mut().find(|(key, _)| *key == "args"))
+                    {
+                        walk_all_strings(surfaces, format!("{part_prefix}.{args_key}"), args);
+                    }
+                }
+                "functionResponse" => {
+                    if let Some((response_key, response)) = value
+                        .as_object_mut()
+                        .and_then(|call| call.iter_mut().find(|(key, _)| *key == "response"))
+                    {
+                        walk_all_strings(
+                            surfaces,
+                            format!("{part_prefix}.{response_key}"),
+                            response,
+                        );
+                    }
+                }
+                _ => {}
             }
         }
     }

--- a/crates/gaze-proxy/src/adapters/gemini.rs
+++ b/crates/gaze-proxy/src/adapters/gemini.rs
@@ -77,6 +77,16 @@ impl ProviderAdapter for GeminiAdapter {
     }
 }
 
+/// Surfaces the free-text carriers of a Gemini request, or the model-authored text of a response.
+///
+/// The request allowlist enumerates positions whose contents the MODEL reads, and which are
+/// therefore safe to pseudonymize.
+///
+/// Resource identifiers and opaque blobs are deliberately NOT surfaced — `cachedContent` is a
+/// provider-side resource name, `fileData.fileUri` is fetched by the provider, and
+/// `inlineData.data` is base64 payload. Substituting a token in any of them would silently break
+/// the request rather than protect it, so PII there is caught by the outbound residual re-scan and
+/// fails closed.
 fn collect_gemini_surfaces(body: &mut Value, request: bool) -> Vec<PiiSurface<'_>> {
     let mut surfaces = Vec::new();
     if let Value::Object(root) = body {
@@ -92,6 +102,17 @@ fn collect_gemini_surfaces(body: &mut Value, request: bool) -> Vec<PiiSurface<'_
                     }
                     "systemInstruction" => {
                         collect_content(&mut surfaces, key.clone(), value);
+                    }
+                    // Tool and schema declarations: names, descriptions, and enum members are
+                    // all read by the model.
+                    "tools" | "toolConfig" => {
+                        walk_all_strings(&mut surfaces, key.clone(), value);
+                    }
+                    // Covers `stopSequences`, which is matched against generated text. Numeric
+                    // members of this subtree are untouched here and are classified by the
+                    // outbound residual re-scan's non-carrier declaration instead.
+                    "generationConfig" => {
+                        walk_all_strings(&mut surfaces, key.clone(), value);
                     }
                     _ => {}
                 }

--- a/crates/gaze-proxy/src/adapters/openai.rs
+++ b/crates/gaze-proxy/src/adapters/openai.rs
@@ -36,6 +36,17 @@ impl ProviderAdapter for OpenAiAdapter {
         &self.upstream
     }
 
+    /// Surfaces the free-text carriers of an OpenAI request.
+    ///
+    /// This allowlist enumerates positions whose contents the MODEL reads, and which are
+    /// therefore safe to pseudonymize: whatever token is substituted round-trips through the
+    /// provider and back through restore.
+    ///
+    /// Resource identifiers are deliberately NOT surfaced — `tool_call_id`, `previous_response_id`,
+    /// and `model` are resolved provider-side, so substituting a token would silently break the
+    /// request rather than protect it. PII in those positions is caught by the outbound residual
+    /// re-scan and fails closed, which tells the adopter their identifier carries PII instead of
+    /// handing them a broken request that looks fine.
     fn request_pii_surfaces<'a>(&self, body: &'a mut Value) -> Vec<PiiSurface<'a>> {
         let mut surfaces = Vec::new();
         if let Value::Object(root) = body {
@@ -56,6 +67,24 @@ impl ProviderAdapter for OpenAiAdapter {
                         }
                     }
                     "input" => push_text_blocks(&mut surfaces, "input", value),
+                    // The documented end-user identifier. Free-form adopter text and a
+                    // first-class PII carrier in practice; opaque to the provider beyond abuse
+                    // monitoring, so pseudonymizing it is safe.
+                    "user" => push_string(&mut surfaces, "user", value),
+                    // Adopter-attached key/value pairs, echoed back verbatim.
+                    "metadata" => walk_all_strings(&mut surfaces, "metadata".to_string(), value),
+                    // Stop sequences are matched against generated text, so they are model-visible.
+                    "stop" => walk_all_strings(&mut surfaces, "stop".to_string(), value),
+                    // Tool and schema declarations: names, descriptions, and enum members are all
+                    // read by the model. `walk_all_strings` covers the whole declaration subtree.
+                    "tools" => walk_all_strings(&mut surfaces, "tools".to_string(), value),
+                    "functions" => walk_all_strings(&mut surfaces, "functions".to_string(), value),
+                    "response_format" => {
+                        walk_all_strings(&mut surfaces, "response_format".to_string(), value);
+                    }
+                    "prediction" => {
+                        walk_all_strings(&mut surfaces, "prediction".to_string(), value);
+                    }
                     _ => {}
                 }
             }
@@ -121,6 +150,9 @@ fn collect_message_surfaces<'a>(
         match key.as_str() {
             "content" => push_text_blocks(surfaces, &format!("{prefix}.content"), value),
             "tool_results" => push_text_blocks(surfaces, &format!("{prefix}.tool_results"), value),
+            // The participant name on a message. A person's name by definition, and read by the
+            // model, so it is pseudonymized rather than rejected.
+            "name" => push_string(surfaces, format!("{prefix}.name"), value),
             "tool_calls" => {
                 if let Value::Array(tool_calls) = value {
                     for (index, tool_call) in tool_calls.iter_mut().enumerate() {

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -35,6 +35,13 @@ pub enum ProxyError {
     /// `Debug`, nor any log line derived from them can egress protected bytes.
     #[error("unsurfaced pii at {field_path}")]
     UnsurfacedPii { field_path: String },
+    /// A request reached the legacy path under a contract that claims codec-proved coverage.
+    ///
+    /// The contract and the router disagree, so no coverage mechanism is known to have run.
+    /// Proxying under an unproven coverage claim is exactly the failure this policy exists to
+    /// prevent, so the request is refused.
+    #[error("adapter coverage contract is unproven on the legacy path")]
+    UnprovenCoverage,
     #[error("pipeline failed")]
     Pipeline {
         #[source]

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -27,6 +27,14 @@ pub enum ProxyError {
     },
     #[error("sse partial frame: {reason}")]
     SsePartialFrame { reason: String },
+    /// A legacy-path request carried PII in a position no adapter surface covered.
+    ///
+    /// Raised by the outbound request residual re-scan, which fails closed rather than
+    /// silently rewriting provider-owned fields. The variant carries the JSON field path
+    /// ONLY -- never the detected value, nor any substring of it -- so neither `Display`,
+    /// `Debug`, nor any log line derived from them can egress protected bytes.
+    #[error("unsurfaced pii at {field_path}")]
+    UnsurfacedPii { field_path: String },
     #[error("pipeline failed")]
     Pipeline {
         #[source]

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1809,11 +1809,12 @@ async fn proxy_inner(
     let session = session_for(&state, &headers).await?;
     let mut json: Value =
         serde_json::from_slice(&body).map_err(|source| ProxyError::InvalidJson { source })?;
-    redact_surfaces(
+    let surfaced = redact_surfaces(
         &state.pipeline,
         &session,
         adapter.request_pii_surfaces(&mut json),
     )?;
+    residual_scan_request(&state.pipeline, &json, &surfaced)?;
 
     let upstream_url = upstream_url(adapter.upstream_base(), &uri)?;
     let mut request = state
@@ -2432,11 +2433,74 @@ async fn session_for(state: &AppState, headers: &HeaderMap) -> Result<Arc<Sessio
     Ok(session)
 }
 
+/// Numeric request positions that are caller-authored generation controls rather than data
+/// supplied by the data owner.
+///
+/// [`residual_scan_request`] treats every JSON number in a legacy request as a potential PII
+/// carrier EXCEPT numbers whose immediate key appears here. Each entry is a sampling or
+/// generation knob: the CALLER picks the value to shape decoding, a data owner's identifier
+/// can never arrive in it, and probing it would reject ordinary traffic — `max_tokens: 20000`
+/// is a five-digit numeral indistinguishable from a postal code to a digit recognizer.
+///
+/// Schema BOUNDS (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`)
+/// are deliberately absent: they remain carriers and fail closed. That matches the Anthropic
+/// codec's ruling on numeric schema literals, and a proxy that answered differently from the
+/// codec for the same input shape would be an axis-4 determinism and traceability regression.
+///
+/// The list is exact and exhaustive — no wildcards, no prefix or suffix matching — so every
+/// position exempt from probing is visible to a reviewer. Entries cover both the snake_case
+/// (OpenAI, Anthropic) and lowerCamelCase (Gemini) spellings of the same control.
+const NON_CARRIER_NUMERIC_KEYS: &[&str] = &[
+    "budget_tokens",
+    "candidateCount",
+    "frequencyPenalty",
+    "frequency_penalty",
+    "logprobs",
+    "maxOutputTokens",
+    "max_completion_tokens",
+    "max_tokens",
+    "n",
+    "presencePenalty",
+    "presence_penalty",
+    "seed",
+    "temperature",
+    "topK",
+    "topP",
+    "top_k",
+    "top_logprobs",
+    "top_p",
+];
+
+/// Path segments whose subtrees keep numeric-carrier status even when a leaf key name collides
+/// with [`NON_CARRIER_NUMERIC_KEYS`].
+///
+/// A tool's JSON Schema may legitimately declare a property named `seed`, `n`, or
+/// `temperature`; a numeric literal in that position is tool-declared DATA, not a sampling
+/// control, and must stay probed. Without this guard the non-carrier list would punch holes in
+/// exactly the schema positions the Anthropic `const` finding proved exploitable.
+const CARRIER_SUBTREE_KEYS: &[&str] = &[
+    "functionDeclarations",
+    "functions",
+    "input_schema",
+    "json_schema",
+    "parameters",
+    "properties",
+    "response_format",
+    "schema",
+    "tools",
+];
+
+/// Redacts every surface an adapter claims and returns the field paths it covered.
+///
+/// The returned set is the authorization input for [`residual_scan_request`]: a position the
+/// adapter surfaced has already been through the pipeline and whatever it decided there
+/// (tokenize, or preserve by policy) is authorized. Every other position is not.
 fn redact_surfaces(
     pipeline: &Pipeline,
     session: &Session,
     surfaces: Vec<crate::adapter::PiiSurface<'_>>,
-) -> Result<(), ProxyError> {
+) -> Result<HashSet<String>, ProxyError> {
+    let mut surfaced = HashSet::new();
     for surface in surfaces {
         let clean = pipeline
             .redact(session, RawDocument::Text(surface.text.clone()))
@@ -2444,8 +2508,119 @@ fn redact_surfaces(
         if let CleanDocument::Text(text) = clean {
             *surface.text = text;
         }
+        surfaced.insert(surface.field_path);
     }
-    Ok(())
+    Ok(surfaced)
+}
+
+/// Fails closed when the outbound legacy request body carries PII outside every adapter surface.
+///
+/// The legacy path forwards the whole original body after mutating only the surfaces an adapter
+/// returned, so any position the adapter's allowlist does not enumerate egresses verbatim. This
+/// re-scan states the missing invariant directly: everything we did not redact must be PII-free.
+///
+/// It REJECTS rather than rewriting. Silently mutating provider-owned fields would break the
+/// provider API contract and the restore round-trip (axis 2); refusing the request preserves
+/// axis 1 and leaves the adapter allowlist as the place to add genuine carriers.
+///
+/// Detection runs under [`LocaleTag::Global`], the same chain [`Pipeline::redact`] pins for the
+/// surface path, so the residual can never be weaker OR stronger than the primary pass.
+fn residual_scan_request(
+    pipeline: &Pipeline,
+    body: &Value,
+    surfaced: &HashSet<String>,
+) -> Result<(), ProxyError> {
+    let session =
+        Session::new(Scope::Ephemeral).map_err(|source| ProxyError::Pipeline { source })?;
+    let scan = RequestResidualScan {
+        pipeline,
+        session,
+        surfaced,
+    };
+    scan.walk("", "", body, false, true)
+}
+
+/// Walk state for the outbound request residual re-scan.
+struct RequestResidualScan<'a> {
+    pipeline: &'a Pipeline,
+    session: Session,
+    surfaced: &'a HashSet<String>,
+}
+
+impl RequestResidualScan<'_> {
+    fn probe(&self, field_path: &str, text: &str) -> Result<(), ProxyError> {
+        let (_, spans, _) = self
+            .pipeline
+            .clean_with_safety_net(
+                &self.session,
+                RawDocument::Text(text.to_owned()),
+                &[LocaleTag::Global],
+            )
+            .map_err(|source| ProxyError::Pipeline { source })?;
+        if spans.is_empty() {
+            return Ok(());
+        }
+        Err(ProxyError::UnsurfacedPii {
+            field_path: field_path.to_string(),
+        })
+    }
+
+    /// Recurses the outbound body probing every scalar the adapter did not surface.
+    ///
+    /// `unambiguous` tracks whether the constructed path can still be compared against adapter
+    /// field paths. A JSON key containing `.` or `[` could make two distinct nodes render the
+    /// same path string, so once such a key is seen the subtree stops trusting path equality and
+    /// probes unconditionally. Extra probing is always safe: a surfaced position is already clean.
+    fn walk(
+        &self,
+        path: &str,
+        leaf_key: &str,
+        value: &Value,
+        in_carrier_subtree: bool,
+        unambiguous: bool,
+    ) -> Result<(), ProxyError> {
+        match value {
+            Value::String(text) => {
+                if !(unambiguous && self.surfaced.contains(path)) {
+                    self.probe(path, text)?;
+                }
+            }
+            Value::Number(number) => {
+                if in_carrier_subtree || !NON_CARRIER_NUMERIC_KEYS.contains(&leaf_key) {
+                    self.probe(path, &number.to_string())?;
+                }
+            }
+            Value::Array(items) => {
+                for (index, item) in items.iter().enumerate() {
+                    self.walk(
+                        &format!("{path}[{index}]"),
+                        leaf_key,
+                        item,
+                        in_carrier_subtree,
+                        unambiguous,
+                    )?;
+                }
+            }
+            Value::Object(map) => {
+                for (key, child) in map {
+                    let child_path = if path.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{path}.{key}")
+                    };
+                    self.walk(
+                        &child_path,
+                        key,
+                        child,
+                        in_carrier_subtree || CARRIER_SUBTREE_KEYS.contains(&key.as_str()),
+                        unambiguous && !key.contains('.') && !key.contains('['),
+                    )?;
+                }
+            }
+            Value::Null | Value::Bool(_) => {}
+        }
+        Ok(())
+    }
 }
 
 fn restore_surfaces(session: &Session, surfaces: Vec<crate::adapter::PiiSurface<'_>>) {
@@ -2560,6 +2735,7 @@ fn proxy_error_response(err: ProxyError) -> Response {
         ProxyError::AdapterNotFound { .. } => StatusCode::NOT_FOUND,
         ProxyError::BodyTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
         ProxyError::InvalidJson { .. } => StatusCode::BAD_REQUEST,
+        ProxyError::UnsurfacedPii { .. } => StatusCode::UNPROCESSABLE_ENTITY,
         ProxyError::UpstreamUnreachable { .. } => StatusCode::BAD_GATEWAY,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
@@ -2584,6 +2760,7 @@ fn proxy_error_name(err: &ProxyError) -> &'static str {
         ProxyError::BodyTooLarge { .. } => "BodyTooLarge",
         ProxyError::InvalidJson { .. } => "InvalidJson",
         ProxyError::SsePartialFrame { .. } => "SsePartialFrame",
+        ProxyError::UnsurfacedPii { .. } => "UnsurfacedPii",
         ProxyError::Pipeline { .. } => "Pipeline",
         ProxyError::Server { .. } => "Server",
         ProxyError::DaemonAlreadyRunning { .. } => "DaemonAlreadyRunning",

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -23,7 +23,7 @@ use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use url::{Host, Url};
 
-use crate::adapter::{ProtocolContract, ProviderAdapter, SessionPolicy, SseEvent};
+use crate::adapter::{CoveragePolicy, ProtocolContract, ProviderAdapter, SessionPolicy, SseEvent};
 use crate::adapters::anthropic::{AnthropicAdapter, DEFAULT_ANTHROPIC_VERSION};
 use crate::codec::{
     BodyCodec, CodecError, CodecErrorCode, CodecLimits, CodecPhase, InspectionParsedFactsV1,
@@ -1814,7 +1814,19 @@ async fn proxy_inner(
         &session,
         adapter.request_pii_surfaces(&mut json),
     )?;
-    residual_scan_request(&state.pipeline, &json, &surfaced)?;
+    // The declared coverage policy SELECTS the mechanism that establishes coverage. Reading it
+    // here is what keeps the declaration honest: a contract cannot claim a coverage posture the
+    // request path never acts on.
+    match contract.coverage_policy() {
+        // Legacy adapters carry no codec proof, so coverage is established right here, by
+        // re-scanning the outbound body and failing closed on anything left unprotected.
+        CoveragePolicy::LegacySurfaces => {
+            residual_scan_request(&state.pipeline, &json, &surfaced)?;
+        }
+        // A codec-proved adapter must have been routed to the codec branch above. Reaching this
+        // point means the contract and the router disagree and no proof has been established.
+        CoveragePolicy::CodecProved => return Err(ProxyError::UnprovenCoverage),
+    }
 
     let upstream_url = upstream_url(adapter.upstream_base(), &uri)?;
     let mut request = state
@@ -2761,6 +2773,7 @@ fn proxy_error_name(err: &ProxyError) -> &'static str {
         ProxyError::InvalidJson { .. } => "InvalidJson",
         ProxyError::SsePartialFrame { .. } => "SsePartialFrame",
         ProxyError::UnsurfacedPii { .. } => "UnsurfacedPii",
+        ProxyError::UnprovenCoverage => "UnprovenCoverage",
         ProxyError::Pipeline { .. } => "Pipeline",
         ProxyError::Server { .. } => "Server",
         ProxyError::DaemonAlreadyRunning { .. } => "DaemonAlreadyRunning",

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -1,20 +1,33 @@
-//! Executed leak proof for the legacy (non-codec) OpenAI and Gemini adapter path.
+//! Leak contract for the legacy (non-codec) OpenAI and Gemini adapter path.
 //!
 //! These tests drive the real public proxy request path (`gaze_proxy::serve`) against a
-//! capturing mock upstream and assert on the bytes that would reach the provider. They
-//! document CURRENT behavior at `origin/main` d32ae07 for zero-leak scoping (Solo todo
-//! #2400 comment 1435 item 2). Every `proof_` test asserts a leak that is present today
-//! and MUST start failing once the corresponding fix lands.
+//! capturing mock upstream and assert on the bytes that would reach the provider.
 //!
-//! Two independent leak sub-classes are isolated:
+//! They began as an executed leak PROOF against `origin/main` d32ae07 (Solo todo #2400
+//! comment 1435 item 2), where every `proof_` test asserted raw PII surviving to the wire.
+//! Each one now asserts the fixed behavior — fail closed, or tokenized — so the file doubles
+//! as the regression contract for the fix.
+//!
+//! Two independent leak sub-classes were confirmed and are covered here:
 //!
 //! * NUMERIC BYPASS — `PiiSurface.text` is `&mut String` (`adapter.rs:432`) and
 //!   `walk_all_strings` no-ops on `Value::Number` (`adapter.rs:488`), so a JSON number can
 //!   never become a detection surface even inside a fully walked subtree.
-//! * FIELD-ALLOWLIST BYPASS — `OpenAiAdapter::request_pii_surfaces` (`adapters/openai.rs:38`)
-//!   and `collect_gemini_surfaces` (`adapters/gemini.rs:49`) match a hardcoded set of
-//!   top-level keys with a `_ => {}` catch-all, and `server.rs:1812` forwards the whole
-//!   original body (`.json(&json)` at `server.rs:1817`) after mutating only those surfaces.
+//! * FIELD-ALLOWLIST BYPASS — `OpenAiAdapter::request_pii_surfaces` and
+//!   `collect_gemini_surfaces` match hardcoded key sets with a `_ => {}` catch-all, and
+//!   `server.rs` forwards the whole original body after mutating only those surfaces.
+//!
+//! Both are closed by `residual_scan_request` (F1), which fails closed on any PII outside an
+//! adapter surface.
+//!
+//! ## Locale note
+//!
+//! `Pipeline::redact` pins `[LocaleTag::Global]` (`gaze/src/pipeline.rs:350`), and the residual
+//! re-scan uses the same chain deliberately, so the residual can be neither weaker nor stronger
+//! than the primary pass. Consequence: locale-gated recognizers (`postal.us`, `postal.de`,
+//! national phone) never activate on proxied traffic at all. The en-US / de-DE corpora below
+//! therefore use locale-agnostic five-digit stand-in recognizers, which is what makes the
+//! carrier / non-carrier boundary observable on this path.
 //!
 //! Fixtures are synthetic-only per AGENTS.md rule 2.
 
@@ -29,9 +42,9 @@ use axum::routing::post;
 use axum::{Json, Router};
 use gaze::{Action, ClassRule, DefaultRule, PiiClass, Pipeline};
 use gaze_proxy::adapters::{GeminiAdapter, OpenAiAdapter};
-use gaze_proxy::{ProviderAdapter, ProxyConfig};
+use gaze_proxy::{ProviderAdapter, ProxyConfig, ProxyError};
 use gaze_recognizers::RegexDetector;
-use reqwest::Client;
+use reqwest::{Client, Response, StatusCode};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use url::Url;
@@ -60,6 +73,26 @@ fn leak_probe_pipeline() -> Pipeline {
         .unwrap()
 }
 
+/// Locale-agnostic five-digit stand-in for a national postal recognizer.
+///
+/// The real `postal.us` / `postal.de` recognizers are locale-gated and therefore never active
+/// on the proxy path (see the module-level locale note). This stand-in reproduces their
+/// detection shape under `LocaleTag::Global` so the numeric carrier / non-carrier boundary is
+/// observable. `class_label` distinguishes the en-US and de-DE corpus runs.
+fn postal_probe_pipeline(class_label: &str) -> Pipeline {
+    Pipeline::builder()
+        .detector(
+            RegexDetector::new(r"\b\d{5}\b", PiiClass::Custom(class_label.to_string())).unwrap(),
+        )
+        .rule(ClassRule::new(
+            PiiClass::Custom(class_label.to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+
 #[derive(Clone)]
 struct UpstreamState {
     forwarded: Arc<Mutex<Vec<Value>>>,
@@ -77,6 +110,16 @@ impl MockUpstream {
         let forwarded = self.forwarded.lock().await.clone();
         assert_eq!(forwarded.len(), 1, "exactly one upstream request expected");
         forwarded[0].clone()
+    }
+
+    /// Asserts the proxy failed closed: nothing at all reached the provider.
+    async fn assert_nothing_forwarded(&self) {
+        let forwarded = self.forwarded.lock().await.clone();
+        assert!(
+            forwarded.is_empty(),
+            "fail-closed expected, but {} request(s) reached the provider",
+            forwarded.len()
+        );
     }
 }
 
@@ -126,10 +169,10 @@ async fn capture_upstream(
     Json((state.response)(body))
 }
 
-async fn spawn_proxy(adapter: Arc<dyn ProviderAdapter>) -> ProxyServer {
+async fn spawn_proxy(adapter: Arc<dyn ProviderAdapter>, pipeline: Pipeline) -> ProxyServer {
     let bind = unused_local_addr();
     let config = ProxyConfig::new(bind, vec![adapter]);
-    let pipeline = Arc::new(leak_probe_pipeline());
+    let pipeline = Arc::new(pipeline);
     let handle = tokio::spawn(async move {
         gaze_proxy::serve(config, pipeline).await.unwrap();
     });
@@ -141,17 +184,33 @@ async fn spawn_proxy(adapter: Arc<dyn ProviderAdapter>) -> ProxyServer {
 }
 
 async fn spawn_openai() -> (MockUpstream, ProxyServer) {
+    spawn_openai_with(leak_probe_pipeline()).await
+}
+
+async fn spawn_openai_with(pipeline: Pipeline) -> (MockUpstream, ProxyServer) {
     let upstream = spawn_upstream(|_| json!({"choices": [{"text": "ok"}]})).await;
-    let proxy = spawn_proxy(Arc::new(OpenAiAdapter::new(upstream.base_url.clone()))).await;
+    let proxy = spawn_proxy(
+        Arc::new(OpenAiAdapter::new(upstream.base_url.clone())),
+        pipeline,
+    )
+    .await;
     (upstream, proxy)
 }
 
 async fn spawn_gemini() -> (MockUpstream, ProxyServer) {
+    spawn_gemini_with(leak_probe_pipeline()).await
+}
+
+async fn spawn_gemini_with(pipeline: Pipeline) -> (MockUpstream, ProxyServer) {
     let upstream = spawn_upstream(
         |_| json!({"candidates": [{"content": {"parts": [{"text": "ok"}], "role": "model"}}]}),
     )
     .await;
-    let proxy = spawn_proxy(Arc::new(GeminiAdapter::new(upstream.base_url.clone()))).await;
+    let proxy = spawn_proxy(
+        Arc::new(GeminiAdapter::new(upstream.base_url.clone())),
+        pipeline,
+    )
+    .await;
     (upstream, proxy)
 }
 
@@ -178,18 +237,42 @@ async fn wait_for_proxy(bind: SocketAddr) {
     }
 }
 
-async fn post_json(proxy: &ProxyServer, path: &str, body: Value) {
-    let response = Client::new()
+async fn post_json(proxy: &ProxyServer, path: &str, body: Value) -> Response {
+    Client::new()
         .post(format!("{}{path}", proxy.base_url))
         .json(&body)
         .send()
         .await
-        .unwrap();
+        .unwrap()
+}
+
+/// Asserts the proxy accepted and forwarded the request.
+async fn post_accepted(proxy: &ProxyServer, path: &str, body: Value) {
+    let response = post_json(proxy, path, body).await;
     assert!(
         response.status().is_success(),
-        "proxy rejected the request: {}",
+        "expected the request to be forwarded, got {}",
         response.status()
     );
+}
+
+/// Asserts the proxy failed closed with `UnsurfacedPii`, and that the client-facing body
+/// discloses only the error name — never the field path and never the detected value.
+async fn post_rejected(proxy: &ProxyServer, upstream: &MockUpstream, path: &str, body: Value) {
+    let response = post_json(proxy, path, body).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "expected a fail-closed rejection"
+    );
+    let rendered = response.text().await.unwrap();
+    assert_eq!(rendered, json!({"error": "UnsurfacedPii"}).to_string());
+    assert!(!rendered.contains(EMAIL), "client body leaked the fixture");
+    assert!(
+        !rendered.contains(ORDER_ID_DIGITS),
+        "client body leaked the fixture"
+    );
+    upstream.assert_nothing_forwarded().await;
 }
 
 /// Asserts a string field was tokenized: marker gone, a gaze token present.
@@ -206,14 +289,14 @@ fn assert_tokenized(value: &Value, marker: &str) {
 }
 
 // ---------------------------------------------------------------------------
-// OpenAI — controls (covered surfaces behave correctly)
+// Controls — covered surfaces still behave correctly (must stay green, unchanged)
 // ---------------------------------------------------------------------------
 
 /// CONTROL: an allowlisted, string-valued surface IS redacted. Calibrates every proof below.
 #[tokio::test]
 async fn control_openai_allowlisted_string_surface_is_tokenized() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_accepted(
         &proxy,
         "/v1/chat/completions",
         json!({
@@ -229,22 +312,46 @@ async fn control_openai_allowlisted_string_surface_is_tokenized() {
     assert_tokenized(content, ORDER_ID_DIGITS);
 }
 
+/// CONTROL: `contents[].parts[].text` and `functionCall.args` string values ARE redacted.
+#[tokio::test]
+async fn control_gemini_allowlisted_surfaces_are_tokenized() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_accepted(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": format!("contact {EMAIL}")},
+                    {"functionCall": {"name": "lookup", "args": {"email": EMAIL}}}
+                ]
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["contents"][0]["parts"][0]["text"], EMAIL);
+    assert_tokenized(
+        &forwarded["contents"][0]["parts"][1]["functionCall"]["args"]["email"],
+        EMAIL,
+    );
+}
+
 // ---------------------------------------------------------------------------
-// OpenAI — sub-class (i): NUMERIC BYPASS
+// Sub-class (i): NUMERIC BYPASS — now fails closed
 // ---------------------------------------------------------------------------
 
-/// PROOF (numeric bypass, isolated): `prompt` IS an allowlisted surface walked by
-/// `push_text_blocks` (`adapters/openai.rs:44`), yet within the SAME array the string element
-/// is tokenized and the numeric element is forwarded raw. `push_text_blocks` falls through
-/// `_ => {}` (`adapter.rs:513`) for any non-string, non-text-block item.
-///
-/// The OpenAI Completions API documents `prompt` as `string | array of strings | array of
-/// tokens | array of token arrays`, so a numeric array element is a legal wire shape.
+/// Was: the numeric element of an allowlisted `prompt` array egressed raw while the string
+/// element beside it was tokenized. `push_text_blocks` falls through `_ => {}` for any
+/// non-string item, and a number can never become a `PiiSurface`.
 #[tokio::test]
 async fn proof_openai_numeric_bypass_inside_allowlisted_prompt_array() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_rejected(
         &proxy,
+        &upstream,
         "/v1/completions",
         json!({
             "model": "gpt-test",
@@ -252,27 +359,16 @@ async fn proof_openai_numeric_bypass_inside_allowlisted_prompt_array() {
         }),
     )
     .await;
-
-    let forwarded = upstream.first_forwarded().await;
-    // Same field, same walk: the string element was detected and tokenized ...
-    assert_tokenized(&forwarded["prompt"][0], ORDER_ID_DIGITS);
-    // ... and the numeric element reached the provider verbatim.
-    assert_eq!(
-        forwarded["prompt"][1],
-        json!(ORDER_ID_NUMBER),
-        "LEAK: numeric array element bypassed detection entirely"
-    );
 }
 
-/// PROOF (numeric bypass, JSON-Schema literal shape): the OpenAI analogue of the Anthropic
-/// `{"description": "order id of the customer", "const": 7001234}` finding. Here the bypass is
-/// compound — `tools` is not allowlisted at all — so BOTH the schema description string and the
-/// numeric literal egress raw.
+/// Was: the OpenAI analogue of the Anthropic `{"description": ..., "const": 7001234}` finding —
+/// both the schema description string and the numeric literal egressed raw.
 #[tokio::test]
 async fn proof_openai_tool_schema_numeric_and_string_literals_leak() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_rejected(
         &proxy,
+        &upstream,
         "/v1/chat/completions",
         json!({
             "model": "gpt-test",
@@ -298,40 +394,43 @@ async fn proof_openai_tool_schema_numeric_and_string_literals_leak() {
         }),
     )
     .await;
+}
 
-    let forwarded = upstream.first_forwarded().await;
-    let function = &forwarded["tools"][0]["function"];
-    assert_eq!(
-        function["description"].as_str().unwrap(),
-        format!("look up the order placed by {EMAIL}"),
-        "LEAK: tools[].function.description egressed raw (field-allowlist bypass)"
-    );
-    let order_id = &function["parameters"]["properties"]["order_id"];
-    assert_eq!(
-        order_id["const"],
-        json!(ORDER_ID_NUMBER),
-        "LEAK: numeric schema const egressed raw"
-    );
-    assert_eq!(
-        order_id["enum"][0],
-        json!(ORDER_ID_NUMBER),
-        "LEAK: numeric schema enum member egressed raw"
-    );
+/// Was: a sibling numeric value inside a fully walked `functionCall.args` object egressed raw
+/// while the string beside it was tokenized. The cleanest isolation of the numeric sub-class:
+/// nothing differs between the two keys but the JSON type.
+#[tokio::test]
+async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"functionCall": {"name": "lookup", "args": {
+                    "order_id_as_string": ORDER_ID_DIGITS,
+                    "order_id_as_number": ORDER_ID_NUMBER
+                }}}]
+            }]
+        }),
+    )
+    .await;
 }
 
 // ---------------------------------------------------------------------------
-// OpenAI — sub-class (ii): FIELD-ALLOWLIST BYPASS (real PII strings)
+// Sub-class (ii): FIELD-ALLOWLIST BYPASS — now fails closed
 // ---------------------------------------------------------------------------
 
-/// PROOF (allowlist bypass, top level): `user` is OpenAI's documented end-user identifier
-/// field. It is a first-class PII carrier in practice and is not in the allowlist
-/// (`adapters/openai.rs:41-59`, `_ => {}`), so it egresses raw in the SAME request whose
-/// `messages` content was correctly tokenized.
+/// Was: `user` (OpenAI's documented end-user identifier), `metadata`, and `stop` all egressed
+/// raw in the same request whose `messages` content was correctly tokenized.
 #[tokio::test]
 async fn proof_openai_user_identifier_field_leaks_raw() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_rejected(
         &proxy,
+        &upstream,
         "/v1/chat/completions",
         json!({
             "model": "gpt-test",
@@ -342,36 +441,16 @@ async fn proof_openai_user_identifier_field_leaks_raw() {
         }),
     )
     .await;
-
-    let forwarded = upstream.first_forwarded().await;
-    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
-    assert_eq!(
-        forwarded["user"].as_str().unwrap(),
-        EMAIL,
-        "LEAK: `user` end-user identifier egressed raw"
-    );
-    assert_eq!(
-        forwarded["metadata"]["customer_email"].as_str().unwrap(),
-        EMAIL,
-        "LEAK: `metadata` string values egressed raw"
-    );
-    assert_eq!(
-        forwarded["stop"][0].as_str().unwrap(),
-        format!("{EMAIL}:"),
-        "LEAK: `stop` sequences egressed raw"
-    );
 }
 
-/// PROOF (allowlist bypass, nested inside an allowlisted parent):
-/// `collect_message_surfaces` (`adapters/openai.rs:111`) matches only `content`,
-/// `tool_results`, and `tool_calls`. OpenAI's per-message `name` (participant name) and a
-/// tool message's `tool_call_id` fall through `_ => {}` and egress raw even though their
-/// parent `messages` IS allowlisted.
+/// Was: `messages[].name` and `messages[].tool_call_id` egressed raw despite `messages` being
+/// allowlisted — the nested-inside-a-covered-parent shape, which is the easiest to miss.
 #[tokio::test]
 async fn proof_openai_message_child_keys_leak_raw() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_rejected(
         &proxy,
+        &upstream,
         "/v1/chat/completions",
         json!({
             "model": "gpt-test",
@@ -382,28 +461,90 @@ async fn proof_openai_message_child_keys_leak_raw() {
         }),
     )
     .await;
-
-    let forwarded = upstream.first_forwarded().await;
-    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
-    assert_eq!(
-        forwarded["messages"][0]["name"].as_str().unwrap(),
-        EMAIL,
-        "LEAK: messages[].name egressed raw"
-    );
-    assert_eq!(
-        forwarded["messages"][1]["tool_call_id"].as_str().unwrap(),
-        format!("call_{ORDER_ID_DIGITS}"),
-        "LEAK: messages[].tool_call_id egressed raw"
-    );
 }
 
-/// MINOR-3 analogue on the legacy path: numeric sampling controls are forwarded verbatim and
-/// are never marked, range-checked, or probed — the legacy path has no coverage machinery at
-/// all, so this is the default for the whole body rather than a special case.
+const GEMINI_PATH: &str = "/v1beta/models/gemini-test:generateContent";
+
+/// Was: the Generative Language API is a protobuf-JSON surface accepting both
+/// `systemInstruction` and `system_instruction`, but the adapter matched the camelCase literal
+/// only — so the snake_case spelling of a COVERED field got zero detection.
+#[tokio::test]
+async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        GEMINI_PATH,
+        json!({
+            "systemInstruction": {"parts": [{"text": format!("camel {EMAIL}")}]},
+            "system_instruction": {"parts": [{"text": format!("snake {EMAIL}")}]},
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}]
+        }),
+    )
+    .await;
+}
+
+/// Was: `tools[].functionDeclarations[].description`, its numeric schema `const`,
+/// `generationConfig.stopSequences`, and `cachedContent` all egressed raw.
+#[tokio::test]
+async fn proof_gemini_request_level_fields_leak_raw() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        GEMINI_PATH,
+        json!({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "tools": [{"functionDeclarations": [{
+                "name": "lookup_order",
+                "description": format!("look up the order placed by {EMAIL}"),
+                "parameters": {"type": "object", "properties": {
+                    "order_id": {"type": "integer", "const": ORDER_ID_NUMBER}
+                }}
+            }]}],
+            "generationConfig": {"stopSequences": [EMAIL], "maxOutputTokens": ORDER_ID_NUMBER},
+            "cachedContent": format!("cachedContents/{EMAIL}")
+        }),
+    )
+    .await;
+}
+
+/// Was: a `fileData.fileUri` part egressed raw despite its `contents[]` parent being
+/// allowlisted — `collect_content` matches only three part kinds.
+#[tokio::test]
+async fn proof_gemini_non_text_part_kinds_leak_raw() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": format!("see attachment for {EMAIL}")},
+                    {"fileData": {"mimeType": "text/plain",
+                                  "fileUri": format!("https://files.example.invalid/{EMAIL}/invoice.pdf")}}
+                ]
+            }]
+        }),
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Numeric carrier scope — the D2 boundary
+// ---------------------------------------------------------------------------
+
+/// Sampling and generation controls are declared non-carriers and are forwarded unprobed.
+///
+/// `max_tokens` here carries the same digits as the `OrderId` fixture: if the non-carrier
+/// declaration were removed, this request would be rejected. That makes this test part of the
+/// mutation probe for `NON_CARRIER_NUMERIC_KEYS`.
 #[tokio::test]
 async fn proof_openai_numeric_controls_are_forwarded_unprobed() {
     let (upstream, proxy) = spawn_openai().await;
-    post_json(
+    post_accepted(
         &proxy,
         "/v1/chat/completions",
         json!({
@@ -422,193 +563,164 @@ async fn proof_openai_numeric_controls_are_forwarded_unprobed() {
     assert_eq!(forwarded["top_p"], json!(0.9));
 }
 
-// ---------------------------------------------------------------------------
-// Gemini — controls
-// ---------------------------------------------------------------------------
-
-const GEMINI_PATH: &str = "/v1beta/models/gemini-test:generateContent";
-
-/// CONTROL: `contents[].parts[].text` and `functionCall.args` string values ARE redacted.
+/// FALSE-REJECT CORPUS (en-US): ordinary sampling-control values in the 4- and 5-digit range
+/// must NOT be rejected, even with a five-digit postal-shaped recognizer active.
+///
+/// This is the precision half of the D2 boundary. Delete `NON_CARRIER_NUMERIC_KEYS` and this
+/// goes red.
 #[tokio::test]
-async fn control_gemini_allowlisted_surfaces_are_tokenized() {
-    let (upstream, proxy) = spawn_gemini().await;
-    post_json(
+async fn ordinary_sampling_controls_are_not_rejected_en_us() {
+    let (upstream, proxy) = spawn_openai_with(postal_probe_pipeline("PostalUs")).await;
+    post_accepted(
         &proxy,
-        GEMINI_PATH,
+        "/v1/chat/completions",
         json!({
-            "contents": [{
-                "role": "user",
-                "parts": [
-                    {"text": format!("contact {EMAIL}")},
-                    {"functionCall": {"name": "lookup", "args": {"email": EMAIL}}}
-                ]
-            }]
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 20000,
+            "max_completion_tokens": 16384,
+            "seed": 12345,
+            "n": 1,
+            "top_p": 0.9,
+            "temperature": 0.7,
+            "presence_penalty": 0,
+            "frequency_penalty": 0
         }),
     )
     .await;
 
     let forwarded = upstream.first_forwarded().await;
-    assert_tokenized(&forwarded["contents"][0]["parts"][0]["text"], EMAIL);
-    assert_tokenized(
-        &forwarded["contents"][0]["parts"][1]["functionCall"]["args"]["email"],
-        EMAIL,
-    );
+    assert_eq!(forwarded["max_tokens"], json!(20000));
+    assert_eq!(forwarded["seed"], json!(12345));
 }
 
-// ---------------------------------------------------------------------------
-// Gemini — sub-class (i): NUMERIC BYPASS (fully isolated)
-// ---------------------------------------------------------------------------
-
-/// PROOF (numeric bypass, fully isolated): `functionCall.args` is walked generically by
-/// `walk_all_strings` (`adapters/gemini.rs:108`). Two sibling keys in the SAME walked object:
-/// the string is tokenized, the number is forwarded raw because `walk_all_strings` no-ops on
-/// `Value::Number` (`adapter.rs:488`) and `PiiSurface.text` is `&mut String`
-/// (`adapter.rs:432`). Nothing about the detector changes between the two — only the JSON type.
+/// FALSE-REJECT CORPUS (de-DE): the Gemini spellings of the same controls, under a de-DE
+/// five-digit postal-shaped recognizer.
 #[tokio::test]
-async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
-    let (upstream, proxy) = spawn_gemini().await;
-    post_json(
+async fn ordinary_sampling_controls_are_not_rejected_de_de() {
+    let (upstream, proxy) = spawn_gemini_with(postal_probe_pipeline("PostalDe")).await;
+    post_accepted(
         &proxy,
         GEMINI_PATH,
         json!({
-            "contents": [{
-                "role": "user",
-                "parts": [{"functionCall": {"name": "lookup", "args": {
-                    "order_id_as_string": ORDER_ID_DIGITS,
-                    "order_id_as_number": ORDER_ID_NUMBER
-                }}}]
-            }]
+            "contents": [{"role": "user", "parts": [{"text": "hallo"}]}],
+            "generationConfig": {
+                "maxOutputTokens": 99999,
+                "candidateCount": 1,
+                "topP": 0.9,
+                "topK": 40,
+                "seed": 54321
+            }
         }),
     )
     .await;
 
     let forwarded = upstream.first_forwarded().await;
-    let args = &forwarded["contents"][0]["parts"][0]["functionCall"]["args"];
-    assert_tokenized(&args["order_id_as_string"], ORDER_ID_DIGITS);
     assert_eq!(
-        args["order_id_as_number"],
-        json!(ORDER_ID_NUMBER),
-        "LEAK: sibling numeric value in the same walked object bypassed detection"
+        forwarded["generationConfig"]["maxOutputTokens"],
+        json!(99999)
     );
+    assert_eq!(forwarded["generationConfig"]["seed"], json!(54321));
 }
 
-// ---------------------------------------------------------------------------
-// Gemini — sub-class (ii): FIELD-ALLOWLIST BYPASS
-// ---------------------------------------------------------------------------
-
-/// PROOF (allowlist bypass, protobuf-JSON snake_case alias): `collect_gemini_surfaces`
-/// (`adapters/gemini.rs:53-70`) matches the literal key `"systemInstruction"` only. The
-/// Google Generative Language API is a protobuf-JSON surface, which accepts BOTH the
-/// lowerCamelCase name and the original snake_case field name. A client sending
-/// `system_instruction` therefore gets zero detection while the camelCase spelling in the
-/// SAME request is tokenized.
+/// BOUNDS ARE CARRIERS (en-US): a five-digit schema `maximum` DOES fail closed.
+///
+/// This pins an intentional decision so a later reader cannot mistake it for an oversight.
+/// Numeric schema bounds stay carriers to match the Anthropic codec's ruling on numeric schema
+/// literals; a proxy that answered differently for the same input shape would be an axis-4
+/// determinism regression. The values-vs-bounds question is recorded as an open user decision
+/// to be resolved once, across both paths.
 #[tokio::test]
-async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
-    let (upstream, proxy) = spawn_gemini().await;
-    post_json(
+async fn schema_numeric_bounds_fail_closed_en_us() {
+    let (upstream, proxy) = spawn_openai_with(postal_probe_pipeline("PostalUs")).await;
+    post_rejected(
         &proxy,
-        GEMINI_PATH,
+        &upstream,
+        "/v1/chat/completions",
         json!({
-            "systemInstruction": {"parts": [{"text": format!("camel {EMAIL}")}]},
-            "system_instruction": {"parts": [{"text": format!("snake {EMAIL}")}]},
-            "contents": [{"role": "user", "parts": [{"text": "hi"}]}]
-        }),
-    )
-    .await;
-
-    let forwarded = upstream.first_forwarded().await;
-    assert_tokenized(&forwarded["systemInstruction"]["parts"][0]["text"], EMAIL);
-    assert_eq!(
-        forwarded["system_instruction"]["parts"][0]["text"]
-            .as_str()
-            .unwrap(),
-        format!("snake {EMAIL}"),
-        "LEAK: snake_case protobuf-JSON alias bypassed the camelCase-only allowlist"
-    );
-}
-
-/// PROOF (allowlist bypass, request-level fields): `tools[].functionDeclarations`,
-/// `generationConfig.stopSequences`, `cachedContent`, and `toolConfig` are all absent from the
-/// two-key request allowlist and egress raw.
-#[tokio::test]
-async fn proof_gemini_request_level_fields_leak_raw() {
-    let (upstream, proxy) = spawn_gemini().await;
-    post_json(
-        &proxy,
-        GEMINI_PATH,
-        json!({
-            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
-            "tools": [{"functionDeclarations": [{
-                "name": "lookup_order",
-                "description": format!("look up the order placed by {EMAIL}"),
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {
+                "name": "lookup", "description": "lookup",
                 "parameters": {"type": "object", "properties": {
-                    "order_id": {"type": "integer", "const": ORDER_ID_NUMBER}
+                    "code": {"type": "integer", "minimum": 10000, "maximum": 99999}
                 }}
-            }]}],
-            "generationConfig": {"stopSequences": [EMAIL], "maxOutputTokens": ORDER_ID_NUMBER},
-            "cachedContent": format!("cachedContents/{EMAIL}")
+            }}]
         }),
     )
     .await;
-
-    let forwarded = upstream.first_forwarded().await;
-    assert_eq!(
-        forwarded["tools"][0]["functionDeclarations"][0]["description"]
-            .as_str()
-            .unwrap(),
-        format!("look up the order placed by {EMAIL}"),
-        "LEAK: tools[].functionDeclarations[].description egressed raw"
-    );
-    assert_eq!(
-        forwarded["tools"][0]["functionDeclarations"][0]["parameters"]["properties"]["order_id"]
-            ["const"],
-        json!(ORDER_ID_NUMBER),
-        "LEAK: numeric schema const egressed raw"
-    );
-    assert_eq!(
-        forwarded["generationConfig"]["stopSequences"][0]
-            .as_str()
-            .unwrap(),
-        EMAIL,
-        "LEAK: generationConfig.stopSequences egressed raw"
-    );
-    assert_eq!(
-        forwarded["cachedContent"].as_str().unwrap(),
-        format!("cachedContents/{EMAIL}"),
-        "LEAK: cachedContent egressed raw"
-    );
 }
 
-/// PROOF (allowlist bypass, inside an allowlisted parent): `collect_content`
-/// (`adapters/gemini.rs:86`) matches only the `text`, `functionCall`, and `functionResponse`
-/// part kinds. A `fileData.fileUri` part — a documented Gemini part kind — falls through
-/// `_ => {}` and egresses raw even though its `contents[]` parent IS allowlisted.
+/// BOUNDS ARE CARRIERS (de-DE): the same decision on the Gemini declaration shape.
 #[tokio::test]
-async fn proof_gemini_non_text_part_kinds_leak_raw() {
-    let (upstream, proxy) = spawn_gemini().await;
-    post_json(
+async fn schema_numeric_bounds_fail_closed_de_de() {
+    let (upstream, proxy) = spawn_gemini_with(postal_probe_pipeline("PostalDe")).await;
+    post_rejected(
         &proxy,
+        &upstream,
         GEMINI_PATH,
         json!({
-            "contents": [{
-                "role": "user",
-                "parts": [
-                    {"text": format!("see attachment for {EMAIL}")},
-                    {"fileData": {"mimeType": "text/plain",
-                                  "fileUri": format!("https://files.example.invalid/{EMAIL}/invoice.pdf")}}
-                ]
-            }]
+            "contents": [{"role": "user", "parts": [{"text": "hallo"}]}],
+            "tools": [{"functionDeclarations": [{
+                "name": "lookup", "description": "lookup",
+                "parameters": {"type": "object", "properties": {
+                    "code": {"type": "integer", "maximum": 99999}
+                }}
+            }]}]
         }),
     )
     .await;
+}
 
-    let forwarded = upstream.first_forwarded().await;
-    assert_tokenized(&forwarded["contents"][0]["parts"][0]["text"], EMAIL);
-    assert_eq!(
-        forwarded["contents"][0]["parts"][1]["fileData"]["fileUri"]
-            .as_str()
-            .unwrap(),
-        format!("https://files.example.invalid/{EMAIL}/invoice.pdf"),
-        "LEAK: fileData.fileUri part egressed raw"
+/// A tool schema may legitimately declare a property NAMED like a sampling control. A numeric
+/// literal there is tool-declared data, not a decoding knob, so `CARRIER_SUBTREE_KEYS` keeps it
+/// probed. Without that guard the non-carrier list would punch holes in exactly the schema
+/// positions the Anthropic `const` finding proved exploitable.
+#[tokio::test]
+async fn control_named_property_inside_a_schema_stays_a_carrier() {
+    let (upstream, proxy) = spawn_openai_with(postal_probe_pipeline("PostalUs")).await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {
+                "name": "weather", "description": "weather",
+                "parameters": {"type": "object", "properties": {
+                    "seed": {"type": "integer", "const": 12345}
+                }}
+            }}]
+        }),
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Error disclosure contract
+// ---------------------------------------------------------------------------
+
+/// The typed error carries the field path ONLY — never the detected value.
+///
+/// `Display` and `Debug` both feed logs, so both are checked. The client-facing body is
+/// covered separately by every `post_rejected` call, which asserts it discloses only the
+/// error name.
+#[test]
+fn unsurfaced_pii_error_discloses_the_field_path_but_never_the_value() {
+    let error = ProxyError::UnsurfacedPii {
+        field_path: "tools[0].function.description".to_string(),
+    };
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("tools[0].function.description"),
+        "the field path is the actionable part of the error: {rendered}"
     );
+    assert!(!rendered.contains(EMAIL), "Display leaked the value");
+    assert!(!rendered.contains(ORDER_ID_DIGITS), "Display leaked digits");
+
+    let debugged = format!("{error:?}");
+    assert!(!debugged.contains(EMAIL), "Debug leaked the value");
+    assert!(!debugged.contains(ORDER_ID_DIGITS), "Debug leaked digits");
 }

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -147,9 +147,9 @@ async fn spawn_openai() -> (MockUpstream, ProxyServer) {
 }
 
 async fn spawn_gemini() -> (MockUpstream, ProxyServer) {
-    let upstream = spawn_upstream(|_| {
-        json!({"candidates": [{"content": {"parts": [{"text": "ok"}], "role": "model"}}]})
-    })
+    let upstream = spawn_upstream(
+        |_| json!({"candidates": [{"content": {"parts": [{"text": "ok"}], "role": "model"}}]}),
+    )
     .await;
     let proxy = spawn_proxy(Arc::new(GeminiAdapter::new(upstream.base_url.clone()))).await;
     (upstream, proxy)

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -468,12 +468,15 @@ const GEMINI_PATH: &str = "/v1beta/models/gemini-test:generateContent";
 /// Was: the Generative Language API is a protobuf-JSON surface accepting both
 /// `systemInstruction` and `system_instruction`, but the adapter matched the camelCase literal
 /// only — so the snake_case spelling of a COVERED field got zero detection.
+///
+/// Now both spellings are recognized as the same field and BOTH are tokenized, rather than the
+/// request merely failing closed. `snake_case_parts_are_also_recognized` covers the nested
+/// spelling; this test pins the top-level one.
 #[tokio::test]
 async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
     let (upstream, proxy) = spawn_gemini().await;
-    post_rejected(
+    post_accepted(
         &proxy,
-        &upstream,
         GEMINI_PATH,
         json!({
             "systemInstruction": {"parts": [{"text": format!("camel {EMAIL}")}]},
@@ -482,6 +485,37 @@ async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
         }),
     )
     .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["systemInstruction"]["parts"][0]["text"], EMAIL);
+    assert_tokenized(&forwarded["system_instruction"]["parts"][0]["text"], EMAIL);
+}
+
+/// The snake_case aliases nested below the top level are recognized too: `function_call` and
+/// `function_response` are the protobuf spellings of part kinds the adapter walks, and
+/// `system_instruction.parts` may itself be spelled either way.
+#[tokio::test]
+async fn snake_case_parts_are_also_recognized() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_accepted(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"function_call": {"name": "lookup", "args": {"email": EMAIL}}},
+                    {"function_response": {"name": "lookup", "response": {"email": EMAIL}}}
+                ]
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let parts = &forwarded["contents"][0]["parts"];
+    assert_tokenized(&parts[0]["function_call"]["args"]["email"], EMAIL);
+    assert_tokenized(&parts[1]["function_response"]["response"]["email"], EMAIL);
 }
 
 /// Was: `tools[].functionDeclarations[].description`, its numeric schema `const`,

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -42,7 +42,7 @@ use axum::routing::post;
 use axum::{Json, Router};
 use gaze::{Action, ClassRule, DefaultRule, PiiClass, Pipeline};
 use gaze_proxy::adapters::{GeminiAdapter, OpenAiAdapter};
-use gaze_proxy::{ProviderAdapter, ProxyConfig, ProxyError};
+use gaze_proxy::{CoveragePolicy, ProviderAdapter, ProxyConfig, ProxyError};
 use gaze_recognizers::RegexDetector;
 use reqwest::{Client, Response, StatusCode};
 use serde_json::{json, Value};
@@ -757,6 +757,45 @@ async fn control_named_property_inside_a_schema_stays_a_carrier() {
                     "seed": {"type": "integer", "const": 12345}
                 }}
             }}]
+        }),
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Coverage policy is load-bearing
+// ---------------------------------------------------------------------------
+
+/// Both legacy adapters declare `CoveragePolicy::LegacySurfaces`, and the legacy request path
+/// READS that declaration to choose how coverage is established — the residual re-scan.
+///
+/// The declaration was previously inert: it was set, exported, and asserted in a contract test,
+/// but the server never consulted it, so it asserted nothing about runtime behavior. Pairing the
+/// declaration with the fail-closed behavior it now selects is what keeps it honest.
+#[tokio::test]
+async fn legacy_coverage_policy_selects_the_residual_rescan() {
+    let openai = OpenAiAdapter::new(Url::parse("https://api.openai.com").unwrap());
+    let gemini =
+        GeminiAdapter::new(Url::parse("https://generativelanguage.googleapis.com").unwrap());
+    assert_eq!(
+        openai.contract().coverage_policy(),
+        CoveragePolicy::LegacySurfaces
+    );
+    assert_eq!(
+        gemini.contract().coverage_policy(),
+        CoveragePolicy::LegacySurfaces
+    );
+
+    // ... and under that declaration an unsurfaced carrier is refused rather than forwarded.
+    let (upstream, proxy) = spawn_openai().await;
+    post_rejected(
+        &proxy,
+        &upstream,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "unknown_future_field": EMAIL
         }),
     )
     .await;

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -425,12 +425,14 @@ async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
 
 /// Was: `user` (OpenAI's documented end-user identifier), `metadata`, and `stop` all egressed
 /// raw in the same request whose `messages` content was correctly tokenized.
+///
+/// All three are free-text carriers the model or the provider reads back verbatim, so they are
+/// now surfaced and pseudonymized rather than merely rejected.
 #[tokio::test]
 async fn proof_openai_user_identifier_field_leaks_raw() {
     let (upstream, proxy) = spawn_openai().await;
-    post_rejected(
+    post_accepted(
         &proxy,
-        &upstream,
         "/v1/chat/completions",
         json!({
             "model": "gpt-test",
@@ -441,12 +443,42 @@ async fn proof_openai_user_identifier_field_leaks_raw() {
         }),
     )
     .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
+    assert_tokenized(&forwarded["user"], EMAIL);
+    assert_tokenized(&forwarded["metadata"]["customer_email"], EMAIL);
+    assert_tokenized(&forwarded["stop"][0], EMAIL);
 }
 
 /// Was: `messages[].name` and `messages[].tool_call_id` egressed raw despite `messages` being
 /// allowlisted — the nested-inside-a-covered-parent shape, which is the easiest to miss.
+///
+/// `name` is a participant name read by the model, so it is now surfaced and pseudonymized.
 #[tokio::test]
 async fn proof_openai_message_child_keys_leak_raw() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_accepted(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "name": EMAIL, "content": format!("ping {EMAIL}")}]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["messages"][0]["name"], EMAIL);
+    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
+}
+
+/// A resource identifier stays UNSURFACED on purpose: `tool_call_id` is correlated provider-side,
+/// so substituting a token would silently break tool calling. PII there fails closed instead,
+/// which tells the adopter their identifier carries PII rather than handing them a broken
+/// request that looks fine.
+#[tokio::test]
+async fn openai_resource_identifiers_fail_closed_rather_than_being_rewritten() {
     let (upstream, proxy) = spawn_openai().await;
     post_rejected(
         &proxy,
@@ -455,8 +487,7 @@ async fn proof_openai_message_child_keys_leak_raw() {
         json!({
             "model": "gpt-test",
             "messages": [
-                {"role": "user", "name": EMAIL, "content": format!("ping {EMAIL}")},
-                {"role": "tool", "tool_call_id": format!("call_{ORDER_ID_DIGITS}"), "content": "ok"}
+                {"role": "tool", "tool_call_id": format!("call-{ORDER_ID_DIGITS}"), "content": "ok"}
             ]
         }),
     )

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -4,9 +4,13 @@
 //! capturing mock upstream and assert on the bytes that would reach the provider.
 //!
 //! They began as an executed leak PROOF against `origin/main` d32ae07 (Solo todo #2400
-//! comment 1435 item 2), where every `proof_` test asserted raw PII surviving to the wire.
-//! Each one now asserts the fixed behavior — fail closed, or tokenized — so the file doubles
-//! as the regression contract for the fix.
+//! comment 1435 item 2), where each one asserted raw PII surviving to the wire. Every such
+//! test now asserts the fixed behavior — fail closed, or tokenized — and carries a
+//! `regression_` prefix naming both the defect it came from and the invariant it now guards,
+//! so the file doubles as the regression contract for the fix.
+//!
+//! `proof_openai_numeric_controls_are_forwarded_unprobed` keeps its original name: it did not
+//! flip. Sampling controls were forwarded unprobed before the fix and still are, by design.
 //!
 //! Two independent leak sub-classes were confirmed and are covered here:
 //!
@@ -347,7 +351,7 @@ async fn control_gemini_allowlisted_surfaces_are_tokenized() {
 /// element beside it was tokenized. `push_text_blocks` falls through `_ => {}` for any
 /// non-string item, and a number can never become a `PiiSurface`.
 #[tokio::test]
-async fn proof_openai_numeric_bypass_inside_allowlisted_prompt_array() {
+async fn regression_openai_numeric_bypass_inside_allowlisted_prompt_array_now_fails_closed() {
     let (upstream, proxy) = spawn_openai().await;
     post_rejected(
         &proxy,
@@ -364,7 +368,7 @@ async fn proof_openai_numeric_bypass_inside_allowlisted_prompt_array() {
 /// Was: the OpenAI analogue of the Anthropic `{"description": ..., "const": 7001234}` finding —
 /// both the schema description string and the numeric literal egressed raw.
 #[tokio::test]
-async fn proof_openai_tool_schema_numeric_and_string_literals_leak() {
+async fn regression_openai_tool_schema_numeric_and_string_literals_now_fail_closed() {
     let (upstream, proxy) = spawn_openai().await;
     post_rejected(
         &proxy,
@@ -400,7 +404,7 @@ async fn proof_openai_tool_schema_numeric_and_string_literals_leak() {
 /// while the string beside it was tokenized. The cleanest isolation of the numeric sub-class:
 /// nothing differs between the two keys but the JSON type.
 #[tokio::test]
-async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
+async fn regression_gemini_numeric_bypass_inside_walked_function_call_args_now_fails_closed() {
     let (upstream, proxy) = spawn_gemini().await;
     post_rejected(
         &proxy,
@@ -429,7 +433,7 @@ async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
 /// All three are free-text carriers the model or the provider reads back verbatim, so they are
 /// now surfaced and pseudonymized rather than merely rejected.
 #[tokio::test]
-async fn proof_openai_user_identifier_field_leaks_raw() {
+async fn regression_openai_user_identifier_field_no_longer_leaks_raw() {
     let (upstream, proxy) = spawn_openai().await;
     post_accepted(
         &proxy,
@@ -456,7 +460,7 @@ async fn proof_openai_user_identifier_field_leaks_raw() {
 ///
 /// `name` is a participant name read by the model, so it is now surfaced and pseudonymized.
 #[tokio::test]
-async fn proof_openai_message_child_keys_leak_raw() {
+async fn regression_openai_message_child_keys_no_longer_leak_raw() {
     let (upstream, proxy) = spawn_openai().await;
     post_accepted(
         &proxy,
@@ -504,7 +508,7 @@ const GEMINI_PATH: &str = "/v1beta/models/gemini-test:generateContent";
 /// request merely failing closed. `snake_case_parts_are_also_recognized` covers the nested
 /// spelling; this test pins the top-level one.
 #[tokio::test]
-async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
+async fn regression_gemini_snake_case_field_alias_no_longer_bypasses_allowlist() {
     let (upstream, proxy) = spawn_gemini().await;
     post_accepted(
         &proxy,
@@ -552,7 +556,7 @@ async fn snake_case_parts_are_also_recognized() {
 /// Was: `tools[].functionDeclarations[].description`, its numeric schema `const`,
 /// `generationConfig.stopSequences`, and `cachedContent` all egressed raw.
 #[tokio::test]
-async fn proof_gemini_request_level_fields_leak_raw() {
+async fn regression_gemini_request_level_fields_no_longer_leak_raw() {
     let (upstream, proxy) = spawn_gemini().await;
     post_rejected(
         &proxy,
@@ -577,7 +581,7 @@ async fn proof_gemini_request_level_fields_leak_raw() {
 /// Was: a `fileData.fileUri` part egressed raw despite its `contents[]` parent being
 /// allowlisted — `collect_content` matches only three part kinds.
 #[tokio::test]
-async fn proof_gemini_non_text_part_kinds_leak_raw() {
+async fn regression_gemini_non_text_part_kinds_no_longer_leak_raw() {
     let (upstream, proxy) = spawn_gemini().await;
     post_rejected(
         &proxy,

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -1,0 +1,614 @@
+//! Executed leak proof for the legacy (non-codec) OpenAI and Gemini adapter path.
+//!
+//! These tests drive the real public proxy request path (`gaze_proxy::serve`) against a
+//! capturing mock upstream and assert on the bytes that would reach the provider. They
+//! document CURRENT behavior at `origin/main` d32ae07 for zero-leak scoping (Solo todo
+//! #2400 comment 1435 item 2). Every `proof_` test asserts a leak that is present today
+//! and MUST start failing once the corresponding fix lands.
+//!
+//! Two independent leak sub-classes are isolated:
+//!
+//! * NUMERIC BYPASS — `PiiSurface.text` is `&mut String` (`adapter.rs:432`) and
+//!   `walk_all_strings` no-ops on `Value::Number` (`adapter.rs:488`), so a JSON number can
+//!   never become a detection surface even inside a fully walked subtree.
+//! * FIELD-ALLOWLIST BYPASS — `OpenAiAdapter::request_pii_surfaces` (`adapters/openai.rs:38`)
+//!   and `collect_gemini_surfaces` (`adapters/gemini.rs:49`) match a hardcoded set of
+//!   top-level keys with a `_ => {}` catch-all, and `server.rs:1812` forwards the whole
+//!   original body (`.json(&json)` at `server.rs:1817`) after mutating only those surfaces.
+//!
+//! Fixtures are synthetic-only per AGENTS.md rule 2.
+
+#![allow(clippy::too_many_lines)]
+
+use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use gaze::{Action, ClassRule, DefaultRule, PiiClass, Pipeline};
+use gaze_proxy::adapters::{GeminiAdapter, OpenAiAdapter};
+use gaze_proxy::{ProviderAdapter, ProxyConfig};
+use gaze_recognizers::RegexDetector;
+use reqwest::Client;
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use url::Url;
+
+/// Synthetic PII marker strings. Never real PII (AGENTS.md rule 2).
+const EMAIL: &str = "alice@example.invalid";
+/// Digit-only order id. Detected as `Custom("OrderId")` when it reaches the pipeline as text.
+const ORDER_ID_DIGITS: &str = "7001234";
+const ORDER_ID_NUMBER: u64 = 7_001_234;
+
+/// Pipeline that CAN detect both markers, so a surviving marker proves the bytes never
+/// reached detection rather than proving a detector miss.
+fn leak_probe_pipeline() -> Pipeline {
+    Pipeline::builder()
+        .detector(RegexDetector::emails().unwrap())
+        .detector(
+            RegexDetector::new(r"\b7001234\b", PiiClass::Custom("OrderId".to_string())).unwrap(),
+        )
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(ClassRule::new(
+            PiiClass::Custom("OrderId".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+
+#[derive(Clone)]
+struct UpstreamState {
+    forwarded: Arc<Mutex<Vec<Value>>>,
+    response: Arc<dyn Fn(Value) -> Value + Send + Sync>,
+}
+
+struct MockUpstream {
+    base_url: Url,
+    forwarded: Arc<Mutex<Vec<Value>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl MockUpstream {
+    async fn first_forwarded(&self) -> Value {
+        let forwarded = self.forwarded.lock().await.clone();
+        assert_eq!(forwarded.len(), 1, "exactly one upstream request expected");
+        forwarded[0].clone()
+    }
+}
+
+impl Drop for MockUpstream {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+struct ProxyServer {
+    base_url: String,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ProxyServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn spawn_upstream(response: impl Fn(Value) -> Value + Send + Sync + 'static) -> MockUpstream {
+    let forwarded = Arc::new(Mutex::new(Vec::new()));
+    let state = UpstreamState {
+        forwarded: forwarded.clone(),
+        response: Arc::new(response),
+    };
+    let app = Router::new()
+        .route("/{*path}", post(capture_upstream))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    MockUpstream {
+        base_url: Url::parse(&format!("http://{addr}")).unwrap(),
+        forwarded,
+        handle,
+    }
+}
+
+async fn capture_upstream(
+    State(state): State<UpstreamState>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    state.forwarded.lock().await.push(body.clone());
+    Json((state.response)(body))
+}
+
+async fn spawn_proxy(adapter: Arc<dyn ProviderAdapter>) -> ProxyServer {
+    let bind = unused_local_addr();
+    let config = ProxyConfig::new(bind, vec![adapter]);
+    let pipeline = Arc::new(leak_probe_pipeline());
+    let handle = tokio::spawn(async move {
+        gaze_proxy::serve(config, pipeline).await.unwrap();
+    });
+    wait_for_proxy(bind).await;
+    ProxyServer {
+        base_url: format!("http://{bind}"),
+        handle,
+    }
+}
+
+async fn spawn_openai() -> (MockUpstream, ProxyServer) {
+    let upstream = spawn_upstream(|_| json!({"choices": [{"text": "ok"}]})).await;
+    let proxy = spawn_proxy(Arc::new(OpenAiAdapter::new(upstream.base_url.clone()))).await;
+    (upstream, proxy)
+}
+
+async fn spawn_gemini() -> (MockUpstream, ProxyServer) {
+    let upstream = spawn_upstream(|_| {
+        json!({"candidates": [{"content": {"parts": [{"text": "ok"}], "role": "model"}}]})
+    })
+    .await;
+    let proxy = spawn_proxy(Arc::new(GeminiAdapter::new(upstream.base_url.clone()))).await;
+    (upstream, proxy)
+}
+
+fn unused_local_addr() -> SocketAddr {
+    let listener = StdTcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap()
+}
+
+async fn wait_for_proxy(bind: SocketAddr) {
+    let client = Client::new();
+    let health_url = format!("http://{bind}/_gaze_proxy/healthz");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(response) = client.get(&health_url).send().await {
+            if response.status().is_success() {
+                return;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "proxy did not start at {bind}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn post_json(proxy: &ProxyServer, path: &str, body: Value) {
+    let response = Client::new()
+        .post(format!("{}{path}", proxy.base_url))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        response.status().is_success(),
+        "proxy rejected the request: {}",
+        response.status()
+    );
+}
+
+/// Asserts a string field was tokenized: marker gone, a gaze token present.
+fn assert_tokenized(value: &Value, marker: &str) {
+    let text = value.as_str().expect("string field expected");
+    assert!(
+        !text.contains(marker),
+        "expected {marker} to be tokenized, got {text}"
+    );
+    assert!(
+        text.contains('<') && text.contains('>'),
+        "expected a gaze token in {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI — controls (covered surfaces behave correctly)
+// ---------------------------------------------------------------------------
+
+/// CONTROL: an allowlisted, string-valued surface IS redacted. Calibrates every proof below.
+#[tokio::test]
+async fn control_openai_allowlisted_string_surface_is_tokenized() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": format!("contact {EMAIL} about order {ORDER_ID_DIGITS}")}]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let content = &forwarded["messages"][0]["content"];
+    assert_tokenized(content, EMAIL);
+    assert_tokenized(content, ORDER_ID_DIGITS);
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI — sub-class (i): NUMERIC BYPASS
+// ---------------------------------------------------------------------------
+
+/// PROOF (numeric bypass, isolated): `prompt` IS an allowlisted surface walked by
+/// `push_text_blocks` (`adapters/openai.rs:44`), yet within the SAME array the string element
+/// is tokenized and the numeric element is forwarded raw. `push_text_blocks` falls through
+/// `_ => {}` (`adapter.rs:513`) for any non-string, non-text-block item.
+///
+/// The OpenAI Completions API documents `prompt` as `string | array of strings | array of
+/// tokens | array of token arrays`, so a numeric array element is a legal wire shape.
+#[tokio::test]
+async fn proof_openai_numeric_bypass_inside_allowlisted_prompt_array() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/completions",
+        json!({
+            "model": "gpt-test",
+            "prompt": [format!("order {ORDER_ID_DIGITS} for {EMAIL}"), ORDER_ID_NUMBER]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    // Same field, same walk: the string element was detected and tokenized ...
+    assert_tokenized(&forwarded["prompt"][0], ORDER_ID_DIGITS);
+    // ... and the numeric element reached the provider verbatim.
+    assert_eq!(
+        forwarded["prompt"][1],
+        json!(ORDER_ID_NUMBER),
+        "LEAK: numeric array element bypassed detection entirely"
+    );
+}
+
+/// PROOF (numeric bypass, JSON-Schema literal shape): the OpenAI analogue of the Anthropic
+/// `{"description": "order id of the customer", "const": 7001234}` finding. Here the bypass is
+/// compound — `tools` is not allowlisted at all — so BOTH the schema description string and the
+/// numeric literal egress raw.
+#[tokio::test]
+async fn proof_openai_tool_schema_numeric_and_string_literals_leak() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "look it up"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup_order",
+                    "description": format!("look up the order placed by {EMAIL}"),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "order_id": {
+                                "type": "integer",
+                                "description": "order id of the customer",
+                                "const": ORDER_ID_NUMBER,
+                                "enum": [ORDER_ID_NUMBER]
+                            }
+                        }
+                    }
+                }
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let function = &forwarded["tools"][0]["function"];
+    assert_eq!(
+        function["description"].as_str().unwrap(),
+        format!("look up the order placed by {EMAIL}"),
+        "LEAK: tools[].function.description egressed raw (field-allowlist bypass)"
+    );
+    let order_id = &function["parameters"]["properties"]["order_id"];
+    assert_eq!(
+        order_id["const"],
+        json!(ORDER_ID_NUMBER),
+        "LEAK: numeric schema const egressed raw"
+    );
+    assert_eq!(
+        order_id["enum"][0],
+        json!(ORDER_ID_NUMBER),
+        "LEAK: numeric schema enum member egressed raw"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI — sub-class (ii): FIELD-ALLOWLIST BYPASS (real PII strings)
+// ---------------------------------------------------------------------------
+
+/// PROOF (allowlist bypass, top level): `user` is OpenAI's documented end-user identifier
+/// field. It is a first-class PII carrier in practice and is not in the allowlist
+/// (`adapters/openai.rs:41-59`, `_ => {}`), so it egresses raw in the SAME request whose
+/// `messages` content was correctly tokenized.
+#[tokio::test]
+async fn proof_openai_user_identifier_field_leaks_raw() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": format!("my address is {EMAIL}")}],
+            "user": EMAIL,
+            "metadata": {"customer_email": EMAIL},
+            "stop": [format!("{EMAIL}:")]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
+    assert_eq!(
+        forwarded["user"].as_str().unwrap(),
+        EMAIL,
+        "LEAK: `user` end-user identifier egressed raw"
+    );
+    assert_eq!(
+        forwarded["metadata"]["customer_email"].as_str().unwrap(),
+        EMAIL,
+        "LEAK: `metadata` string values egressed raw"
+    );
+    assert_eq!(
+        forwarded["stop"][0].as_str().unwrap(),
+        format!("{EMAIL}:"),
+        "LEAK: `stop` sequences egressed raw"
+    );
+}
+
+/// PROOF (allowlist bypass, nested inside an allowlisted parent):
+/// `collect_message_surfaces` (`adapters/openai.rs:111`) matches only `content`,
+/// `tool_results`, and `tool_calls`. OpenAI's per-message `name` (participant name) and a
+/// tool message's `tool_call_id` fall through `_ => {}` and egress raw even though their
+/// parent `messages` IS allowlisted.
+#[tokio::test]
+async fn proof_openai_message_child_keys_leak_raw() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [
+                {"role": "user", "name": EMAIL, "content": format!("ping {EMAIL}")},
+                {"role": "tool", "tool_call_id": format!("call_{ORDER_ID_DIGITS}"), "content": "ok"}
+            ]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["messages"][0]["content"], EMAIL);
+    assert_eq!(
+        forwarded["messages"][0]["name"].as_str().unwrap(),
+        EMAIL,
+        "LEAK: messages[].name egressed raw"
+    );
+    assert_eq!(
+        forwarded["messages"][1]["tool_call_id"].as_str().unwrap(),
+        format!("call_{ORDER_ID_DIGITS}"),
+        "LEAK: messages[].tool_call_id egressed raw"
+    );
+}
+
+/// MINOR-3 analogue on the legacy path: numeric sampling controls are forwarded verbatim and
+/// are never marked, range-checked, or probed — the legacy path has no coverage machinery at
+/// all, so this is the default for the whole body rather than a special case.
+#[tokio::test]
+async fn proof_openai_numeric_controls_are_forwarded_unprobed() {
+    let (upstream, proxy) = spawn_openai().await;
+    post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": ORDER_ID_NUMBER,
+            "temperature": 0.7,
+            "top_p": 0.9
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_eq!(forwarded["max_tokens"], json!(ORDER_ID_NUMBER));
+    assert_eq!(forwarded["temperature"], json!(0.7));
+    assert_eq!(forwarded["top_p"], json!(0.9));
+}
+
+// ---------------------------------------------------------------------------
+// Gemini — controls
+// ---------------------------------------------------------------------------
+
+const GEMINI_PATH: &str = "/v1beta/models/gemini-test:generateContent";
+
+/// CONTROL: `contents[].parts[].text` and `functionCall.args` string values ARE redacted.
+#[tokio::test]
+async fn control_gemini_allowlisted_surfaces_are_tokenized() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_json(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": format!("contact {EMAIL}")},
+                    {"functionCall": {"name": "lookup", "args": {"email": EMAIL}}}
+                ]
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["contents"][0]["parts"][0]["text"], EMAIL);
+    assert_tokenized(
+        &forwarded["contents"][0]["parts"][1]["functionCall"]["args"]["email"],
+        EMAIL,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gemini — sub-class (i): NUMERIC BYPASS (fully isolated)
+// ---------------------------------------------------------------------------
+
+/// PROOF (numeric bypass, fully isolated): `functionCall.args` is walked generically by
+/// `walk_all_strings` (`adapters/gemini.rs:108`). Two sibling keys in the SAME walked object:
+/// the string is tokenized, the number is forwarded raw because `walk_all_strings` no-ops on
+/// `Value::Number` (`adapter.rs:488`) and `PiiSurface.text` is `&mut String`
+/// (`adapter.rs:432`). Nothing about the detector changes between the two — only the JSON type.
+#[tokio::test]
+async fn proof_gemini_numeric_bypass_inside_walked_function_call_args() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_json(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"functionCall": {"name": "lookup", "args": {
+                    "order_id_as_string": ORDER_ID_DIGITS,
+                    "order_id_as_number": ORDER_ID_NUMBER
+                }}}]
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let args = &forwarded["contents"][0]["parts"][0]["functionCall"]["args"];
+    assert_tokenized(&args["order_id_as_string"], ORDER_ID_DIGITS);
+    assert_eq!(
+        args["order_id_as_number"],
+        json!(ORDER_ID_NUMBER),
+        "LEAK: sibling numeric value in the same walked object bypassed detection"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gemini — sub-class (ii): FIELD-ALLOWLIST BYPASS
+// ---------------------------------------------------------------------------
+
+/// PROOF (allowlist bypass, protobuf-JSON snake_case alias): `collect_gemini_surfaces`
+/// (`adapters/gemini.rs:53-70`) matches the literal key `"systemInstruction"` only. The
+/// Google Generative Language API is a protobuf-JSON surface, which accepts BOTH the
+/// lowerCamelCase name and the original snake_case field name. A client sending
+/// `system_instruction` therefore gets zero detection while the camelCase spelling in the
+/// SAME request is tokenized.
+#[tokio::test]
+async fn proof_gemini_snake_case_field_alias_bypasses_allowlist() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_json(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "systemInstruction": {"parts": [{"text": format!("camel {EMAIL}")}]},
+            "system_instruction": {"parts": [{"text": format!("snake {EMAIL}")}]},
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["systemInstruction"]["parts"][0]["text"], EMAIL);
+    assert_eq!(
+        forwarded["system_instruction"]["parts"][0]["text"]
+            .as_str()
+            .unwrap(),
+        format!("snake {EMAIL}"),
+        "LEAK: snake_case protobuf-JSON alias bypassed the camelCase-only allowlist"
+    );
+}
+
+/// PROOF (allowlist bypass, request-level fields): `tools[].functionDeclarations`,
+/// `generationConfig.stopSequences`, `cachedContent`, and `toolConfig` are all absent from the
+/// two-key request allowlist and egress raw.
+#[tokio::test]
+async fn proof_gemini_request_level_fields_leak_raw() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_json(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "tools": [{"functionDeclarations": [{
+                "name": "lookup_order",
+                "description": format!("look up the order placed by {EMAIL}"),
+                "parameters": {"type": "object", "properties": {
+                    "order_id": {"type": "integer", "const": ORDER_ID_NUMBER}
+                }}
+            }]}],
+            "generationConfig": {"stopSequences": [EMAIL], "maxOutputTokens": ORDER_ID_NUMBER},
+            "cachedContent": format!("cachedContents/{EMAIL}")
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_eq!(
+        forwarded["tools"][0]["functionDeclarations"][0]["description"]
+            .as_str()
+            .unwrap(),
+        format!("look up the order placed by {EMAIL}"),
+        "LEAK: tools[].functionDeclarations[].description egressed raw"
+    );
+    assert_eq!(
+        forwarded["tools"][0]["functionDeclarations"][0]["parameters"]["properties"]["order_id"]
+            ["const"],
+        json!(ORDER_ID_NUMBER),
+        "LEAK: numeric schema const egressed raw"
+    );
+    assert_eq!(
+        forwarded["generationConfig"]["stopSequences"][0]
+            .as_str()
+            .unwrap(),
+        EMAIL,
+        "LEAK: generationConfig.stopSequences egressed raw"
+    );
+    assert_eq!(
+        forwarded["cachedContent"].as_str().unwrap(),
+        format!("cachedContents/{EMAIL}"),
+        "LEAK: cachedContent egressed raw"
+    );
+}
+
+/// PROOF (allowlist bypass, inside an allowlisted parent): `collect_content`
+/// (`adapters/gemini.rs:86`) matches only the `text`, `functionCall`, and `functionResponse`
+/// part kinds. A `fileData.fileUri` part — a documented Gemini part kind — falls through
+/// `_ => {}` and egresses raw even though its `contents[]` parent IS allowlisted.
+#[tokio::test]
+async fn proof_gemini_non_text_part_kinds_leak_raw() {
+    let (upstream, proxy) = spawn_gemini().await;
+    post_json(
+        &proxy,
+        GEMINI_PATH,
+        json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": format!("see attachment for {EMAIL}")},
+                    {"fileData": {"mimeType": "text/plain",
+                                  "fileUri": format!("https://files.example.invalid/{EMAIL}/invoice.pdf")}}
+                ]
+            }]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["contents"][0]["parts"][0]["text"], EMAIL);
+    assert_eq!(
+        forwarded["contents"][0]["parts"][1]["fileData"]["fileUri"]
+            .as_str()
+            .unwrap(),
+        format!("https://files.example.invalid/{EMAIL}/invoice.pdf"),
+        "LEAK: fileData.fileUri part egressed raw"
+    );
+}


### PR DESCRIPTION
# Close the legacy OpenAI/Gemini adapter leak path (zero-leak push, todo #2400)

## What was leaking

The `gaze-proxy` legacy (non-codec) path redacts only the surfaces an adapter hands back, then
forwards the **entire original body** upstream — `redact_surfaces(...)` at `server.rs:1812`,
`.json(&json)` at `server.rs:1817`. Anything an adapter's allowlist does not enumerate egressed
verbatim. There was no residual re-scan of the outbound request body; the response path has one
(`PipelineResponseResidualValidator`, `server.rs:1369`, used at `:2054` and `:2266`), the request
path had nothing.

Neither `OpenAiAdapter` nor `GeminiAdapter` overrides `contract()`, so both take
`AdapterContract::legacy()` from the default trait method at `adapter.rs:420`. `AnthropicAdapter`
is the only codec-proved adapter (`adapters/anthropic.rs:348`).

This was **shipped-default behavior**, not an opt-in path: `gaze proxy` registers both adapters
unconditionally at `gaze-cli/src/commands/proxy.rs:231` and `:233`.

Two independent sub-classes were confirmed by executed proof — tests that drive the real
`gaze_proxy::serve` request path against a capturing mock upstream and assert on the bytes that
would reach the provider. The probe pipeline detects both fixture markers, and two control tests
show covered surfaces ARE tokenized, so a surviving marker proves the bytes never reached
detection rather than proving a detector miss.

**1. Numeric bypass — structural, type-level.** `PiiSurface.text` is `&'a mut String`
(`adapter.rs:432`), so a `Value::Number` can never be represented as a detection surface at all;
`walk_all_strings` makes it explicit with a `Value::Number(_) => {}` arm at `adapter.rs:488`, and
`push_text_blocks` falls through `_ => {}` at `adapter.rs:513`. The cleanest isolation is on
Gemini: inside a `functionCall.args` object that IS walked generically, `order_id_as_string:
"7001234"` was tokenized while its sibling `order_id_as_number: 7001234` reached the wire raw.
Nothing differs between the two keys but the JSON type. This is the same shape as the Anthropic
`{"description": "order id of the customer", "const": 7001234}` finding, with no residual re-scan
to backstop it.

**2. Field-allowlist bypass — default-open.** Four hardcoded key sets with `_ => {}` catch-alls:
`adapters/openai.rs:38` (top level) and `:111` (per message), `adapters/gemini.rs:53` (top level)
and `:96` (part kinds). Confirmed leaking: OpenAI `user` (the documented end-user identifier),
`metadata`, `stop`, `messages[].name`, `tool_call_id`, `tools[].function.description`; Gemini
`tools[].functionDeclarations[].description`, `generationConfig.stopSequences`, `cachedContent`,
`fileData.fileUri`. The two nested allowlists matter most for review, because those fields sit
under a covered parent and therefore look covered.

Gemini additionally had a **key-spelling bypass that defeated a surface it believed it covered**.
The Generative Language API is a protobuf-JSON surface, and protobuf JSON parsers accept both the
lowerCamelCase name and the original snake_case field name. The adapter matched
`"systemInstruction"` literally, so `system_instruction` — the same field, spelled the other legal
way — got zero detection.

## What this PR does

**F1 — fail closed on PII outside every adapter surface.** `residual_scan_request` walks the
mutated outbound body, skips positions the adapter surfaced, probes every remaining scalar, and
rejects on any detection. It states the missing invariant directly: everything we did not redact
must be PII-free. It **rejects rather than rewrites** — silently mutating provider-owned fields
would break the provider API contract and the restore round-trip (axis 2). Detection runs under
`LocaleTag::Global`, the same chain `Pipeline::redact` pins for the surface path, so the residual
can be neither weaker nor stronger than the primary pass.

Numeric carrier scope: every JSON number is a carrier except those whose immediate key is a
declared sampling/generation control (`NON_CARRIER_NUMERIC_KEYS` — exact, exhaustive, no
wildcards, rustdoc'd with why each entry is a non-carrier). Schema **bounds** (`minimum`,
`maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`) stay carriers and fail closed,
matching the Anthropic codec's ruling on numeric schema literals — a proxy that answered
differently from the codec for the same input shape would be an axis-4 determinism regression.
The values-vs-bounds question is recorded as an open user decision to be resolved once, across
both paths.

**F3 — recognize protobuf-JSON snake_case aliases in the Gemini adapter.**
`canonical_field_name` normalizes a key to its lowerCamelCase spelling at match time rather than
adding a second literal arm, so the two spellings cannot drift apart as keys are added. Field
paths keep the caller's original key, so a path still names the bytes actually on the wire and
F1's surfaced-path comparison stays exact.

**F2 — surface the documented free-text carriers both adapters missed.** F1 alone is correct but
turns legitimate carriers into rejections, so this converts them into tokenizations. OpenAI:
`user`, `metadata`, `stop`, `tools`, `functions`, `response_format`, `prediction`,
`messages[].name`. Gemini: `tools`, `toolConfig`, `generationConfig` (which covers
`stopSequences`).

**F4 — make the declared coverage policy select the coverage mechanism.** `CoveragePolicy` was
set on every contract, exported, and asserted in a contract test, but `server.rs` never read it —
a declaration the request path never acts on asserts nothing about runtime behavior. The legacy
path now matches on it: `LegacySurfaces` runs the residual re-scan; `CodecProved` on this path
means the contract and the router disagree and no proof exists, so the request is refused.

## Decisions taken beyond the brief

**`CARRIER_SUBTREE_KEYS` — a second const guarding the first.** Numeric non-carrier status is
suppressed inside tool/schema subtrees (`tools`, `functions`, `functionDeclarations`,
`parameters`, `properties`, `input_schema`, `json_schema`, `response_format`, `schema`). Without
it, a tool schema declaring a property merely *named* `seed`, `n`, or `temperature` would exempt
its numeric `const` from probing — punching a hole in exactly the schema position the Anthropic
finding proved exploitable. Pinned by
`control_named_property_inside_a_schema_stays_a_carrier`.

**Resource identifiers fail closed rather than being rewritten.** A longer allowlist alone would
be wrong. `tool_call_id`, `cachedContent`, `fileData.fileUri`, `inlineData.data`, `model`, and
`previous_response_id` are resolved or fetched provider-side; substituting a token would silently
break the request rather than protect it — a provider cannot fetch
`cachedContents/<Email_1_ab12>`. So the rule applied is: **surface positions whose contents the
model reads, because a token round-trips through the provider and back through restore; leave
resource identifiers unsurfaced so PII in them fails closed.** Rejecting tells the adopter their
identifier carries PII; tokenizing would hand them a broken request that looks fine. Pinned by
`openai_resource_identifiers_fail_closed_rather_than_being_rewritten`.

**Ambiguous-key defense in the surfaced-path comparison.** F1 skips a position the adapter
surfaced, matched by field path. A JSON key containing `.` or `[` could make two distinct nodes
render the same path string, so once such a key is seen the subtree stops trusting path equality
and probes unconditionally. Extra probing is always safe — a surfaced position is already clean.

**One of my own proof fixtures was vacuous, and is corrected here.** `call_7001234` cannot match
the `\b7001234\b` probe regex, because `_` is a word character and `\b` never fires. The original
`tool_call_id` assertion was carried by its sibling `name` field, not by the identifier. Changed
to `call-7001234`, which actually exercises the identifier path. Reporting rather than quietly
fixing, because a test that passes for the wrong reason is a dormant gate.

## Error surface

Two additive variants: `ProxyError::UnsurfacedPii { field_path }` and
`ProxyError::UnprovenCoverage`. **Not a breaking change** — `ProxyError` is `#[non_exhaustive]`
(`error.rs:11`), so downstream matches already require a wildcard arm.

`UnsurfacedPii` carries the **field path only, never the detected value or any substring of it**,
in `Display`, in `Debug`, and in any log line derived from them. The client-facing body discloses
only the error name (`{"error":"UnsurfacedPii"}`). Pinned by
`unsurfaced_pii_error_discloses_the_field_path_but_never_the_value`, and re-asserted by every
`post_rejected` helper call.

`UnprovenCoverage`'s `CodecProved`-on-legacy-path arm is unreachable from outside the crate —
`AdapterContract::codec` is `pub(crate)` and sets `ProtocolContract::Codec`, which routes to the
codec branch first — so the inconsistent state cannot be constructed to test it. Stating the
limitation rather than fabricating a test. The reachable half is pinned by
`legacy_coverage_policy_selects_the_residual_rescan`.

## Deliberately NOT in this PR

**F5 — numbers as first-class surfaces.** Would require changing
`pub struct PiiSurface<'a> { pub text: &'a mut String }` (`adapter.rs:432`, re-exported at
`lib.rs:42`, not `#[non_exhaustive]`) — a breaking public API change. F1 avoids it by probing the
body directly.

**R6 — third-party adapters are default-open.** Every adopter-authored adapter inherits
`AdapterContract::legacy()` from the default trait method (`adapter.rs:420`). Closing it means
changing that default to fail-closed — a breaking behavioral change for existing adopters.

**Both F5 and R6 are breaking changes, and both are still open, awaiting an explicit owner
decision.** `adapter.rs` is untouched by this PR.

If a reader carries away one thing about what remains open, make it R6: because
`AdapterContract::legacy()` is the DEFAULT trait method, **every third-party adapter an adopter
writes today is default-open** — it inherits the same allowlist-in, forward-everything-else
posture this PR just fixed for the two built-in adapters, and nothing warns them. This PR closes
the leak for `OpenAiAdapter` and `GeminiAdapter`; it does not and cannot close it for adapters
outside this repo without changing that default.

## Follow-up: R8, the locale finding (todo #2403)

While implementing, I found that `Pipeline::redact` hardcodes `[LocaleTag::Global]`
(`gaze/src/pipeline.rs:344`) and the proxy calls it, so **locale-gated recognizers — `postal.us`,
`postal.de`, national phone — never fire on proxied traffic at all.** That is an axis-1 detection
gap in its own right, tracked separately.

It has a direct consequence for this PR, and it is why the test corpora look the way they do: the
5-digit numeric false-reject class that the Anthropic numeric fix created **cannot occur on this
path today**, because the postal recognizers are inactive under the pinned `Global` chain. The
false-reject and bounds corpora therefore use locale-agnostic five-digit stand-in recognizers,
which is what makes the carrier/non-carrier boundary observable at all. This is documented in the
test module header.

**Todo #2403 is filed for R8**, and carries an explicit scope constraint: fixing it must move the
primary pass and the residual re-scan **together**. I pinned both to the same `Global` chain on
purpose, so that the residual can be neither weaker nor stronger than the primary pass. Widening
one without the other would break that property in one direction or the other — a stronger
residual would start rejecting traffic the primary pass considers clean, and a stronger primary
pass would leave the residual unable to backstop it.

## Observation for follow-up: two numeric probes now exist in this crate

Rebasing onto #399 (`7511db1`) put a second numeric-probe implementation in `gaze-proxy`:
`request_number_literal_control` (`codecs/anthropic.rs:3035`) probes a schema number and rejects
with `ControlWouldMutate` if the probe would change it. F1's residual re-scan does the
conceptually identical thing on the legacy path. They are intentionally NOT unified here — that
would mean refactoring across a just-merged change and would put this PR's reviewed diff out of
date.

Tracked as **#2405**. Worth recording for whoever unifies them, because the inputs are not
identical: the codec probes the number's **raw lexical text** as its parser saw it, while the
residual re-scan probes serde's re-serialization (`Number::to_string()`). So `1e5` and `100000` —
the same logical value — can reach different decisions on the two paths, because digit detection
is lexical. This is an axis-4 determinism issue, **not a known leak**: no input is known to escape
because of it. It should be closed deliberately rather than left to chance.

## Scorecard: deferred, not waived

F1–F4 touch no recognizer, rulepack, or model — the diff is confined to `gaze-proxy`
(`server.rs`, `error.rs`, `adapters/openai.rs`, `adapters/gemini.rs`) plus its tests. The required
evidence is a **no-op proof**: the full no-OPF 3-cell schema-v3 scorecard vs the authoritative
baseline 7395e7a should come back byte-identical, and any delta would mean the change escaped the
proxy layer.

Logistics caveat, verified: the bench tooling is **not on `main`**. `run_no_opf_benchmark.py`,
`test_run_no_opf_benchmark.py`, `scripts/bench/README.md`, and
`docs/reference/benchmarks/v0.12-no-opf-scorecard-v3.json` exist only on the
`agent/current-gaze-benchmark` (7395e7a) branch, so the comparison must run from a worktree based
on that branch with this fix applied.

## North-star axis assessment (AGENTS.md rule 1)

- **Axis 1 (never leak): strengthened.** Two confirmed leak sub-classes closed on a shipped-default
  path, with a fail-closed default for everything not explicitly enumerated.
- **Axis 2 (reversibility): preserved.** F1 rejects instead of rewriting precisely so restore
  round-trips are not broken, and F2 surfaces only positions where a token round-trips.
- **Axis 3 (agentic-first): preserved.** Tool schemas, tool arguments, and multi-turn message
  shapes are the positions being fixed.
- **Axis 4 (auditable/deterministic): strengthened.** The numeric boundary is an explicit, exact,
  rustdoc'd declaration rather than an implicit gap; the coverage policy stops being dormant; the
  bounds decision is aligned with the Anthropic codec rather than diverging per provider.
- **Axis 5 (adopter ergonomics): mild, bounded cost.** Requests carrying PII in a resource
  identifier now get a 422 where they previously succeeded while leaking. That is the intended
  trade — axis 1 over axis 5 — and F2 keeps the common carriers working by tokenizing them rather
  than rejecting. No adopter-visible API break: both new error variants are additive under
  `#[non_exhaustive]`.

## Verification

Rebased onto `e4ab149`; no conflicts. All 7 commits signed and DCO-signed off.

Gates under pinned rustc 1.96.0 with `PATH`/`RUSTC`/`RUSTDOC` bound — **actual exit codes**:

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | **0** |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | **0** (0 error lines) |
| `cargo test --workspace --all-features` | **101** — one subprocess-timeout flake, see below |
| `cargo run -p xtask -- ci-feature-matrix` | **0** (`ci_feature_matrix: passed`) |

`legacy_adapter_leak_proof`: **20/20** in that same run.

The workspace test gate exited **101** on
`gaze-recognizers/tests/kiji_distilbert_subprocess.rs::subprocess_span_round_trips_through_manifest_diff`,
with `Runtime { message: "kiji subprocess timed out and was killed" }` (tracked as **#2404**).

**Why it cannot be this change — the dependency graph excludes it.** `gaze-recognizers` does not
depend on `gaze-proxy`: `grep -c gaze-proxy crates/gaze-recognizers/Cargo.toml` is `0`, and
`cargo tree -p gaze-recognizers --all-features -e normal,dev,build` contains zero `gaze-proxy`
nodes — dev-dependencies included, which is what a test binary would link. This PR's entire diff
lives in `gaze-proxy`, so not one byte of it is compiled into that test binary. Causation is
excluded at compile time. That is the whole proof, and it does not depend on any re-run.

**The test is load-flaky, and an isolated run is NOT a stable control.** It races a Python+ONNX
subprocess against a fixed timeout and loses whenever the machine is busy. Both observations, so
nobody has to take one of them on faith: the same isolated `--exact` invocation **passed in 0.29s**
on one run and **failed at 5.01s** minutes later on another, the latter with load average 4.77, a
competing Python process at 103% CPU, and `syspolicyd` / `XprotectService` at 32.8% / 34.8%
(Gatekeeper and XProtect scanning). Anyone can reproduce either result by choosing when to run it.
So do not read "it passes in isolation" as evidence here — it is not.

**Two distinct false-red sources were observed on this branch, both the same shape.** #2404 (Kiji
subprocess) and the gaze-cli safety-net OPF timeout, which emits
`{"error":"SafetyNet","exit":3,"variant":"Timeout"}`. Both are an external subprocess racing a
fixed deadline under CPU contention. #398/#2401 serialized only the gaze-proxy panic-hook writers,
so neither of these classes is covered by that fix.

For the full record, this branch's gate history: on the previous rebase base (`e4ab149`, quiet
machine) all four gates exited 0 with 121 `ok` result lines. Before that, under heavy load, the
workspace test exited 101 twice on gaze-cli safety-net tests; I reproduced the surviving one
identically at merge base `d32ae07` with these commits absent. **No run, at any point, has
produced a failure inside `gaze-proxy`.**

CI is the authoritative gate and runs on a quiet machine. If #2404's test reds there, that is a
real signal and this should not be merged past it.

Mutation probes, observed:

- Reverting the `residual_scan_request` call site turns **10** tests red — F1 is load-bearing.
- Emptying `NON_CARRIER_NUMERIC_KEYS` turns **3** red — the non-carrier declaration is
  load-bearing, and the false-reject corpus is not vacuous.

Both restored afterwards; worktree clean.

Test inventory in `crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs` (20): 2 controls
(unchanged from the pre-fix proof) · 8 flipped regressions · 2 false-reject corpora · 2
bounds-are-carriers · 1 carrier-subtree guard · 1 resource-identifier fail-closed · 1 snake_case
nested aliases · 1 coverage-policy binding · 1 error-disclosure contract · 1 numeric-controls
forwarded.

All fixtures are synthetic per AGENTS.md rule 2 (`alice@example.invalid`, `7001234`).
