### PR TITLE
[agent] Add a corpus-informed scheme/www-anchored URL recognizer to the core rule floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Scheme- and `www.`-anchored URL detection at the deterministic rule floor**
+  (todo #2254). The new `url.anchored` recognizer in the embedded `core` bundle
+  tokenizes `http://`, `https://`, and `www.`-prefixed URLs as
+  `custom:url`, covering the whole span rather than a fragment. It is
+  `safety_tier = "safe_default"` with `locales = ["global"]`, so it is active for
+  every adopter of the default bundle, not only for configurations that
+  auto-activate locale-gated recognizers.
+
+  Measured against the EN/DE benchmark holdout: those two anchors carry 232 of
+  276 gold URL spans and 6,385 of 7,209 leaked URL bytes (88.6%), while matching
+  nothing at all across the 1,024 documents of the committed A4 negative corpus.
+  Before this recognizer the deterministic rule floor was completely blind to
+  URLs — 0 of 276 spans covered and 0 overlapped.
+
+  **Bare-host URLs are deliberately out of scope.** Shapes with no scheme and no
+  `www.` prefix (`example.invalid/orders`) are the remaining 47 spans / 887 bytes
+  / 12.3% of the bucket, and 97 of the 1,024 committed negative documents contain
+  bare-host shapes, so no bare-host rule can clear the negative gate.
+
+  **Documentation, repository, and example URLs are tokenized.** This is
+  intentional: 16 of the 232 gold spans the rule covers are themselves
+  reference-host shaped, so the corpus treats a reference URL inside a
+  data-owner document as PII to protect. Tokens stay restorable through the
+  manifest, so an over-tokenized public URL is a recoverable ergonomics cost
+  (axis 5) while an under-tokenized private one is a leak (axis 1).
+
+### Changed
+
+- `[bundle-tokenization-drift]` snapshot for bundle `core` regenerated: the new
+  `url.anchored` recognizer adds one `custom:url` detection to the drift corpus
+  (11 -> 12 detections). No existing detection changed class, span, or shape.
+
 ## [0.12.0] - 2026-07-06
 
 ### Added

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -717,3 +717,44 @@ base = 0.70
 priority = 70
 
 [recognizers.token]
+
+# URL detection is anchored on an explicit scheme (`http://`, `https://`) or a `www.` host
+# prefix. Measured against the EN/DE holdout, those two anchors carry 232 of 276 gold URL spans
+# and 6,385 of 7,209 leaked URL bytes (88.6%), while matching NOTHING in all 1,024 documents of
+# the committed A4 negative corpus. Bare-host URLs (`example.invalid/path`, no scheme, no `www.`)
+# are the remaining 12.3% and are deliberately NOT matched: 97 of the A4 negative documents
+# contain bare-host shapes, so no bare-host rule can clear the negative gate. See todo #2254.
+#
+# Trailing-boundary rule: the match runs to the next whitespace and then gives back a run of
+# sentence and markup punctuation, so `.`, `,`, `;`, `:`, `!`, `?`, `)`, `]`, `}`, `>`, `"`, `'`
+# never end a match. This is measured, not stylistic: running to whitespace without giving those
+# back covers exactly the same 232 spans and 6,385 bytes but produces non-gold matched bytes in
+# 107 holdout documents instead of 12 — sentence-final punctuation is the dominant
+# false-positive driver for an anchored URL rule.
+[[recognizers]]
+id = "url.anchored"
+safety_tier = "safe_default"
+class = "custom:url"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+# Adding this recognizer changes the committed core-no-policy bundle tokenization snapshot
+# (11 -> 12 detections). The `// drift-ack:` acknowledgement the gate requires lives in
+# crates/gaze-recognizers/tests/url_anchored.rs; the rationale lives in CHANGELOG.md.
+pattern = '''(?i)(?-u:\b)(?:https?://|www\.)[^\s]*[^\s.,;:!?)\]}>"']'''
+
+[recognizers.scoring]
+# Above the 0.70 heuristic floor: an explicit scheme or `www.` prefix is structural evidence,
+# not a guess. Priority stays below `email.global` (90) so an explicit address inside a URL
+# keeps its Email class rather than being absorbed; note that `PiiClass::Custom` sits at
+# class-priority 50 in the resolver, so Email wins containment regardless.
+base = 0.75
+priority = 85
+
+[recognizers.token]
+
+[recognizers.source]
+origin = "project-authored"
+license = "Apache-2.0"

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 29);
+        assert_eq!(rulepack.recognizers.len(), 30);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
@@ -101,7 +101,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 29);
+        assert_eq!(rulepack.recognizers.len(), 30);
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/tests/url_anchored.rs
+++ b/crates/gaze-recognizers/tests/url_anchored.rs
@@ -1,0 +1,465 @@
+//! Regression fixtures for the `url.anchored` core recognizer (solo todo #2254).
+//!
+//! EVERY positive fixture here encodes a structural shape that was MEASURED in the Dataiku EN/DE
+//! holdout, not a phrasing invented alongside the implementation. The previous attempt at this
+//! bucket (todo #2412) shipped 962 green tests for cue phrasings — "my profile is <url>" — that
+//! occur in 5 of 276 gold spans, and produced a zero real-corpus delta. The measured distribution
+//! of the 232 gold URL spans this rule covers is:
+//!
+//! | dimension      | counts                                            |
+//! |----------------|---------------------------------------------------|
+//! | anchor         | scheme 169, `www.` 63                             |
+//! | shape          | host-only 149, has-path 83                        |
+//! | host labels    | 2 labels 57, 3 labels 154, 4 labels 21            |
+//! | query string   | 1                                                 |
+//! | reference host | 16 (docs./github/wiki/example. shapes — all GOLD) |
+//!
+//! Every row above has at least one fixture below, and the trailing-boundary cases exist because
+//! the boundary rule was chosen on measured false-positive counts (107 documents vs 12).
+//!
+//! Fixture values are synthetic and use reserved `.invalid` hosts only.
+
+use gaze::Context;
+use gaze::{
+    Action, CleanDocument, DictionaryBundle, LocaleChain, LocaleTag, PiiClass, Pipeline,
+    RawDocument, RuleSpec, Rulepack, RulepackSource, Scope, Session,
+};
+use gaze_recognizers::embedded;
+
+/// `global` only, which is what `core`'s `default_locales` already resolves to.
+fn global_chain() -> LocaleChain {
+    LocaleChain::merge_cli_policy_rulepack_default(None, None, Some(&[LocaleTag::Global]))
+}
+
+fn empty_context() -> Context {
+    Context {
+        dictionaries: std::collections::HashMap::new(),
+        class_map: std::collections::HashMap::new(),
+        fields: serde_json::Map::new(),
+    }
+}
+
+fn url_class() -> PiiClass {
+    PiiClass::custom("url")
+}
+
+/// The core bundle assembled through the real activation path, with `global` as the only active
+/// locale and locale-gated auto-activation OFF.
+///
+/// That combination is deliberate: it is the weakest configuration a default adopter can have.
+/// `url.anchored` is declared `safety_tier = "safe_default"` with `locales = ["global"]`, so
+/// `gaze_assembly::detector_wiring::recognizer_activates` admits it unconditionally. If the
+/// recognizer were instead declared `locale_gated`, every test in this file would still pass under
+/// the benchmark's configuration (which sets `auto_activate_locale_gated = true` for all three
+/// cells) while a default adopter got no URL protection at all. Building the pipeline this way is
+/// what makes that distinction fail loudly rather than silently.
+fn pipeline() -> Pipeline {
+    let rulepack = Rulepack::load(RulepackSource::Embedded(
+        embedded("core").expect("core rulepack"),
+    ))
+    .expect("core loads");
+    let mut policy = gaze::Policy::default();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: url_class(),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+    policy.rulepacks.bundled = vec!["core".to_string()];
+    policy.rulepacks.auto_activate_locale_gated = false;
+    gaze_assembly::build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &global_chain(),
+        None,
+    )
+    .expect("pipeline")
+}
+
+fn clean_with(pipeline: &Pipeline, session: &Session, text: &str) -> String {
+    let (clean, _, _) = pipeline
+        .clean_with_safety_net_detect_context(
+            session,
+            RawDocument::Text(text.to_string()),
+            &[LocaleTag::Global],
+            &DictionaryBundle::default(),
+        )
+        .expect("clean");
+    match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    }
+}
+
+fn clean(text: &str) -> String {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    clean_with(&pipeline(), &session, text)
+}
+
+/// Asserts the whole URL is gone from the clean text and that the surrounding prose survives.
+///
+/// Whole-span coverage is the point: the scorecard shows the NER passes already overlap ~100 URL
+/// entities while fully covering zero of them, at roughly 8.4 covered bytes of ~26 per entity.
+/// A fragment is not a fix.
+fn assert_url_removed(text: &str, url: &str, surviving_context: &[&str]) {
+    let cleaned = clean(text);
+    assert!(
+        !cleaned.contains(url),
+        "url {url:?} survived tokenization in {cleaned:?}"
+    );
+    for fragment in surviving_context {
+        assert!(
+            cleaned.contains(fragment),
+            "context {fragment:?} should survive but is missing from {cleaned:?}"
+        );
+    }
+}
+
+fn assert_unchanged(text: &str) {
+    assert_eq!(clean(text), text, "text must pass through untouched");
+}
+
+// drift-ack: url.anchored adds one `custom:url` detection to the committed core-no-policy
+// bundle tokenization snapshot (11 -> 12 detections on the drift corpus). No pre-existing
+// detection changes class, span, or shape. Rationale and measurements: CHANGELOG.md [Unreleased].
+#[test]
+fn drift_corpus_url_line_is_the_only_new_core_detection() {
+    // Pins the shape the snapshot change records: the drift corpus' URL line is tokenized whole,
+    // and the surrounding prose on that line is untouched.
+    assert_url_removed(
+        "URL fragment https://example.invalid/orders#id12345 remains a URL fragment.",
+        "https://example.invalid/orders#id12345",
+        &["URL fragment ", " remains a URL fragment."],
+    );
+}
+
+// ---------------------------------------------------------------- anchor: scheme (169 of 232)
+
+#[test]
+fn https_scheme_host_only_is_tokenized() {
+    assert_url_removed(
+        "Reach the portal at https://portal.example.invalid for the update.",
+        "https://portal.example.invalid",
+        &["Reach the portal at ", " for the update."],
+    );
+}
+
+#[test]
+fn http_scheme_is_tokenized_like_https() {
+    assert_url_removed(
+        "Legacy mirror http://mirror.example.invalid is deprecated.",
+        "http://mirror.example.invalid",
+        &["Legacy mirror ", " is deprecated."],
+    );
+}
+
+#[test]
+fn uppercase_scheme_is_tokenized() {
+    assert_url_removed(
+        "See HTTPS://PORTAL.EXAMPLE.INVALID for details.",
+        "HTTPS://PORTAL.EXAMPLE.INVALID",
+        &["See ", " for details."],
+    );
+}
+
+// ---------------------------------------------------------------- anchor: www. (63 of 232)
+
+#[test]
+fn www_prefixed_host_without_scheme_is_tokenized() {
+    assert_url_removed(
+        "Details live at www.profile.example.invalid today.",
+        "www.profile.example.invalid",
+        &["Details live at ", " today."],
+    );
+}
+
+#[test]
+fn uppercase_www_is_tokenized() {
+    assert_url_removed(
+        "Mirror WWW.PROFILE.EXAMPLE.INVALID is stale.",
+        "WWW.PROFILE.EXAMPLE.INVALID",
+        &["Mirror ", " is stale."],
+    );
+}
+
+// ---------------------------------------------------------------- shape: has-path (83 of 232)
+
+#[test]
+fn scheme_with_path_segments_is_tokenized_whole() {
+    assert_url_removed(
+        "Account page https://profile.example.invalid/users/alice/settings was updated.",
+        "https://profile.example.invalid/users/alice/settings",
+        &["Account page ", " was updated."],
+    );
+}
+
+#[test]
+fn trailing_slash_is_part_of_the_url() {
+    assert_url_removed(
+        "Open https://portal.example.invalid/orders/ now.",
+        "https://portal.example.invalid/orders/",
+        &["Open ", " now."],
+    );
+}
+
+#[test]
+fn fragment_is_part_of_the_url() {
+    // Mirrors the committed drift-corpus URL line shape.
+    assert_url_removed(
+        "URL fragment https://example.invalid/orders#id12345 remains a fragment.",
+        "https://example.invalid/orders#id12345",
+        &["URL fragment ", " remains a fragment."],
+    );
+}
+
+// ---------------------------------------------------------------- query string (1 of 232)
+
+#[test]
+fn query_string_is_part_of_the_url() {
+    assert_url_removed(
+        "Search https://portal.example.invalid/find?q=alice&page=2 returned one row.",
+        "https://portal.example.invalid/find?q=alice&page=2",
+        &["Search ", " returned one row."],
+    );
+}
+
+// ---------------------------------------------------------------- host label counts (57/154/21)
+
+#[test]
+fn two_label_host_is_tokenized() {
+    assert_url_removed(
+        "Root site https://example.invalid is live.",
+        "https://example.invalid",
+        &["Root site ", " is live."],
+    );
+}
+
+#[test]
+fn four_label_host_is_tokenized() {
+    assert_url_removed(
+        "Deep host https://eu.west.portal.example.invalid responded.",
+        "https://eu.west.portal.example.invalid",
+        &["Deep host ", " responded."],
+    );
+}
+
+// ---------------------------------------------------------------- trailing-boundary rule
+//
+// The boundary rule gives back trailing sentence and markup punctuation. Measured: without the
+// give-back, coverage is identical (232 spans / 6,385 bytes) but non-gold matched bytes appear in
+// 107 holdout documents instead of 12.
+
+#[test]
+fn sentence_final_period_is_not_part_of_the_url() {
+    let cleaned = clean("Log in at https://portal.example.invalid.");
+    assert!(
+        cleaned.ends_with('.'),
+        "the sentence period must survive outside the token: {cleaned:?}"
+    );
+    assert!(!cleaned.contains("https://portal.example.invalid"));
+}
+
+#[test]
+fn trailing_comma_in_a_list_is_not_part_of_the_url() {
+    let cleaned = clean("Mirrors: https://a.example.invalid, https://b.example.invalid.");
+    assert!(
+        !cleaned.contains("a.example.invalid") && !cleaned.contains("b.example.invalid"),
+        "both list members must be tokenized: {cleaned:?}"
+    );
+    assert!(
+        cleaned.contains(", "),
+        "the list separator must survive: {cleaned:?}"
+    );
+}
+
+#[test]
+fn enclosing_parentheses_are_not_part_of_the_url() {
+    let cleaned = clean("Details (https://portal.example.invalid) follow.");
+    assert!(!cleaned.contains("https://portal.example.invalid"));
+    assert!(
+        cleaned.contains('(') && cleaned.contains(')'),
+        "both parentheses must survive outside the token: {cleaned:?}"
+    );
+}
+
+#[test]
+fn angle_bracket_markup_is_not_part_of_the_url() {
+    let cleaned = clean("Link <https://portal.example.invalid> in the footer.");
+    assert!(!cleaned.contains("https://portal.example.invalid"));
+    assert!(
+        cleaned.contains('<') && cleaned.contains('>'),
+        "markup delimiters must survive outside the token: {cleaned:?}"
+    );
+}
+
+#[test]
+fn quoted_url_keeps_its_quotes_outside_the_token() {
+    let cleaned = clean("Href is \"https://portal.example.invalid\" exactly.");
+    assert!(!cleaned.contains("https://portal.example.invalid"));
+    assert_eq!(
+        cleaned.matches('"').count(),
+        2,
+        "both quotes must survive outside the token: {cleaned:?}"
+    );
+}
+
+#[test]
+fn interior_punctuation_is_kept_when_the_url_continues() {
+    // A path that genuinely contains `,` and `:` mid-URL must not be truncated there.
+    assert_url_removed(
+        "Batch https://portal.example.invalid/ids/a,b,c:v2/list ran.",
+        "https://portal.example.invalid/ids/a,b,c:v2/list",
+        &["Batch ", " ran."],
+    );
+}
+
+// ---------------------------------------------------------------- reference hosts (16 of 232)
+//
+// PRECISION OBLIGATION (todo #2254 item 3). This rule DOES tokenize documentation, repository,
+// and example URLs. That is deliberate, and it is what the corpus asks for: of the 232 gold URL
+// spans this rule covers, 16 are themselves documentation/repository/reference-host shaped, and
+// ZERO of the 9 non-gold anchored matches are. The benchmark's labelling policy treats a
+// reference URL inside a data-owner document as PII to protect, and axis 1 says an over-tokenized
+// public URL is a recoverable ergonomics cost while an under-tokenized private one is a leak.
+// Both are restorable through the manifest, so nothing is destroyed either way.
+
+#[test]
+fn documentation_url_is_tokenized_by_design() {
+    assert_url_removed(
+        "Full guide at https://docs.example.invalid/guide/getting-started explains it.",
+        "https://docs.example.invalid/guide/getting-started",
+        &["Full guide at ", " explains it."],
+    );
+}
+
+#[test]
+fn repository_url_is_tokenized_by_design() {
+    assert_url_removed(
+        "Source at https://github.example.invalid/org/repo builds cleanly.",
+        "https://github.example.invalid/org/repo",
+        &["Source at ", " builds cleanly."],
+    );
+}
+
+#[test]
+fn documentation_url_round_trips_through_restore() {
+    // The axis-2 half of the precision argument: an over-tokenized reference URL is not lost.
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let text = "Guide: https://docs.example.invalid/guide/getting-started here.";
+    let cleaned = clean_with(&pipeline(), &session, text);
+    assert_ne!(cleaned, text, "the reference URL must have been tokenized");
+    assert_eq!(
+        session
+            .restore_strict_text(&cleaned)
+            .expect("reference URL restores"),
+        text
+    );
+}
+
+// ---------------------------------------------------------------- HARD NEGATIVES
+//
+// The bare-host tail (47 spans / 887 bytes / 12.3%) is out of scope: 97 of the 1,024 committed A4
+// negative documents contain bare-host shapes, so a bare-host rule cannot clear the negative
+// gate. These fixtures pin that boundary so a future widening has to break a test.
+
+#[test]
+fn bare_host_without_scheme_or_www_is_not_matched() {
+    assert_unchanged("The vendor is portal.example.invalid according to the contract.");
+}
+
+#[test]
+fn bare_host_with_a_path_is_not_matched() {
+    assert_unchanged("Path reference example.invalid/orders/2026 appears in the ticket.");
+}
+
+#[test]
+fn file_name_with_a_dotted_extension_is_not_matched() {
+    assert_unchanged("Attachment quarterly.report.pdf was received.");
+}
+
+#[test]
+fn package_version_string_is_not_matched() {
+    // Shape drawn from the A4 temporal_numeric negative category.
+    assert_unchanged("Numeric benchmark 00: package version v3.1.16 shipped.");
+}
+
+#[test]
+fn scheme_prefix_alone_is_not_matched() {
+    assert_unchanged("The scheme https:// is not a URL on its own.");
+}
+
+#[test]
+fn www_prefix_alone_is_not_matched() {
+    assert_unchanged("Prefix www. carries no host.");
+}
+
+#[test]
+fn word_ending_in_www_is_not_matched() {
+    assert_unchanged("The token notwww.example is not anchored.");
+}
+
+#[test]
+fn decimal_number_is_not_matched() {
+    assert_unchanged("Length 81.9 cm and price EUR 400.13 stay intact.");
+}
+
+// ---------------------------------------------------------------- interaction with Email
+
+#[test]
+fn an_email_address_outside_a_url_still_wins_its_own_class() {
+    // Email sits at class-priority 90 and `custom:url` at 50, so an address is never absorbed
+    // into a URL token. Measured: the holdout contains 0 userinfo-style URLs, so this is a
+    // contract guard rather than a corpus-driven case.
+    let rulepack = Rulepack::load(RulepackSource::Embedded(
+        embedded("core").expect("core rulepack"),
+    ))
+    .expect("core loads");
+    let mut policy = gaze::Policy::default();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: PiiClass::Email,
+            action: Action::Tokenize,
+        },
+        RuleSpec::Class {
+            class: url_class(),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+    policy.rulepacks.bundled = vec!["core".to_string()];
+    let pipeline = gaze_assembly::build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &global_chain(),
+        None,
+    )
+    .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let (clean, manifest, _) = pipeline
+        .clean_with_safety_net_detect_context(
+            &session,
+            RawDocument::Text(
+                "Write alice@example.invalid or open https://portal.example.invalid now."
+                    .to_string(),
+            ),
+            &[LocaleTag::Global],
+            &DictionaryBundle::default(),
+        )
+        .expect("clean");
+    let cleaned = match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    };
+    assert!(!cleaned.contains("alice@example.invalid"));
+    assert!(!cleaned.contains("https://portal.example.invalid"));
+    assert_eq!(manifest.len(), 2, "one Email token and one URL token");
+    assert!(manifest.iter().any(|span| span.class == PiiClass::Email));
+    assert!(manifest.iter().any(|span| span.class == url_class()));
+}

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1291,6 +1291,7 @@ window_chars = 48
                 PiiClass::custom("credit_card"),
                 PiiClass::custom("ip_address"),
                 PiiClass::custom("eth_address"),
