### PR TITLE
[agent] add deterministic SECURITYTOKEN recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rule floor and 2,985 with pass2 NER. Each deterministic cell added 17
   false-positive bytes, ratios of about 180:1 and 176:1, while the rule matched
   0 of all 1,024 committed A4 negative documents. Cue anchoring is supported by
-  the corpus asymmetry: 88.1% of SECURITYTOKEN spans are cue-adjacent, versus
-  only 1.8% of URL spans.
+  the corpus asymmetry: 88.1% of SECURITYTOKEN spans have `token` or `secret`
+  in the preceding 64 characters, versus only 1.8% cue context for URL.
+
+  Arm 2 requires at least one unambiguous delimiter between cue and value.
+  Whitespace and `:`, `=`, or `#` qualify; `_` and a directly abutting `-` do
+  not. The holdout has 0 of 193 cue-context spans with no delimiter and 0 using
+  direct hyphen alone, so the requirement costs no measured gold coverage.
+  This prevents the safe default from splitting cue-prefixed snake_case
+  identifiers such as tokenization helper names. A4 does not contain this
+  identifier class; post-fix dogfooding across project documentation and Rust
+  source produced zero SECURITYTOKEN detections.
 
   **The shipped no-policy `CorePipelineConfig` default now tokenizes
   credential-shaped strings in ordinary adopter text.** Git tokens in logs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   manifest, so an over-tokenized public URL is a recoverable ergonomics cost
   (axis 5) while an under-tokenized private one is a leak (axis 1).
 
