### PR TITLE
[agent] fail closed when safety-net RESOLVE cannot verify its own result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A provably corrupt clean-text manifest now hard-errors in every safety-net
+  fallback mode, including `Tolerant`** (#403). The safety-net RESOLVE path checks
+  that the manifest describes a monotonic, gap-preserving clean/raw alignment
+  before it makes any manifest-derived decision. A manifest that fails that check
+  contradicts the document it describes, so it fails closed as
+  `SafetyNetError::InvalidOutput` with a `manifest-integrity:` message prefix
+  rather than taking the configured fallback — `Tolerant` no longer returns
+  `Ok(())` and `Redact` does not attempt redaction. This is deliberate: redaction
+  derives its deletion spans from manifest coordinates, so a manifest that
+  misdescribes the document makes the redactor delete the wrong bytes and can
+  leave the flagged PII in place. That is a leak, not a degraded-but-safe
+  document, and `Tolerant` was contracted to tolerate residual suspects, never an
+  internally inconsistent manifest. Axis 1 (never leak) over axis 5 (adopter
+  ergonomics).
+
+  **Not reachable from the public surface today.** `redact_text_with_manifest`
+  emits an `EmittedTokenSpan` for every replacing action — `Tokenize`, `Redact`,
+  `Generalize`, `FormatPreserve` — so every clean/raw divergence is described by a
+  manifest entry and a pipeline-produced manifest satisfies the check by
+  construction. The checks are defense in depth against a future change to the
+  primary pass, not a response to a reachable failure. No new `Error` or
+  `FallbackReason` variant; `gaze-types` is unchanged.
+
+### Fixed
+
+- **Safety-net RESOLVE no longer returns `Ok` on a result it cannot verify**
+  (#403). The mode's only post-condition used to be a follow-up net scan, so any
+  net whose second pass disagreed with its first — an ML net, a cached net, a
+  sampled net — could leave a raw PII fragment in the clean text and emit a
+  permanently unrestorable manifest while the call succeeded. Resolutions are now
+  planned against the unmutated clean text and rejected as a typed
+  `FallbackReason` when they overlap each other, when a suspect's coverage claim
+  contradicts the manifest, or when a residual suspect survives the follow-up
+  pass; suspects lying wholly inside a live token are audited as reversible
+  no-ops instead of destroying the token. `SafetyNetFallback::Redact` keeps its
+  existing redact-and-deliver meaning for every fallback reason.
+
 ## [0.12.0] - 2026-07-06
 
 ### Added

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -2975,6 +2975,61 @@ mod tests {
         );
     }
 
+    /// The redact path derives its deletion spans from manifest coordinates
+    /// (`expand_span_to_overlapping_manifest_entries`), so it must refuse a manifest that is
+    /// already proven inconsistent: expanding against a manifest that misdescribes the document
+    /// can delete the wrong bytes and leave the flagged PII in place.
+    ///
+    /// No public-API fixture can present a corrupt manifest to this path — the primary pass is
+    /// gap-preserving by construction — so the precondition is probed here, at the call site, to
+    /// keep it falsifiable rather than unverifiable.
+    #[test]
+    fn redact_safety_net_suspects_refuses_a_proven_inconsistent_manifest() {
+        let pipeline = Pipeline::builder()
+            .rule(DefaultRule::new(Action::Preserve))
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let mut target = ProtectionTarget::Live(&session);
+        // One clean byte separates the entries while four raw bytes do: an alignment no document
+        // can have.
+        let mut clean = CleanText {
+            text: "<aabbccdd:Email_1> tail".to_string(),
+            manifest: vec![
+                EmittedTokenSpan::new(0..18, 0..21, PiiClass::Email),
+                EmittedTokenSpan::new(19..23, 25..29, PiiClass::Email),
+            ],
+        };
+        let report = LeakReport::from_parts(
+            vec![LeakSuspect::new(
+                19..23,
+                PiiClass::Email,
+                "probe",
+                Some(0.99),
+                LeakKind::Uncovered,
+                "private_email",
+                None,
+            )],
+            Vec::new(),
+        );
+
+        let error = pipeline
+            .redact_safety_net_suspects(
+                &mut target,
+                &mut clean,
+                &report,
+                DocumentKind::Text,
+                None,
+                None,
+                false,
+            )
+            .expect_err("redaction on a proven-inconsistent manifest must fail closed");
+        assert!(
+            format!("{error}").contains("manifest-integrity"),
+            "expected the manifest-integrity class, got {error}"
+        );
+    }
+
     /// A resolution replaces raw bytes with a token restoring to exactly those bytes, so the
     /// restored document is byte-identical before and after. Probed directly for the same reason.
     #[test]

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -242,6 +242,31 @@ impl ProtectionTarget<'_, '_> {
         }
     }
 
