### PR TITLE
[agent] record safety-net RESOLVE manifest raw_span in original-request coordinates

### DIFF
--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1051,6 +1051,9 @@ impl Pipeline {
             if !is_char_boundary_range(&clean.text, &span) {
                 return Ok(Some(FallbackReason::ResidualSuspect));
             }
+            // Establish the ORIGINAL-request interval before tokenization mutates the
+            // session or any clean-text / manifest state.
+            let raw_span = map_clean_span_to_raw(clean, &span)?;
             let raw = clean.text[span.clone()].to_string();
             let replacement = target.tokenize_with_family("safety_net", &suspect.class, &raw)?;
             self.log_safety_net_entry(
@@ -1069,7 +1072,7 @@ impl Pipeline {
                 &replacement,
                 Some(EmittedTokenSpan::new(
                     span.start..span.start + replacement.len(),
-                    span,
+                    raw_span,
                     suspect.class.clone(),
                 )),
             );
@@ -1482,6 +1485,75 @@ fn fallback_action(fallback: SafetyNetFallback) -> Action {
         SafetyNetFallback::Strict | SafetyNetFallback::Tolerant => Action::Preserve,
         SafetyNetFallback::Redact => Action::Redact,
     }
+}
+
+fn clean_to_raw_mapping_error(message: &'static str) -> Error {
+    Error::SafetyNet(SafetyNetError::InvalidOutput {
+        message: message.to_string(),
+    })
+}
+
+/// Translate a CLEAN-text span into the ORIGINAL-request byte interval it covers.
+///
+/// `EmittedTokenSpan::raw_span` is an original-document coordinate by contract: downstream
+/// consumers slice the original request bytes with it (`gaze-token-bridge` ingest) and compare
+/// it against authorized original-coordinate ranges (`gaze-proxy` residual validation). The
+/// safety-net RESOLVE path only ever sees clean coordinates, so it must map them back through
+/// the manifest emitted by the primary pass before recording a manifest entry.
+///
+/// Fails closed when the mapping is ambiguous — a clean boundary that lands strictly inside an
+/// already-emitted token has no single original counterpart, and a manifest that is not a
+/// monotonic, gap-preserving clean/raw alignment cannot be walked at all.
+fn map_clean_span_to_raw(clean: &CleanText, span: &Range<usize>) -> Result<Range<usize>> {
+    if span.start >= span.end || !is_char_boundary_range(&clean.text, span) {
+        return Err(Error::SafetyNetSpanInvalid {
+            start: span.start,
+            end: span.end,
+            text_len: clean.text.len(),
+        });
+    }
+    let start = map_clean_boundary_to_raw(&clean.manifest, span.start)
+        .ok_or_else(|| clean_to_raw_mapping_error("clean-to-raw start mapping failed"))?;
+    let end = map_clean_boundary_to_raw(&clean.manifest, span.end)
+        .ok_or_else(|| clean_to_raw_mapping_error("clean-to-raw end mapping failed"))?;
+    if start >= end {
+        return Err(clean_to_raw_mapping_error("empty clean-to-raw mapping"));
+    }
+    Ok(start..end)
+}
+
+/// Map a single clean-text byte boundary to its original-request byte boundary.
+///
+/// Walks the manifest in clean order, carrying a clean cursor and a raw cursor: untokenized
+/// runs advance both by the same amount, and each emitted token jumps them to its own
+/// clean/raw ends. Returns `None` (caller fails closed) when the offset falls strictly inside
+/// an emitted token, or when the manifest is not monotonic / not gap-preserving.
+fn map_clean_boundary_to_raw(manifest: &[EmittedTokenSpan], offset: usize) -> Option<usize> {
+    let mut clean_cursor = 0usize;
+    let mut raw_cursor = 0usize;
+    for emitted in manifest {
+        if emitted.clean_span.start < clean_cursor
+            || emitted.raw_span.start < raw_cursor
+            || emitted.clean_span.start - clean_cursor != emitted.raw_span.start - raw_cursor
+        {
+            return None;
+        }
+        if offset < emitted.clean_span.start {
+            return raw_cursor.checked_add(offset.checked_sub(clean_cursor)?);
+        }
+        if offset == emitted.clean_span.start {
+            return Some(emitted.raw_span.start);
+        }
+        if offset < emitted.clean_span.end {
+            return None;
+        }
+        if offset == emitted.clean_span.end {
+            return Some(emitted.raw_span.end);
+        }
+        clean_cursor = emitted.clean_span.end;
+        raw_cursor = emitted.raw_span.end;
+    }
+    raw_cursor.checked_add(offset.checked_sub(clean_cursor)?)
 }
 
 fn is_char_boundary_range(text: &str, span: &Range<usize>) -> bool {

--- a/crates/gaze/tests/audit_safety_net_raw_span.rs
+++ b/crates/gaze/tests/audit_safety_net_raw_span.rs
@@ -1,0 +1,191 @@
+//! Audit proof (spawn 4759): safety-net RESOLVE must record `EmittedTokenSpan.raw_span`
+//! in ORIGINAL-request byte coordinates, not clean-text coordinates.
+//!
+//! Synthetic fixtures only. Uses the public `clean_with_safety_net_policy_detect_context`
+//! surface plus the same MockNet shape as `tests/safety_net.rs`.
+
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, Detection, Detector, EmittedTokenSpan, LeakKind,
+    LeakSuspect, PiiClass, Pipeline, RawDocument, SafetyNet, SafetyNetContext, SafetyNetError,
+    Scope, Session,
+};
+
+const EMAIL: &str = "alice@example.invalid";
+const RAW: &str = "alice@example.invalid tail";
+
+#[derive(Clone)]
+struct FixedDetector {
+    span: Range<usize>,
+    class: PiiClass,
+}
+
+impl Detector for FixedDetector {
+    fn detect(&self, _input: &str) -> Vec<Detection> {
+        vec![Detection::new(
+            self.span.clone(),
+            self.class.clone(),
+            "fixed",
+        )]
+    }
+}
+
+#[derive(Clone)]
+struct MockNet {
+    span: Arc<Mutex<Option<Range<usize>>>>,
+    class: PiiClass,
+    whole_clean: bool,
+}
+
+impl MockNet {
+    fn whole_clean(class: PiiClass) -> Self {
+        Self {
+            span: Arc::new(Mutex::new(None)),
+            class,
+            whole_clean: true,
+        }
+    }
+}
+
+impl SafetyNet for MockNet {
+    fn id(&self) -> &str {
+        "mock"
+    }
+
+    fn supported_locales(&self) -> &[gaze::LocaleTag] {
+        &[gaze::LocaleTag::Global]
+    }
+
+    fn check(
+        &self,
+        clean_text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        let span = if self.whole_clean {
+            0..clean_text.len()
+        } else {
+            match self.span.lock().unwrap().clone() {
+                Some(span) => span,
+                None => return Ok(Vec::new()),
+            }
+        };
+        if span.start >= span.end || span.end > clean_text.len() {
+            return Ok(Vec::new());
+        }
+        let Some(kind) = context.manifest.diff_against(&span, &self.class) else {
+            return Ok(Vec::new());
+        };
+        Ok(vec![LeakSuspect::new(
+            span,
+            self.class.clone(),
+            self.id(),
+            Some(0.99),
+            kind,
+            "private_email",
+            context.field_path.map(str::to_string),
+        )])
+    }
+}
+
+fn text(clean: CleanDocument) -> String {
+    match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    }
+}
+
+/// Every manifest entry must satisfy: restore(clean[clean_span]) == raw[raw_span].
+///
+/// This is the axis-2 reversibility contract: `raw_span` is consumed by downstream
+/// crates (`gaze-token-bridge::ingest::build_index_hit` slices the ORIGINAL text by it;
+/// `gaze-proxy::PipelineResponseResidualValidator` compares it against authorized
+/// ORIGINAL-coordinate ranges). If safety-net RESOLVE records clean coordinates there,
+/// both consumers silently read the wrong bytes of the original document.
+#[test]
+fn safety_net_resolve_manifest_raw_span_indexes_original_request_bytes() {
+    // Primary pipeline tokenizes the email, so the clean text is SHORTER than the raw
+    // text and clean coordinates diverge from original coordinates after that point.
+    let pipeline = Pipeline::builder()
+        .detector(FixedDetector {
+            span: 0..EMAIL.len(),
+            class: PiiClass::Email,
+        })
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(MockNet::whole_clean(PiiClass::Email))
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let (clean, manifest, report) = pipeline
+        .clean_with_safety_net_policy_detect_context(
+            &session,
+            RawDocument::Text(RAW.to_string()),
+            &[gaze::LocaleTag::Global],
+            &gaze::DictionaryBundle::default(),
+            gaze::SafetyNetPolicy::new(
+                gaze::SafetyNetMode::Resolve,
+                gaze::SafetyNetFallback::Redact,
+            ),
+        )
+        .expect("resolve clean");
+    let clean_text = text(clean);
+
+    assert!(
+        matches!(report.suspects[0].kind, LeakKind::PartialBleed { .. }),
+        "fixture must exercise the partial-bleed resolve path, got {:?}",
+        report.suspects[0].kind
+    );
+    assert_eq!(manifest.len(), 2, "primary token + safety-net promotion");
+
+    for span in &manifest {
+        assert_valid(&span.clean_span, &clean_text, "clean");
+        assert_valid(&span.raw_span, RAW, "raw");
+
+        let token = &clean_text[span.clean_span.clone()];
+        let restored = session
+            .restore(token)
+            .unwrap_or_else(|| panic!("manifest token {token:?} must restore"));
+        assert_eq!(
+            restored,
+            &RAW[span.raw_span.clone()],
+            "manifest raw_span {:?} must address the ORIGINAL bytes that token {token:?} \
+             restores to; raw[{:?}] = {:?}",
+            span.raw_span,
+            span.raw_span,
+            &RAW[span.raw_span.clone()],
+        );
+    }
+
+    // And the whole document must round-trip exactly.
+    assert_eq!(
+        session
+            .restore_strict_text(&clean_text)
+            .expect("clean text restores"),
+        RAW
+    );
+}
+
+fn assert_valid(span: &Range<usize>, text: &str, label: &str) {
+    assert!(
+        span.start < span.end
+            && span.end <= text.len()
+            && text.is_char_boundary(span.start)
+            && text.is_char_boundary(span.end),
+        "{label}_span {span:?} is not a valid range into {label} text of len {}",
+        text.len()
+    );
+}
+
+// Keep the unused-field lint quiet on the branch where `span` is never populated.
+#[allow(dead_code)]
+fn _unused(net: &MockNet) -> Option<Range<usize>> {
+    net.span.lock().unwrap().clone()
+}
+
+#[allow(dead_code)]
+fn _unused_manifest(spans: &[EmittedTokenSpan]) -> usize {
+    spans.len()
+}


