### PR TITLE
[agent] wire an explicit locale chain through both legacy proxy detection passes

### DIFF
--- a/crates/gaze-cli/src/commands/proxy.rs
+++ b/crates/gaze-cli/src/commands/proxy.rs
@@ -81,7 +81,12 @@ pub(crate) fn serve(args: ServeArgs) -> Result<(), CliError> {
             },
         }
     }
-    let pipeline = build_pipeline(args.policy, &args.rulepack)?;
+    // The locale chain the pipeline was assembled under must also reach the proxy: assembly
+    // decides which recognizers are registered, `ProxyConfig` decides which may fire. Dropping
+    // it here is what pinned proxied traffic to `[LocaleTag::Global]` and left locale-gated
+    // recognizers inert for adopters who had configured a locale (solo todo #2403).
+    let (pipeline, locale_chain) = build_pipeline(args.policy, &args.rulepack)?;
+    config = config.with_locale_chain(locale_chain);
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| CliError::ProxyDetail(format!("runtime: {err}")))?;
     runtime
@@ -191,7 +196,17 @@ pub(crate) fn uninstall_systemd_user() -> Result<(), CliError> {
     ))
 }
 
-fn build_pipeline(policy: Option<PathBuf>, rulepack: &str) -> Result<gaze::Pipeline, CliError> {
+/// Builds the proxy pipeline and returns the locale chain it was assembled under.
+///
+/// The chain is the canonical 4-tier resolution (CLI > policy > rulepack default > system
+/// default). `gaze proxy` has no `--locale` flag, so the CLI tier is empty and a policy
+/// `locale = [...]` is the adopter's lever; with no policy the bundled defaults resolve to
+/// `[LocaleTag::Global]`. Both values are returned together because the proxy needs them
+/// together — see [`gaze_proxy::ProxyConfig::with_locale_chain`].
+fn build_pipeline(
+    policy: Option<PathBuf>,
+    rulepack: &str,
+) -> Result<(gaze::Pipeline, gaze::LocaleChain), CliError> {
     if let Some(path) = policy {
         let policy = gaze::Policy::load_for_cli(&path).map_err(map_policy_error)?;
         let rulepacks = load_rulepacks(&policy).map_err(map_pipeline_error)?;
@@ -201,22 +216,24 @@ fn build_pipeline(policy: Option<PathBuf>, rulepack: &str) -> Result<gaze::Pipel
             policy.locale.as_deref(),
             Some(&rulepack_default_locales),
         );
-        return build_pipeline_from_policy(
+        let pipeline = build_pipeline_from_policy(
             &policy,
             &rulepacks,
             None,
             &locale_chain,
             resolve_ner_threshold(None, Some(&policy)),
-        );
+        )?;
+        return Ok((pipeline, locale_chain));
     }
     let mut config = gaze_assembly::CorePipelineConfig::new();
     if rulepack != "core" {
         config = config.with_bundled_rulepack(rulepack);
     }
-    config
+    let core = config
         .build()
-        .map(gaze_assembly::CorePipeline::into_pipeline)
-        .map_err(|err| CliError::ProxyDetail(format!("pipeline: {err}")))
+        .map_err(|err| CliError::ProxyDetail(format!("pipeline: {err}")))?;
+    let locale_chain = core.locale_chain().clone();
+    Ok((core.into_pipeline(), locale_chain))
 }
 
 fn proxy_config(

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -47,6 +47,36 @@ upstream = "https://api.anthropic.com/"
 upstream = "https://generativelanguage.googleapis.com/"
 ```
 
+## Locale
+
+Recognizers that declare `locales = [...]` — `postal.de`, `postal.us`, the national phone
+recognizers — only run when the active locale chain intersects that list. The proxy resolves
+that chain once and uses it for both the primary surface pass and the outbound residual
+re-scan, so the two can never disagree about what counts as PII.
+
+`gaze proxy` has no `--locale` flag; the chain comes from the policy you pass:
+
+```toml
+locale = ["de-DE"]
+```
+
+```bash
+gaze proxy serve --policy ./gaze.toml
+```
+
+With no policy the chain is `["global"]` and locale-gated recognizers stay inert. Library
+adopters set it explicitly, passing the same chain the pipeline was assembled under:
+
+```rust,ignore
+let core = gaze_assembly::CorePipelineConfig::new()
+    .with_bundled_rulepack("core-extended")
+    .with_locale(&[gaze::LocaleTag::DeDe])
+    .build()?;
+let config = ProxyConfig::new(bind, adapters).with_locale_chain(core.locale_chain().clone());
+```
+
+A locale chain always ends in `global`, so configuring one can only widen detection.
+
 ## Providers
 
 - OpenAI: `POST /v1/chat/completions`, `/v1/completions`, `/v1/responses`

--- a/crates/gaze-proxy/src/lib.rs
+++ b/crates/gaze-proxy/src/lib.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use adapters::AnthropicAdapter;
-use gaze::Pipeline;
+use gaze::{LocaleChain, LocaleTag, Pipeline};
 
 pub use adapter::{
     AdapterContract, CoveragePolicy, FormatPolicy, HeaderPolicy, PiiSurface, ProtocolContract,
@@ -71,6 +71,7 @@ pub struct ProxyConfig {
     pub adapters: Vec<Arc<dyn ProviderAdapter>>,
     pub session_ttl: Duration,
     pub body_limit_bytes: u64,
+    pub(crate) locale_chain: LocaleChain,
     pub(crate) direct_anthropic: Option<Arc<AnthropicAdapter>>,
     pub(crate) inspection: Option<Arc<ProxyInspectionProducerV1>>,
 }
@@ -82,6 +83,7 @@ impl ProxyConfig {
             adapters,
             session_ttl: Duration::from_secs(30 * 60),
             body_limit_bytes: 2 * 1024 * 1024,
+            locale_chain: default_locale_chain(),
             direct_anthropic: None,
             inspection: None,
         }
@@ -101,9 +103,48 @@ impl ProxyConfig {
             adapters: vec![dynamic],
             session_ttl: Duration::from_secs(30 * 60),
             body_limit_bytes: 2 * 1024 * 1024,
+            locale_chain: default_locale_chain(),
             direct_anthropic: Some(adapter),
             inspection: None,
         }
+    }
+
+    /// Sets the locale chain every detection pass on this proxy runs under.
+    ///
+    /// # Why this is explicit
+    ///
+    /// Recognizers declare `locales = [...]` and only run when the active chain intersects
+    /// that list. Before this setting existed the proxy pinned `[LocaleTag::Global]`, so an
+    /// adopter who had already configured `de-DE` silently got no `postal.de` and no DE
+    /// national-phone detection on proxied traffic — an axis-1 leak the adopter had no way to
+    /// observe. The chain is now adopter-supplied rather than inherited from a system default,
+    /// so what activates is a stated configuration decision.
+    ///
+    /// # Derivation
+    ///
+    /// Callers derive the value from the canonical 4-tier chain
+    /// (CLI > policy > rulepack default > system default) with
+    /// [`gaze::LocaleChain::merge_cli_policy_rulepack_default`], or read it straight off a
+    /// `gaze_assembly::CorePipeline::locale_chain`, and pass the result here. It MUST be the
+    /// same chain the supplied [`gaze::Pipeline`] was assembled under: assembly decides which
+    /// recognizers are REGISTERED, this chain decides which of them are allowed to FIRE.
+    ///
+    /// Omitting this call leaves the chain at `[LocaleTag::Global]`, which reproduces the
+    /// pre-existing behavior exactly. [`gaze::LocaleChain`] always appends `Global` as its
+    /// final tier, so configuring a locale can only widen detection, never narrow it.
+    ///
+    /// Both the primary surface pass and the outbound residual re-scan read this one field,
+    /// which is what keeps the residual neither weaker nor stronger than the primary pass.
+    #[must_use]
+    pub fn with_locale_chain(mut self, locale_chain: LocaleChain) -> Self {
+        self.locale_chain = locale_chain;
+        self
+    }
+
+    /// Returns the locale chain detection runs under on this proxy.
+    #[must_use]
+    pub fn locale_chain(&self) -> &[LocaleTag] {
+        self.locale_chain.as_slice()
     }
 
     /// Installs the immutable provider-neutral inspection producer for this launch.
@@ -116,6 +157,16 @@ impl ProxyConfig {
         self.inspection = Some(Arc::new(inspection));
         self
     }
+}
+
+/// The locale chain used when an adopter configures none.
+///
+/// Deliberately `[LocaleTag::Global]`: it is exactly the chain the proxy pinned before
+/// [`ProxyConfig::with_locale_chain`] existed, so adopters who configure nothing observe no
+/// behavior change. Widening this default would activate `postal.us` / `postal.de` for every
+/// adopter at once and is a separate decision (Solo todo #2400, values-vs-bounds).
+fn default_locale_chain() -> LocaleChain {
+    LocaleChain::from_tags(vec![LocaleTag::Global])
 }
 
 pub async fn serve_foreground(

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1809,10 +1809,15 @@ async fn proxy_inner(
     let session = session_for(&state, &headers).await?;
     let mut json: Value =
         serde_json::from_slice(&body).map_err(|source| ProxyError::InvalidJson { source })?;
+    // One source of truth for both passes below: widening or narrowing detection on this
+    // path is a configuration decision, and it must land on the primary pass and the residual
+    // re-scan identically or the two disagree about what counts as PII.
+    let locale_chain = state.config.locale_chain();
     let surfaced = redact_surfaces(
         &state.pipeline,
         &session,
         adapter.request_pii_surfaces(&mut json),
+        locale_chain,
     )?;
     // The declared coverage policy SELECTS the mechanism that establishes coverage. Reading it
     // here is what keeps the declaration honest: a contract cannot claim a coverage posture the
@@ -1821,7 +1826,7 @@ async fn proxy_inner(
         // Legacy adapters carry no codec proof, so coverage is established right here, by
         // re-scanning the outbound body and failing closed on anything left unprotected.
         CoveragePolicy::LegacySurfaces => {
-            residual_scan_request(&state.pipeline, &json, &surfaced)?;
+            residual_scan_request(&state.pipeline, &json, &surfaced, locale_chain)?;
         }
         // A codec-proved adapter must have been routed to the codec branch above. Reaching this
         // point means the contract and the router disagree and no proof has been established.
@@ -2507,15 +2512,26 @@ const CARRIER_SUBTREE_KEYS: &[&str] = &[
 /// The returned set is the authorization input for [`residual_scan_request`]: a position the
 /// adapter surfaced has already been through the pipeline and whatever it decided there
 /// (tokenize, or preserve by policy) is authorized. Every other position is not.
+///
+/// `locale_chain` is the adopter-configured chain from
+/// [`crate::ProxyConfig::with_locale_chain`], NOT the `[LocaleTag::Global]` that
+/// [`Pipeline::redact`] pins. Passing it is what lets locale-gated recognizers
+/// (`postal.de`, `postal.us`, the national phone recognizers) run on proxied traffic at all.
+/// [`residual_scan_request`] MUST be given the same slice.
 fn redact_surfaces(
     pipeline: &Pipeline,
     session: &Session,
     surfaces: Vec<crate::adapter::PiiSurface<'_>>,
+    locale_chain: &[LocaleTag],
 ) -> Result<HashSet<String>, ProxyError> {
     let mut surfaced = HashSet::new();
     for surface in surfaces {
         let clean = pipeline
-            .redact(session, RawDocument::Text(surface.text.clone()))
+            .pseudonymize_with_context(
+                session,
+                RawDocument::Text(surface.text.clone()),
+                locale_chain,
+            )
             .map_err(|source| ProxyError::Pipeline { source })?;
         if let CleanDocument::Text(text) = clean {
             *surface.text = text;
@@ -2535,12 +2551,16 @@ fn redact_surfaces(
 /// provider API contract and the restore round-trip (axis 2); refusing the request preserves
 /// axis 1 and leaves the adapter allowlist as the place to add genuine carriers.
 ///
-/// Detection runs under [`LocaleTag::Global`], the same chain [`Pipeline::redact`] pins for the
-/// surface path, so the residual can never be weaker OR stronger than the primary pass.
+/// Detection runs under the caller-supplied `locale_chain`, which MUST be the same slice
+/// [`redact_surfaces`] was given — both read [`crate::ProxyConfig::locale_chain`]. That shared
+/// source is what keeps the residual neither weaker NOR stronger than the primary pass: a
+/// chain that activated a recognizer for the surface pass but not here would forward PII the
+/// primary would have tokenized, and the reverse would reject traffic the primary accepts.
 fn residual_scan_request(
     pipeline: &Pipeline,
     body: &Value,
     surfaced: &HashSet<String>,
+    locale_chain: &[LocaleTag],
 ) -> Result<(), ProxyError> {
     let session =
         Session::new(Scope::Ephemeral).map_err(|source| ProxyError::Pipeline { source })?;
@@ -2548,6 +2568,7 @@ fn residual_scan_request(
         pipeline,
         session,
         surfaced,
+        locale_chain,
     };
     scan.walk("", "", body, false, true)
 }
@@ -2557,6 +2578,8 @@ struct RequestResidualScan<'a> {
     pipeline: &'a Pipeline,
     session: Session,
     surfaced: &'a HashSet<String>,
+    /// The same chain the primary pass ran under. See [`residual_scan_request`].
+    locale_chain: &'a [LocaleTag],
 }
 
 impl RequestResidualScan<'_> {
@@ -2566,7 +2589,7 @@ impl RequestResidualScan<'_> {
             .clean_with_safety_net(
                 &self.session,
                 RawDocument::Text(text.to_owned()),
-                &[LocaleTag::Global],
+                self.locale_chain,
             )
             .map_err(|source| ProxyError::Pipeline { source })?;
         if spans.is_empty() {

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -26,12 +26,17 @@
 //!
 //! ## Locale note
 //!
-//! `Pipeline::redact` pins `[LocaleTag::Global]` (`gaze/src/pipeline.rs:350`), and the residual
-//! re-scan uses the same chain deliberately, so the residual can be neither weaker nor stronger
-//! than the primary pass. Consequence: locale-gated recognizers (`postal.us`, `postal.de`,
-//! national phone) never activate on proxied traffic at all. The en-US / de-DE corpora below
-//! therefore use locale-agnostic five-digit stand-in recognizers, which is what makes the
-//! carrier / non-carrier boundary observable on this path.
+//! Both proxy passes read one adopter-configured chain, `ProxyConfig::locale_chain` (solo
+//! todo #2403), so the residual is still neither weaker nor stronger than the primary pass.
+//! The tests below construct their proxies without configuring a locale, which leaves that
+//! chain at its default `[LocaleTag::Global]`; locale-gated recognizers (`postal.us`,
+//! `postal.de`, national phone) are therefore inert HERE by construction rather than
+//! unconditionally. The en-US / de-DE corpora accordingly use locale-agnostic five-digit
+//! stand-in recognizers, which is what makes the carrier / non-carrier boundary observable
+//! on this path without depending on locale activation.
+//!
+//! Activation and primary/residual agreement under a configured locale are covered in
+//! `proxy_locale_chain.rs`.
 //!
 //! Fixtures are synthetic-only per AGENTS.md rule 2.
 
@@ -79,10 +84,10 @@ fn leak_probe_pipeline() -> Pipeline {
 
 /// Locale-agnostic five-digit stand-in for a national postal recognizer.
 ///
-/// The real `postal.us` / `postal.de` recognizers are locale-gated and therefore never active
-/// on the proxy path (see the module-level locale note). This stand-in reproduces their
-/// detection shape under `LocaleTag::Global` so the numeric carrier / non-carrier boundary is
-/// observable. `class_label` distinguishes the en-US and de-DE corpus runs.
+/// The real `postal.us` / `postal.de` recognizers are locale-gated and these proxies configure
+/// no locale (see the module-level locale note), so they are inert here. This stand-in
+/// reproduces their detection shape under `LocaleTag::Global` so the numeric carrier /
+/// non-carrier boundary is observable. `class_label` distinguishes the en-US and de-DE runs.
 fn postal_probe_pipeline(class_label: &str) -> Pipeline {
     Pipeline::builder()
         .detector(

--- a/crates/gaze-proxy/tests/proxy_locale_chain.rs
+++ b/crates/gaze-proxy/tests/proxy_locale_chain.rs
@@ -1,0 +1,390 @@
+//! Locale-chain contract for the legacy (non-codec) proxy request path.
+//!
+//! Solo todo #2403. Before the fix, `redact_surfaces` called [`gaze::Pipeline::redact`], which
+//! pins `[LocaleTag::Global]`, and the outbound residual re-scan pinned the same chain
+//! deliberately. Consequence: every recognizer declaring `locales = [...]` — `postal.de`,
+//! `postal.us`, the national phone recognizers — was inert on proxied traffic no matter what
+//! locale the adopter had configured. An adopter running `de-DE` got no German detection and
+//! had no way to observe that. Axis-1 leak, not a precision issue.
+//!
+//! The fix routes both passes through one source of truth,
+//! [`gaze_proxy::ProxyConfig::with_locale_chain`]. These tests hold three things:
+//!
+//! 1. CALIBRATION — the recognizer under test really is locale-gated, proven against the
+//!    pipeline directly, so a proxy-level failure below cannot be a detector miss.
+//! 2. ACTIVATION — a configured locale makes the gated recognizer fire on the proxy path,
+//!    and the unconfigured default still behaves exactly as it did before.
+//! 3. AGREEMENT — the primary surface pass and the residual re-scan reach the same verdict
+//!    for every fixture under a configured non-global locale. Neither may be weaker or
+//!    stronger than the other; a surfaced position that tokenizes must correspond to an
+//!    unsurfaced position that fails closed, and a fixture the primary leaves alone must not
+//!    be rejected by the residual.
+//!
+//! Fixtures are synthetic-only per AGENTS.md rule 2. `10115` is a published Berlin postal
+//! prefix, not personal data; it carries no identity on its own and is used purely as a
+//! locale-gated recognizer trigger.
+
+use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use gaze::{CleanDocument, LocaleChain, LocaleTag, Pipeline, RawDocument, Scope, Session};
+use gaze_assembly::CorePipelineConfig;
+use gaze_proxy::adapters::OpenAiAdapter;
+use gaze_proxy::{ProviderAdapter, ProxyConfig};
+use reqwest::{Client, Response, StatusCode};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use url::Url;
+
+/// German postal code. Locale-gated: detected by `postal.de` under a `de-DE` chain only.
+const DE_POSTAL_CONTEXT: &str = "Berlin 10115";
+const DE_POSTAL_DIGITS: &str = "10115";
+/// Locale-agnostic control. `email.basic` is not locale-gated, so it must behave identically
+/// under every chain — it separates "the locale chain moved" from "detection broke".
+const EMAIL: &str = "alice@example.invalid";
+/// Carries no PII under any chain. Guards the residual against over-rejection.
+const INERT: &str = "please summarize the attached report";
+
+// ---------------------------------------------------------------------------
+// Pipelines
+// ---------------------------------------------------------------------------
+
+/// Builds the `core-extended` pipeline plus the locale chain it was assembled under.
+///
+/// This mirrors what an adopter does: assembly decides which recognizers are REGISTERED,
+/// and the returned chain is what decides which of them may FIRE. Handing the same chain to
+/// [`ProxyConfig::with_locale_chain`] is the whole contract under test.
+fn assembled(locales: &[LocaleTag]) -> (Pipeline, LocaleChain) {
+    let core = CorePipelineConfig::new()
+        .with_bundled_rulepack("core-extended")
+        .with_locale(locales)
+        .build()
+        .expect("core-extended assembles");
+    let chain = core.locale_chain().clone();
+    (core.into_pipeline(), chain)
+}
+
+fn tokenize_directly(pipeline: &Pipeline, chain: &[LocaleTag], text: &str) -> String {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let CleanDocument::Text(clean) = pipeline
+        .pseudonymize_with_context(&session, RawDocument::Text(text.to_owned()), chain)
+        .expect("pipeline runs")
+    else {
+        panic!("text variant expected");
+    };
+    clean
+}
+
+// ---------------------------------------------------------------------------
+// (1) CALIBRATION — the recognizer is genuinely locale-gated
+// ---------------------------------------------------------------------------
+
+/// Proves `postal.de` fires under `de-DE` and is inert under `[Global]`, against the pipeline
+/// directly. Without this, an activation failure on the proxy path would be ambiguous between
+/// "the proxy pinned the wrong chain" and "the recognizer never matches this fixture".
+#[test]
+fn calibration_postal_de_is_locale_gated_at_the_pipeline() {
+    let (de_pipeline, de_chain) = assembled(&[LocaleTag::DeDe]);
+    let de_clean = tokenize_directly(&de_pipeline, de_chain.as_slice(), DE_POSTAL_CONTEXT);
+    assert!(
+        !de_clean.contains(DE_POSTAL_DIGITS),
+        "postal.de must tokenize under de-DE, got {de_clean}"
+    );
+
+    let global_clean = tokenize_directly(&de_pipeline, &[LocaleTag::Global], DE_POSTAL_CONTEXT);
+    assert!(
+        global_clean.contains(DE_POSTAL_DIGITS),
+        "postal.de must be inert under a bare Global chain, got {global_clean}"
+    );
+
+    // Locale-agnostic control: identical verdict under both chains.
+    for chain in [de_chain.as_slice(), &[LocaleTag::Global]] {
+        let clean = tokenize_directly(&de_pipeline, chain, EMAIL);
+        assert!(
+            !clean.contains(EMAIL),
+            "email must tokenize under every chain, got {clean}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) ACTIVATION — the configured chain reaches the proxy primary pass
+// ---------------------------------------------------------------------------
+
+/// REGRESSION (todo #2403): a configured `de-DE` chain makes `postal.de` fire on the proxy
+/// path. Before the fix this position egressed the raw postal code because
+/// `redact_surfaces` pinned `[LocaleTag::Global]`.
+#[tokio::test]
+async fn regression_configured_locale_activates_gated_recognizer_on_proxy_path() {
+    let (pipeline, chain) = assembled(&[LocaleTag::DeDe]);
+    let (upstream, proxy) = spawn_openai(pipeline, Some(chain)).await;
+
+    post_accepted(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": format!("ship it to {DE_POSTAL_CONTEXT}")}]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let content = forwarded["messages"][0]["content"]
+        .as_str()
+        .expect("string content");
+    assert!(
+        !content.contains(DE_POSTAL_DIGITS),
+        "de-DE was configured, so postal.de must tokenize on the proxy path; forwarded {content}"
+    );
+    assert!(
+        content.contains('<') && content.contains('>'),
+        "expected a gaze token in {content}"
+    );
+}
+
+/// The unconfigured default is unchanged: no locale configured still means `[Global]`, so a
+/// locale-gated recognizer stays inert and this adopter sees exactly the pre-fix behavior.
+///
+/// This is deliberately NOT a leak the fix closes. Widening the no-configuration default would
+/// activate `postal.us` / `postal.de` for every adopter at once and is coupled to the open
+/// values-vs-bounds numeric-carrier decision (Solo todo #2400).
+#[tokio::test]
+async fn unconfigured_locale_default_is_unchanged() {
+    let (pipeline, _chain) = assembled(&[LocaleTag::DeDe]);
+    let (upstream, proxy) = spawn_openai(pipeline, None).await;
+
+    post_accepted(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": format!("ship it to {DE_POSTAL_CONTEXT} for {EMAIL}")}]
+        }),
+    )
+    .await;
+
+    let forwarded = upstream.first_forwarded().await;
+    let content = forwarded["messages"][0]["content"]
+        .as_str()
+        .expect("string content");
+    assert!(
+        content.contains(DE_POSTAL_DIGITS),
+        "no locale configured must keep the pre-fix Global behavior; forwarded {content}"
+    );
+    assert!(
+        !content.contains(EMAIL),
+        "locale-agnostic detection must still run under the default chain; forwarded {content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) AGREEMENT — primary pass and residual re-scan reach the same verdict
+// ---------------------------------------------------------------------------
+
+/// The two passes must move together. For each fixture, the same bytes are sent twice under
+/// one configured `de-DE` proxy: once in a surfaced position (`messages[].content`, handled by
+/// the primary pass) and once in an unsurfaced position (`safety_identifier`, handled only by
+/// the residual re-scan). The verdicts must match — tokenized on the primary side if and only
+/// if failed closed on the residual side.
+///
+/// This is the test the mutation probe in the PR body drives RED: pinning the residual back to
+/// `[LocaleTag::Global]` while the primary stays on `de-DE` makes the `postal.de` fixture
+/// tokenize on the primary side and forward untouched on the residual side.
+#[tokio::test]
+async fn regression_residual_rescan_agrees_with_primary_under_configured_locale() {
+    // (fixture, expected to carry PII under the configured de-DE chain)
+    let fixtures = [
+        (DE_POSTAL_CONTEXT, true),
+        (EMAIL, true),
+        (INERT, false),
+    ];
+
+    for (fixture, expected_pii) in fixtures {
+        // Primary pass: a surfaced position.
+        let (pipeline, chain) = assembled(&[LocaleTag::DeDe]);
+        let (upstream, proxy) = spawn_openai(pipeline, Some(chain)).await;
+        post_accepted(
+            &proxy,
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-test",
+                "messages": [{"role": "user", "content": fixture}]
+            }),
+        )
+        .await;
+        let forwarded = upstream.first_forwarded().await;
+        let content = forwarded["messages"][0]["content"]
+            .as_str()
+            .expect("string content");
+        let primary_saw_pii = content != fixture;
+        drop((upstream, proxy));
+
+        // Residual re-scan: an unsurfaced position. `safety_identifier` is a real OpenAI
+        // request field that `OpenAiAdapter::request_pii_surfaces` does not claim, so it falls
+        // through to `_ => {}` and is reached by the residual re-scan and nothing else.
+        let (pipeline, chain) = assembled(&[LocaleTag::DeDe]);
+        let (upstream, proxy) = spawn_openai(pipeline, Some(chain)).await;
+        let response = post_json(
+            &proxy,
+            "/v1/chat/completions",
+            json!({
+                "model": "gpt-test",
+                "messages": [{"role": "user", "content": "look it up"}],
+                "safety_identifier": fixture
+            }),
+        )
+        .await;
+        let residual_saw_pii = response.status() == StatusCode::UNPROCESSABLE_ENTITY;
+
+        assert_eq!(
+            primary_saw_pii, residual_saw_pii,
+            "primary and residual disagreed on {fixture:?}: primary_saw_pii={primary_saw_pii}, \
+             residual_saw_pii={residual_saw_pii} (residual status {})",
+            response.status()
+        );
+        assert_eq!(
+            primary_saw_pii, expected_pii,
+            "unexpected verdict for {fixture:?} under de-DE; forwarded {content}"
+        );
+        drop((upstream, proxy));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct UpstreamState {
+    forwarded: Arc<Mutex<Vec<Value>>>,
+}
+
+struct MockUpstream {
+    base_url: Url,
+    forwarded: Arc<Mutex<Vec<Value>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl MockUpstream {
+    async fn first_forwarded(&self) -> Value {
+        let forwarded = self.forwarded.lock().await.clone();
+        assert_eq!(forwarded.len(), 1, "exactly one upstream request expected");
+        forwarded[0].clone()
+    }
+}
+
+impl Drop for MockUpstream {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+struct ProxyServer {
+    base_url: String,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ProxyServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn spawn_upstream() -> MockUpstream {
+    let forwarded = Arc::new(Mutex::new(Vec::new()));
+    let state = UpstreamState {
+        forwarded: forwarded.clone(),
+    };
+    let app = Router::new()
+        .route("/{*path}", post(capture_upstream))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    MockUpstream {
+        base_url: Url::parse(&format!("http://{addr}")).unwrap(),
+        forwarded,
+        handle,
+    }
+}
+
+async fn capture_upstream(
+    State(state): State<UpstreamState>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    state.forwarded.lock().await.push(body);
+    Json(json!({"choices": [{"text": "ok"}]}))
+}
+
+async fn spawn_openai(
+    pipeline: Pipeline,
+    locale_chain: Option<LocaleChain>,
+) -> (MockUpstream, ProxyServer) {
+    let upstream = spawn_upstream().await;
+    let adapter: Arc<dyn ProviderAdapter> = Arc::new(OpenAiAdapter::new(upstream.base_url.clone()));
+    let bind = unused_local_addr();
+    let mut config = ProxyConfig::new(bind, vec![adapter]);
+    if let Some(chain) = locale_chain {
+        config = config.with_locale_chain(chain);
+    }
+    let pipeline = Arc::new(pipeline);
+    let handle = tokio::spawn(async move {
+        gaze_proxy::serve(config, pipeline).await.unwrap();
+    });
+    wait_for_proxy(bind).await;
+    (
+        upstream,
+        ProxyServer {
+            base_url: format!("http://{bind}"),
+            handle,
+        },
+    )
+}
+
+fn unused_local_addr() -> SocketAddr {
+    let listener = StdTcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap()
+}
+
+async fn wait_for_proxy(bind: SocketAddr) {
+    let client = Client::new();
+    let health_url = format!("http://{bind}/_gaze_proxy/healthz");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(response) = client.get(&health_url).send().await {
+            if response.status().is_success() {
+                return;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "proxy did not start at {bind}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn post_json(proxy: &ProxyServer, path: &str, body: Value) -> Response {
+    Client::new()
+        .post(format!("{}{path}", proxy.base_url))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn post_accepted(proxy: &ProxyServer, path: &str, body: Value) {
+    let response = post_json(proxy, path, body).await;
+    assert!(
+        response.status().is_success(),
+        "expected the request to be forwarded, got {}",
+        response.status()
+    );
+}

--- a/crates/gaze-proxy/tests/proxy_locale_chain.rs
+++ b/crates/gaze-proxy/tests/proxy_locale_chain.rs
@@ -198,11 +198,7 @@ async fn unconfigured_locale_default_is_unchanged() {
 #[tokio::test]
 async fn regression_residual_rescan_agrees_with_primary_under_configured_locale() {
     // (fixture, expected to carry PII under the configured de-DE chain)
-    let fixtures = [
-        (DE_POSTAL_CONTEXT, true),
-        (EMAIL, true),
-        (INERT, false),
-    ];
+    let fixtures = [(DE_POSTAL_CONTEXT, true), (EMAIL, true), (INERT, false)];
 
     for (fixture, expected_pii) in fixtures {
         // Primary pass: a surfaced position.
@@ -242,7 +238,8 @@ async fn regression_residual_rescan_agrees_with_primary_under_configured_locale(
         let residual_saw_pii = response.status() == StatusCode::UNPROCESSABLE_ENTITY;
 
         assert_eq!(
-            primary_saw_pii, residual_saw_pii,
+            primary_saw_pii,
+            residual_saw_pii,
             "primary and residual disagreed on {fixture:?}: primary_saw_pii={primary_saw_pii}, \
              residual_saw_pii={residual_saw_pii} (residual status {})",
             response.status()


### PR DESCRIPTION
## Summary

`Pipeline::redact` pins `[LocaleTag::Global]`, and the legacy proxy path called exactly that (`crates/gaze-proxy/src/server.rs`, `redact_surfaces`). The outbound residual re-scan deliberately pinned the same chain so it could be neither weaker nor stronger than the primary pass. The consequence was that **every recognizer declaring `locales = [...]` — `postal.de`, `postal.us`, the national phone recognizers — could never fire on proxied traffic, regardless of what locale the adopter had configured.**

An adopter who has already configured `de-DE` gets no German recognizers on the flagship chokepoint surface and has no way to observe that. That silent narrowing is the bug. This PR introduces one explicit locale-chain source both passes read, so what activates is a stated configuration decision rather than an inherited default.

Adopters who configured nothing keep `[LocaleTag::Global]` and see no behavior change, so this is a **strict leak reduction with no surprise default flip**.

Resolves solo todo #2403.

## What changed

| | |
|---|---|
| `ProxyConfig::with_locale_chain` / `::locale_chain` | the one source of truth; default `[LocaleTag::Global]` |
| `redact_surfaces` | `Pipeline::redact` → `pseudonymize_with_context(.., locale_chain)` |
| `residual_scan_request` | `&[LocaleTag::Global]` → the same slice, threaded through `RequestResidualScan` |
| request handler | reads `state.config.locale_chain()` **once** and passes it to both |
| `gaze proxy serve` | already resolved the canonical 4-tier chain when assembling the pipeline, then dropped it; now passes it to `ProxyConfig` |

The scope constraint is honored structurally: there is one read of one field, handed to both passes at the same call site. Widening one without the other is not expressible without editing both function signatures.

Derivation is documented in rustdoc on `with_locale_chain`: CLI > policy > rulepack default > system default, via `LocaleChain::merge_cli_policy_rulepack_default` or `CorePipeline::locale_chain()`. `LocaleChain` always appends `Global` as its final tier, so configuring a locale can only widen detection, never narrow it.

## Evidence

All runs under the pinned toolchain (`rustc 1.96.0`).

### 1. Activation — RED before, GREEN after

New `crates/gaze-proxy/tests/proxy_locale_chain.rs`. Run with the `ProxyConfig` surface present but both call sites still on `[LocaleTag::Global]` (i.e. main's behavior):

```
running 4 tests
test calibration_postal_de_is_locale_gated_at_the_pipeline ... ok
test unconfigured_locale_default_is_unchanged ... ok
test regression_configured_locale_activates_gated_recognizer_on_proxy_path ... FAILED
test regression_residual_rescan_agrees_with_primary_under_configured_locale ... FAILED

---- regression_configured_locale_activates_gated_recognizer_on_proxy_path stdout ----
panicked at crates/gaze-proxy/tests/proxy_locale_chain.rs:140:5:
de-DE was configured, so postal.de must tokenize on the proxy path; forwarded ship it to Berlin 10115

---- regression_residual_rescan_agrees_with_primary_under_configured_locale stdout ----
panicked at crates/gaze-proxy/tests/proxy_locale_chain.rs:252:9:
assertion `left == right` failed: unexpected verdict for "Berlin 10115" under de-DE; forwarded Berlin 10115
  left: false
 right: true

test result: FAILED. 2 passed; 2 failed
```

After the fix: `test result: ok. 4 passed; 0 failed`.

`calibration_postal_de_is_locale_gated_at_the_pipeline` passes in both runs and is what makes the RED meaningful: it proves against the pipeline directly that `postal.de` fires under `de-DE` and is inert under `[Global]`, so the proxy-level failure cannot be a detector miss.

`unconfigured_locale_default_is_unchanged` also passes in both runs — the no-configuration default is untouched.

### 2. Primary / residual agreement under a configured non-global locale

`regression_residual_rescan_agrees_with_primary_under_configured_locale` sends each fixture twice through one `de-DE`-configured proxy: once in a surfaced position (`messages[].content`, primary pass) and once in an unsurfaced position (`safety_identifier`, reached only by the residual re-scan), then asserts the two verdicts are equal. Fixtures cover a locale-gated carrier (`Berlin 10115`), a locale-agnostic carrier (`alice@example.invalid`), and an inert string — so the test catches asymmetry in both directions: residual weaker (leak) and residual stronger (false reject).

### 3. Mutation probe — the invariant test is not dormant

Reverted **only** the residual call site to `[LocaleTag::Global]`, leaving the primary on the configured chain:

```
running 4 tests
test calibration_postal_de_is_locale_gated_at_the_pipeline ... ok
test unconfigured_locale_default_is_unchanged ... ok
test regression_configured_locale_activates_gated_recognizer_on_proxy_path ... ok
test regression_residual_rescan_agrees_with_primary_under_configured_locale ... FAILED

---- regression_residual_rescan_agrees_with_primary_under_configured_locale stdout ----
panicked at crates/gaze-proxy/tests/proxy_locale_chain.rs:244:9:
assertion `left == right` failed: primary and residual disagreed on "Berlin 10115": primary_saw_pii=true, residual_saw_pii=false (residual status 200 OK)
  left: true
 right: false

test result: FAILED. 3 passed; 1 failed
```

One observed failure, naming the exact asymmetry (`residual status 200 OK` — the residual forwarded what the primary had tokenized). Mutation reverted; suite back to `4 passed; 0 failed`.

### Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `cargo test -p gaze-proxy --all-features` — all suites pass (includes the 20 existing legacy-adapter leak-proof tests)
- `cargo test -p gaze-cli --all-features` — all suites pass
- `cargo run -p xtask -- fixture-citation-lint`, `readme-version-check` — pass

**One gate is RED, pre-existing and unrelated:** `cargo clippy --workspace --all-targets -- -D warnings` (DEFAULT features) fails with 7 `dead_code` errors in `crates/gaze-cli/src/style.rs` (`RESET`, `GREEN`, `YELLOW`, `RED`, `ansi_enabled`, `paint`, `env_non_empty`). Verified identical on a pristine detached worktree at `main` (f0897ee); `git diff main -- crates/gaze-cli/src/style.rs` is empty. Not touched here.

Fixtures are synthetic-only per AGENTS.md rule 2. `10115` is a published Berlin postal prefix used purely as a locale-gated recognizer trigger; it carries no identity on its own.

## Axis assessment (AGENTS.md rule 1)

- **Axis 1 (never leak): improved.** Locale-gated recognizers can now fire on proxied traffic for adopters who configured a locale. No axis is weakened.
- **Axis 4 (trust/determinism): improved.** The chain is stated configuration rather than an inherited default, and both passes provably agree.
- **Axis 5 (adopter ergonomics): mild new surface.** Library adopters must now pass the chain their pipeline was assembled under; omitting it silently reproduces the old behavior. Mitigated by rustdoc on `with_locale_chain`, a README section, and CLI wiring that does it automatically from the policy. Accepted: the alternative (inferring a chain from the pipeline) would re-introduce the implicit default this PR exists to remove.

No tradeoff against axes 1–4.

## Deliberately NOT changed

**The no-configuration default stays `[LocaleTag::Global]`.** Widening it is a pending USER decision, coupled to the open values-vs-bounds numeric-carrier question (solo todo #2400): a wider default re-activates `postal.us` / `postal.de` for every adopter at once and would surface a 5-digit hard-reject class on the proxy path for the first time — ordinary 4/5-digit numeric traffic would start being rejected. That coupling is why this PR stops at making the chain configurable. Noted and left alone.

## Known remaining gap (out of scope, follow-up)

The **direct/codec** path has the same defect in its own primary/residual pair, untouched here:

- `PipelineRequestPseudonymizer::protect_unstaged_segment` (`server.rs:1300`) — request primary
- `PipelineResponseResidualValidator::validate` (`server.rs:1397`) — response residual

Both still pin `[LocaleTag::Global]`. Fixing them means threading the chain through `prepare_and_commit_direct_request_with_hook`, the spawned SSE task, and `restore_direct_response`, and re-verifying the codec proof invariants — a materially larger diff on a different pair than the one todo #2403 names. Fixing one of those two without the other would create exactly the asymmetry this PR's hard scope constraint forbids, so they must move together, in their own change. Recommend a follow-up todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5m1EUHEPzjfGEzf7sMU3o