+    /// Restores a single token against the state this run is writing into.
+    ///
+    /// Integrity checks must ask the target, not the session: in `Staged` mode the tokens this
+    /// run just emitted live in an uncommitted transaction and are invisible to the session.
+    fn restore(&self, token: &str) -> Option<String> {
+        match self {
+            Self::Live(session) => session.restore(token),
+            Self::Staged(transaction, _) => transaction.restore(token),
+        }
+    }
+
+    fn contains_token(&self, token: &str) -> bool {
+        match self {
+            Self::Live(session) => session.contains_token(token),
+            Self::Staged(transaction, _) => transaction.contains_token(token),
+        }
+    }
+
+    fn restore_strict_text(&self, text: &str) -> std::result::Result<String, crate::RestoreError> {
+        match self {
+            Self::Live(session) => session.restore_strict_text(text),
+            Self::Staged(transaction, _) => transaction.restore_strict_text(text),
+        }
+    }
+
     fn lookup_prefix_cache(&self, text: &str) -> Option<PrefixCacheHit> {
         match self {
             Self::Live(session) => session.lookup_prefix_cache(text),
@@ -1011,8 +1036,13 @@ impl Pipeline {
                             field_path,
                             SafetyNetMode::Resolve,
                         )?;
-                        (follow_up.stats.uncovered_count + follow_up.stats.partial_bleed_count > 0)
-                            .then_some(FallbackReason::ResidualSuspect)
+                        self.post_resolution_fallback_reason(
+                            target,
+                            clean,
+                            &follow_up,
+                            document_kind,
+                            field_path,
+                        )?
                     }
                 };
                 if let Some(reason) = reason {
@@ -1039,23 +1069,83 @@ impl Pipeline {
         document_kind: DocumentKind,
         field_path: Option<&str>,
     ) -> Result<Option<FallbackReason>> {
-        if report
-            .suspects
-            .iter()
-            .any(|suspect| matches!(suspect.kind, LeakKind::ClassMismatch { .. }))
-        {
-            return Ok(Some(FallbackReason::OverlapConflict));
+        if report.suspects.is_empty() {
+            return Ok(None);
         }
-        for suspect in actionable_suspects(report).into_iter().rev() {
+        validate_clean_manifest(clean)?;
+
+        // Phase 1: classify. A suspect that lies wholly inside a live token is already
+        // protected — acting on it would re-tokenize a token and destroy restore.
+        let mut protected = Vec::new();
+        let mut actionable = Vec::new();
+        for suspect in &report.suspects {
+            if suspect_is_inside_live_token(target, clean, suspect) {
+                protected.push(suspect);
+            } else if matches!(suspect.kind, LeakKind::ClassMismatch { .. }) {
+                return Ok(Some(FallbackReason::OverlapConflict));
+            } else {
+                actionable.push(suspect);
+            }
+        }
+        sort_safety_net_suspects(&mut protected);
+        sort_safety_net_suspects(&mut actionable);
+
+        // Phase 2: plan every resolution against the UNMUTATED clean text, so each plan's
+        // coordinates are established before any of them is applied.
+        let mut plans = Vec::with_capacity(actionable.len());
+        for suspect in actionable {
             let span = suspect_action_span(suspect);
             if !is_char_boundary_range(&clean.text, &span) {
                 return Ok(Some(FallbackReason::ResidualSuspect));
+            }
+            if !suspect_action_span_matches_manifest(clean, suspect) {
+                return Ok(Some(FallbackReason::OverlapConflict));
             }
             // Establish the ORIGINAL-request interval before tokenization mutates the
             // session or any clean-text / manifest state.
             let raw_span = map_clean_span_to_raw(clean, &span)?;
             let raw = clean.text[span.clone()].to_string();
-            let replacement = target.tokenize_with_family("safety_net", &suspect.class, &raw)?;
+            plans.push(PlannedSafetyNetResolution {
+                suspect,
+                clean_span: span,
+                raw_span,
+                raw,
+            });
+        }
+        // `plans` is sorted by clean-span start, so pairwise adjacency is sufficient.
+        if plans
+            .windows(2)
+            .any(|pair| ranges_overlap(&pair[0].clean_span, &pair[1].clean_span))
+        {
+            return Ok(Some(FallbackReason::OverlapConflict));
+        }
+
+        for suspect in protected {
+            self.log_safety_net_entry(
+                target,
+                suspect,
+                document_kind,
+                field_path,
+                Action::Preserve,
+                true,
+                ConflictTier::Resolve,
+                None,
+            )?;
+        }
+        if plans.is_empty() {
+            return Ok(None);
+        }
+
+        // Baseline for the restore-integrity check. `None` means the clean text was already
+        // un-restorable before this pass (e.g. the source document quotes a foreign token);
+        // exact-restore preservation is undefined there, so it is not this pass's invariant.
+        let restore_baseline = target.restore_strict_text(&clean.text).ok();
+
+        // Phase 3: apply right-to-left, so an applied plan never shifts an unapplied one.
+        for plan in plans.into_iter().rev() {
+            let suspect = plan.suspect;
+            let replacement =
+                target.tokenize_with_family("safety_net", &suspect.class, &plan.raw)?;
             self.log_safety_net_entry(
                 target,
                 suspect,
@@ -1068,14 +1158,69 @@ impl Pipeline {
             )?;
             replace_clean_span(
                 clean,
-                span.clone(),
+                plan.clean_span.clone(),
                 &replacement,
                 Some(EmittedTokenSpan::new(
-                    span.start..span.start + replacement.len(),
-                    raw_span,
+                    plan.clean_span.start..plan.clean_span.start + replacement.len(),
+                    plan.raw_span,
                     suspect.class.clone(),
                 )),
             );
+        }
+
+        validate_clean_manifest(clean)?;
+        if let Some(baseline) = restore_baseline {
+            let restored = target
+                .restore_strict_text(&clean.text)
+                .map_err(|_| manifest_integrity_error("resolution left unrestorable clean text"))?;
+            assert_resolution_preserved_restore(&baseline, &restored)?;
+        }
+        Ok(None)
+    }
+
+    /// Post-resolution verdict: replaces the bare `uncovered + partial_bleed > 0` count.
+    ///
+    /// Any residual suspect that is not already protected by a live token means the resolve pass
+    /// did not converge, so the document takes the configured fallback. Residual suspects that
+    /// *are* inside a live token are audited as no-ops rather than counted as residue — the net
+    /// is re-flagging text the pipeline already tokenized.
+    fn post_resolution_fallback_reason(
+        &self,
+        target: &mut ProtectionTarget<'_, '_>,
+        clean: &CleanText,
+        report: &LeakReport,
+        document_kind: DocumentKind,
+        field_path: Option<&str>,
+    ) -> Result<Option<FallbackReason>> {
+        if report.suspects.is_empty() {
+            return Ok(None);
+        }
+        validate_clean_manifest(clean)?;
+        let mut protected = Vec::new();
+        for suspect in &report.suspects {
+            if suspect_is_inside_live_token(target, clean, suspect) {
+                protected.push(suspect);
+                continue;
+            }
+            let reason = if matches!(suspect.kind, LeakKind::ClassMismatch { .. }) {
+                FallbackReason::OverlapConflict
+            } else {
+                FallbackReason::ResidualSuspect
+            };
+            return Ok(Some(reason));
+        }
+        sort_safety_net_suspects(&mut protected);
+        for suspect in protected {
+            self.log_safety_net_entry(
+                target,
+                suspect,
+                document_kind,
+                field_path,
+                Action::Preserve,
+                true,
+                ConflictTier::Resolve,
+                None,
+            )?;
         }
         Ok(None)
     }
@@ -1129,6 +1274,12 @@ impl Pipeline {
         fallback_reason: Option<FallbackReason>,
         log_entries: bool,
     ) -> Result<()> {
+        // Redaction spans are derived from manifest coordinates via
+        // `expand_span_to_overlapping_manifest_entries`. A manifest that misdescribes the
+        // document would make the redactor delete the wrong bytes and can leave the flagged
+        // PII in place, so a proven-inconsistent manifest must fail closed here rather than
+        // produce a "degraded but safe" document.
+        validate_clean_manifest(clean)?;
         for suspect in redaction_suspects(report).into_iter().rev() {
             let span =
                 round_span_outward_to_char_boundaries(&clean.text, suspect_action_span(suspect))?;
@@ -1452,21 +1603,6 @@ struct CleanText {
     manifest: Vec<EmittedTokenSpan>,
 }
 
-fn actionable_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
-    let mut suspects = report
-        .suspects
-        .iter()
-        .filter(|suspect| {
-            matches!(
-                suspect.kind,
-                LeakKind::Uncovered | LeakKind::PartialBleed { .. }
-            )
-        })
-        .collect::<Vec<_>>();
-    suspects.sort_by_key(|suspect| suspect_action_span(suspect).start);
-    suspects
-}
-
 fn redaction_suspects(report: &LeakReport) -> Vec<&LeakSuspect> {
     let mut suspects = report.suspects.iter().collect::<Vec<_>>();
     suspects.sort_by_key(|suspect| suspect_action_span(suspect).start);
@@ -1485,6 +1621,152 @@ fn fallback_action(fallback: SafetyNetFallback) -> Action {
         SafetyNetFallback::Strict | SafetyNetFallback::Tolerant => Action::Preserve,
         SafetyNetFallback::Redact => Action::Redact,
     }
+}
+
+struct PlannedSafetyNetResolution<'a> {
+    suspect: &'a LeakSuspect,
+    clean_span: Range<usize>,
+    raw_span: Range<usize>,
+    raw: String,
+}
+
+/// Provable manifest corruption. Reached only when the manifest contradicts the document it
+/// describes, which no pipeline-produced manifest can do; see `validate_clean_manifest`.
+///
+/// This is deliberately the same closed error variant the rest of the safety-net surface uses:
+/// the `manifest-integrity:` message prefix names the class without widening `Error`.
+fn manifest_integrity_error(message: &'static str) -> Error {
+    Error::SafetyNet(SafetyNetError::InvalidOutput {
+        message: format!("manifest-integrity: {message}"),
+    })
+}
+
+/// Every manifest entry must sit in a monotonic, gap-preserving clean/raw alignment: walking the
+/// manifest from the document start must reach each entry's own clean span unambiguously.
+///
+/// Defense in depth. `redact_text_with_manifest` emits an entry for every replacing action, so a
+/// pipeline-produced manifest satisfies this by construction and the check cannot fire from the
+/// public surface. It guards the manifest-derived decisions that follow — span/manifest agreement,
+/// live-token classification, redaction-span expansion — against a path that breaks the invariant,
+/// instead of letting those decisions silently read a manifest that lies. The corruption shape it
+/// rejects is an entry whose clean span was rewritten while its `raw_span` kept its old length.
+fn validate_clean_manifest(clean: &CleanText) -> Result<()> {
+    for emitted in &clean.manifest {
+        map_clean_span_to_raw(clean, &emitted.clean_span).map_err(|_| {
+            manifest_integrity_error("manifest entry has no unambiguous original span")
+        })?;
+    }
+    Ok(())
+}
+
+/// A safety-net resolution replaces raw bytes with a token that restores to exactly those bytes,
+/// so the restored document must be byte-identical before and after.
+fn assert_resolution_preserved_restore(baseline: &str, restored: &str) -> Result<()> {
+    if restored != baseline {
+        return Err(manifest_integrity_error(
+            "safety-net resolution broke exact restore",
+        ));
+    }
+    Ok(())
+}
+
+/// True when the suspect span lies wholly inside exactly one live token.
+///
+/// Such a suspect is the net re-flagging text the pipeline already protected. Acting on it would
+/// tokenize a token and permanently break restore, so it is audited as a no-op instead.
+fn suspect_is_inside_live_token(
+    target: &ProtectionTarget<'_, '_>,
+    clean: &CleanText,
+    suspect: &LeakSuspect,
+) -> bool {
+    let span = &suspect.span;
+    if span.start >= span.end || !is_char_boundary_range(&clean.text, span) {
+        return false;
+    }
+    let mut containing = clean.manifest.iter().filter(|emitted| {
+        emitted.clean_span.start <= span.start && span.end <= emitted.clean_span.end
+    });
+    let Some(emitted) = containing.next() else {
+        return false;
+    };
+    if containing.next().is_some() {
+        return false;
+    }
+    let Some(token) = clean.text.get(emitted.clean_span.clone()) else {
+        return false;
+    };
+    let Some(restored) = target.restore(token) else {
+        return false;
+    };
+    target.contains_token(token)
+        && emitted.raw_span.start < emitted.raw_span.end
+        && restored.len() == emitted.raw_span.end - emitted.raw_span.start
+}
+
+/// True when the suspect's own coverage claim matches what the manifest actually covers.
+///
+/// `Uncovered` must touch no emitted token, and `PartialBleed { uncovered }` must name the single
+/// gap the manifest leaves inside the suspect span. A suspect that disagrees with the manifest is
+/// stale or wrong; resolving it would tokenize across live tokens.
+fn suspect_action_span_matches_manifest(clean: &CleanText, suspect: &LeakSuspect) -> bool {
+    if suspect.span.start >= suspect.span.end || !is_char_boundary_range(&clean.text, &suspect.span)
+    {
+        return false;
+    }
+    match &suspect.kind {
+        LeakKind::Uncovered => !clean
+            .manifest
+            .iter()
+            .any(|emitted| ranges_overlap(&emitted.clean_span, &suspect.span)),
+        LeakKind::PartialBleed { uncovered } => {
+            if uncovered.start >= uncovered.end
+                || !is_char_boundary_range(&clean.text, uncovered)
+                || uncovered.start < suspect.span.start
+                || uncovered.end > suspect.span.end
+            {
+                return false;
+            }
+            let mut cursor = suspect.span.start;
+            let mut gaps = Vec::new();
+            for emitted in clean
+                .manifest
+                .iter()
+                .filter(|emitted| ranges_overlap(&emitted.clean_span, &suspect.span))
+            {
+                let covered_start = emitted.clean_span.start.max(suspect.span.start);
+                let covered_end = emitted.clean_span.end.min(suspect.span.end);
+                if cursor < covered_start {
+                    gaps.push(cursor..covered_start);
+                }
+                cursor = cursor.max(covered_end);
+            }
+            if cursor < suspect.span.end {
+                gaps.push(cursor..suspect.span.end);
+            }
+            gaps.as_slice() == [uncovered.clone()]
+        }
+        LeakKind::ClassMismatch { .. } => false,
+        _ => false,
+    }
+}
+
+/// Total order over suspects. The pairwise overlap check below is only correct on a sorted list,
+/// and the tie-breakers keep audit-row order independent of safety-net iteration order.
+fn sort_safety_net_suspects(suspects: &mut [&LeakSuspect]) {
+    suspects.sort_by(|left, right| {
+        (
+            left.span.start,
+            left.span.end,
+            left.class.to_canonical_str(),
+            left.safety_net_id.as_str(),
+        )
+            .cmp(&(
+                right.span.start,
+                right.span.end,
+                right.class.to_canonical_str(),
+                right.safety_net_id.as_str(),
+            ))
+    });
 }
 
 fn clean_to_raw_mapping_error(message: &'static str) -> Error {
@@ -2661,6 +2943,56 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Vec::new())
         }
+    }
+
+    /// `validate_clean_manifest` is defense in depth: `redact_text_with_manifest` emits an entry
+    /// for every replacing action, so a pipeline-produced manifest is gap-preserving and this
+    /// cannot fire from the public surface. Probe it directly so the check is not unfalsifiable.
+    #[test]
+    fn validate_clean_manifest_rejects_a_manifest_that_contradicts_its_own_alignment() {
+        // "<tok> tail" where the entry claims to stand for 21 raw bytes.
+        let sound = CleanText {
+            text: "<aabbccdd:Email_1> tail".to_string(),
+            manifest: vec![EmittedTokenSpan::new(0..18, 0..21, PiiClass::Email)],
+        };
+        validate_clean_manifest(&sound).expect("a gap-preserving manifest must validate");
+
+        // Same document, but the second entry's raw_span cannot follow the first: one clean byte
+        // separates the entries while four raw bytes do, so the manifest describes a document
+        // that cannot exist. This is the shape a rewritten clean span leaves behind.
+        let corrupt = CleanText {
+            text: "<aabbccdd:Email_1> tail".to_string(),
+            manifest: vec![
+                EmittedTokenSpan::new(0..18, 0..21, PiiClass::Email),
+                EmittedTokenSpan::new(19..23, 25..29, PiiClass::Email),
+            ],
+        };
+        let error = validate_clean_manifest(&corrupt)
+            .expect_err("a manifest that contradicts its own alignment must fail closed");
+        assert!(
+            format!("{error}").contains("manifest-integrity"),
+            "manifest corruption must surface as the manifest-integrity class, got {error}"
+        );
+    }
+
+    /// A resolution replaces raw bytes with a token restoring to exactly those bytes, so the
+    /// restored document is byte-identical before and after. Probed directly for the same reason.
+    #[test]
+    fn assert_resolution_preserved_restore_rejects_a_changed_restore() {
+        assert_resolution_preserved_restore(
+            "alice@example.invalid tail",
+            "alice@example.invalid tail",
+        )
+        .expect("an unchanged restore must pass");
+        let error = assert_resolution_preserved_restore(
+            "alice@example.invalid tail",
+            "alice@example.invalid",
+        )
+        .expect_err("a resolution that changed the restored document must fail closed");
+        assert!(
+            format!("{error}").contains("manifest-integrity"),
+            "broken restore must surface as the manifest-integrity class, got {error}"
+        );
     }
 
     #[test]

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1072,6 +1072,9 @@ impl Pipeline {
         if report.suspects.is_empty() {
             return Ok(None);
         }
+        // Precondition for every manifest-derived decision below. Unreachable from the public
+        // surface (the primary pass is gap-preserving by construction) but driven directly by
+        // `resolve_safety_net_suspects_refuses_a_proven_inconsistent_manifest`.
         validate_clean_manifest(clean)?;
 
         // Phase 1: classify. A suspect that lies wholly inside a live token is already
@@ -1168,6 +1171,11 @@ impl Pipeline {
             );
         }
 
+        // UNREACHABLE DEFENSE IN DEPTH — no test drives these two, at any level. They verify
+        // output that the phase-2 checks above have already proven sound, so the only thing that
+        // can trip them is a future bug in phase 3 itself. Their bodies are covered by
+        // `validate_clean_manifest_rejects_*` and `assert_resolution_preserved_restore_rejects_*`;
+        // this PLACEMENT is not covered. Do not read it as a tested guard.
         validate_clean_manifest(clean)?;
         if let Some(baseline) = restore_baseline {
             let restored = target
@@ -1195,6 +1203,9 @@ impl Pipeline {
         if report.suspects.is_empty() {
             return Ok(None);
         }
+        // Precondition for the live-token classification below. Unreachable from the public
+        // surface; driven directly by
+        // `post_resolution_fallback_reason_refuses_a_proven_inconsistent_manifest`.
         validate_clean_manifest(clean)?;
         let mut protected = Vec::new();
         for suspect in &report.suspects {
@@ -1278,7 +1289,8 @@ impl Pipeline {
         // `expand_span_to_overlapping_manifest_entries`. A manifest that misdescribes the
         // document would make the redactor delete the wrong bytes and can leave the flagged
         // PII in place, so a proven-inconsistent manifest must fail closed here rather than
-        // produce a "degraded but safe" document.
+        // produce a "degraded but safe" document. Unreachable from the public surface; driven
+        // directly by `redact_safety_net_suspects_refuses_a_proven_inconsistent_manifest`.
         validate_clean_manifest(clean)?;
         for suspect in redaction_suspects(report).into_iter().rev() {
             let span =
@@ -2975,6 +2987,95 @@ mod tests {
         );
     }
 
+    /// A `CleanText` whose entries cannot both be true: one clean byte separates them while four
+    /// raw bytes do. No document has this shape, which is exactly why only a direct call can
+    /// present it to the checks.
+    fn inconsistent_clean_text() -> CleanText {
+        CleanText {
+            text: "<aabbccdd:Email_1> tail".to_string(),
+            manifest: vec![
+                EmittedTokenSpan::new(0..18, 0..21, PiiClass::Email),
+                EmittedTokenSpan::new(19..23, 25..29, PiiClass::Email),
+            ],
+        }
+    }
+
+    fn probe_report() -> LeakReport {
+        LeakReport::from_parts(
+            vec![LeakSuspect::new(
+                19..23,
+                PiiClass::Email,
+                "probe",
+                Some(0.99),
+                LeakKind::Uncovered,
+                "private_email",
+                None,
+            )],
+            Vec::new(),
+        )
+    }
+
+    fn assert_manifest_integrity(error: Error) {
+        assert!(
+            format!("{error}").contains("manifest-integrity"),
+            "expected the manifest-integrity class, got {error}"
+        );
+    }
+
+    /// Call-site coverage for the resolve-entry precondition.
+    ///
+    /// Everything after it — live-token classification, suspect/manifest agreement, clean-to-raw
+    /// mapping — reads the manifest as ground truth, so the entry check is what makes those
+    /// decisions trustworthy. Driven directly because no reachable input can corrupt the manifest.
+    #[test]
+    fn resolve_safety_net_suspects_refuses_a_proven_inconsistent_manifest() {
+        let pipeline = Pipeline::builder()
+            .rule(DefaultRule::new(Action::Preserve))
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let mut target = ProtectionTarget::Live(&session);
+        let mut clean = inconsistent_clean_text();
+
+        let error = pipeline
+            .resolve_safety_net_suspects(
+                &mut target,
+                &mut clean,
+                &probe_report(),
+                DocumentKind::Text,
+                None,
+            )
+            .expect_err("resolution on a proven-inconsistent manifest must fail closed");
+        assert_manifest_integrity(error);
+    }
+
+    /// Call-site coverage for the follow-up-verdict precondition.
+    ///
+    /// This one classifies residual suspects as protected-or-not by asking the manifest which
+    /// spans are live tokens, so a manifest that lies would silently downgrade real residue to a
+    /// no-op.
+    #[test]
+    fn post_resolution_fallback_reason_refuses_a_proven_inconsistent_manifest() {
+        let pipeline = Pipeline::builder()
+            .rule(DefaultRule::new(Action::Preserve))
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let mut target = ProtectionTarget::Live(&session);
+        let clean = inconsistent_clean_text();
+
+        let error = pipeline
+            .post_resolution_fallback_reason(
+                &mut target,
+                &clean,
+                &probe_report(),
+                DocumentKind::Text,
+                None,
+            )
+            .expect_err("a follow-up verdict on a proven-inconsistent manifest must fail closed");
+        assert_manifest_integrity(error);
+    }
+
     /// The redact path derives its deletion spans from manifest coordinates
     /// (`expand_span_to_overlapping_manifest_entries`), so it must refuse a manifest that is
     /// already proven inconsistent: expanding against a manifest that misdescribes the document
@@ -2991,43 +3092,20 @@ mod tests {
             .expect("pipeline");
         let session = Session::new(Scope::Ephemeral).expect("session");
         let mut target = ProtectionTarget::Live(&session);
-        // One clean byte separates the entries while four raw bytes do: an alignment no document
-        // can have.
-        let mut clean = CleanText {
-            text: "<aabbccdd:Email_1> tail".to_string(),
-            manifest: vec![
-                EmittedTokenSpan::new(0..18, 0..21, PiiClass::Email),
-                EmittedTokenSpan::new(19..23, 25..29, PiiClass::Email),
-            ],
-        };
-        let report = LeakReport::from_parts(
-            vec![LeakSuspect::new(
-                19..23,
-                PiiClass::Email,
-                "probe",
-                Some(0.99),
-                LeakKind::Uncovered,
-                "private_email",
-                None,
-            )],
-            Vec::new(),
-        );
+        let mut clean = inconsistent_clean_text();
 
         let error = pipeline
             .redact_safety_net_suspects(
                 &mut target,
                 &mut clean,
-                &report,
+                &probe_report(),
                 DocumentKind::Text,
                 None,
                 None,
                 false,
             )
             .expect_err("redaction on a proven-inconsistent manifest must fail closed");
-        assert!(
-            format!("{error}").contains("manifest-integrity"),
-            "expected the manifest-integrity class, got {error}"
-        );
+        assert_manifest_integrity(error);
     }
 
     /// A resolution replaces raw bytes with a token restoring to exactly those bytes, so the

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, Mutex};
 
 use gaze::{
     Action, ClassRule, CleanDocument, ConflictTier, DefaultRule, Detection, Detector, DocumentKind,
-    EmittedTokenSpan, FallbackReason, LeakKind, LeakReportTelemetry, LeakSuspect, PiiClass,
-    Pipeline, RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, SafetyNet,
-    SafetyNetContext, SafetyNetError, Scope, Session, Value,
+    EmittedTokenSpan, LeakKind, LeakReportTelemetry, LeakSuspect, PiiClass, Pipeline, RawDocument,
+    RedactionEntry, RedactionLogError, RedactionLogger, SafetyNet, SafetyNetContext,
+    SafetyNetError, Scope, Session, Value,
 };
 
 #[derive(Clone)]

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -437,8 +437,14 @@ fn safety_net_redact_mode_keeps_aligned_span_redaction_behavior() {
     assert_eq!(report.stats.uncovered_count, 1);
 }
 
+/// A class-mismatch suspect that lies wholly inside a live token is the net re-flagging text the
+/// pipeline already protected. Resolving or redacting it would destroy a live token (and with it
+/// the restore path) to remove nothing, so it is audited as a conflict-loser no-op.
+///
+/// Before the fail-closed integrity work this fell back to redaction: the clean text became
+/// `" ok"`, the manifest was emptied, and the document was permanently irreversible.
 #[test]
-fn safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit() {
+fn safety_net_resolve_class_mismatch_inside_live_token_is_audited_noop() {
     let session = session();
     let raw = RawDocument::Text("alice@example.invalid ok".to_string());
     let baseline = text(
@@ -469,13 +475,24 @@ fn safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit() {
             &gaze::DictionaryBundle::default(),
             gaze::SafetyNetPolicy::default(),
         )
-        .expect("fallback redact");
+        .expect("protected mismatch must not fail closed");
 
     assert_eq!(report.stats.class_mismatch_count, 1);
-    assert_eq!(text(clean), " ok");
+    let clean = text(clean);
+    assert_eq!(
+        clean, baseline,
+        "protected mismatch must not alter the document"
+    );
+    assert_eq!(
+        session
+            .restore_strict_text(&clean)
+            .expect("protected mismatch stays restorable"),
+        "alice@example.invalid ok"
+    );
     assert!(logger.entries().iter().any(|entry| {
-        entry.decided_by == ConflictTier::Fallback
-            && entry.fallback_triggered == Some(FallbackReason::OverlapConflict)
+        entry.decided_by == ConflictTier::Resolve
+            && entry.conflict_loser
+            && entry.fallback_triggered.is_none()
     }));
 }
 

--- a/crates/gaze/tests/safety_net_fail_closed.rs
+++ b/crates/gaze/tests/safety_net_fail_closed.rs
@@ -115,6 +115,12 @@ impl Detector for FixedDetector {
     }
 }
 
+/// One primary-pass detection. Named because a bare `vec![a..b]` of ranges is ambiguous enough
+/// that clippy rejects it.
+fn detected(span: Range<usize>) -> Vec<Range<usize>> {
+    Vec::from([span])
+}
+
 fn text(clean: CleanDocument) -> String {
     match clean {
         CleanDocument::Text(text) => text,
@@ -235,11 +241,11 @@ fn overlapping_resolutions_under_redact_fallback_still_deliver_a_document() {
 #[test]
 fn uncovered_suspect_overlapping_a_live_token_fails_closed_with_overlap_conflict() {
     let raw = format!("{EMAIL} tail");
-    let clean_len = primary_clean(vec![0..EMAIL.len()], &raw).len();
+    let clean_len = primary_clean(detected(0..EMAIL.len()), &raw).len();
     // The net claims the WHOLE clean document is uncovered — a claim the manifest contradicts,
     // yet whose boundaries both map cleanly, so span arithmetic alone cannot catch it.
     let pipeline = pipeline_with(
-        vec![0..EMAIL.len()],
+        detected(0..EMAIL.len()),
         vec![vec![ScriptedSuspect::uncovered(0..clean_len)]],
     );
     let session = Session::new(Scope::Ephemeral).expect("session");
@@ -285,7 +291,7 @@ fn follow_up_class_mismatch_outside_a_token_fails_closed() {
     let raw = format!("{EMAIL} tail");
     // Pass 1 reports nothing; the follow-up pass reports a mismatch over untokenized text.
     let pipeline = pipeline_with(
-        vec![0..EMAIL.len()],
+        detected(0..EMAIL.len()),
         vec![Vec::new(), vec![ScriptedSuspect::class_mismatch(19..23)]],
     );
     let session = Session::new(Scope::Ephemeral).expect("session");
@@ -304,11 +310,11 @@ fn follow_up_class_mismatch_outside_a_token_fails_closed() {
 #[test]
 fn suspect_inside_a_live_token_is_a_reversible_noop() {
     let raw = format!("{EMAIL} tail");
-    let baseline = primary_clean(vec![0..EMAIL.len()], &raw);
+    let baseline = primary_clean(detected(0..EMAIL.len()), &raw);
     let token_end = baseline.find(" tail").expect("token suffix");
 
     let pipeline = pipeline_with(
-        vec![0..EMAIL.len()],
+        detected(0..EMAIL.len()),
         vec![vec![ScriptedSuspect::uncovered(2..token_end - 1)]],
     );
     let session = Session::new(Scope::Ephemeral).expect("session");
@@ -324,6 +330,9 @@ fn suspect_inside_a_live_token_is_a_reversible_noop() {
         raw
     );
 }
+
+/// One corpus row: raw document, primary-pass detections, scripted net passes.
+type CorpusDocument = (String, Vec<Range<usize>>, Vec<Vec<ScriptedSuspect>>);
 
 /// AVAILABILITY REGRESSION CORPUS.
 ///
@@ -341,22 +350,26 @@ fn availability_corpus_has_no_new_failed_closed_outcomes() {
         EMAIL.len() + 5..EMAIL.len() + 5 + OTHER.len(),
     ];
 
-    let corpus: Vec<(&str, Vec<Range<usize>>, Vec<Vec<ScriptedSuspect>>)> = vec![
+    let corpus: Vec<CorpusDocument> = vec![
         // No detections, no suspects.
-        ("plain text with no pii at all", Vec::new(), Vec::new()),
+        (
+            "plain text with no pii at all".to_string(),
+            Vec::new(),
+            Vec::new(),
+        ),
         // Primary tokenization, net silent.
-        (tail.as_str(), vec![0..EMAIL.len()], Vec::new()),
+        (tail.clone(), detected(0..EMAIL.len()), Vec::new()),
         // Two primary tokens, net silent.
-        (two.as_str(), both, Vec::new()),
+        (two.clone(), both, Vec::new()),
         // A single promotion of untokenized text.
         (
-            tail.as_str(),
+            tail.clone(),
             Vec::new(),
             vec![vec![ScriptedSuspect::uncovered(0..EMAIL.len())]],
         ),
         // Two non-overlapping promotions.
         (
-            two.as_str(),
+            two.clone(),
             Vec::new(),
             vec![vec![
                 ScriptedSuspect::uncovered(0..EMAIL.len()),
@@ -365,21 +378,21 @@ fn availability_corpus_has_no_new_failed_closed_outcomes() {
         ),
         // A promotion of trailing text alongside an existing token.
         (
-            tail.as_str(),
-            vec![0..EMAIL.len()],
+            tail.clone(),
+            detected(0..EMAIL.len()),
             vec![vec![ScriptedSuspect::uncovered(0..0)]], // replaced below with real offsets
         ),
         // A document quoting a FOREIGN gaze token: its clean text is not restorable, so the
         // restore-integrity baseline is undefined. It must still complete.
         (
-            foreign.as_str(),
-            vec![foreign_at..foreign_at + EMAIL.len()],
+            foreign.clone(),
+            detected(foreign_at..foreign_at + EMAIL.len()),
             Vec::new(),
         ),
     ];
 
     // Fill in the one fixture whose suspect span depends on the emitted token length.
-    let tail_clean = primary_clean(vec![0..EMAIL.len()], &tail);
+    let tail_clean = primary_clean(detected(0..EMAIL.len()), &tail);
     let tail_token_end = tail_clean.find(" tail").expect("token suffix");
     let promotion_next_to_token = vec![vec![ScriptedSuspect::uncovered(
         tail_token_end + 1..tail_clean.len(),

--- a/crates/gaze/tests/safety_net_fail_closed.rs
+++ b/crates/gaze/tests/safety_net_fail_closed.rs
@@ -1,0 +1,417 @@
+//! Fail-closed integrity contract for safety-net RESOLVE (solo todo #2410).
+//!
+//! `SafetyNetMode::Resolve` used to have exactly one post-condition: re-run the nets and take the
+//! fallback if the follow-up still counted uncovered/partial-bleed suspects. Every other guarantee
+//! was delegated to the net agreeing with itself on a second pass over text the first pass had just
+//! mutated. A net whose second pass disagrees with its first — an ML net, a cached net, a sampled
+//! net — could therefore drive the pipeline to `Ok(...)` with raw PII surviving in the clean text
+//! and a permanently unrestorable manifest.
+//!
+//! These tests pin the replacement contract. Each one asserts the TYPED outcome, because the
+//! interesting failure is not "did it error" but "did it produce a reason an adopter can act on":
+//! a typed `FallbackReason` lets `Tolerant`/`Redact` adopters degrade gracefully, whereas a bare
+//! integrity error is a hard stop for everyone.
+//!
+//! Synthetic fixtures only.
+
+use std::collections::VecDeque;
+use std::ops::Range;
+use std::sync::Mutex;
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, Detection, Detector, EmittedTokenSpan,
+    FallbackReason, LeakKind, LeakReport, LeakSuspect, PiiClass, Pipeline, RawDocument, SafetyNet,
+    SafetyNetContext, SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope,
+    Session,
+};
+
+const EMAIL: &str = "alice@example.invalid";
+const OTHER: &str = "bob@example.invalid";
+
+/// One scripted suspect: the net reports exactly this, whatever the text says.
+///
+/// Lying stubs are the point. A real net can report a stale or wrong span — that is the failure
+/// class this contract exists for — so the pipeline must not trust a suspect's coverage claim to
+/// agree with the manifest. It has to check.
+#[derive(Clone)]
+struct ScriptedSuspect {
+    span: Range<usize>,
+    kind: LeakKind,
+    class: PiiClass,
+}
+
+impl ScriptedSuspect {
+    fn uncovered(span: Range<usize>) -> Self {
+        Self {
+            span,
+            kind: LeakKind::Uncovered,
+            class: PiiClass::Email,
+        }
+    }
+
+    fn class_mismatch(span: Range<usize>) -> Self {
+        Self {
+            kind: LeakKind::ClassMismatch {
+                pipeline_class: PiiClass::Email,
+                safety_net_class: PiiClass::Name,
+            },
+            span,
+            class: PiiClass::Name,
+        }
+    }
+}
+
+/// A net that replays a fixed script, one entry per `check` call.
+///
+/// Deterministic by construction: no model, no sampling, no dependence on the mutated text.
+struct ScriptedNet {
+    passes: Mutex<VecDeque<Vec<ScriptedSuspect>>>,
+}
+
+impl SafetyNet for ScriptedNet {
+    fn id(&self) -> &str {
+        "scripted"
+    }
+
+    fn supported_locales(&self) -> &[gaze::LocaleTag] {
+        &[gaze::LocaleTag::Global]
+    }
+
+    fn check(
+        &self,
+        clean_text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        let pass = self.passes.lock().unwrap().pop_front().unwrap_or_default();
+        Ok(pass
+            .into_iter()
+            .filter(|suspect| suspect.span.end <= clean_text.len())
+            .map(|suspect| {
+                LeakSuspect::new(
+                    suspect.span,
+                    suspect.class,
+                    self.id(),
+                    Some(0.99),
+                    suspect.kind,
+                    "private_email",
+                    context.field_path.map(str::to_string),
+                )
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+struct FixedDetector {
+    spans: Vec<Range<usize>>,
+}
+
+impl Detector for FixedDetector {
+    fn detect(&self, _input: &str) -> Vec<Detection> {
+        self.spans
+            .iter()
+            .map(|span| Detection::new(span.clone(), PiiClass::Email, "fixed"))
+            .collect()
+    }
+}
+
+fn text(clean: CleanDocument) -> String {
+    match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    }
+}
+
+/// Tokenizing pipeline plus a scripted net. `detected` are the primary-pass Email spans.
+fn pipeline_with(detected: Vec<Range<usize>>, passes: Vec<Vec<ScriptedSuspect>>) -> Pipeline {
+    Pipeline::builder()
+        .detector(FixedDetector { spans: detected })
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(ScriptedNet {
+            passes: Mutex::new(passes.into()),
+        })
+        .build()
+        .expect("pipeline")
+}
+
+type CleanOutcome = gaze::Result<(CleanDocument, Vec<EmittedTokenSpan>, LeakReport)>;
+
+fn run(
+    pipeline: &Pipeline,
+    session: &Session,
+    raw: &str,
+    fallback: SafetyNetFallback,
+) -> CleanOutcome {
+    pipeline.clean_with_safety_net_policy_detect_context(
+        session,
+        RawDocument::Text(raw.to_string()),
+        &[gaze::LocaleTag::Global],
+        &gaze::DictionaryBundle::default(),
+        SafetyNetPolicy::new(SafetyNetMode::Resolve, fallback),
+    )
+}
+
+/// Clean text produced by the primary pass alone, for fixtures that need token offsets.
+fn primary_clean(detected: Vec<Range<usize>>, raw: &str) -> String {
+    let pipeline = pipeline_with(detected, Vec::new());
+    let session = Session::new(Scope::Ephemeral).expect("probe session");
+    text(
+        run(&pipeline, &session, raw, SafetyNetFallback::Strict)
+            .expect("primary-only baseline must succeed")
+            .0,
+    )
+}
+
+fn expect_fallback(outcome: CleanOutcome, expected: FallbackReason, context: &str) {
+    match outcome {
+        Err(gaze::Error::SafetyNetFallback(reason)) => {
+            assert_eq!(reason, expected, "{context}: wrong typed fallback reason");
+        }
+        Err(other) => panic!(
+            "{context}: expected a typed SafetyNetFallback({expected:?}) an adopter can act on, \
+             got {other:?}"
+        ),
+        Ok((clean, manifest, _)) => panic!(
+            "{context}: expected fail-closed, got Ok(clean={:?}, manifest={manifest:?})",
+            text(clean)
+        ),
+    }
+}
+
+/// Overlapping resolutions must be rejected before any of them is applied.
+///
+/// Applied in sequence they tokenize over a token emitted moments earlier: the second suspect's
+/// raw fragment survives in the clean text and the manifest can no longer restore the document.
+/// This is the shipped-main leak from todo #2410.
+#[test]
+fn overlapping_resolutions_fail_closed_with_a_typed_overlap_conflict() {
+    let raw = format!("{EMAIL} and {OTHER}");
+    let pipeline = pipeline_with(
+        Vec::new(),
+        vec![vec![
+            ScriptedSuspect::uncovered(0..EMAIL.len()),
+            ScriptedSuspect::uncovered(10..EMAIL.len() + 5),
+        ]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    expect_fallback(
+        run(&pipeline, &session, &raw, SafetyNetFallback::Strict),
+        FallbackReason::OverlapConflict,
+        "overlapping resolutions",
+    );
+}
+
+/// The same overlap under the DEFAULT fallback still delivers a document.
+///
+/// This is the adopter-facing half of the contract: integrity failures route through the existing
+/// fallback path, so `SafetyNetFallback::Redact` keeps meaning redact-and-deliver.
+#[test]
+fn overlapping_resolutions_under_redact_fallback_still_deliver_a_document() {
+    let raw = format!("{EMAIL} and {OTHER}");
+    let pipeline = pipeline_with(
+        Vec::new(),
+        vec![vec![
+            ScriptedSuspect::uncovered(0..EMAIL.len()),
+            ScriptedSuspect::uncovered(10..EMAIL.len() + 5),
+        ]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let (clean, _, _) = run(&pipeline, &session, &raw, SafetyNetFallback::Redact)
+        .expect("Redact fallback must deliver a redacted document, not a hard error");
+    let clean = text(clean);
+    assert!(
+        !clean.contains("example.invalid"),
+        "redact fallback left raw fixture bytes in {clean:?}"
+    );
+}
+
+/// A suspect claiming `Uncovered` while overlapping a live token contradicts the manifest.
+///
+/// Resolving it would tokenize across an existing token. The suspect/manifest agreement gate
+/// rejects it instead of trusting the net's coverage claim.
+#[test]
+fn uncovered_suspect_overlapping_a_live_token_fails_closed_with_overlap_conflict() {
+    let raw = format!("{EMAIL} tail");
+    let clean_len = primary_clean(vec![0..EMAIL.len()], &raw).len();
+    // The net claims the WHOLE clean document is uncovered — a claim the manifest contradicts,
+    // yet whose boundaries both map cleanly, so span arithmetic alone cannot catch it.
+    let pipeline = pipeline_with(
+        vec![0..EMAIL.len()],
+        vec![vec![ScriptedSuspect::uncovered(0..clean_len)]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    expect_fallback(
+        run(&pipeline, &session, &raw, SafetyNetFallback::Strict),
+        FallbackReason::OverlapConflict,
+        "uncovered suspect overlapping a live token",
+    );
+}
+
+/// Overlap detection is only correct on sorted plans.
+///
+/// Two overlapping suspects reported non-adjacently (A, C, B with A∩B) are invisible to a pairwise
+/// scan of the report order. Without the ordering discipline both would be applied and the
+/// document would be corrupted.
+#[test]
+fn overlapping_suspects_reported_non_adjacently_still_fail_closed() {
+    let raw = format!("{EMAIL} and {OTHER} and more text here");
+    let pipeline = pipeline_with(
+        Vec::new(),
+        vec![vec![
+            ScriptedSuspect::uncovered(0..5),
+            ScriptedSuspect::uncovered(40..45),
+            ScriptedSuspect::uncovered(3..8),
+        ]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    expect_fallback(
+        run(&pipeline, &session, &raw, SafetyNetFallback::Strict),
+        FallbackReason::OverlapConflict,
+        "non-adjacent overlapping suspects",
+    );
+}
+
+/// A residual suspect that only appears on the FOLLOW-UP pass must still be decided.
+///
+/// The follow-up verdict used to be `uncovered_count + partial_bleed_count > 0`, so a follow-up
+/// class mismatch counted as zero residue and the document completed silently.
+#[test]
+fn follow_up_class_mismatch_outside_a_token_fails_closed() {
+    let raw = format!("{EMAIL} tail");
+    // Pass 1 reports nothing; the follow-up pass reports a mismatch over untokenized text.
+    let pipeline = pipeline_with(
+        vec![0..EMAIL.len()],
+        vec![Vec::new(), vec![ScriptedSuspect::class_mismatch(19..23)]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    expect_fallback(
+        run(&pipeline, &session, &raw, SafetyNetFallback::Strict),
+        FallbackReason::OverlapConflict,
+        "follow-up class mismatch",
+    );
+}
+
+/// A suspect wholly inside a live token is the net re-flagging protected text.
+///
+/// It must be a reversible no-op: acting on it would tokenize a token and destroy restore, and
+/// failing closed would deny a document that is already safe.
+#[test]
+fn suspect_inside_a_live_token_is_a_reversible_noop() {
+    let raw = format!("{EMAIL} tail");
+    let baseline = primary_clean(vec![0..EMAIL.len()], &raw);
+    let token_end = baseline.find(" tail").expect("token suffix");
+
+    let pipeline = pipeline_with(
+        vec![0..EMAIL.len()],
+        vec![vec![ScriptedSuspect::uncovered(2..token_end - 1)]],
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+
+    let (clean, manifest, _) = run(&pipeline, &session, &raw, SafetyNetFallback::Strict)
+        .expect("a suspect inside a live token must not fail closed");
+    let clean = text(clean);
+    assert_eq!(manifest.len(), 1, "no second token may be emitted");
+    assert_eq!(
+        session
+            .restore_strict_text(&clean)
+            .expect("protected suspect keeps the document restorable"),
+        raw
+    );
+}
+
+/// AVAILABILITY REGRESSION CORPUS.
+///
+/// Every document here completes on unmodified main. The integrity checks must not turn any of
+/// them into a failed-closed outcome under any fallback setting. This is the explicit guard
+/// against importing the availability drop the upstream fail-closed commit shipped.
+#[test]
+fn availability_corpus_has_no_new_failed_closed_outcomes() {
+    let tail = format!("{EMAIL} tail");
+    let two = format!("{EMAIL} and {OTHER}");
+    let foreign = format!("ticket <deadbeef:Email_9> from {EMAIL}");
+    let foreign_at = foreign.find(EMAIL).expect("email offset");
+    let both = vec![
+        0..EMAIL.len(),
+        EMAIL.len() + 5..EMAIL.len() + 5 + OTHER.len(),
+    ];
+
+    let corpus: Vec<(&str, Vec<Range<usize>>, Vec<Vec<ScriptedSuspect>>)> = vec![
+        // No detections, no suspects.
+        ("plain text with no pii at all", Vec::new(), Vec::new()),
+        // Primary tokenization, net silent.
+        (tail.as_str(), vec![0..EMAIL.len()], Vec::new()),
+        // Two primary tokens, net silent.
+        (two.as_str(), both, Vec::new()),
+        // A single promotion of untokenized text.
+        (
+            tail.as_str(),
+            Vec::new(),
+            vec![vec![ScriptedSuspect::uncovered(0..EMAIL.len())]],
+        ),
+        // Two non-overlapping promotions.
+        (
+            two.as_str(),
+            Vec::new(),
+            vec![vec![
+                ScriptedSuspect::uncovered(0..EMAIL.len()),
+                ScriptedSuspect::uncovered(EMAIL.len() + 5..EMAIL.len() + 5 + OTHER.len()),
+            ]],
+        ),
+        // A promotion of trailing text alongside an existing token.
+        (
+            tail.as_str(),
+            vec![0..EMAIL.len()],
+            vec![vec![ScriptedSuspect::uncovered(0..0)]], // replaced below with real offsets
+        ),
+        // A document quoting a FOREIGN gaze token: its clean text is not restorable, so the
+        // restore-integrity baseline is undefined. It must still complete.
+        (
+            foreign.as_str(),
+            vec![foreign_at..foreign_at + EMAIL.len()],
+            Vec::new(),
+        ),
+    ];
+
+    // Fill in the one fixture whose suspect span depends on the emitted token length.
+    let tail_clean = primary_clean(vec![0..EMAIL.len()], &tail);
+    let tail_token_end = tail_clean.find(" tail").expect("token suffix");
+    let promotion_next_to_token = vec![vec![ScriptedSuspect::uncovered(
+        tail_token_end + 1..tail_clean.len(),
+    )]];
+
+    let fallbacks = [
+        SafetyNetFallback::Strict,
+        SafetyNetFallback::Tolerant,
+        SafetyNetFallback::Redact,
+    ];
+    let mut completed = 0usize;
+    let mut failed_closed = Vec::new();
+    for (index, (raw, detected, passes)) in corpus.iter().enumerate() {
+        for fallback in fallbacks {
+            let passes = if index == 5 {
+                promotion_next_to_token.clone()
+            } else {
+                passes.clone()
+            };
+            let pipeline = pipeline_with(detected.clone(), passes);
+            let session = Session::new(Scope::Ephemeral).expect("session");
+            match run(&pipeline, &session, raw, fallback) {
+                Ok(_) => completed += 1,
+                Err(error) => failed_closed.push(format!("doc {index} / {fallback:?}: {error:?}")),
+            }
+        }
+    }
+    assert!(
+        failed_closed.is_empty(),
+        "{} of {} corpus runs failed closed: {failed_closed:?}",
+        failed_closed.len(),
+        completed + failed_closed.len()
+    );
+    assert_eq!(completed, corpus.len() * fallbacks.len());
+}


### PR DESCRIPTION
Resolves solo todo #2410

Rebased onto `main` (`a7708ee`) now that #402 has merged; base retargeted from
`agent/fix-2409-safety-net-raw-span` to `main`. This PR depends on #402's
`map_clean_span_to_raw` / `map_clean_boundary_to_raw` helpers.

## The defect

`SafetyNetMode::Resolve` had exactly one post-condition: re-run the nets and take the fallback if
`uncovered_count + partial_bleed_count > 0`. No manifest self-check, no restore-equality check, no
overlap check between planned resolutions, no gate on a suspect's coverage claim agreeing with the
manifest. The entire guarantee was delegated to the net agreeing with itself on a second pass over
text the first pass had just mutated — so any net whose second pass disagrees with its first (an ML
net, a cached net, a sampled net: `KijiDistilbertSafetyNet`, `OpenAiFilterSafetyNet`) could drive the
pipeline to `Ok(...)` with a raw PII fragment surviving in the clean text and a permanently
unrestorable manifest. Resolve is the default mode since v0.8.1.

## What this PR does

Ports the integrity checks from `b1a336e` onto main's `ProtectionTarget<'_, '_>` shape (hand-ported,
not cherry-picked):

- **Two-phase plan-then-apply.** `PlannedSafetyNetResolution` captures every resolution's clean span,
  raw span, and raw bytes against the *unmutated* clean text, before any of them is applied.
- **Cross-plan overlap rejection.** Overlapping resolutions were the leak: applied in sequence, the
  second tokenizes over a token emitted moments earlier.
- **`sort_safety_net_suspects`.** A total order over suspects — the pairwise overlap scan is only
  correct on a sorted list.
- **`suspect_is_inside_live_token`.** A suspect wholly inside a live token is the net re-flagging
  already-protected text; it becomes an audited no-op instead of a destructive action.
- **`suspect_action_span_matches_manifest`.** `Uncovered` must touch no emitted token; `PartialBleed`
  must name the single gap the manifest actually leaves.
- **`post_resolution_fallback_reason`** replaces the bare residual count, so a follow-up class
  mismatch is decided instead of counted as zero residue.
- **`validate_clean_manifest`** and a restore-equality check across the resolution.

`ProtectionTarget` gains `restore`, `contains_token`, and `restore_strict_text`. This matters: main
refactored onto `Live(&Session)` / `Staged(&mut SessionTransaction)`, and `b1a336e` predates that. In
`Staged` (daemon) mode the tokens this run just emitted live in an uncommitted transaction, so asking
the *session* would answer "not a token" for tokens the same run created — the integrity checks have
to ask the target.

## `SafetyNetFallback::Redact` — before/after, and the one new hard-error class

**Before:** `SafetyNetFallback::Redact => self.redact_safety_net_suspects(...)` — redact and deliver.
**After:** `SafetyNetFallback::Redact => self.redact_safety_net_suspects(...)` — redact and deliver.
Byte-identical; `b1a336e`'s rewrite of that arm to `Err(Error::SafetyNetFallback(reason))` is **not
inherited**. All the integrity failures above route through the existing fallback path as typed
`FallbackReason`s, so every fallback mode keeps its meaning.

The analytic question was whether Redact can be applied when the failure is specifically a
manifest-integrity failure. **It cannot.** `redact_safety_net_suspects` derives its deletion spans
from manifest coordinates via `expand_span_to_overlapping_manifest_entries`, so a manifest that
misdescribes the document makes the redactor delete the *wrong* bytes and can leave the flagged PII in
place. That is a leak, not a degraded-but-safe document.

So there is exactly one new hard-error class, named and enumerated:

**`manifest-integrity:` — provable manifest corruption.** Carried on the existing
`SafetyNetError::InvalidOutput` variant (no new `Error` variant, no new `FallbackReason`,
`gaze-types` untouched — the closed error-variant set is preserved). Exactly four call sites reach it,
all of them "the manifest contradicts the document it describes":

| # | line | site | condition |
|---|------|------|-----------|
| 1 | 1075 | `resolve_safety_net_suspects` entry | an entry's clean span is not reachable by a monotonic, gap-preserving walk |
| 2 | 1171 | after applying resolutions | as above, plus `assert_resolution_preserved_restore` — this pass changed what the document restores to |
| 3 | 1198 | `post_resolution_fallback_reason` entry | as site 1, before residual suspects are classified against the manifest |
| 4 | 1282 | `redact_safety_net_suspects` entry | as site 1; the only guard on the `SafetyNetMode::Redact` path, which never runs the resolve checks |

### Axis-5 tradeoff, disclosed per AGENTS.md rule 1

This class hard-errors in **every** fallback mode, including `Tolerant`, which otherwise returns
`Ok(())`. `Tolerant` was contracted to tolerate residual suspects, never an internally inconsistent
manifest, and the alternative (redacting against a manifest known to misdescribe the document) is the
leak argued above — so axis 1 beats axis 5 here. It is **not reachable from the public surface
today**: `redact_text_with_manifest` emits an `EmittedTokenSpan` for every replacing action
(`Tokenize`, `Redact`, `Generalize`, `FormatPreserve`), so every clean/raw divergence is described by
an entry and a pipeline-produced manifest satisfies the check by construction. The checks are defense
in depth against a future change to the primary pass. Written up in `CHANGELOG.md` under Unreleased.

### Also deliberately not inherited from `b1a336e`

- The unconditional `map_clean_span_to_raw` + overlapping-span error inside
  `redact_safety_net_suspects`. It buys nothing here: redaction emits no manifest entry, is terminal,
  and overlapping deletions are a sound superset delete. Inheriting it would fail documents that
  `SafetyNetMode::Redact` delivers today.
- The unconditional pre-resolution `restore_strict_text`. It hard-errors any document whose clean text
  was already unrestorable — e.g. one quoting a foreign gaze token — even when no safety net acted.
  Here the baseline is taken only when a resolution will actually mutate the document, and only when
  it is computable (`.ok()`).
- `validate_clean_manifest`'s `mapped != emitted.raw_span` arm: a clean span's boundaries always
  coincide with its own entry's edges, so a successful walk returns exactly the recorded raw bounds.
  Provably unreachable, and shipping it would be dead code.

## Evidence

Toolchain `rustc 1.96.0 (ac68faa20 2026-05-25)` (repo pin). **`RUSTUP_TOOLCHAIN` alone is not
sufficient** — without `RUSTC`/`RUSTDOC` also bound to the pinned toolchain, the `tests/contracts.rs`
trybuild compiler guard fires and produces 2 spurious failures. All numbers below were taken with:

```
export RUSTUP_TOOLCHAIN=1.96.0
export RUSTC=$(rustup which --toolchain 1.96.0 rustc)
export RUSTDOC=$(rustup which --toolchain 1.96.0 rustdoc)
```

Synthetic fixtures only (`alice@example.invalid`, `bob@example.invalid`). New suite:
`crates/gaze/tests/safety_net_fail_closed.rs` — a deterministic `ScriptedNet` replaying one fixed
suspect list per `check` call, no model, no sampling. Tests assert the **typed** outcome, because the
interesting failure is not "did it error" but "did it produce a reason an adopter can act on".

### 1. RED on unmodified `main` — 6 of 7, with visible leaks

```
overlapping resolutions: expected fail-closed, got Ok(clean="<2293f964:Email_2>mail_1>bob@example.invalid", manifest=[EmittedTokenSpan { clean_span: 0..18, raw_span: 0..21, class: Email }])
redact fallback left raw fixture bytes in "<3025c1d7:Email_2>mail_1>bob@example.invalid"
non-adjacent overlapping suspects: expected fail-closed, got Ok(clean="<fbcf9e27:Email_3>bcf9e27:Email_2>ample.invalid and bob@example.in<fbcf9e27:Email_1> and more text here", manifest=[EmittedTokenSpan { clean_span: 0..18, raw_span: 0..5, class: Email }, EmittedTokenSpan { clean_span: 66..84, raw_span: 40..45, class: Email }])
follow-up class mismatch: expected fail-closed, got Ok(clean="<caa6d7e4:Email_1> tail", manifest=[EmittedTokenSpan { clean_span: 0..18, raw_span: 0..21, class: Email }])
uncovered suspect overlapping a live token: expected fail-closed, got Ok(clean="<21d626b1:Email_2>", manifest=[EmittedTokenSpan { clean_span: 0..18, raw_span: 0..23, class: Email }])
protected suspect keeps the document restorable: UnknownToken { class: Custom("unknown"), ordinal: 0, raw: "<eda22667:Email_2>>" }

test result: FAILED. 1 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out
```

The one that passes is the availability corpus — that is the point of it.

### 1b. On #402 alone (raw_span fix only) — still 6 RED

Records precisely what this PR adds on top of #402: two of the six stop being silent leaks and become
**untyped** errors, i.e. a hard stop for `Tolerant`/`Redact` adopters rather than a graceful degrade.

```
overlapping resolutions: expected a typed SafetyNetFallback(OverlapConflict) an adopter can act on, got SafetyNet(InvalidOutput { message: "clean-to-raw end mapping failed" })
non-adjacent overlapping suspects: expected a typed SafetyNetFallback(OverlapConflict) an adopter can act on, got SafetyNet(InvalidOutput { message: "clean-to-raw end mapping failed" })
follow-up class mismatch: expected fail-closed, got Ok(clean="<f0e629b0:Email_1> tail", ...)
uncovered suspect overlapping a live token: expected fail-closed, got Ok(clean="<555aa9a2:Email_2>", manifest=[EmittedTokenSpan { clean_span: 0..18, raw_span: 0..26, class: Email }])

test result: FAILED. 1 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out
```

### 2. GREEN after the fix

```
test follow_up_class_mismatch_outside_a_token_fails_closed ... ok
test overlapping_resolutions_fail_closed_with_a_typed_overlap_conflict ... ok
test overlapping_suspects_reported_non_adjacently_still_fail_closed ... ok
test uncovered_suspect_overlapping_a_live_token_fails_closed_with_overlap_conflict ... ok
test overlapping_resolutions_under_redact_fallback_still_deliver_a_document ... ok
test suspect_inside_a_live_token_is_a_reversible_noop ... ok
test availability_corpus_has_no_new_failed_closed_outcomes ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

### 3a. Mutation probes on check BODIES — 8 of 8 RED

Each probe disables one check's logic and re-runs. **This measures whether each check's body is
load-bearing. It says nothing about whether each call site is.** Those are separate experiments and
3b is the one that covers placement.

```
########## PROBE: overlap-plans (integration) ##########
test overlapping_suspects_reported_non_adjacently_still_fail_closed ... FAILED
test overlapping_resolutions_under_redact_fallback_still_deliver_a_document ... FAILED
test overlapping_resolutions_fail_closed_with_a_typed_overlap_conflict ... FAILED
test result: FAILED. 4 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: span-matches-manifest (integration) ##########
test uncovered_suspect_overlapping_a_live_token_fails_closed_with_overlap_conflict ... FAILED
test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: sort-suspects (integration) ##########
test overlapping_suspects_reported_non_adjacently_still_fail_closed ... FAILED
test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: live-token (integration) ##########
test safety_net_resolve_class_mismatch_inside_live_token_is_audited_noop ... FAILED
test result: FAILED. 15 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: post-resolution (integration) ##########
test follow_up_class_mismatch_outside_a_token_fails_closed ... FAILED
test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: validate-manifest (unit) ##########
test pipeline::tests::redact_safety_net_suspects_refuses_a_proven_inconsistent_manifest ... FAILED
test pipeline::tests::validate_clean_manifest_rejects_a_manifest_that_contradicts_its_own_alignment ... FAILED
test result: FAILED. 158 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: restore-equality (unit) ##########
test pipeline::tests::assert_resolution_preserved_restore_rejects_a_changed_restore ... FAILED
test result: FAILED. 159 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

########## PROBE: redact-precondition (unit) ##########
test pipeline::tests::redact_safety_net_suspects_refuses_a_proven_inconsistent_manifest ... FAILED
test result: FAILED. 159 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

### 3b. Mutation probes on `validate_clean_manifest` CALL-SITE PLACEMENT

The probes in 3a neuter shared check bodies, so the `validate-manifest` probe takes all four call
sites down at once and cannot tell them apart. Removing **one call site at a time** and running the
whole `gaze-pii --all-features` suite is a different measurement — and initially a much worse result.

**As first submitted, 3 of the 4 sites were unfalsifiable** (reviewer-run, and reproduced here):

| site | line | failures with the site removed |
|------|------|-------------------------------|
| resolve entry | 1075 | **0** |
| post-apply | 1171 | **0** |
| post_resolution entry | 1198 | **0** |
| redact entry | 1282 | 1 |

Commit `1e3a451` adds call-site tests for the resolve-entry and post_resolution-entry preconditions,
driving both private methods directly with a manifest whose clean and raw gaps disagree — the
technique `8885d8a` already used for the redact site. Re-run, same method, control included:

```
########## CONTROL (all four sites present) ##########
total failures: 0
########## SITE PROBE: resolve-entry ##########
total failures: 1
########## SITE PROBE: post-apply ##########
total failures: 0
########## SITE PROBE: post-resolution ##########
total failures: 1
########## SITE PROBE: redact-entry ##########
total failures: 1
########## RESTORED ##########
total failures: 0
```

**Placement coverage is now 3 of 4 sites, not 4 of 4.** Site 2 (line 1171, the post-apply
verification) cannot be driven at any level: it checks output that the phase-2 gates above have
already proven sound, so the only thing that can trip it is a future bug in phase 3 itself. Per the
reviewer's direction it is kept — defense in depth against a future primary-pass change is the point
— and is now labelled in code so no future reader mistakes it for a tested guard:

```rust
// UNREACHABLE DEFENSE IN DEPTH — no test drives these two, at any level. They verify
// output that the phase-2 checks above have already proven sound, so the only thing that
// can trip them is a future bug in phase 3 itself. Their bodies are covered by
// `validate_clean_manifest_rejects_*` and `assert_resolution_preserved_restore_rejects_*`;
// this PLACEMENT is not covered. Do not read it as a tested guard.
```

Sites 1, 3, and 4 carry a one-line comment naming the test that drives them.

### 4. Availability regression corpus — zero new failed-closed outcomes

`availability_corpus_has_no_new_failed_closed_outcomes`: 7 documents × 3 fallback settings
(`Strict`/`Tolerant`/`Redact`) = 21 runs, every one `Ok` before and after. The corpus covers: no
detections and no suspects; primary tokenization with a silent net; two primary tokens; a single
promotion of untokenized text; two non-overlapping promotions; a promotion alongside an existing
token; and a document quoting a **foreign** gaze token (unrestorable clean text — the case
`b1a336e`'s unconditional restore would have failed).

**Exactly one outcome changed anywhere in the workspace**, and it changed for the better:
`safety_net_resolve_overlap_conflict_triggers_redact_fallback_audit` — a class-mismatch suspect wholly
inside a live token — used to redact the live token away, leaving clean text `" ok"`, an empty
manifest, and a permanently irreversible document. It is now an audited reversible no-op, renamed
`safety_net_resolve_class_mismatch_inside_live_token_is_audited_noop` and re-asserted on the new
behavior (document unchanged, `restore_strict_text` round-trips, audit row is a
`ConflictTier::Resolve` conflict-loser with no fallback). Observed diff:

```
assertion `left == right` failed
  left: "<96d0c709:Email_1> ok"
 right: " ok"
```

That is: **1 document changed outcome, 0 new failed-closed outcomes.**

### 5. Gates, post-rebase, with the toolchain bound as above

```
cargo fmt --all -- --check                                             -> clean
cargo clippy --workspace --all-features --all-targets -- -D warnings   -> clean
cargo test -p gaze-pii --all-features                                  -> 0 failures across all suites
```

Downstream all-features suites, `0 failed` in every one: `gaze-token-bridge` (7 suites),
`gaze-proxy` (16), `gaze-cli` (10), `gaze-assembly` / `gaze-mcp-core` / `gaze-document` (13).

No `--workspace --all-features` test run is cited, so the known ~101-failure kiji subprocess-timeout
class (todo #2404) is not involved. The 7 pre-existing `dead_code` errors in
`crates/gaze-cli/src/style.rs` under DEFAULT-features clippy also pre-exist on `main`; no `gaze-cli`
source file is in this diff.

## Axis assessment (AGENTS.md rule 1)

- **Axis 1 (never leak): substantially improved.** The silent-Ok-with-leaked-PII path is closed; the
  `Redact`-fallback leak (`"<hex:Email_2>mail_1>bob@example.invalid"`) is closed; a corrupt manifest
  can no longer drive redaction into deleting the wrong bytes.
- **Axis 2 (reversibility): improved.** An `Ok` resolve now implies the document still restores;
  suspects inside live tokens no longer destroy a live token and empty the manifest.
- **Axis 4 (trust): improved, with one honest gap.** Integrity failures carry a typed
  `FallbackReason` or the named `manifest-integrity:` class, and no error variants were added. The
  gap: one of the four call sites is unfalsifiable and is labelled as such rather than counted as
  covered.
- **Axis 5 (adopter ergonomics): one disclosed tradeoff.** `Redact` keeps its meaning and the corpus
  shows no new failed-closed outcomes, but a provably corrupt manifest now hard-errors in every
  fallback mode including `Tolerant`. CHANGELOG'd under Unreleased.
- **Performance:** one extra manifest walk per resolve document with suspects, and one restore pass
  per document that actually gets a resolution. Correctness axes beat performance per AGENTS.md.