### PR DESCRIPTION
Resolves solo todo #2409

## The defect (shipped on main, axis-2 reversibility → axis-1 leak downstream)

`crates/gaze/src/pipeline.rs` `resolve_safety_net_suspects` recorded its manifest entry as:

```rust
Some(EmittedTokenSpan::new(
    span.start..span.start + replacement.len(),
    span,                       // <-- CLEAN-text coordinates stored as raw_span
    suspect.class.clone(),
))
```

`EmittedTokenSpan::raw_span` is an **ORIGINAL-request** coordinate by contract, but the
safety-net RESOLVE path only ever sees clean-text coordinates. Any document where a primary
tokenization precedes a safety-net promotion — the normal mixed-detector case, and RESOLVE has
been the default SafetyNet mode since v0.8.1 — therefore got a manifest entry whose `raw_span`
addresses the wrong bytes of the original document. Nothing panics and restore still works, so
the corruption is silent.

Two shipped consumers read that field and are unsound today:

- `crates/gaze-token-bridge/src/ingest.rs:144` — `slice(raw_text, span.raw_span, "raw")` indexes
  the **wrong** original substring and stores it as `IndexEntity.raw_value`; the true value is
  never indexed.
- `crates/gaze-proxy/src/server.rs:1402` — `authorized.start <= span.raw_span.start &&
  authorized.end >= span.raw_span.end` compares a garbage range against authorized
  ORIGINAL-coordinate ranges in `PipelineResponseResidualValidator`. Unsound in both directions;
  the false-accept direction is a provider-origin PII leak (axis 1).