+- **Cue-anchored bearer-credential detection at the deterministic rule floor**
+  (todo #2318). The new `security_token.anchored` recognizer is one two-arm,
+  `safe_default`, global rule in the embedded `core` bundle. It protects
+  structurally typed AWS access-key/JWT shapes and high-entropy values adjacent
+  to explicit English or German credential cues, emitting the reversible
+  `custom:security_token` class.
+
+  A fresh full EN/DE comparison removed 3,065 leaked SECURITYTOKEN bytes at the
+  rule floor and 2,985 with pass2 NER. Each deterministic cell added 17
+  false-positive bytes, ratios of about 180:1 and 176:1, while the rule matched
+  0 of all 1,024 committed A4 negative documents. Cue anchoring is supported by
+  the corpus asymmetry: 88.1% of SECURITYTOKEN spans are cue-adjacent, versus
+  only 1.8% of URL spans.
+
+  **The shipped no-policy `CorePipelineConfig` default now tokenizes
+  credential-shaped strings in ordinary adopter text.** Git tokens in logs,
+  API keys in documentation, and similar cue-anchored secrets are protected
+  and remain restorable through the manifest. This is a deliberate,
+  recoverable axis-5 ergonomics cost in service of axis-1 reliability. The CLI's
+  separate no-policy stub path is unchanged.
+
 ### Changed
 
 - `[bundle-tokenization-drift]` snapshot for bundle `core` regenerated: the new

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -758,3 +758,104 @@ priority = 85
 [recognizers.source]
 origin = "project-authored"
 license = "Apache-2.0"
+
+# SECURITYTOKEN detection is split into two deliberately narrow recognizers. Measured over the
+# EN/DE holdout, the label carries 219 gold spans and 4,342 bytes, and the deterministic rule
+# floor covered NONE of it before this change (fully_covered 0 AND overlapped 0). See todo #2318.
+#
+# Why nothing unanchored: the committed A4 negative corpus is purpose-built to punish naive
+# high-entropy rules. Across its 1,024 documents, an unanchored base64url run of >=20 chars
+# matches 448 times in 320 documents (code_log_syntax 128, commerce_identifiers 128,
+# unicode_mixed_language 64); unanchored hex >=32 matches in 128 documents; a bare UUID matches
+# in 128 documents. Every rule below matches ZERO A4 documents.
+#
+# Why no validator: the closed `ValidatorKind` set is `EmailRfc`, `E164Phone`, `Luhn`, and
+# `IbanMod97`. None applies to a credential, so validator-backed matching is unavailable here
+# rather than skipped. Structural evidence carries the whole burden, which is why both rules
+# require either a fixed issuer prefix, a decodable structure, or an explicit lexical cue.
+#
+# Both rules are `locales = ["global"]` and their German cues are literal alternatives inside the
+# pattern, not `[locale.cues.*]` bundle lookups. They therefore fire on every locale chain,
+# including the `global` chain the benchmark cells and the default adopter surface both use. This
+# is deliberate: a locale-gated credential rule that silently never fires is the failure mode
+# behind todo #2403.
+
+# Provider-prefixed and structurally-typed credentials. Case-SENSITIVE by design: lowercasing
+# would admit ordinary prose words.
+#
+# `AKIA` alone accounts for 78 of the 219 gold spans (35.6%) and is the dominant character-class
+# silhouette in the corpus (U12dU7, 73 spans). `ASIA` is the AWS temporary-credential sibling of
+# the same fixed 4 + 16 shape: it has zero occurrences in this corpus and therefore contributes
+# nothing to the benchmark number, but omitting it would ship a rule that catches permanent AWS
+# keys and silently misses temporary ones. Included on axis-1 grounds for shipped adopters, at
+# zero measured corpus cost, and disclosed as such rather than counted as coverage.
+#
+# On the JWT arm: `eyJ` is NOT a vendor prefix. It is the base64url encoding of the two bytes `{"`,
+# so requiring it is equivalent to requiring that the first segment decodes to a JSON object whose
+# first key is a string — the JOSE header. Combined with the mandatory three dot-separated
+# base64url segments, this matches the RFC 7519 structure rather than a brand. That is as close to
+# validator-backed matching as the closed `ValidatorKind` set permits for a credential, and it
+# costs nothing: the arm matches zero A4 negative documents.
+[[recognizers]]
+id = "security_token.provider_prefixed"
+safety_tier = "safe_default"
+class = "custom:security_token"
+cooperates_with = ["security_token.cue_anchored"]
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''(?-u:\b)(?:(?:AKIA|ASIA)[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})(?-u:\b)'''
+
+[recognizers.scoring]
+# Highest of the two: a fixed issuer prefix with an exact length, or a decodable JOSE structure,
+# is structural proof rather than inference. Kept below `email.global` (90) for the same
+# containment reason as `url.anchored`.
+base = 0.90
+priority = 88
+
+[recognizers.token]
+
+[recognizers.source]
+origin = "project-authored"
+license = "Apache-2.0"
+
+# Cue-anchored credentials. This is the inverse of the URL finding and the reason it is safe here:
+# 193 of 219 gold SECURITYTOKEN spans (88.1%) sit immediately after an explicit lexical cue
+# ("token" 192, "sicherheitstoken" 37), where only 1.8% of gold URL spans did. The cue is what
+# makes a high-entropy run attributable; without it the same run is indistinguishable from the
+# commit hashes, order identifiers, and log payloads the A4 negatives are full of.
+#
+# The >=14 minimum length is a measured knee, not a round number. Over the holdout, with the
+# provider-prefixed rule also active: >=20 covers 101 spans at 0 non-gold matches, >=16 covers 141
+# at 1, >=14 covers 151 (3,084 of 4,342 gold bytes, 71.0%) at 1, >=12 covers 159 at 5, and >=10
+# covers 163 at 7. Relaxing from 14 to 10 buys 139 further bytes for six additional non-gold
+# matches, so 14 is where coverage stops paying for itself.
+[[recognizers]]
+id = "security_token.cue_anchored"
+safety_tier = "safe_default"
+class = "custom:security_token"
+cooperates_with = ["security_token.provider_prefixed"]
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "regex"
+# Only the credential itself is captured; the cue stays in the clean text so the sentence remains
+# readable and the token boundary is exact. Measured exact-boundary rate is 100% (every covered
+# span is exact, not merely overlapping).
+pattern = '''(?i)(?-u:\b)(?:security[ _-]?token|sicherheitstoken|zugangstoken|zugangsschl[uü]ssel|api[ _-]?key|access[ _-]?token|auth(?:orization)?[ _-]?token|bearer|token)[ \t]{0,4}(?:(?:ist|lautet|is)[ \t]{1,4})?(?:[:=#-][ \t]{0,4})?([A-Za-z0-9_-]{14,})(?-u:\b)'''
+capture_groups = [1]
+
+[recognizers.scoring]
+# Below the provider-prefixed rule: a cue plus entropy is strong evidence but weaker than a fixed
+# issuer prefix or a decodable structure. Still above the 0.70 heuristic floor.
+base = 0.80
+priority = 86
+
+[recognizers.token]
+
+[recognizers.source]
+origin = "project-authored"
+license = "Apache-2.0"

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -769,10 +769,11 @@ license = "Apache-2.0"
 # unicode_mixed_language 64); unanchored hex >=32 matches in 128 documents; a bare UUID matches
 # in 128 documents. Both arms below match ZERO A4 documents.
 #
-# Why no validator: the closed `ValidatorKind` set is `EmailRfc`, `E164Phone`, `Luhn`, and
-# `IbanMod97`. None applies to a credential, so validator-backed matching is unavailable here
-# rather than skipped. Structural evidence carries the whole burden, which is why each arm
-# requires a fixed issuer prefix, a decodable structure, or an explicit lexical cue.
+# Why no validator: the built-in `ValidatorKind` set covers email, phone, payment, network, and
+# government-ID shapes, but none applies to a bearer credential. Validator-backed matching is
+# therefore unavailable here rather than skipped. Structural evidence carries the whole burden,
+# which is why each arm requires a fixed issuer prefix, a decodable structure, or an explicit
+# lexical cue.
 #
 # Why ONE recognizer with two arms rather than two cooperating recognizers: two same-class
 # recognizers must declare `cooperates_with` (`RulepackError::SameClassWithoutCooperation`), and
@@ -807,7 +808,7 @@ kind = "regex"
 # bytes `{"`, so requiring it is equivalent to requiring that the first segment decodes to a JSON
 # object whose first key is a string -- the JOSE header. With the mandatory three dot-separated
 # base64url segments this matches RFC 7519 structure rather than a brand, which is as close to
-# validator-backed matching as the closed `ValidatorKind` set permits for a credential.
+# validator-backed matching as the built-in `ValidatorKind` set permits for a credential.
 #
 # Arm 2 (group 2), case-insensitive: cue-anchored credentials. This is the inverse of the URL
 # finding and the reason it is safe here: 193 of 219 gold spans (88.1%) sit immediately after an

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -759,100 +759,77 @@ priority = 85
 origin = "project-authored"
 license = "Apache-2.0"
 
-# SECURITYTOKEN detection is split into two deliberately narrow recognizers. Measured over the
-# EN/DE holdout, the label carries 219 gold spans and 4,342 bytes, and the deterministic rule
-# floor covered NONE of it before this change (fully_covered 0 AND overlapped 0). See todo #2318.
+# SECURITYTOKEN detection. Measured over the EN/DE holdout, the label carries 219 gold spans and
+# 4,342 bytes, and the deterministic rule floor covered NONE of it before this change
+# (fully_covered 0 AND overlapped 0). See todo #2318.
 #
 # Why nothing unanchored: the committed A4 negative corpus is purpose-built to punish naive
 # high-entropy rules. Across its 1,024 documents, an unanchored base64url run of >=20 chars
 # matches 448 times in 320 documents (code_log_syntax 128, commerce_identifiers 128,
 # unicode_mixed_language 64); unanchored hex >=32 matches in 128 documents; a bare UUID matches
-# in 128 documents. Every rule below matches ZERO A4 documents.
+# in 128 documents. Both arms below match ZERO A4 documents.
 #
 # Why no validator: the closed `ValidatorKind` set is `EmailRfc`, `E164Phone`, `Luhn`, and
 # `IbanMod97`. None applies to a credential, so validator-backed matching is unavailable here
-# rather than skipped. Structural evidence carries the whole burden, which is why both rules
-# require either a fixed issuer prefix, a decodable structure, or an explicit lexical cue.
+# rather than skipped. Structural evidence carries the whole burden, which is why each arm
+# requires a fixed issuer prefix, a decodable structure, or an explicit lexical cue.
 #
-# Both rules are `locales = ["global"]` and their German cues are literal alternatives inside the
-# pattern, not `[locale.cues.*]` bundle lookups. They therefore fire on every locale chain,
-# including the `global` chain the benchmark cells and the default adopter surface both use. This
-# is deliberate: a locale-gated credential rule that silently never fires is the failure mode
-# behind todo #2403.
-
-# Provider-prefixed and structurally-typed credentials. Case-SENSITIVE by design: lowercasing
-# would admit ordinary prose words.
+# Why ONE recognizer with two arms rather than two cooperating recognizers: two same-class
+# recognizers must declare `cooperates_with` (`RulepackError::SameClassWithoutCooperation`), and
+# when two cooperating recognizers actually co-fire on one span the resolver merges their ids into
+# a `+`-joined composite (`a+b`). The benchmark scorer's source-ID grammar admits only
+# `[._:/-]` as separators, so that composite fails closed with "expected a metadata-only stable
+# identifier" — measured at 40 trace items across 40 documents. A single recognizer emits one
+# stable id per detection and sidesteps the whole question. See todo #2416.
 #
-# `AKIA` alone accounts for 78 of the 219 gold spans (35.6%) and is the dominant character-class
-# silhouette in the corpus (U12dU7, 73 spans). `ASIA` is the AWS temporary-credential sibling of
-# the same fixed 4 + 16 shape: it has zero occurrences in this corpus and therefore contributes
-# nothing to the benchmark number, but omitting it would ship a rule that catches permanent AWS
-# keys and silently misses temporary ones. Included on axis-1 grounds for shipped adopters, at
-# zero measured corpus cost, and disclosed as such rather than counted as coverage.
-#
-# On the JWT arm: `eyJ` is NOT a vendor prefix. It is the base64url encoding of the two bytes `{"`,
-# so requiring it is equivalent to requiring that the first segment decodes to a JSON object whose
-# first key is a string — the JOSE header. Combined with the mandatory three dot-separated
-# base64url segments, this matches the RFC 7519 structure rather than a brand. That is as close to
-# validator-backed matching as the closed `ValidatorKind` set permits for a credential, and it
-# costs nothing: the arm matches zero A4 negative documents.
+# `locales = ["global"]` with the German cues carried as literal pattern alternatives rather than
+# `[locale.cues.*]` bundle lookups, so this fires on every locale chain including the one a default
+# adopter gets. A locale-gated credential rule that silently never fires is the failure mode behind
+# todo #2403.
 [[recognizers]]
-id = "security_token.provider_prefixed"
+id = "security_token.anchored"
 safety_tier = "safe_default"
 class = "custom:security_token"
-cooperates_with = ["security_token.cue_anchored"]
 enabled = true
 locales = ["global"]
 
 [recognizers.match]
 kind = "regex"
-pattern = '''(?-u:\b)(?:(?:AKIA|ASIA)[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})(?-u:\b)'''
-
-[recognizers.scoring]
-# Highest of the two: a fixed issuer prefix with an exact length, or a decodable JOSE structure,
-# is structural proof rather than inference. Kept below `email.global` (90) for the same
-# containment reason as `url.anchored`.
-base = 0.90
-priority = 88
-
-[recognizers.token]
-
-[recognizers.source]
-origin = "project-authored"
-license = "Apache-2.0"
-
-# Cue-anchored credentials. This is the inverse of the URL finding and the reason it is safe here:
-# 193 of 219 gold SECURITYTOKEN spans (88.1%) sit immediately after an explicit lexical cue
-# ("token" 192, "sicherheitstoken" 37), where only 1.8% of gold URL spans did. The cue is what
-# makes a high-entropy run attributable; without it the same run is indistinguishable from the
-# commit hashes, order identifiers, and log payloads the A4 negatives are full of.
+# Arm 1 (group 1), case-SENSITIVE via `(?-i:...)`: provider-prefixed and structurally-typed
+# credentials. `AKIA` alone accounts for 78 of the 219 gold spans (35.6%) and is the dominant
+# character-class silhouette in the corpus (U12dU7, 73 spans). `ASIA` is the AWS
+# temporary-credential sibling of the same fixed 4 + 16 shape: zero occurrences in this corpus, so
+# it contributes nothing to the benchmark number, but omitting it would ship a rule that catches
+# permanent AWS keys and silently misses temporary ones. Included on axis-1 grounds at zero
+# measured corpus cost, and disclosed as such rather than counted as coverage.
 #
-# The >=14 minimum length is a measured knee, not a round number. Over the holdout, with the
-# provider-prefixed rule also active: >=20 covers 101 spans at 0 non-gold matches, >=16 covers 141
-# at 1, >=14 covers 151 (3,084 of 4,342 gold bytes, 71.0%) at 1, >=12 covers 159 at 5, and >=10
-# covers 163 at 7. Relaxing from 14 to 10 buys 139 further bytes for six additional non-gold
-# matches, so 14 is where coverage stops paying for itself.
-[[recognizers]]
-id = "security_token.cue_anchored"
-safety_tier = "safe_default"
-class = "custom:security_token"
-cooperates_with = ["security_token.provider_prefixed"]
-enabled = true
-locales = ["global"]
-
-[recognizers.match]
-kind = "regex"
-# Only the credential itself is captured; the cue stays in the clean text so the sentence remains
-# readable and the token boundary is exact. Measured exact-boundary rate is 100% (every covered
-# span is exact, not merely overlapping).
-pattern = '''(?i)(?-u:\b)(?:security[ _-]?token|sicherheitstoken|zugangstoken|zugangsschl[uü]ssel|api[ _-]?key|access[ _-]?token|auth(?:orization)?[ _-]?token|bearer|token)[ \t]{0,4}(?:(?:ist|lautet|is)[ \t]{1,4})?(?:[:=#-][ \t]{0,4})?([A-Za-z0-9_-]{14,})(?-u:\b)'''
-capture_groups = [1]
+# On the JWT alternative: `eyJ` is NOT a vendor prefix. It is the base64url encoding of the two
+# bytes `{"`, so requiring it is equivalent to requiring that the first segment decodes to a JSON
+# object whose first key is a string -- the JOSE header. With the mandatory three dot-separated
+# base64url segments this matches RFC 7519 structure rather than a brand, which is as close to
+# validator-backed matching as the closed `ValidatorKind` set permits for a credential.
+#
+# Arm 2 (group 2), case-insensitive: cue-anchored credentials. This is the inverse of the URL
+# finding and the reason it is safe here: 193 of 219 gold spans (88.1%) sit immediately after an
+# explicit lexical cue ("token" 192, "sicherheitstoken" 37), where only 1.8% of gold URL spans did.
+# The cue is what makes a high-entropy run attributable; without it the same run is
+# indistinguishable from the commit hashes, order identifiers, and log payloads the A4 negatives
+# are full of. Only the credential is captured, so the cue stays in the clean text.
+#
+# The >=14 minimum length is a measured knee, not a round number. Over the holdout, with arm 1 also
+# active: >=20 covers 101 spans at 0 non-gold matches, >=16 covers 141 at 1, >=14 covers 151
+# (3,084 of 4,342 gold bytes, 71.0%) at 1, >=12 covers 159 at 5, and >=10 covers 163 at 7.
+# Relaxing from 14 to 10 buys 139 further bytes for six additional non-gold matches, so 14 is where
+# coverage stops paying for itself.
+pattern = '''(?i)(?:(?-i:(?-u:\b)((?:AKIA|ASIA)[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})(?-u:\b))|(?-u:\b)(?:security[ _-]?token|sicherheitstoken|zugangstoken|zugangsschl[uü]ssel|api[ _-]?key|access[ _-]?token|auth(?:orization)?[ _-]?token|bearer|token)[ \t]{0,4}(?:(?:ist|lautet|is)[ \t]{1,4})?(?:[:=#-][ \t]{0,4})?([A-Za-z0-9_-]{14,})(?-u:\b))'''
+capture_groups = [1, 2]
 
 [recognizers.scoring]
-# Below the provider-prefixed rule: a cue plus entropy is strong evidence but weaker than a fixed
-# issuer prefix or a decodable structure. Still above the 0.70 heuristic floor.
-base = 0.80
-priority = 86
+# Above the 0.70 heuristic floor: every match carries either a fixed issuer prefix, a decodable
+# JOSE structure, or an explicit lexical cue. Priority stays below `email.global` (90) so an
+# address is never absorbed into a credential span.
+base = 0.85
+priority = 87
 
 [recognizers.token]
 

--- a/crates/gaze-recognizers/embedded/core.toml
+++ b/crates/gaze-recognizers/embedded/core.toml
@@ -811,18 +811,26 @@ kind = "regex"
 # validator-backed matching as the built-in `ValidatorKind` set permits for a credential.
 #
 # Arm 2 (group 2), case-insensitive: cue-anchored credentials. This is the inverse of the URL
-# finding and the reason it is safe here: 193 of 219 gold spans (88.1%) sit immediately after an
-# explicit lexical cue ("token" 192, "sicherheitstoken" 37), where only 1.8% of gold URL spans did.
-# The cue is what makes a high-entropy run attributable; without it the same run is
+# finding and the reason it is safe here: 193 of 219 gold spans (88.1%) have "token" or "secret"
+# in the preceding 64 characters, where only 1.8% of gold URL spans carry their proposed cues.
+# The immediate shipping grammar is narrower: 126 spans have a supported cue directly before the
+# value, and 113 of those meet the >=14 value shape. All 193 broad cue-context spans contain a
+# delimiter other than `_` or `-`; zero abut their cue and zero use a direct hyphen as their only
+# delimiter. Requiring a real delimiter therefore keeps the 113 value-eligible gold spans.
+#
+# A direct `cue-credential` form is deliberately rejected: `-` is both plausible punctuation and
+# a legal credential/identifier character, and the holdout contains zero direct-hyphen-only gold
+# gaps. A spaced `cue - credential` form remains accepted because the whitespace is the required
+# unambiguous delimiter. The cue makes a high-entropy run attributable; without it the same run is
 # indistinguishable from the commit hashes, order identifiers, and log payloads the A4 negatives
-# are full of. Only the credential is captured, so the cue stays in the clean text.
+# are full of. Only the credential is captured, so the cue and delimiter stay in the clean text.
 #
 # The >=14 minimum length is a measured knee, not a round number. Over the holdout, with arm 1 also
 # active: >=20 covers 101 spans at 0 non-gold matches, >=16 covers 141 at 1, >=14 covers 151
 # (3,084 of 4,342 gold bytes, 71.0%) at 1, >=12 covers 159 at 5, and >=10 covers 163 at 7.
 # Relaxing from 14 to 10 buys 139 further bytes for six additional non-gold matches, so 14 is where
 # coverage stops paying for itself.
-pattern = '''(?i)(?:(?-i:(?-u:\b)((?:AKIA|ASIA)[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})(?-u:\b))|(?-u:\b)(?:security[ _-]?token|sicherheitstoken|zugangstoken|zugangsschl[uü]ssel|api[ _-]?key|access[ _-]?token|auth(?:orization)?[ _-]?token|bearer|token)[ \t]{0,4}(?:(?:ist|lautet|is)[ \t]{1,4})?(?:[:=#-][ \t]{0,4})?([A-Za-z0-9_-]{14,})(?-u:\b))'''
+pattern = '''(?i)(?:(?-i:(?-u:\b)((?:AKIA|ASIA)[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})(?-u:\b))|(?-u:\b)(?:security[ _-]?token|sicherheitstoken|zugangstoken|zugangsschl[uü]ssel|api[ _-]?key|access[ _-]?token|auth(?:orization)?[ _-]?token|bearer|token)(?:[ \t]{1,4}(?:(?:ist|lautet|is)[ \t]{1,4})?(?:[:=#-][ \t]{0,4})?|[ \t]{0,4}[:=#][ \t]{0,4})([A-Za-z0-9_-]{14,})(?-u:\b))'''
 capture_groups = [1, 2]
 
 [recognizers.scoring]

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 30);
+        assert_eq!(rulepack.recognizers.len(), 32);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
@@ -101,7 +101,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 30);
+        assert_eq!(rulepack.recognizers.len(), 32);
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/src/lib.rs
+++ b/crates/gaze-recognizers/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
         let core = embedded("core").expect("core rulepack");
         let rulepack = Rulepack::load(RulepackSource::Embedded(core)).expect("valid core");
 
-        assert_eq!(rulepack.recognizers.len(), 32);
+        assert_eq!(rulepack.recognizers.len(), 31);
         assert_eq!(rulepack.recognizers[0].id, "email.global");
         assert_eq!(rulepack.recognizers[1].id, "email.header.name");
         assert_eq!(rulepack.recognizers[2].id, "email.header.name.paren");
@@ -101,7 +101,7 @@ mod tests {
         let rulepack =
             Rulepack::load(RulepackSource::Embedded(core_extended)).expect("valid core-extended");
 
-        assert_eq!(rulepack.recognizers.len(), 32);
+        assert_eq!(rulepack.recognizers.len(), 31);
         assert!(rulepack
             .recognizers
             .iter()

--- a/crates/gaze-recognizers/tests/security_token.rs
+++ b/crates/gaze-recognizers/tests/security_token.rs
@@ -13,10 +13,12 @@
 //! | entropy proxy    | >=0.7 on 204 of 219 (93%)                                  |
 //! | utf8 length      | min 10, p25 16, median 20, p90 29, max 55                  |
 //! | fixed prefix     | `AKIA` 78 (35.6%), JWT `eyJ` 6, `sk_` 1, none 134          |
-//! | cue adjacency    | 193 of 219 (88.1%) — "token" 192, "sicherheitstoken" 37    |
+//! | cue context      | 193 of 219 (88.1%) have "token" or "secret" in prior 64 chars |
 //!
-//! The cue-adjacency row is the inverse of URL's (1.8%) and is why a cue-anchored rule is correct
-//! here and was wrong there. Only measurement distinguishes the two cases.
+//! The cue-context row is the inverse of URL's (1.8%) and is why a cue-anchored rule is correct
+//! here and was wrong there. The shipping grammar is narrower: 126 gold spans have a supported
+//! cue directly before the value, 113 meet the >=14 value shape, and all 193 broad cue-context
+//! spans contain a delimiter other than `_` or `-`. Only measurement distinguishes the cases.
 //!
 //! Fixture values are synthetic. The AWS shapes use the key IDs published in AWS's own
 //! documentation as non-functional examples; the JWT and cue-anchored payloads are hand-built
@@ -44,8 +46,8 @@ fn security_token_class() -> PiiClass {
 /// Builds the core bundle under an explicit locale chain with locale-gated auto-activation OFF.
 ///
 /// `auto_activate_locale_gated = false` is the weakest configuration a default adopter can have.
-/// Both `security_token.*` recognizers are declared `safety_tier = "safe_default"` with
-/// `locales = ["global"]`, so `recognizer_activates` admits them unconditionally. If either were
+/// The `security_token.anchored` recognizer is declared `safety_tier = "safe_default"` with
+/// `locales = ["global"]`, so `recognizer_activates` admits it unconditionally. If it were
 /// declared `locale_gated` instead, these tests would still pass under the benchmark's
 /// configuration (all three cells set `auto_activate_locale_gated = true`) while a default adopter
 /// got no credential protection at all. That is exactly the silent-inertness failure behind todo
@@ -214,6 +216,54 @@ fn cue_anchored_minimum_length_is_fourteen() {
         "Rk9PQkFSLXNhbQ",
         &["api key: ", " now active."],
     );
+}
+
+#[test]
+fn supported_real_delimiter_forms_are_tokenized() {
+    let credential = "Rk9PQkFSLXNhbXBsZQ";
+    for text in [
+        format!("token: {credential}"),
+        format!("token = {credential}"),
+        format!("token {credential}"),
+        format!("token ist {credential}"),
+        format!("token lautet {credential}"),
+        format!("token is {credential}"),
+        format!("token - {credential}"),
+    ] {
+        assert_token_removed(&text, credential, &[]);
+    }
+}
+
+// ---------------------------------------------------------- identifier-splitting hard negatives
+
+#[test]
+fn tokenization_helper_registry_is_not_split() {
+    assert_unchanged("Case A: the tokenization_helper_registry module was refactored.");
+}
+
+#[test]
+fn bearer_authentication_handler_impl_is_not_split() {
+    assert_unchanged("Case B: see bearer_authentication_handler_impl for details.");
+}
+
+#[test]
+fn api_key_rotation_schedule_v2_is_not_split() {
+    assert_unchanged("Case C: api_key_rotation_schedule_v2 is documented elsewhere.");
+}
+
+#[test]
+fn access_token_refresh_coordinator_is_not_split() {
+    assert_unchanged("Case D: access_token_refresh_coordinator handles retries.");
+}
+
+#[test]
+fn authorization_token_provider_factory_is_not_split() {
+    assert_unchanged("Case G: authorization_token_provider_factory implements the trait.");
+}
+
+#[test]
+fn tokenizer_vocabulary_builder_test_is_not_split() {
+    assert_unchanged("Case J: tokenizer_vocabulary_builder_test passed.");
 }
 
 // ----------------------------------------------------------------------- hard negatives (A4)

--- a/crates/gaze-recognizers/tests/security_token.rs
+++ b/crates/gaze-recognizers/tests/security_token.rs
@@ -1,0 +1,305 @@
+//! Regression fixtures for the `security_token.*` core recognizers (solo todo #2318).
+//!
+//! EVERY positive fixture here encodes a structural shape that was MEASURED in the Dataiku EN/DE
+//! holdout, not a phrasing invented alongside the implementation. That discipline exists because
+//! todo #2412 shipped 962 green tests for URL cue phrasings that occur in 5 of 276 gold spans and
+//! produced a zero real-corpus delta. The measured distribution of the 219 gold SECURITYTOKEN
+//! spans is:
+//!
+//! | dimension        | counts                                                     |
+//! |------------------|------------------------------------------------------------|
+//! | language         | en 117, de 102                                             |
+//! | charset          | base64url 202, hex-only 9, uuid 5, other 3                 |
+//! | entropy proxy    | >=0.7 on 204 of 219 (93%)                                  |
+//! | utf8 length      | min 10, p25 16, median 20, p90 29, max 55                  |
+//! | fixed prefix     | `AKIA` 78 (35.6%), JWT `eyJ` 6, `sk_` 1, none 134          |
+//! | cue adjacency    | 193 of 219 (88.1%) — "token" 192, "sicherheitstoken" 37    |
+//!
+//! The cue-adjacency row is the inverse of URL's (1.8%) and is why a cue-anchored rule is correct
+//! here and was wrong there. Only measurement distinguishes the two cases.
+//!
+//! Fixture values are synthetic. The AWS shapes use the key IDs published in AWS's own
+//! documentation as non-functional examples; the JWT and cue-anchored payloads are hand-built
+//! base64url strings that decode to nothing sensitive.
+
+use gaze::Context;
+use gaze::{
+    Action, CleanDocument, DictionaryBundle, LocaleChain, LocaleTag, PiiClass, Pipeline,
+    RawDocument, RuleSpec, Rulepack, RulepackSource, Scope, Session,
+};
+use gaze_recognizers::embedded;
+
+fn empty_context() -> Context {
+    Context {
+        dictionaries: std::collections::HashMap::new(),
+        class_map: std::collections::HashMap::new(),
+        fields: serde_json::Map::new(),
+    }
+}
+
+fn security_token_class() -> PiiClass {
+    PiiClass::custom("security_token")
+}
+
+/// Builds the core bundle under an explicit locale chain with locale-gated auto-activation OFF.
+///
+/// `auto_activate_locale_gated = false` is the weakest configuration a default adopter can have.
+/// Both `security_token.*` recognizers are declared `safety_tier = "safe_default"` with
+/// `locales = ["global"]`, so `recognizer_activates` admits them unconditionally. If either were
+/// declared `locale_gated` instead, these tests would still pass under the benchmark's
+/// configuration (all three cells set `auto_activate_locale_gated = true`) while a default adopter
+/// got no credential protection at all. That is exactly the silent-inertness failure behind todo
+/// #2403, so the distinction is made to fail loudly here.
+fn pipeline_for(chain: &[LocaleTag]) -> Pipeline {
+    let rulepack = Rulepack::load(RulepackSource::Embedded(
+        embedded("core").expect("core rulepack"),
+    ))
+    .expect("core loads");
+    let mut policy = gaze::Policy::default();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: security_token_class(),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+    policy.rulepacks.bundled = vec!["core".to_string()];
+    policy.rulepacks.auto_activate_locale_gated = false;
+    let locale_chain = LocaleChain::merge_cli_policy_rulepack_default(None, None, Some(chain));
+    gaze_assembly::build_pipeline(&policy, &empty_context(), &[rulepack], &locale_chain, None)
+        .expect("pipeline")
+}
+
+fn clean_under(chain: &[LocaleTag], text: &str) -> String {
+    let pipeline = pipeline_for(chain);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let (clean, _, _) = pipeline
+        .clean_with_safety_net_detect_context(
+            &session,
+            RawDocument::Text(text.to_string()),
+            chain,
+            &DictionaryBundle::default(),
+        )
+        .expect("clean");
+    match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    }
+}
+
+fn clean(text: &str) -> String {
+    clean_under(&[LocaleTag::Global], text)
+}
+
+/// Asserts the whole credential is gone and the surrounding prose survives.
+///
+/// Whole-span coverage is the point. In the before-state the kiji cell overlapped 65 of 150
+/// SECURITYTOKEN entities while fully covering only 2 — 63 overlapped-but-not-covered. A
+/// fragment of a credential is still a leaked credential.
+fn assert_token_removed(text: &str, token: &str, surviving_context: &[&str]) {
+    let cleaned = clean(text);
+    assert!(
+        !cleaned.contains(token),
+        "credential {token:?} survived tokenization in {cleaned:?}"
+    );
+    for fragment in surviving_context {
+        assert!(
+            cleaned.contains(fragment),
+            "context {fragment:?} should survive but is missing from {cleaned:?}"
+        );
+    }
+}
+
+fn assert_unchanged(text: &str) {
+    assert_eq!(clean(text), text, "text must pass through untouched");
+}
+
+// ------------------------------------------------- provider-prefixed: AWS (78 of 219 gold spans)
+
+#[test]
+fn aws_access_key_id_is_tokenized_whole() {
+    assert_token_removed(
+        "Please rotate AKIAIOSFODNN7EXAMPLE before Friday.",
+        "AKIAIOSFODNN7EXAMPLE",
+        &["Please rotate ", " before Friday."],
+    );
+}
+
+#[test]
+fn aws_temporary_access_key_id_is_tokenized_whole() {
+    // `ASIA` has zero occurrences in the holdout and contributes nothing to the benchmark number.
+    // It ships because omitting it would catch permanent AWS keys and silently miss temporary
+    // ones. This fixture is the adopter-facing guarantee, not a coverage claim.
+    assert_token_removed(
+        "Temporary credential ASIAY34FZKBOKMUTVV7A expires in one hour.",
+        "ASIAY34FZKBOKMUTVV7A",
+        &["Temporary credential ", " expires in one hour."],
+    );
+}
+
+#[test]
+fn aws_shape_is_case_sensitive() {
+    // Lowercasing the prefix would admit ordinary prose. The rule is deliberately case-sensitive.
+    assert_unchanged("the akiaiosfodnn7example string is not a credential");
+}
+
+#[test]
+fn aws_shape_requires_exact_sixteen_trailing_characters() {
+    // 15 trailing characters: one short of the fixed AWS shape, so not a match.
+    assert_unchanged("AKIAIOSFODNN7EXAMPL is one character short");
+}
+
+// ------------------------------------------------------- provider-prefixed: JWT (6 of 219 spans)
+
+#[test]
+fn jwt_three_segment_structure_is_tokenized_whole() {
+    // `eyJ` is the base64url encoding of `{"`, so this asserts the first segment decodes to a JSON
+    // object — the JOSE header — rather than asserting a vendor brand.
+    let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlIn0.c2lnbmF0dXJlLXNhbXBsZQ";
+    assert_token_removed(
+        &format!("Authorization header carried {jwt} in the request."),
+        jwt,
+        &["Authorization header carried ", " in the request."],
+    );
+}
+
+#[test]
+fn jwt_requires_all_three_segments() {
+    // Two segments is not a JWT. Structure is the whole basis for this arm, so a partial
+    // structure must not match.
+    assert_unchanged("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlIn0");
+}
+
+// ------------------------------------------------- cue-anchored (193 of 219 spans carry a cue)
+
+#[test]
+fn english_token_cue_is_tokenized_and_cue_survives() {
+    // "token" is the dominant cue: 192 of 219 gold spans.
+    assert_token_removed(
+        "The API token: Rk9PQkFSLXNhbXBsZQ was issued yesterday.",
+        "Rk9PQkFSLXNhbXBsZQ",
+        &["The API token: ", " was issued yesterday."],
+    );
+}
+
+#[test]
+fn german_sicherheitstoken_cue_is_tokenized() {
+    // "sicherheitstoken" appears before 37 gold spans. The German cues are literal alternatives
+    // inside the pattern, NOT `[locale.cues.*]` bundle lookups, so they need no locale bundle.
+    assert_token_removed(
+        "Das Sicherheitstoken lautet Rk9PQkFSLXNhbXBsZQ und ist heute gültig.",
+        "Rk9PQkFSLXNhbXBsZQ",
+        &["Das Sicherheitstoken lautet ", " und ist heute gültig."],
+    );
+}
+
+#[test]
+fn bearer_cue_is_tokenized() {
+    assert_token_removed(
+        "Send Bearer Rk9PQkFSLXNhbXBsZQ with every call.",
+        "Rk9PQkFSLXNhbXBsZQ",
+        &["Send Bearer ", " with every call."],
+    );
+}
+
+#[test]
+fn cue_anchored_minimum_length_is_fourteen() {
+    // The >=14 knee is measured: >=14 covers 151 spans at 1 non-gold holdout match, >=12 covers
+    // 159 at 5, >=10 covers 163 at 7. A 13-character run must NOT match, or the knee is fiction.
+    assert_unchanged("api key: Rk9PQkFSLXNh1");
+    assert_token_removed(
+        "api key: Rk9PQkFSLXNhbQ now active.",
+        "Rk9PQkFSLXNhbQ",
+        &["api key: ", " now active."],
+    );
+}
+
+// ----------------------------------------------------------------------- hard negatives (A4)
+
+#[test]
+fn unanchored_high_entropy_runs_are_not_credentials() {
+    // These are the shapes the committed A4 negative corpus is full of: an unanchored base64url
+    // run of >=20 chars matches 448 times across 320 of its 1,024 documents, unanchored hex >=32
+    // in 128 documents, and a bare UUID in 128 documents — all `code_log_syntax` and
+    // `commerce_identifiers`. Every one of them must pass through untouched.
+    assert_unchanged("commit 9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c landed");
+    assert_unchanged("request id 3f2504e0-4f89-11d3-9a0c-0305e82c3301 completed");
+    assert_unchanged("order reference AB12CD34EF56GH78IJ90 shipped");
+}
+
+#[test]
+fn cue_without_high_entropy_run_is_not_a_credential() {
+    // The cue alone must not tokenize ordinary following prose.
+    assert_unchanged("The token expired and had to be reissued by support.");
+}
+
+// -------------------------------------------------------------------- locale-chain activation
+//
+// Todo #2403 shipped a leak because a locale-gated recognizer silently never fired on a chain
+// pinned to Global. The benchmark builds its chain as `[<lang>-<region>, "global"]`
+// (gaze_bench_score.py:87), and the corpus is en 117 / de 102, so roughly half the value of this
+// change sits on the German side. These tests assert firing on every chain that matters instead
+// of assuming `locales = ["global"]` behaves as documented.
+
+#[test]
+fn fires_under_every_benchmark_and_default_adopter_chain() {
+    let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlIn0.c2lnbmF0dXJlLXNhbXBsZQ";
+    for chain in [
+        vec![LocaleTag::Global],
+        vec![LocaleTag::parse("en-US").expect("tag"), LocaleTag::Global],
+        vec![LocaleTag::parse("en-GB").expect("tag"), LocaleTag::Global],
+        vec![LocaleTag::parse("de-DE").expect("tag"), LocaleTag::Global],
+        vec![LocaleTag::parse("de-AT").expect("tag"), LocaleTag::Global],
+        vec![LocaleTag::parse("de-CH").expect("tag"), LocaleTag::Global],
+    ] {
+        let aws = clean_under(&chain, "rotate AKIAIOSFODNN7EXAMPLE now");
+        assert!(
+            !aws.contains("AKIAIOSFODNN7EXAMPLE"),
+            "AWS key survived on chain {chain:?}: {aws:?}"
+        );
+
+        let cued = clean_under(
+            &chain,
+            "Das Sicherheitstoken lautet Rk9PQkFSLXNhbXBsZQ heute.",
+        );
+        assert!(
+            !cued.contains("Rk9PQkFSLXNhbXBsZQ"),
+            "German cue-anchored credential survived on chain {chain:?}: {cued:?}"
+        );
+
+        let structured = clean_under(&chain, &format!("header {jwt} sent"));
+        assert!(
+            !structured.contains(jwt),
+            "JWT survived on chain {chain:?}: {structured:?}"
+        );
+    }
+}
+
+// ------------------------------------------------------------------------------ restore path
+
+#[test]
+fn credentials_restore_exactly() {
+    // Axis 2: reversibility. A credential that cannot be restored is a broken contract, not a fix.
+    let pipeline = pipeline_for(&[LocaleTag::Global]);
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let original = "rotate AKIAIOSFODNN7EXAMPLE and the api key: Rk9PQkFSLXNhbXBsZQ today";
+    let (clean, _manifest, _) = pipeline
+        .clean_with_safety_net_detect_context(
+            &session,
+            RawDocument::Text(original.to_string()),
+            &[LocaleTag::Global],
+            &DictionaryBundle::default(),
+        )
+        .expect("clean");
+    let clean_text = match clean {
+        CleanDocument::Text(text) => text,
+        _ => panic!("expected text"),
+    };
+    assert!(!clean_text.contains("AKIAIOSFODNN7EXAMPLE"));
+    let restored = pipeline
+        .restore_strict_text(&session, &clean_text)
+        .expect("restore");
+    assert_eq!(restored, original, "manifest-first restore must round-trip");
+}

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -1292,6 +1292,7 @@ window_chars = 48
                 PiiClass::custom("ip_address"),
                 PiiClass::custom("eth_address"),
                 PiiClass::custom("url"),
+                PiiClass::custom("security_token"),
                 PiiClass::custom("aadhaar"),
                 PiiClass::custom("nir"),
                 PiiClass::custom("steuer_id"),


### PR DESCRIPTION
## Full-scale measurement

This is a fresh schema-v4 post-delimiter-fix measurement. The baseline came
from a separate clean anvil checkout at
`origin/agent/current-gaze-benchmark`
(`8ebdd2c1c1aafa1dcdb29b7819d715f7f3e73c9f`); the candidate is clean commit
`ff1a5e6b026f352cb3035c310ededb95abad6020`. Before comparison, both artifacts
printed and passed assertions for those exact revisions and `gaze.dirty=false`.
No schema-v3 artifact was used as a baseline.

The two deterministic cells are exactly like-for-like under v4 set identity:
each scores all 2,910 documents, fails closed on zero, and carries the same
scored/failed population digest on both sides. Kiji is not like-for-like:
documents move 2,250 → 2,257, gold entities move 10,665 → 10,699, and
failed-closed documents move 660 → 653. V4 shows that this is a membership
swap, not a seven-document superset: the candidate newly scores 9
baseline-failed documents and newly fails 2 baseline-scored documents.
Every Kiji aggregate below is therefore descriptive, not attributable.

| Cell | Documents | Gold entities | Failed closed | Total leaked bytes | SECURITYTOKEN leaked bytes | SECURITYTOKEN fully covered |
|---|---:|---:|---:|---:|---:|---:|
| rule-floor | 2,910 → 2,910 | 14,719 → 14,719 | 0 → 0 | 106,068 → 103,003 (-3,065) | 4,342 → 1,277 (-3,065) | 0 → 150 |
| pass2 NER | 2,910 → 2,910 | 14,719 → 14,719 | 0 → 0 | 40,695 → 37,710 (-2,985) | 4,306 → 1,321 (-2,985) | 0 → 146 |
| Kiji resolve (set moved) | 2,250 → 2,257 | 10,665 → 10,699 | 660 → 653 | 27,728 → 26,358 (-1,370) | 2,246 → 796 (-1,450) | 2 → 112 |

## Exact-integer reproduction

Two independent schema-v4 post-fix candidate full runs compared `1,130`
integer leaves
under all three `runs` objects and produced zero differences. Randomized
per-session token text and floating-point latency fields are intentionally
outside that integer comparison; raw token hex is not a reproducibility
contract.

The full aggregate coverage/false-positive integers remain unchanged from the
post-delimiter schema-v3 measurement. The v3 artifact was not compared as a v4
baseline; the unchanged aggregates are evidence that the benchmark lacked the
identifier false-positive class, not evidence that the false positive was
benign.

## Full-scale false positives

These are the fresh post-fix full-profile figures, not quick-profile estimates:

| Cell | False-positive bytes | Documents with false positives | Leak reduction / added FP bytes |
|---|---:|---:|---:|
| rule-floor | 5,353 → 5,370 (+17) | 221 → 222 (+1) | 3,065 / 17 ≈ 180:1 |
| pass2 NER | 27,775 → 27,792 (+17) | 1,944 → 1,944 (+0) | 2,985 / 17 ≈ 176:1 |
| Kiji resolve (set moved) | 92,847 → 93,484 (+637) | 1,857 → 1,863 (+6) | not like-for-like |

## Every-label sweep: entity buckets and bytes

The merged coverage gate reports:

```text
status: failed
class_coverage_loss failures = 0
class_population_evaluability failures = 29
reason = population_moved, cannot evaluate
```

All 29 evaluability failures are in Kiji: v4 correctly refuses to evaluate
every label when the scored-document set differs. Green under
`class_coverage_loss` therefore means no loss was proven on an identical
population; it does not clear the 29 explicitly unevaluable Kiji labels.

The entity-bucket arm is clean in both provably like-for-like cells. No label
loses `fully_covered` or `overlapped`; BUILDINGNUM gains one in each. Kiji has
zero `class_coverage_loss` failures, but all 29 labels cannot be
evaluated by that arm.

The independent byte arm is also clean in the two identical-set cells.
IDCARDNUM's Kiji aggregates still read entities 136 → 136, fully covered
0 → 0, overlapped 5 → 5, total gold bytes 1,372 → 1,372, covered bytes
15 → 14, and leaked bytes 1,357 → 1,358. Schema v4 proves that the Kiji scored
set is **not identical** (9 IDs added, 2 removed), so set identity is not
confirmed for IDCARDNUM and the +1 byte is **not attributable**. The earlier
schema-v3 interpretation treated constant gold count/bytes as stronger
evidence than they were; v4 correctly reports
`population_moved, cannot evaluate`.

Every label that moved in any direction is listed here as
`baseline → candidate (delta)`:

| Cell | Label | Entities | Fully covered | Overlapped | Leaked UTF-8 bytes |
|---|---|---:|---:|---:|---:|
| rule-floor | BUILDINGNUM | 1,437 → 1,437 (0) | 13 → 14 (+1) | 13 → 14 (+1) | 3,166 → 3,165 (-1) |
| rule-floor | SECURITYTOKEN | 219 → 219 (0) | 0 → 150 (+150) | 0 → 151 (+151) | 4,342 → 1,277 (-3,065) |
| pass2 NER | BUILDINGNUM | 1,437 → 1,437 (0) | 26 → 27 (+1) | 28 → 29 (+1) | 3,122 → 3,121 (-1) |
| pass2 NER | SECURITYTOKEN | 219 → 219 (0) | 0 → 146 (+146) | 4 → 151 (+147) | 4,306 → 1,321 (-2,985) |
| Kiji (set moved) | AGE | 158 → 160 (+2) | 0 → 0 (0) | 0 → 0 (0) | 316 → 320 (+4) |
| Kiji (set moved) | BUILDINGNUM | 1,054 → 1,056 (+2) | 13 → 14 (+1) | 17 → 18 (+1) | 2,405 → 2,407 (+2) |
| Kiji (set moved) | CITY | 1,158 → 1,160 (+2) | 1,155 → 1,157 (+2) | 1,158 → 1,160 (+2) | 9 → 9 (0) |
| Kiji (set moved) | COMPANYNAME | 334 → 331 (-3) | 324 → 321 (-3) | 334 → 331 (-3) | 55 → 55 (0) |
| Kiji (set moved) | COUNTRY | 243 → 244 (+1) | 241 → 242 (+1) | 242 → 243 (+1) | 16 → 16 (0) |
| Kiji (set moved) | CREDITCARDNUMBER | 83 → 82 (-1) | 19 → 18 (-1) | 21 → 20 (-1) | 850 → 850 (0) |
| Kiji (set moved) | DATEOFBIRTH | 209 → 211 (+2) | 0 → 0 (0) | 4 → 4 (0) | 2,165 → 2,185 (+20) |
| Kiji (set moved) | DRIVERLICENSENUM | 156 → 158 (+2) | 1 → 1 (0) | 10 → 10 (0) | 1,545 → 1,565 (+20) |
| Kiji (set moved) | FIRSTNAME | 1,451 → 1,458 (+7) | 1,434 → 1,441 (+7) | 1,439 → 1,446 (+7) | 55 → 55 (0) |
| Kiji (set moved) | IDCARDNUM | 136 → 136 (0) | 0 → 0 (0) | 5 → 5 (0) | 1,357 → 1,358 (+1) |
| Kiji (set moved) | LICENSEPLATENUM | 158 → 159 (+1) | 0 → 0 (0) | 47 → 48 (+1) | 1,197 → 1,203 (+6) |
| Kiji (set moved) | NATIONALID | 135 → 136 (+1) | 2 → 2 (0) | 2 → 2 (0) | 1,500 → 1,516 (+16) |
| Kiji (set moved) | PASSPORTID | 152 → 154 (+2) | 0 → 0 (0) | 17 → 17 (0) | 1,336 → 1,355 (+19) |
| Kiji (set moved) | PHONENUMBER | 290 → 291 (+1) | 180 → 181 (+1) | 180 → 181 (+1) | 1,435 → 1,435 (0) |
| Kiji (set moved) | SECURITYTOKEN | 150 → 157 (+7) | 2 → 112 (+110) | 65 → 120 (+55) | 2,246 → 796 (-1,450) |
| Kiji (set moved) | SSN | 150 → 149 (-1) | 8 → 8 (0) | 9 → 9 (0) | 1,572 → 1,556 (-16) |
| Kiji (set moved) | STATE | 702 → 703 (+1) | 629 → 630 (+1) | 646 → 647 (+1) | 150 → 150 (0) |
| Kiji (set moved) | STREET | 1,009 → 1,011 (+2) | 977 → 979 (+2) | 1,009 → 1,011 (+2) | 135 → 135 (0) |
| Kiji (set moved) | SURNAME | 1,202 → 1,204 (+2) | 1,194 → 1,196 (+2) | 1,198 → 1,200 (+2) | 24 → 24 (0) |
| Kiji (set moved) | URL | 219 → 221 (+2) | 105 → 107 (+2) | 194 → 196 (+2) | 1,922 → 1,922 (0) |
| Kiji (set moved) | ZIP | 782 → 784 (+2) | 243 → 243 (0) | 259 → 259 (0) | 2,763 → 2,771 (+8) |

## Attribution arithmetic

At the rule floor, the whole-cell reduction 106,068 → 103,003 is exactly
-3,065 bytes, and SECURITYTOKEN is also exactly -3,065. Its candidate
`covered_utf8_bytes` is 3,065, from zero at baseline.

At pass2 NER, the whole-cell reduction 40,695 → 37,710 is exactly -2,985,
and SECURITYTOKEN leaked bytes are also exactly -2,985. Its candidate
`covered_utf8_bytes` is 3,021; 36 bytes were already covered at baseline, so
the coverage delta is +2,985. BUILDINGNUM gains a separately scored byte in
both deterministic label tables. The whole-cell metric is a class-agnostic
covered-byte union, so overlapping per-label gains do not sum independently;
the BUILDINGNUM movement is a gain, not a hidden regression.

Kiji is non-like-for-like under schema-v4 set identity. Its aggregate total
reduction is -1,370 while the aggregate SECURITYTOKEN label delta is -1,450,
leaving +80 bytes elsewhere:

| Label | Leaked-byte delta | Population interpretation |
|---|---:|---|
| AGE | +4 | population moved |
| BUILDINGNUM | +2 | population moved |
| DATEOFBIRTH | +20 | population moved |
| DRIVERLICENSENUM | +20 | population moved |
| IDCARDNUM | +1 | count/total bytes constant, but scored set moved; not attributable |
| LICENSEPLATENUM | +6 | population moved |
| NATIONALID | +16 | population moved |
| PASSPORTID | +19 | population moved |
| ZIP | +8 | population moved |
| SSN | -16 | population moved |
| **Net** | **+80** | |

The arithmetic is exact, but none of the Kiji label rows is attributable
because the scored set changed by 9 additions and 2 removals. Pass2 NER is
clean, while only the resolve-mode cell changes population; that still
localizes the systemic interaction surface to the safety net running against
already-tokenized output (#2420), but it does **not** prove an IDCARDNUM
regression. The earlier schema-v3 claim that IDCARDNUM +1 was a confirmed
byte-only instance is superseded and corrected on #2420.

V4 also types the Kiji population movement. All 11 membership swaps are
`safety_net_fallback_residual_suspect` failures in the clean stage: 9 baseline
failures become scored and 2 baseline-scored documents become failures, for
513 → 506 (-7) net. `unknown_token` remains 147 → 147. Subprocess timeout,
non-zero exit, malformed output, label-registry/decode mismatch, oversized
input, and every other typed reason remain zero.

## Negative corpus and cue evidence

I re-ran the post-fix candidate `clean_for_bench` binary across the committed A4
negative corpus: **0 of 1,024 documents** matched
`security_token.anchored` (512 English, 512 German). The same corpus is
purpose-built to reject naive entropy rules: unanchored base64url runs of at
least 20 characters hit 320 documents.

A4 does not contain the cue-prefixed snake_case identifier class found during
review, so its genuine 0/1,024 result did not catch this safe-default defect.
Repository dogfooding is an additional negative arm below.

The corpus figure previously described as cue adjacency is 88.1% for
SECURITYTOKEN: 193/219 gold spans have `token` or `secret` in the preceding
64 characters, versus 1.8% cue context for URL. That asymmetry is why cue
anchoring is correct here and was wrong for URL: the cue is strong corpus
evidence for credentials, while an unanchored entropy shape is
indistinguishable from ordinary hashes and identifiers.

## Review-hold delimiter remediation

Before the fix, the built CLI reproduced all six review cases as
`Custom:security_token` identifier-tail splits. Arm 2 allowed both its
whitespace and punctuation groups to be empty. The fix requires at least one
unambiguous delimiter between cue and value:

- whitespace, `:`, `=`, or `#` qualifies;
- `_` never qualifies;
- a directly abutting `-` does not qualify because it is also a legal
  credential/identifier character;
- a spaced hyphen remains accepted because the whitespace supplies the
  unambiguous delimiter.

Arm 1 is unchanged: its AKIA/ASIA and JWT alternatives remain case-sensitive
and prefix/structure anchored.

This preserves `token: value`, `token = value`, `token value`,
`token ist value`, `token lautet value`, and `token is value`. Measurement
found 193/219 gold spans behind the cue-context claim before and after the
requirement, with 0 zero-character gaps and 0 direct-hyphen-only gaps. Among
gold values meeting arm 2's length/shape requirement, coverage is
113 → 113: **0 measured gold spans lost**.

The six behavioral negative tests drive the real Pipeline and cover
`tokenization_helper_registry`, `bearer_authentication_handler_impl`,
`api_key_rotation_schedule_v2`, `access_token_refresh_coordinator`,
`authorization_token_provider_factory`, and
`tokenizer_vocabulary_builder_test`. With the fixed rule they remain unchanged.
A mutation that restored the optional/zero-width delimiter produced:

```text
failures:

failures:
    access_token_refresh_coordinator_is_not_split
    api_key_rotation_schedule_v2_is_not_split
    authorization_token_provider_factory_is_not_split
    bearer_authentication_handler_impl_is_not_split
    tokenization_helper_registry_is_not_split
    tokenizer_vocabulary_builder_test_is_not_split
test result: FAILED. 15 passed; 6 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.70s
error: test failed, to rerun pass `-p gaze-recognizers --test security_token`
```

Post-fix dogfooding used the built `gaze clean --rulepack-bundled core`
binary over real repository text:

| File | SECURITYTOKEN detections | Raw values |
|---|---:|---|
| `README.md` | 0 | none |
| `CHANGELOG.md` | 0 | none |
| `AGENTS.md` | 0 | none |
| `crates/xtask/src/main.rs` | 0 | none |

The separate `std::collections::HashMap` probe still emitted the pre-existing
`Custom:ip_address` false positives with raw values `d::c` and `::`. That is
todo #2402, exists on the integration tip, and is observed here only; this PR
does not change it.

## Rulepack placement and shipped-default impact

`security_token.anchored` belongs in `core`, not `core-extended`: bearer
credentials and API keys are global, high-consequence secrets, and leaving the
deterministic floor blind weakens the never-leak axis. It is `safe_default`
because arm 1 requires issuer/structural evidence and arm 2 now requires both
an explicit English/German cue and an unambiguous delimiter. It is global
rather than locale-gated; the literal English and German cues are evidence
inside the regex, and a locale-gated credential rule could silently be absent
from a default locale chain. `core-extended` inherits it through `core`.

A shipped adopter using no-policy `CorePipelineConfig` now tokenizes these
credential-shaped strings automatically and can restore them through the
manifest. That includes Git tokens in logs, API keys in documentation, AWS
access keys, JWTs, and cue-delimited high-entropy values in ordinary text.
Public or example-shaped credentials can therefore be over-tokenized; that is
a recoverable adopter-ergonomics cost. Cue-prefixed snake_case identifiers are
not split. The CLI's separate no-policy stub path is unchanged.

The two cue shapes remain one two-arm recognizer with one stable source ID.
Splitting them into same-class recognizers can co-fire, producing a `+`-joined
composite source ID that the current scorer rejects (#2416).

## #2254 item 8 — enumerated deviations

1. Rule-floor false positives: +17 bytes and +1 affected document.
2. Pass2-NER false positives: +17 bytes and +0 affected documents.
3. Kiji false positives: +637 bytes and +6 affected documents; this cell is not
   like-for-like because its scored-document set changed.
4. Kiji IDCARDNUM aggregate: entities 136 → 136, total bytes
   1,372 → 1,372, fully covered 0 → 0, overlapped 5 → 5, covered bytes
   15 → 14, and leaked bytes 1,357 → 1,358. V4 proves the scored set differs,
   so the +1 leaked byte is not attributable and the label is not evaluable.
5. Kiji population movement: documents 2,250 → 2,257, gold entities
   10,665 → 10,699, and failed-closed documents 660 → 653. The candidate
   newly scores 9 baseline-failed IDs and newly fails 2 baseline-scored IDs;
   this is a membership swap, not a seven-document superset.
6. Typed Kiji failures: all 11 swapped IDs are clean-stage
   `safety_net_fallback_residual_suspect`; that reason moves 513 → 506 (-7),
   while `unknown_token` remains 147 → 147. Every other typed reason is zero.
7. Exactly 29 Kiji labels are `population_moved, cannot evaluate`: AGE,
   BUILDINGNUM, CITY, COMPANYNAME, COUNTRY, CREDITCARDNUMBER, DATEOFBIRTH,
   DRIVERLICENSENUM, EMAIL, FIRSTNAME, IBAN, IDCARDNUM, LICENSEPLATENUM,
   NATIONALID, ORGANIZATION, PASSPORTID, PASSWORD, PHONENUMBER, REGION,
   SECURITYTOKEN, SSN, STATE, STREET, SURNAME, TAXNUM, TITLE, URL, USERNAME,
   and ZIP.
8. Kiji documents with leaks move 1,331 → 1,333 (+2); this is confounded by
   the scored-set membership swap.
9. Kiji residual suspects move 172 → 175 (+3); this is also on the
   non-identical resolve-mode population.
10. The committed A4 negative corpus has no cue-prefixed snake_case identifier
   class; repository dogfooding now covers that gap for this review.
11. The pre-existing IP-address split of Rust `::` syntax remains under #2402
    and is not changed here.

## Axes note

- **Reliability:** deterministic leak reduction is 3,065 bytes at rule-floor
  and 2,985 at pass2, with exact attribution. The delimiter fix removes a
  safe-default false-positive class at zero measured gold cost. Kiji's raw
  IDCARDNUM +1 byte is disclosed, but v4 set identity correctly prevents a
  false regression attribution; #2420 owns the systemic resolve-mode
  population interaction.
- **Reversibility:** the new class uses normal manifest-backed tokens and does
  not change restore semantics.
- **Agentic-first:** credentials in tool logs, documentation, and model-bound
  context are protected at the default floor.
- **Trust:** one auditable recognizer, one stable source ID, deterministic
  structural/cue/delimiter evidence, mutation-sensitive behavioral tests,
  exact 1,130-integer reproduction, asserted clean revisions, identified
  populations, typed failures, and no unlabelled special-cases.
- **Adopter ergonomics:** ordinary credential-shaped text can now be tokenized,
  but the behavior is reversible, documented, measured, and no longer splits
  cue-prefixed identifiers. The remaining axis-5 cost is justified by the
  axis-1 gain.

## Validation

- `rustup run 1.96.0 cargo fmt --all -- --check`
- `rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `rustup run 1.96.0 cargo test --workspace --all-features`
- `rustup run 1.96.0 cargo test -p gaze-recognizers --test security_token --all-features`
- `uv run --with pyarrow python3 scripts/bench/test_class_coverage_gate.py`
- `uv run --with pyarrow python3 scripts/bench/test_run_no_opf_benchmark.py`

Resolves solo todo #2318