+                PiiClass::custom("url"),
                 PiiClass::custom("aadhaar"),
                 PiiClass::custom("nir"),
                 PiiClass::custom("steuer_id"),

--- a/crates/xtask/snapshots/core-no-policy.json
+++ b/crates/xtask/snapshots/core-no-policy.json
@@ -124,17 +124,29 @@
       "family": "session_custom_counter",
       "token_shape": "<session:Custom:ip_address_{N}>",
       "count": 1
+    },
+    {
+      "recognizer_id": "url.anchored",
+      "class": "custom:url",
+      "byte_span": {
+        "start": 1245,
+        "len": 38
+      },
+      "family": "session_custom_counter",
+      "token_shape": "<session:Custom:url_{N}>",
+      "count": 1
     }
   ],
   "stats": {
-    "detections": 11,
+    "detections": 12,
     "classes": {
       "Email": 3,
       "Name": 1,
       "custom:credit_card": 1,
       "custom:eth_address": 1,
       "custom:family:payment-card-or-iban": 1,
-      "custom:ip_address": 4
+      "custom:ip_address": 4,
+      "custom:url": 1
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a corpus-informed scheme/`www.`-anchored URL recognizer to the core rule floor. Before this change the deterministic rule floor was **100% blind to URLs** — 0 fully covered *and* 0 overlapped of 276 gold entities — and URL was the largest measured leak bucket in the no-OPF benchmark (todo #2254).

The recognizer is `safe_default` and locale-`global`, so it fires in all three benchmark cells and for default adopters, not only under the benchmark's configuration.

The rule shape was chosen by measurement over the corpus, not by intuition:

- **83.0% of gold URL spans (229/276) and 87.7% of the leaked URL bytes (6,322/7,209) carry an explicit `https://`, `http://`, or `www.` anchor.** Only the bare-host tail (47 spans, 887 bytes, 12.3%) lacks one, and that tail is deliberately left out.
- The committed A4 negative corpus (1,024 documents, 512 en / 512 de) contains **zero** scheme-anchored and **zero** `www.`-anchored URL-shaped matches, so the anchored form is provably safe against the negative corpus that #2254 item 3 requires it to clear. Bare-host shapes appear in 97 A4 documents, which is precisely why the bare-host tail is excluded.
- The boundary rule (give back trailing punctuation vs. run to whitespace) was also chosen by measurement: identical coverage, false positives in 12 documents versus 107.

## Measured result (full profile, complete EN/DE holdout + 1,024 A4 negatives)

Baseline: `origin/agent/current-gaze-benchmark` @ `3163b56`, which reproduces the committed schema-v3 scorecard exactly (URL 7,209 / 6,223 / 4,847 leaked bytes per cell).

| | rule-floor-extended | pass2-ner | full-stack-kiji-resolve ⚠ |
|---|---:|---:|---:|
| **URL leaked bytes** | 7,209 → **824** (−6,385, −88.6%) | 6,223 → **2,357** (−3,866, −62.1%) | 4,847 → **1,922** (−2,925, −60.3%) |
| **URL fully covered** | 0 → **232** | 0 → **138** | 0 → **105** |
| URL overlapped | 0 → 232 | 104 → 242 | 100 → 194 |
| URL wholly missed | 276 → **44** | 172 → **34** | 120 → **25** |
| **Total leaked bytes** | 112,453 → **106,068** (−6,385) | 44,561 → **40,695** (−3,866) | 30,693 → **27,728** (−2,965) |
| **Zero-leak documents** | 1,024 → 1,024 (+0) | 1,054 → **1,067** (+13) | 908 → **919** (+11) |

⚠ See the population caveat under deviation 3 below.

## Reproduction evidence

The full profile was run **twice** on the candidate with `--compare-baseline`. **1,117 integer leaves compared across all three cells; zero differences.** Every integer in the tables above reproduces exactly.

Gates under the repo-pinned toolchain (rustc 1.96.0): `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, and `cargo test --workspace --all-features` all pass with **zero** test failures.

## Contract intact

No change to any reversibility, manifest, or trace counter:

| | rule-floor-extended | pass2-ner | full-stack-kiji-resolve |
|---|---|---|---|
| Restore exact documents | 2910 → 2910 | 2910 → 2910 | 2250 → 2250 |
| Manifest valid documents | 2910 → 2910 | 2910 → 2910 | 2250 → 2250 |
| Manifest integrity errors | 0 → 0 | 0 → 0 | 0 → 0 |
| Redact actions | 0 → 0 | 0 → 0 | 0 → 0 |
| Strict would-reject documents | 0 → 0 | 0 → 0 | 1,268 → **1,264** (improved) |
| Completed / failed-closed | 2910 / 0 (+0) | 2910 / 0 (+0) | 2250 / 660 (+0) |

Manifest spans and final protection trace items rise in step with tokenize actions (+241 / +140 / +257), which is the expected consequence of emitting more tokens; spans, trace items, and tokenize actions stay equal to one another in every cell.

## #2254 item 8 deviations

**This PR does not clear #2254 item 8.** Strict reduction in leaked bytes: yes, decisively. No regression in any other canonical counter: **no**. All three deviations are enumerated below rather than summarized, and the merge decision belongs to the user.

For context, the release-readiness verdict fails on **both** sides — the base is not release-ready either — and the candidate is strictly better than the base on every leak gate.

### 1. False-positive increase — accepted, disclosed

| | FP bytes | FP documents |
|---|---:|---:|
| rule-floor-extended | 5,038 → 5,353 (**+315**) | 209 → 221 (**+12**) |
| pass2-ner | 27,681 → 27,775 (**+94**) | 1,943 → 1,944 (**+1**) |
| full-stack-kiji-resolve | 92,106 → 92,847 (**+741**) | 1,857 → 1,857 (+0) |

These are the **full-scale** numbers and are the ones that must be quoted; earlier quick-profile figures (+44 B / +1 doc deterministic, +151 B / 0 docs kiji) sampled only 256 of 2,910 documents and understate the cost.

The increase is caused by 9 anchored URLs that the corpus never labelled. Accepted on the following basis:

- The trade is **20:1** (rule-floor), **41:1** (pass2), and **4:1** (kiji); overall **11.5:1** — 13,216 leaked bytes removed for 1,150 false-positive bytes added.
- Scaling was checked rather than assumed: from quick (256 docs) to full (2,910 docs, ~11×), FP grew ~7× while leak reduction grew ~10×. The FP cost grew **slower** than the win, and the rule-floor ratio improved from 14:1 to 20:1.
- AGENTS.md axis 1 (never leak) beats axis 5 (adopter ergonomics), and correctness axes 1–4 beat performance.
- No principled narrowing exists. Fitting the rule to those 9 unlabelled instances was explicitly refused: it would be corpus overfitting, the same failure mode that caused a competing Kiji stack to be dropped from this wave. A clean FP column bought by special-casing unlabelled instances is worth less than an honest one.

### 2. Kiji residual/post-policy suspects 170 → 172 (+2) — confounded, not attributable

Bounded attribution, aggregate/non-PII telemetry only. The question asked was whether the 2 additional residual suspects sit in documents inside the membership-swap delta or in documents common to both scored sets. **It cannot be resolved from available telemetry, and the evidence is exactly consistent with confounding by the population swap in deviation 3:**

- At full scope, exactly **2** documents flip from zero-suspect to non-zero (`post_policy_zero_suspect_documents` 2,122 → 2,120) and suspects rise by exactly **2**; so each contributes exactly one suspect.
- At full scope, exactly **2** documents change language membership in the kiji cell (en 1,488 → 1,486, de 762 → 764) while the total stays 2,250. The arithmetic matches the swap one-for-one.
- Against a systematic mechanism: at the quick profile the recognizer is demonstrably active in the kiji cell (+41 tokenize actions), yet residual suspects do **not** move at all (20 → 20). If new URL tokens systematically changed what the observer-only post-clean pass sees, the quick profile should show it.
- There is no per-document or per-language residual telemetry, so the two documents cannot be located directly.

Disclosed as confounded pending #2414. No fix attempted.

### 3. `gold_entities_match` population failure — kiji cell is not provably like-for-like

The regression verdict fails `gold_entities_match` in the kiji cell: candidate 10,665 versus baseline 10,668, together with `pii_utf8_bytes_match` 93,985 versus 94,037.

`gaze_bench_score.py:861` computes `self.entities += len(document.spans)` from corpus ground truth and never reads `predictions`, so **for a fixed document set gold is detector-invariant**. This is not a gold-derivation defect, not entity segmentation, and not overlap attribution. The only available mechanism is a **scored-set membership swap at constant cardinality**: one document begins failing closed while a different one stops, preserving counts but not identity.

Confirmed at both scales, in both directions, with `documents` and `failed_closed_documents` identical on both sides:

| profile | documents | failed-closed | gold entities |
|---|---:|---:|---:|
| quick | 199 → 199 | 57 → 57 | 934 → **940** |
| full | 2,250 → 2,250 | 660 → 660 | 10,668 → **10,665** |

Consequences, stated precisely:

- **`rule-floor-extended` and `pass2-ner` are strictly like-for-like and quotable without caveat.** Both have `failed_closed_documents = 0` and score the complete corpus: documents 2,910 and gold 14,719, identical on both sides. There is no population to swap.
- **The `full-stack-kiji-resolve` cell is not provably like-for-like** and every figure from it in this PR carries the #2414 caveat.

For context — and as context only, not as a dismissal of the caveat — the swap is 3 gold entities out of 10,668 and 1 URL entity out of 220, against a 2,925-byte URL reduction, so it cannot plausibly account for the measured delta. The caveat stands regardless: a delta over a population that is not provably identical is not a like-for-like delta.

Tracked as todo #2414 (scored population reported as a cardinality, so membership swaps are invisible).

### 4. Class coverage losses in the kiji cell — found after this PR was drafted

This section was added after the fact and it corrects an omission in the original body. The
analysis behind the first draft read only the `URL` label. Applying a like-for-like discriminator
across **every** label — gold entity count unchanged **and** `fully_covered` or `overlapped`
decreased — shows this change also removed protection from three classes it was not aiming at:

| class | entities | fully_covered | overlapped | leaked bytes |
|---|---:|---|---|---:|
| SURNAME | 1,202 (**constant**) | 1,196 → **1,194** (−2) | 1,199 → 1,198 (−1) | +5 |
| LICENSEPLATENUM | 158 (**constant**) | 0 → 0 | 48 → **47** (−1) | +1 |
| TAXNUM | 149 (**constant**) | 0 → 0 | 10 → **9** (−1) | +8 |

All three sit in `full-stack-kiji-resolve`; `rule-floor-extended` and `pass2-ner` are clean.

**Why the entity-constant qualifier matters, and how to verify it independently.** The scorer
merges every prediction class-agnostically before computing coverage (`gaze_bench_score.py`,
`MetricAccumulator.add`: `predicted = merge_intervals(... for span in predictions)`, no class
filter). So on an unchanged population, an entity leaving the `overlapped` bucket means **no
prediction of any class intersects it any more** — the bytes are raw on the wire, not merely
attributed to the wrong class. A wrong-class token would still count as both overlapped and
covered. Anyone can re-derive the table above from `diagnostics.json`'s `per_label` block in the
two committed runs.

**Scale, stated honestly.** 2 fully-covered entities lost, +14 leaked bytes across the three
classes, against this change's −6,385 URL bytes at the rule floor. The ratio is overwhelmingly
favourable. It is disclosed because a net-favourable trade is still a trade, and because a
credential-class instance of this same mechanism was later found on a different branch and judged
serious enough to hold that work.

**Mechanism.** Every known instance is confined to `full-stack-kiji-resolve`, whose safety net
runs in resolve mode against already-tokenized output — so adding tokens upstream changes the
input that pass sees, and therefore what it predicts. It is not a resolver or collision-family
decision: a collision-precedence fix aimed at this on another branch changed **zero** of 1,117
integers. Tracked as todo #2420.

**Detection.** A `class_coverage_loss` regression gate implementing exactly this discriminator now
exists; replayed against this change it fires on all three classes above. It did not exist when
this PR was drafted, which is why the losses went unnoticed.

## Not caused by this work

Both deterministic cells report 5 `restore_decision_failures` (`restore_success_decisions` 2,905 of 2,910). These counts are **byte-identical in the base run** and predate this change entirely. Filed separately as todo #2415 so this PR's deviation list is not contaminated with a defect that is not its own.

## Scope

No change to the stable public API, the schema-v3 wire/cell/verdict shape, the root `Cargo.toml`, or the root `Cargo.lock`. No OPF, OCR, document, structured, or streaming scope. Committed baseline evidence is untouched; the comparison baseline used here is a local, gitignored file under `target/bench-data/`.

Resolves solo todo #2254.

### Status

This body presents evidence; it does not recommend a merge decision. Under `#2254` item 8 the
change is a strict, large reduction in leaked bytes with **four** categories of deviation — the
accepted false-positive increase, the confounded kiji residual +2, the population/`gold_entities_match` failure, and the class
coverage losses documented above. The merge decision rests with the maintainer.
