### PR TITLE
[agent] Add a like-for-like class coverage-loss regression gate

### DIFF
--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -1737,6 +1737,119 @@ def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, obj
     return {"passed": not failures, "failures": failures}
 
 
+CLASS_COVERAGE_LOSS_GATE = "class_coverage_loss"
+CLASS_POPULATION_EVALUABILITY_GATE = "class_population_evaluability"
+
+
+def _label_coverage(
+    run: Mapping[str, object], context: str
+) -> dict[str, tuple[int, int, int, int]] | None:
+    """Returns {label: (entities, fully_covered, overlapped, leaked_utf8_bytes)}.
+
+    Returns None when the block is ABSENT, so that two scorecards which both lack
+    it stay comparable; a PRESENT but malformed block still fails closed. Whether
+    an absent block on only one side is acceptable is decided by the caller, which
+    treats that asymmetry as a non-pass.
+    """
+    labels = run.get("per_label_recall")
+    if labels is None:
+        return None
+    if not isinstance(labels, Mapping):
+        raise ValueError(f"{context}: per_label_recall is not a table")
+    out: dict[str, tuple[int, int, int, int]] = {}
+    for name, payload in labels.items():
+        if not isinstance(payload, Mapping):
+            raise ValueError(f"{context}.per_label_recall[{name}]: not a table")
+        values = []
+        for field in ("entities", "fully_covered", "overlapped", "leaked_utf8_bytes"):
+            value = payload.get(field)
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError(
+                    f"{context}.per_label_recall[{name}].{field}: expected an integer"
+                )
+            values.append(value)
+        out[str(name)] = (values[0], values[1], values[2], values[3])
+    return out
+
+
+def _class_coverage_failures(
+    config: str,
+    candidate_run: Mapping[str, object],
+    baseline_run: Mapping[str, object],
+) -> list[dict[str, object]]:
+    """Flags any class that LOST coverage on an unchanged population.
+
+    The discriminator is deliberately narrow: for a given class, if the gold
+    entity count is IDENTICAL between baseline and candidate, then any decrease
+    in `fully_covered` or `overlapped` means protection that existed before does
+    not exist now. Because the scorer merges every prediction class-agnostically
+    before computing coverage, an entity leaving `overlapped` means NO prediction
+    of ANY class intersects it any more -- the bytes are raw, not merely
+    mislabelled. That is an axis-1 leak introduced by a change, and it is exactly
+    the condition that three manual reviews missed.
+
+    Where the entity count DIFFERS the comparison is not like-for-like, and this
+    gate emits a NON-PASS `class_population_evaluability` entry rather than
+    staying silent. Silence there would let a change hide a coverage loss by also
+    perturbing the population -- the precise shape that disqualified an earlier
+    candidate whose leak "win" came from denominator shrinkage.
+
+    Depends on the scored population being identifiable at all (todo #2414) and
+    is the companion of typed failure reporting (todo #2413).
+    """
+    failures: list[dict[str, object]] = []
+    candidate_labels = _label_coverage(candidate_run, f"candidate {config}")
+    baseline_labels = _label_coverage(baseline_run, f"baseline {config}")
+    if candidate_labels is None and baseline_labels is None:
+        # Neither side carries per-label telemetry: nothing to compare, and the
+        # symmetry means a candidate cannot dodge the gate by dropping the block.
+        return failures
+    if candidate_labels is None or baseline_labels is None:
+        # Asymmetric telemetry IS a dodge, so it is a non-pass rather than a skip.
+        failures.append(
+            {
+                "config": config,
+                "gate": CLASS_COVERAGE_LOSS_GATE,
+                "reason": "per_label_recall present on only one side, cannot evaluate",
+                "candidate_has_per_label_recall": candidate_labels is not None,
+                "baseline_has_per_label_recall": baseline_labels is not None,
+            }
+        )
+        return failures
+    for label in sorted(set(candidate_labels) & set(baseline_labels)):
+        c_entities, c_full, c_overlap, c_leaked = candidate_labels[label]
+        b_entities, b_full, b_overlap, b_leaked = baseline_labels[label]
+        if c_entities != b_entities:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": CLASS_POPULATION_EVALUABILITY_GATE,
+                    "label": label,
+                    "reason": "population_moved, cannot evaluate",
+                    "candidate_entities": c_entities,
+                    "baseline_entities": b_entities,
+                }
+            )
+            continue
+        if c_full < b_full or c_overlap < b_overlap:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": CLASS_COVERAGE_LOSS_GATE,
+                    "label": label,
+                    "entities": c_entities,
+                    "baseline_fully_covered": b_full,
+                    "candidate_fully_covered": c_full,
+                    "fully_covered_delta": c_full - b_full,
+                    "baseline_overlapped": b_overlap,
+                    "candidate_overlapped": c_overlap,
+                    "overlapped_delta": c_overlap - b_overlap,
+                    "leaked_utf8_bytes_delta": c_leaked - b_leaked,
+                }
+            )
+    return failures
+
+
 def compare_scorecards(
     candidate: Mapping[str, object], baseline: Mapping[str, object]
 ) -> dict[str, object]:
@@ -1883,6 +1996,20 @@ def compare_scorecards(
                             "baseline": baseline_values[gate],
                         }
                     )
+            try:
+                regression_failures.extend(
+                    _class_coverage_failures(
+                        config, candidate_runs[config], baseline_runs[config]
+                    )
+                )
+            except (KeyError, TypeError, ValueError) as error:
+                regression_failures.append(
+                    {
+                        "config": config,
+                        "gate": CLASS_COVERAGE_LOSS_GATE,
+                        "reason": str(error),
+                    }
+                )
 
     return {
         "schema_version": SCORECARD_SCHEMA_VERSION,

--- a/scripts/bench/test_class_coverage_gate.py
+++ b/scripts/bench/test_class_coverage_gate.py
@@ -1,0 +1,127 @@
+"""Tests for the like-for-like class coverage-loss regression gate.
+
+The gate exists because three separate manual reviews missed a credential going
+from fully protected to raw on the wire. Each test below is a MUTATION PROBE: it
+constructs the condition and asserts the gate goes red, so the gate cannot rot
+into a dormant symbol-presence check.
+"""
+
+import copy
+import unittest
+
+import gaze_bench_score as bench
+
+
+def run(label_table):
+    return {"config": "full-stack-kiji-resolve", "per_label_recall": label_table}
+
+
+def label(entities, fully_covered, overlapped, leaked=100):
+    return {
+        "entities": entities,
+        "fully_covered": fully_covered,
+        "overlapped": overlapped,
+        "leaked_utf8_bytes": leaked,
+    }
+
+
+BASE = {
+    "SECURITYTOKEN": label(157, 112, 120, 796),
+    "SURNAME": label(1202, 1196, 1199, 19),
+}
+
+
+class ClassCoverageGateTests(unittest.TestCase):
+    def failures(self, candidate_table, baseline_table=None):
+        baseline_table = BASE if baseline_table is None else baseline_table
+        return bench._class_coverage_failures(
+            "full-stack-kiji-resolve",
+            run(candidate_table),
+            run(baseline_table),
+        )
+
+    def test_identical_scorecards_pass(self):
+        self.assertEqual(self.failures(copy.deepcopy(BASE)), [])
+
+    def test_fully_covered_decrease_on_constant_population_is_red(self):
+        # MUTATION: the exact condition observed on the government-ID change.
+        candidate = copy.deepcopy(BASE)
+        candidate["SECURITYTOKEN"] = label(157, 111, 119, 828)
+        found = self.failures(candidate)
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0]["gate"], bench.CLASS_COVERAGE_LOSS_GATE)
+        self.assertEqual(found[0]["label"], "SECURITYTOKEN")
+        self.assertEqual(found[0]["entities"], 157)
+        self.assertEqual(found[0]["fully_covered_delta"], -1)
+        self.assertEqual(found[0]["overlapped_delta"], -1)
+        self.assertEqual(found[0]["leaked_utf8_bytes_delta"], 32)
+
+    def test_overlap_only_decrease_is_red(self):
+        # MUTATION: the shape observed on LICENSEPLATENUM and TAXNUM in the URL
+        # change, where fully_covered never moved and only overlap was lost.
+        candidate = copy.deepcopy(BASE)
+        candidate["SURNAME"] = label(1202, 1196, 1198, 24)
+        found = self.failures(candidate)
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0]["overlapped_delta"], -1)
+        self.assertEqual(found[0]["fully_covered_delta"], 0)
+
+    def test_coverage_gain_is_not_a_failure(self):
+        candidate = copy.deepcopy(BASE)
+        candidate["SECURITYTOKEN"] = label(157, 130, 140, 400)
+        self.assertEqual(self.failures(candidate), [])
+
+    def test_population_move_is_a_non_pass_not_a_silent_skip(self):
+        # MUTATION: this is the dodge the gate must refuse. A change that loses
+        # coverage AND perturbs the population must not slip through quietly --
+        # that is the shape that disqualified an earlier candidate whose leak
+        # "win" was denominator shrinkage.
+        candidate = copy.deepcopy(BASE)
+        candidate["SECURITYTOKEN"] = label(150, 90, 95, 900)
+        found = self.failures(candidate)
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0]["gate"], bench.CLASS_POPULATION_EVALUABILITY_GATE)
+        self.assertEqual(found[0]["reason"], "population_moved, cannot evaluate")
+        self.assertEqual(found[0]["candidate_entities"], 150)
+        self.assertEqual(found[0]["baseline_entities"], 157)
+        self.assertNotEqual(found, [], "population movement must never pass silently")
+
+    def test_absent_on_both_sides_is_comparable_as_empty(self):
+        found = bench._class_coverage_failures(
+            "full-stack-kiji-resolve",
+            {"config": "full-stack-kiji-resolve"},
+            {"config": "full-stack-kiji-resolve"},
+        )
+        self.assertEqual(found, [])
+
+    def test_asymmetric_telemetry_is_a_non_pass(self):
+        # Dropping the block on one side must not be a way to silence the gate.
+        found = bench._class_coverage_failures(
+            "full-stack-kiji-resolve",
+            {"config": "full-stack-kiji-resolve"},
+            run(copy.deepcopy(BASE)),
+        )
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0]["gate"], bench.CLASS_COVERAGE_LOSS_GATE)
+        self.assertIn("only one side", found[0]["reason"])
+
+    def test_malformed_block_fails_closed(self):
+        with self.assertRaises(ValueError):
+            bench._class_coverage_failures(
+                "full-stack-kiji-resolve",
+                run({"SECURITYTOKEN": {"entities": "many"}}),
+                run(copy.deepcopy(BASE)),
+            )
+
+    def test_gate_is_wired_into_compare_scorecards(self):
+        # Guards against the gate existing but never being invoked -- the
+        # dormant-gate failure mode. Verified through the public entry point.
+        self.assertIn(
+            "_class_coverage_failures",
+            bench.compare_scorecards.__code__.co_names,
+            "compare_scorecards must invoke the coverage gate",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a like-for-like **class coverage-loss** regression gate to the no-OPF benchmark comparison.

Three separate passes of manual analysis over three measured detection changes missed a credential
going from **fully protected to raw on the wire**, because each pass read only the label the change
was aiming at. This gate makes that condition loud.

## What it detects

For each cell and each label present in both baseline and candidate:

> if the gold **entity count is EQUAL** and **`fully_covered` or `overlapped` decreased**, emit a
> typed `class_coverage_loss` failure naming the cell, label, entity count, both deltas, and the
> leaked-byte delta.

The discriminator is exact rather than heuristic. The scorer merges every prediction
**class-agnostically** before computing coverage (`MetricAccumulator.add`:
`predicted = merge_intervals((span.start, span.end) for span in predictions)`, no class filter
anywhere). So on an unchanged population, an entity leaving the `overlapped` bucket means **no
prediction of any class intersects it any more** — those bytes are raw, not merely attributed to
the wrong class. A wrong-class token would still count as both overlapped and covered.

## The population-inequality branch, and why it is a NON-PASS

Where the entity count **differs**, the comparison is not like-for-like and the gate emits
`class_population_evaluability` with `reason: "population_moved, cannot evaluate"` — as a
**failure**, not a skip.

This is the anti-dodge property and it is deliberate. **A gate that passes silently on a shifted
population can be beaten by shifting the population.** That is not hypothetical: a candidate
earlier in this programme produced an apparent leak "win" of 2,803 → 2,587 bytes that was entirely
denominator shrinkage — 11 documents dropped out of scoring — and it was dropped for exactly that
reason. A coverage gate that went quiet under the same conditions would have blessed it.

Two related holes are closed the same way:

- **Asymmetric telemetry** — `per_label_recall` present on only one side — is a non-pass, so the
  gate cannot be silenced by dropping the field.
- **A block absent from BOTH sides** is comparable as empty, which keeps symmetric comparisons
  honest without opening a dodge.
- A **present but malformed** block fails closed.

## Evidence

### Mutation probe A — coverage-loss branch

Run through the public `compare_scorecards` entry point against a real committed scorecard:

```
== CONTROL: identical real scorecard compared against itself
   regression passed=True  coverage_loss=0  population_moved=0

== MUTATION 1: drop fully_covered for one class, population held constant
   regression passed=False  coverage_loss=1  population_moved=0
      RED: [full-stack-kiji-resolve] SECURITYTOKEN entities=157 fully_covered -1 overlapped -1 leaked +32

== RESTORE: unmutated scorecard again
   regression passed=True  coverage_loss=0  population_moved=0
```

### Mutation probe B — population-inequality branch

```
== MUTATION 2: same loss, but ALSO perturb the population (the dodge)
   regression passed=False  coverage_loss=0  population_moved=1
      NON-PASS: [full-stack-kiji-resolve] SECURITYTOKEN 157 -> 150  reason='population_moved, cannot evaluate'
```

`passed=False`. The dodge does not succeed.

### Replay over the three measured changes

```
== URL           (base -> url)
   coverage-loss failures: 3   population-not-evaluable: 17
      [full-stack-kiji-resolve] LICENSEPLATENUM: entities=158 fully_covered 0->0 (+0)  overlapped 48->47 (-1)  leaked +1
      [full-stack-kiji-resolve] SURNAME: entities=1202 fully_covered 1196->1194 (-2)  overlapped 1199->1198 (-1)  leaked +5
      [full-stack-kiji-resolve] TAXNUM: entities=149 fully_covered 0->0 (+0)  overlapped 10->9 (-1)  leaked +8
== SECURITYTOKEN (url -> sectok)
   coverage-loss failures: 0   population-not-evaluable: 20
== GOV-ID        (sectok -> govid)
   coverage-loss failures: 1   population-not-evaluable: 21
      [full-stack-kiji-resolve] SECURITYTOKEN: entities=157 fully_covered 112->111 (-1)  overlapped 120->119 (-1)  leaked +32
```

**It would have fired on 2 of the 3 changes measured today** — including the URL change, whose
SURNAME, LICENSEPLATENUM and TAXNUM losses three passes of hand analysis missed entirely because
every pass read only the URL label.

Every instance sits in `full-stack-kiji-resolve`; `rule-floor-extended` and `pass2-ner` are clean
throughout all three changes.

## A green gate does not mean nothing regressed

**In those same runs, 17, 20 and 21 labels per comparison were `population_not_evaluable`.** That
is roughly twenty labels per comparison where this gate **cannot evaluate coverage at all**,
because the scored population moved underneath it.

This must not be read as reassurance. "The coverage gate is green" currently means "no loss was
detectable among the labels whose population held still" — not "nothing regressed". Closing that
blind spot needs the scored population to be identifiable (**#2414**) and clean-stage failures to
be typed rather than collapsed into one opaque code (**#2413**). Those two todos are this gate's
prerequisites, not adjacent nice-to-haves, and the dependency is recorded in the code itself
(`gaze_bench_score.py`, `_class_coverage_failures` docstring) rather than only here.

## Detection-neutral by construction

This change **alters no detection whatsoever** — no recognizer, no rulepack, no model, no
threshold, no locale. It cannot move a leaked-byte or false-positive number, so `#2254` item 8 has
nothing to bite on.

Verified rather than asserted: the diff touches exactly two files, both under `scripts/bench/`, and
`git diff --name-only` returns **zero** paths outside that directory.

```
scripts/bench/gaze_bench_score.py
scripts/bench/test_class_coverage_gate.py
```

## Tests

`scripts/bench/test_class_coverage_gate.py` — 9 tests, each a **mutation probe** that constructs
the condition and asserts the gate goes red, rather than a symbol-presence check. One of them
asserts that `compare_scorecards` actually **invokes** the gate, so it cannot rot into a dormant
gate that exists but never runs.

Full bench suite: **96 tests OK** (was 87). Pinned toolchain (rustc 1.96.0) `cargo fmt --all --
--check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, and
`cargo test --workspace --all-features` all pass with zero failures.

## Where it lives

`gaze_bench_score.compare_scorecards`, beside the existing integer ratchets, feeding
`regression-status.json` through `run_no_opf_benchmark.py` — same fail-closed, zero-tolerance
semantics as the gates already there.

Refs solo todo #2420, #2413, #2414.