Root cause of the exposure: this was fixed on 2026-07-10 in `a6c20ab`, but that commit landed on
the long-lived integration branch `agent/current-gaze-benchmark` and never reached `main`.

## The fix

Hand-ported the span arithmetic from `a6c20ab` — `map_clean_span_to_raw` and
`map_clean_boundary_to_raw` — and corrected the `EmittedTokenSpan::new` argument. `main` refactored
`pipeline.rs` onto `ProtectionTarget<'_, '_>`, so a direct cherry-pick conflicts and would also drag
in `GazeLocalProtectionTraceItem`, `ProtectionTraceCollector`, `Error::UnsupportedActionVariant`
and a `#[doc(hidden)]` public method that `main` does not need. **None of that is in this PR.** The
only deviation from `a6c20ab`'s arithmetic is that its private error helper `protection_trace_error`
is named `clean_to_raw_mapping_error` here (identical body:
`Error::SafetyNet(SafetyNetError::InvalidOutput { .. })`) so no trace-subsystem naming enters `main`.

Mechanics:

- The mapping is taken **before** `tokenize_with_family` and `replace_clean_span`, because both
  mutate the manifest the mapper walks. Suspects are already applied right-to-left (`.rev()`), so a
  resolution never invalidates coordinates to its left.
- `map_clean_boundary_to_raw` is a two-cursor walk over `clean.manifest` (which `replace_clean_span`
  keeps sorted by `clean_span.start`): untokenized runs advance the clean and raw cursors equally,
  and each emitted token jumps them to its own clean/raw ends.

### Fail-closed behavior change (narrow, called out per AGENTS.md rule 1)

`map_clean_span_to_raw` returns `Err` in two cases that previously completed with a corrupt
`raw_span`:

1. the clean boundary lands **strictly inside** an already-emitted token — it has no single original
   counterpart, so the mapping is genuinely ambiguous;
2. the manifest is not a monotonic, gap-preserving clean/raw alignment — it cannot be walked at all.

Both surface through `main`'s existing error path as `Error::SafetyNet(SafetyNetError::InvalidOutput)`
— no new error variant, no new public API. This trades a hair of availability for axis-2 correctness
(axes 1–4 beat performance/availability). It is the same fail-closed choice `a6c20ab` made. Neither
case is reachable for a well-formed manifest: the pipeline's own primary pass produces a monotonic,
gap-preserving manifest, and safety-net suspect spans are boundary-checked against the clean text
before the mapping is attempted. No existing test changed behavior (see evidence below).

### Explicitly NOT touched

The `SafetyNetFallback::Redact` arm of `apply_safety_net_fallback` (`pipeline.rs:1106`) is
**unchanged** and still calls `redact_safety_net_suspects`. The bench branch rewrote that arm to
`Err(Error::SafetyNetFallback(reason))` in a *later* commit (`b1a336e`, not `a6c20ab`), which would
silently turn redact-and-deliver into a hard error for every adopter, since `Redact` is the default
fallback. That is out of scope here. Todo #2410 (the fail-closed integrity checks) is deliberately
not attempted in this PR.

## Evidence

Toolchain: `rustc 1.96.0 (ac68faa20 2026-05-25)` (repo pin, bound on PATH — Homebrew rustc 1.95
otherwise wins).
Proof test: `crates/gaze/tests/audit_safety_net_raw_span.rs`, shipped with the fix. Synthetic
fixtures only (`alice@example.invalid`). It asserts the axis-2 contract per manifest entry:
`session.restore(clean[clean_span]) == raw[raw_span]`, plus a whole-document `restore_strict_text`
round-trip. Token hex is random per session in production, so the assertions are on bytes, never on hex.

### 1. RED on unmodified `main` (f0897ee + the test file only)

```
running 1 test
test safety_net_resolve_manifest_raw_span_indexes_original_request_bytes ... FAILED

thread '...' panicked at crates/gaze/tests/audit_safety_net_raw_span.rs:151:9:
assertion `left == right` failed: manifest raw_span 18..23 must address the ORIGINAL bytes that token "<a6bb2bea:Email_2>" restores to; raw[18..23] = "lid t"
  left: " tail"
 right: "lid t"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

### 2. GREEN with the fix

```
running 1 test
test safety_net_resolve_manifest_raw_span_indexes_original_request_bytes ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

### 3. Mutation probe — reverted ONLY the `EmittedTokenSpan::new` argument back to the clean span

(`raw_span` → `span`; the `map_clean_span_to_raw` call left in place, bound to `_raw_span`, so the
helpers still compile and run and only the recorded coordinate changes.)

```
running 1 test
test safety_net_resolve_manifest_raw_span_indexes_original_request_bytes ... FAILED

assertion `left == right` failed: manifest raw_span 18..23 must address the ORIGINAL bytes that token "<17344347:Email_2>" restores to; raw[18..23] = "lid t"
  left: " tail"
 right: "lid t"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

Restored, re-run:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

Non-zero observed failure count under mutation → the test is not vacuous.

### 4. No regression in the two downstream consumers

`cargo test -p gaze-token-bridge --all-features` — all suites pass:

```
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
```

`cargo test -p gaze-proxy --all-features` — all 16 suites pass (48/7/22/19+1 ignored/12/1/3/1/11/20/6/1/5/10/15/10), e.g.:

```
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
test result: ok. 19 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.14s
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 29.32s
```

`cargo test -p gaze-pii --all-features` — all 13 suites pass, including the pre-existing safety-net
suite (`157 passed`, `42 passed`, `16 passed`, …); `0 failed` everywhere. I did not cite a
`--workspace --all-features` run, so none of the known ~101-failure kiji subprocess-timeout class
(todo #2404) is involved either way.

### 5. Gates

```
cargo fmt --all -- --check                                              -> clean
cargo clippy --workspace --all-features --all-targets -- -D warnings    -> clean
```

A default-features run (`cargo clippy --workspace --all-targets -- -D warnings`) fails with 7
`dead_code` errors in `crates/gaze-cli/src/style.rs` (`RED`/`GREEN`/`YELLOW`/`RESET`,
`ansi_enabled`, `paint`, `env_non_empty`). **Pre-existing on `main`, not from this PR** — verified by
reverting `crates/gaze/src/pipeline.rs` to pristine `main` and re-running: byte-identical 7 errors.
No file under `crates/gaze-cli/` is touched by this PR.

## Axis assessment

- **Axis 2 (reversibility): fixed.** The manifest's `raw_span` now addresses the original request
  bytes the token restores to, which is what the field means and what both consumers assume.
- **Axis 1 (never leak): improved.** `gaze-proxy`'s residual authorization check becomes sound, so
  its false-accept provider-origin-PII path closes. Ambiguous mappings fail closed rather than
  recording a wrong coordinate.
- **Axis 4 (trust): improved.** No silent mismatch between a manifest coordinate and the document it
  claims to address.
- **Axis 5 (adopter ergonomics): marginal, narrow.** Two previously-silent-and-wrong cases now
  return `SafetyNetError::InvalidOutput` (see above). No new error variant and no API change; a
  well-formed manifest never hits them.
