### PR TITLE
[agent] identify benchmark populations and typed failures

### DIFF
--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use gaze::{
-    Action, CleanDocument, Context, EmittedTokenSpan, GazeLocalProtectionTraceItem, LeakKind,
-    LeakReportStats, LocaleChain, LocaleTag, NerPolicy, PiiClass, Pipeline, RuleSpec, Rulepack,
-    RulepackSource, SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy, Scope,
-    Session,
+    Action, CleanDocument, Context, EmittedTokenSpan, FallbackReason, GazeLocalProtectionTraceItem,
+    LeakKind, LeakReportStats, LocaleChain, LocaleTag, NerPolicy, PiiClass, Pipeline, RuleSpec,
+    Rulepack, RulepackSource, SafetyNetError, SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
+    Scope, Session,
 };
 use gaze_recognizers::embedded;
 use serde::{Deserialize, Serialize};
@@ -176,7 +176,7 @@ enum Outcome {
     PipelineError {
         fixture_id: String,
         stage: &'static str,
-        code: &'static str,
+        reason: PipelineFailureReason,
         total_ms: f64,
     },
 }
@@ -202,10 +202,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Outcome::PipelineError {
                 fixture_id,
                 stage,
-                code,
+                reason,
                 total_ms,
             } => {
-                write_pipeline_error(&mut stdout, &fixture_id, stage, code, total_ms)?;
+                write_pipeline_error(&mut stdout, &fixture_id, stage, reason, total_ms)?;
             }
         }
     }
@@ -239,10 +239,12 @@ fn handle_request(
         Ok(result) => result,
         Err(error) => {
             emit_invalid_output_diagnostic("clean", &error);
+            let reason = pipeline_failure_reason(&error)
+                .ok_or("unclassified clean-stage pipeline error variant")?;
             return Ok(Outcome::PipelineError {
                 fixture_id: request.fixture_id,
                 stage: "clean",
-                code: pipeline_error_code(&error),
+                reason,
                 total_ms: clean_ms,
             });
         }
@@ -274,10 +276,12 @@ fn handle_request(
             Ok(result) => result,
             Err(error) => {
                 emit_invalid_output_diagnostic("post_policy_scan", &error);
+                let reason = pipeline_failure_reason(&error)
+                    .ok_or("unclassified post-policy pipeline error variant")?;
                 return Ok(Outcome::PipelineError {
                     fixture_id: request.fixture_id,
                     stage: "post_policy_scan",
-                    code: pipeline_error_code(&error),
+                    reason,
                     total_ms: clean_ms,
                 });
             }
@@ -376,7 +380,7 @@ fn write_pipeline_error(
     stdout: &mut impl Write,
     fixture_id: &str,
     stage: &str,
-    code: &str,
+    reason: PipelineFailureReason,
     total_ms: f64,
 ) -> Result<(), Box<dyn std::error::Error>> {
     serde_json::to_writer(
@@ -384,7 +388,7 @@ fn write_pipeline_error(
         &PipelineErrorResponse {
             fixture_id,
             pipeline_error_stage: stage,
-            pipeline_error_code: code,
+            pipeline_error_code: reason.as_str(),
             timing: PipelineErrorTiming { total_ms },
         },
     )?;
@@ -393,12 +397,210 @@ fn write_pipeline_error(
     Ok(())
 }
 
-fn pipeline_error_code(error: &gaze::Error) -> &'static str {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PipelineFailureReason {
+    InvalidRegex,
+    UnknownToken,
+    ExportForbidden,
+    EmptyDocumentIntegrity,
+    InvalidSnapshotVersion,
+    InvalidSnapshotSignature,
+    BlobExpired,
+    SnapshotDecode,
+    InvalidSnapshotPayload,
+    Sqlite,
+    Policy,
+    Rulepack,
+    RecognizerDetect,
+    RedactionLog,
+    SafetyNetUnavailable,
+    SafetyNetWeightsMissing,
+    SafetyNetModelUnavailable,
+    SafetyNetModelIntegrityMismatch,
+    SafetyNetInputTooLarge,
+    SafetyNetRuntimeSubprocessTimeout,
+    SafetyNetRuntimeSubprocessNonZeroExit,
+    SafetyNetRuntimeOther,
+    SafetyNetInvalidOutputMalformedBackendOutput,
+    SafetyNetInvalidOutputLabelDecodeMismatch,
+    SafetyNetInvalidOutputCleanToRawMapping,
+    SafetyNetInvalidOutputTraceManifestMismatch,
+    SafetyNetInvalidOutputOther,
+    SafetyNetFallbackOverlapConflict,
+    SafetyNetFallbackValidatorVeto,
+    SafetyNetFallbackAnchorMissing,
+    SafetyNetFallbackResidualSuspect,
+    SafetyNetSpanInvalid,
+    UnsupportedCapitalHeuristicLocale,
+    UnsupportedRawDocumentVariant,
+    UnsupportedStructuredValueVariant,
+    UnsupportedPolicyActionVariant,
+}
+
+impl PipelineFailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRegex => "invalid_regex",
+            Self::UnknownToken => "unknown_token",
+            Self::ExportForbidden => "export_forbidden",
+            Self::EmptyDocumentIntegrity => "empty_document_integrity",
+            Self::InvalidSnapshotVersion => "invalid_snapshot_version",
+            Self::InvalidSnapshotSignature => "invalid_snapshot_signature",
+            Self::BlobExpired => "blob_expired",
+            Self::SnapshotDecode => "snapshot_decode",
+            Self::InvalidSnapshotPayload => "invalid_snapshot_payload",
+            Self::Sqlite => "sqlite",
+            Self::Policy => "policy",
+            Self::Rulepack => "rulepack",
+            Self::RecognizerDetect => "recognizer_detect",
+            Self::RedactionLog => "redaction_log",
+            Self::SafetyNetUnavailable => "safety_net_unavailable",
+            Self::SafetyNetWeightsMissing => "safety_net_weights_missing",
+            Self::SafetyNetModelUnavailable => "safety_net_model_unavailable",
+            Self::SafetyNetModelIntegrityMismatch => "safety_net_model_integrity_mismatch",
+            Self::SafetyNetInputTooLarge => "safety_net_input_too_large",
+            Self::SafetyNetRuntimeSubprocessTimeout => "safety_net_runtime_subprocess_timeout",
+            Self::SafetyNetRuntimeSubprocessNonZeroExit => {
+                "safety_net_runtime_subprocess_non_zero_exit"
+            }
+            Self::SafetyNetRuntimeOther => "safety_net_runtime_other",
+            Self::SafetyNetInvalidOutputMalformedBackendOutput => {
+                "safety_net_invalid_output_malformed_backend_output"
+            }
+            Self::SafetyNetInvalidOutputLabelDecodeMismatch => {
+                "safety_net_invalid_output_label_decode_mismatch"
+            }
+            Self::SafetyNetInvalidOutputCleanToRawMapping => {
+                "safety_net_invalid_output_clean_to_raw_mapping"
+            }
+            Self::SafetyNetInvalidOutputTraceManifestMismatch => {
+                "safety_net_invalid_output_trace_manifest_mismatch"
+            }
+            Self::SafetyNetInvalidOutputOther => "safety_net_invalid_output_other",
+            Self::SafetyNetFallbackOverlapConflict => "safety_net_fallback_overlap_conflict",
+            Self::SafetyNetFallbackValidatorVeto => "safety_net_fallback_validator_veto",
+            Self::SafetyNetFallbackAnchorMissing => "safety_net_fallback_anchor_missing",
+            Self::SafetyNetFallbackResidualSuspect => "safety_net_fallback_residual_suspect",
+            Self::SafetyNetSpanInvalid => "safety_net_span_invalid",
+            Self::UnsupportedCapitalHeuristicLocale => "unsupported_capital_heuristic_locale",
+            Self::UnsupportedRawDocumentVariant => "unsupported_raw_document_variant",
+            Self::UnsupportedStructuredValueVariant => "unsupported_structured_value_variant",
+            Self::UnsupportedPolicyActionVariant => "unsupported_policy_action_variant",
+        }
+    }
+}
+
+fn pipeline_failure_reason(error: &gaze::Error) -> Option<PipelineFailureReason> {
     match error {
-        gaze::Error::SafetyNet(SafetyNetError::InvalidOutput { .. }) => "safety_net_invalid_output",
-        gaze::Error::SafetyNet(SafetyNetError::Runtime { .. }) => "safety_net_runtime",
-        gaze::Error::SafetyNet(_) => "safety_net_error",
-        _ => "pipeline_error",
+        gaze::Error::InvalidRegex(_) => Some(PipelineFailureReason::InvalidRegex),
+        gaze::Error::UnknownToken { .. } => Some(PipelineFailureReason::UnknownToken),
+        gaze::Error::ExportForbidden => Some(PipelineFailureReason::ExportForbidden),
+        gaze::Error::EmptyDocumentIntegrity => Some(PipelineFailureReason::EmptyDocumentIntegrity),
+        gaze::Error::InvalidSnapshotVersion(_) => {
+            Some(PipelineFailureReason::InvalidSnapshotVersion)
+        }
+        gaze::Error::InvalidSnapshotSignature => {
+            Some(PipelineFailureReason::InvalidSnapshotSignature)
+        }
+        gaze::Error::BlobExpired { .. } => Some(PipelineFailureReason::BlobExpired),
+        gaze::Error::SnapshotDecode(_) => Some(PipelineFailureReason::SnapshotDecode),
+        gaze::Error::InvalidSnapshotPayload => Some(PipelineFailureReason::InvalidSnapshotPayload),
+        gaze::Error::Sqlite(_) => Some(PipelineFailureReason::Sqlite),
+        gaze::Error::Policy(_) => Some(PipelineFailureReason::Policy),
+        gaze::Error::Rulepack(_) => Some(PipelineFailureReason::Rulepack),
+        gaze::Error::SafetyNet(error) => safety_net_failure_reason(error),
+        gaze::Error::RecognizerDetect(_) => Some(PipelineFailureReason::RecognizerDetect),
+        gaze::Error::RedactionLog(_) => Some(PipelineFailureReason::RedactionLog),
+        gaze::Error::SafetyNetFallback(reason) => Some(match reason {
+            FallbackReason::OverlapConflict => {
+                PipelineFailureReason::SafetyNetFallbackOverlapConflict
+            }
+            FallbackReason::ValidatorVeto => PipelineFailureReason::SafetyNetFallbackValidatorVeto,
+            FallbackReason::AnchorMissing => PipelineFailureReason::SafetyNetFallbackAnchorMissing,
+            FallbackReason::ResidualSuspect => {
+                PipelineFailureReason::SafetyNetFallbackResidualSuspect
+            }
+            _ => return None,
+        }),
+        gaze::Error::SafetyNetSpanInvalid { .. } => {
+            Some(PipelineFailureReason::SafetyNetSpanInvalid)
+        }
+        gaze::Error::UnsupportedCapitalHeuristicLocale { .. } => {
+            Some(PipelineFailureReason::UnsupportedCapitalHeuristicLocale)
+        }
+        gaze::Error::UnsupportedRawDocumentVariant => {
+            Some(PipelineFailureReason::UnsupportedRawDocumentVariant)
+        }
+        gaze::Error::UnsupportedValueVariant => {
+            Some(PipelineFailureReason::UnsupportedStructuredValueVariant)
+        }
+        gaze::Error::UnsupportedActionVariant => {
+            Some(PipelineFailureReason::UnsupportedPolicyActionVariant)
+        }
+        _ => None,
+    }
+}
+
+fn safety_net_failure_reason(error: &SafetyNetError) -> Option<PipelineFailureReason> {
+    Some(match error {
+        SafetyNetError::Unavailable { .. } => PipelineFailureReason::SafetyNetUnavailable,
+        SafetyNetError::WeightsMissing { .. } => PipelineFailureReason::SafetyNetWeightsMissing,
+        SafetyNetError::ModelUnavailable { .. } => PipelineFailureReason::SafetyNetModelUnavailable,
+        SafetyNetError::ModelIntegrityMismatch { .. } => {
+            PipelineFailureReason::SafetyNetModelIntegrityMismatch
+        }
+        SafetyNetError::InputTooLarge { .. } => PipelineFailureReason::SafetyNetInputTooLarge,
+        SafetyNetError::Runtime { message } => runtime_failure_reason(message),
+        SafetyNetError::InvalidOutput { message } => invalid_output_failure_reason(message),
+        _ => return None,
+    })
+}
+
+fn runtime_failure_reason(message: &str) -> PipelineFailureReason {
+    if message.ends_with("subprocess timed out and was killed") {
+        PipelineFailureReason::SafetyNetRuntimeSubprocessTimeout
+    } else if message.starts_with("kiji subprocess exited with status ")
+        || message.starts_with("opf subprocess exited with status ")
+    {
+        PipelineFailureReason::SafetyNetRuntimeSubprocessNonZeroExit
+    } else {
+        PipelineFailureReason::SafetyNetRuntimeOther
+    }
+}
+
+fn invalid_output_failure_reason(message: &str) -> PipelineFailureReason {
+    match message {
+        "kiji returned invalid label"
+        | "kiji returned unsupported label"
+        | "opf returned invalid label"
+        | "opf returned unsupported label" => {
+            PipelineFailureReason::SafetyNetInvalidOutputLabelDecodeMismatch
+        }
+        "clean-to-raw start mapping failed"
+        | "clean-to-raw end mapping failed"
+        | "empty clean-to-raw mapping" => {
+            PipelineFailureReason::SafetyNetInvalidOutputCleanToRawMapping
+        }
+        "overlapping protection trace" | "trace-manifest mismatch" | "manifest-trace mismatch" => {
+            PipelineFailureReason::SafetyNetInvalidOutputTraceManifestMismatch
+        }
+        "kiji stdout was not valid UTF-8"
+        | "kiji stdout was not valid JSON"
+        | "kiji returned non-finite score"
+        | "kiji returned out-of-bounds span"
+        | "kiji returned overlapping spans"
+        | "kiji candle returned no outputs"
+        | "kiji candle returned invalid logits shape"
+        | "kiji ort returned invalid logits shape"
+        | "kiji tract returned invalid logits shape"
+        | "opf stdout was not valid UTF-8"
+        | "opf stdout was not valid JSON"
+        | "opf returned non-finite score"
+        | "opf returned out-of-bounds span"
+        | "opf returned overlapping spans" => {
+            PipelineFailureReason::SafetyNetInvalidOutputMalformedBackendOutput
+        }
+        _ => PipelineFailureReason::SafetyNetInvalidOutputOther,
     }
 }
 
@@ -1220,31 +1422,57 @@ mod tests {
     }
 
     #[test]
-    fn pipeline_error_codes_cover_each_mapping_arm() {
+    fn pipeline_failure_reasons_cover_required_clean_stage_classes() {
         let cases = [
             (
                 gaze::Error::SafetyNet(SafetyNetError::InvalidOutput {
-                    message: "synthetic invalid output".to_string(),
+                    message: "kiji stdout was not valid JSON".to_string(),
                 }),
-                "safety_net_invalid_output",
+                "safety_net_invalid_output_malformed_backend_output",
+            ),
+            (
+                gaze::Error::SafetyNet(SafetyNetError::InvalidOutput {
+                    message: "kiji returned unsupported label".to_string(),
+                }),
+                "safety_net_invalid_output_label_decode_mismatch",
+            ),
+            (
+                gaze::Error::SafetyNet(SafetyNetError::InputTooLarge {
+                    limit: 1024,
+                    actual: 2048,
+                }),
+                "safety_net_input_too_large",
             ),
             (
                 gaze::Error::SafetyNet(SafetyNetError::Runtime {
-                    message: "synthetic runtime failure".to_string(),
+                    message: "kiji subprocess timed out and was killed".to_string(),
                 }),
-                "safety_net_runtime",
+                "safety_net_runtime_subprocess_timeout",
+            ),
+            (
+                gaze::Error::SafetyNet(SafetyNetError::Runtime {
+                    message: "kiji subprocess exited with status exit status: 2".to_string(),
+                }),
+                "safety_net_runtime_subprocess_non_zero_exit",
             ),
             (
                 gaze::Error::SafetyNet(SafetyNetError::Unavailable {
                     reason: "synthetic unavailable backend".to_string(),
                 }),
-                "safety_net_error",
+                "safety_net_unavailable",
             ),
-            (gaze::Error::ExportForbidden, "pipeline_error"),
+            (
+                gaze::Error::SafetyNetFallback(FallbackReason::ResidualSuspect),
+                "safety_net_fallback_residual_suspect",
+            ),
+            (gaze::Error::ExportForbidden, "export_forbidden"),
         ];
 
         for (error, expected) in cases {
-            assert_eq!(pipeline_error_code(&error), expected);
+            assert_eq!(
+                pipeline_failure_reason(&error).map(PipelineFailureReason::as_str),
+                Some(expected)
+            );
         }
     }
 
@@ -1272,13 +1500,13 @@ mod tests {
         let response = PipelineErrorResponse {
             fixture_id: "failure-1",
             pipeline_error_stage: "clean",
-            pipeline_error_code: "safety_net_runtime",
+            pipeline_error_code: "safety_net_runtime_subprocess_timeout",
             timing: PipelineErrorTiming { total_ms: 12.5 },
         };
         let serialized = serde_json::to_string(&response).expect("error response should serialize");
         assert_eq!(
             serialized,
-            r#"{"fixture_id":"failure-1","pipeline_error_stage":"clean","pipeline_error_code":"safety_net_runtime","timing":{"total_ms":12.5}}"#
+            r#"{"fixture_id":"failure-1","pipeline_error_stage":"clean","pipeline_error_code":"safety_net_runtime_subprocess_timeout","timing":{"total_ms":12.5}}"#
         );
 
         let value = serde_json::to_value(&response).expect("error response should serialize");
@@ -1306,7 +1534,7 @@ mod tests {
             &mut output,
             "failure-1",
             "clean",
-            "safety_net_runtime",
+            PipelineFailureReason::SafetyNetRuntimeSubprocessTimeout,
             12.5,
         )
         .expect("error response should be written");
@@ -1406,12 +1634,12 @@ mod tests {
                 Outcome::PipelineError {
                     fixture_id,
                     stage,
-                    code,
+                    reason,
                     ..
                 } => serde_json::json!({
                     "fixture_id": fixture_id,
                     "pipeline_error_stage": stage,
-                    "pipeline_error_code": code,
+                    "pipeline_error_code": reason.as_str(),
                 }),
             };
             println!(

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -92,7 +92,7 @@ Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
 
 | Artifact | Purpose |
 | --- | --- |
-| `scorecard-v3.json` | full schema-v3 scorecard, runner provenance, and identified scored/failed-closed populations per cell |
+| `scorecard-v4.json` | full schema-v4 scorecard, runner provenance, and identified scored/failed-closed populations per cell |
 | `summary.md` | concise human-readable result |
 | `diagnostics.json` | per-language, per-label, and per-negative-category diagnostics |
 | `regression-status.json` | baseline-relative integer-count ratchet verdict |
@@ -116,11 +116,12 @@ failed-closed total. Regression comparison requires scored-set identity before
 emitting any metric or per-label delta. A mismatch names the IDs added to and
 removed from the scored set even when cardinality and gold counts are unchanged.
 
-These fields are an additive schema-v3 extension. Older schema-v3 artifacts
-remain readable as historical evidence, but because they do not identify each
-cell's scored set they cannot pass the current like-for-like population or
-per-label evaluability gates. Generate a new baseline with the current harness
-before using those gates; the committed historical artifact is not rewritten.
+These fields define schema v4. Older schema-v3 artifacts remain readable for
+diagnostic replay and their aggregate evidence is not rewritten. Because v3
+does not identify each cell's scored set, however, it cannot pass the current
+like-for-like population or per-label evaluability gates and cannot serve as a
+v4 comparison baseline. Generate a v4 baseline with the current harness before
+using those gates.
 
 A quick result is always marked not release-ready because it samples the
 population. Quick exits successfully when that incompleteness is its only
@@ -150,7 +151,7 @@ uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py \
   --accept-baseline-confirm I_HAVE_REVIEWED_FULL_RESULTS
 ```
 
-Review `scorecard-v3.json`, all three status files, `diagnostics.json`, and the
+Review `scorecard-v4.json`, all three status files, `diagnostics.json`, and the
 stderr logs before using that command. Quick results and failed candidates can
 never replace a baseline.
 

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -92,7 +92,7 @@ Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
 
 | Artifact | Purpose |
 | --- | --- |
-| `scorecard-v3.json` | full schema-v3 scorecard and runner provenance |
+| `scorecard-v3.json` | full schema-v3 scorecard, runner provenance, and identified scored/failed-closed populations per cell |
 | `summary.md` | concise human-readable result |
 | `diagnostics.json` | per-language, per-label, and per-negative-category diagnostics |
 | `regression-status.json` | baseline-relative integer-count ratchet verdict |
@@ -107,6 +107,20 @@ cell to have no pipeline, restore, manifest, telemetry-agreement, or strict
 rejection failures. The production candidate cell must additionally have no
 leaked labeled bytes, uncovered entities, unscanned documents, residual suspects,
 or redact actions. A full command exits nonzero for either correctness failure.
+
+Every cell records sorted `scored_population.document_ids` and
+`failed_closed_population.document_ids` plus a SHA-256 digest over each list.
+Failed-closed entries also name the synthetic document ID, closed failure reason,
+and closed stage; their reason/stage counts must reconcile exactly to the
+failed-closed total. Regression comparison requires scored-set identity before
+emitting any metric or per-label delta. A mismatch names the IDs added to and
+removed from the scored set even when cardinality and gold counts are unchanged.
+
+These fields are an additive schema-v3 extension. Older schema-v3 artifacts
+remain readable as historical evidence, but because they do not identify each
+cell's scored set they cannot pass the current like-for-like population or
+per-label evaluability gates. Generate a new baseline with the current harness
+before using those gates; the committed historical artifact is not rewritten.
 
 A quick result is always marked not release-ready because it samples the
 population. Quick exits successfully when that incompleteness is its only

--- a/scripts/bench/gaze-pipeline-bench.py
+++ b/scripts/bench/gaze-pipeline-bench.py
@@ -6,7 +6,7 @@ coverage from manifests and leak suspects. That inference can credit protection
 which was never applied, so the legacy generator is intentionally disabled.
 
 Use ``openpii_gaze_bench.py`` or ``dataiku_en_de_gaze_bench.py``. Both delegate
-all scoring to the strict schema-v3 ``gaze_bench_score`` library and consume
+all scoring to the strict schema-v4 ``gaze_bench_score`` library and consume
 producer-authored ``final_protection_trace`` evidence only.
 
 The historical implementation remains available in git history before PR #373.
@@ -14,5 +14,5 @@ It must not be restored as an executable scorer.
 """
 
 raise SystemExit(
-    "frozen legacy v0.9 benchmark is disabled; use a schema-v3 benchmark adapter"
+    "frozen legacy v0.9 benchmark is disabled; use a schema-v4 benchmark adapter"
 )

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -29,6 +29,47 @@ from typing import Iterable, Mapping, Sequence
 SCORECARD_SCHEMA_VERSION = 3
 DEFAULT_SAMPLE_SEED = 20_260_710
 SAMPLING_STRATEGY = "deterministic-stratified-language-region-v1"
+PIPELINE_FAILURE_STAGES = frozenset({"clean", "post_policy_scan"})
+PIPELINE_FAILURE_REASONS = frozenset(
+    {
+        "invalid_regex",
+        "unknown_token",
+        "export_forbidden",
+        "empty_document_integrity",
+        "invalid_snapshot_version",
+        "invalid_snapshot_signature",
+        "blob_expired",
+        "snapshot_decode",
+        "invalid_snapshot_payload",
+        "sqlite",
+        "policy",
+        "rulepack",
+        "recognizer_detect",
+        "redaction_log",
+        "safety_net_unavailable",
+        "safety_net_weights_missing",
+        "safety_net_model_unavailable",
+        "safety_net_model_integrity_mismatch",
+        "safety_net_input_too_large",
+        "safety_net_runtime_subprocess_timeout",
+        "safety_net_runtime_subprocess_non_zero_exit",
+        "safety_net_runtime_other",
+        "safety_net_invalid_output_malformed_backend_output",
+        "safety_net_invalid_output_label_decode_mismatch",
+        "safety_net_invalid_output_clean_to_raw_mapping",
+        "safety_net_invalid_output_trace_manifest_mismatch",
+        "safety_net_invalid_output_other",
+        "safety_net_fallback_overlap_conflict",
+        "safety_net_fallback_validator_veto",
+        "safety_net_fallback_anchor_missing",
+        "safety_net_fallback_residual_suspect",
+        "safety_net_span_invalid",
+        "unsupported_capital_heuristic_locale",
+        "unsupported_raw_document_variant",
+        "unsupported_structured_value_variant",
+        "unsupported_policy_action_variant",
+    }
+)
 
 # These are direct or account-linked identifiers. The remaining observed
 # labels (date, time, age, gender, sex, title, amount, and currency) are still
@@ -95,6 +136,26 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def document_ids_digest(document_ids: Sequence[str]) -> dict[str, str]:
+    payload = json.dumps(
+        list(document_ids), ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+    return {"algorithm": "sha256", "value": hashlib.sha256(payload).hexdigest()}
+
+
+def identified_document_population(document_ids: Iterable[str]) -> dict[str, object]:
+    ids = sorted(document_ids)
+    if not all(isinstance(uid, str) and uid for uid in ids):
+        raise ValueError("document IDs must be non-empty strings")
+    if len(set(ids)) != len(ids):
+        raise ValueError("document IDs must be unique")
+    return {
+        "documents": len(ids),
+        "document_ids": ids,
+        "document_ids_digest": document_ids_digest(ids),
+    }
+
+
 def char_to_byte_offsets(text: str) -> list[int]:
     offsets = [0]
     byte_offset = 0
@@ -148,8 +209,7 @@ def _proportional_allocation(
     if budget > capacity_total:
         raise ValueError("sample allocation exceeds available population")
     quotas = {
-        key: budget * capacity / capacity_total
-        for key, capacity in capacities.items()
+        key: budget * capacity / capacity_total for key, capacity in capacities.items()
     }
     for key, quota in quotas.items():
         allocations[key] = min(capacities[key], math.floor(quota))
@@ -205,15 +265,13 @@ def stratified_sample(
     evaluated: list[Document] = []
     for key in sorted(strata):
         ranked = sorted(
-            strata[key], key=lambda document: (_document_rank(seed, document), document.uid)
+            strata[key],
+            key=lambda document: (_document_rank(seed, document), document.uid),
         )
         evaluated.extend(ranked[: allocation[key]])
     evaluated.sort(key=lambda document: (_document_rank(seed, document), document.uid))
 
     evaluated_ids = [document.uid for document in evaluated]
-    digest_payload = json.dumps(
-        evaluated_ids, ensure_ascii=False, separators=(",", ":")
-    ).encode("utf-8")
     report: dict[str, object] = {
         "strategy": SAMPLING_STRATEGY,
         "seed": seed,
@@ -221,10 +279,7 @@ def stratified_sample(
         "available_population": population_summary(documents),
         "evaluated_population": population_summary(evaluated),
         "evaluated_document_ids": evaluated_ids,
-        "evaluated_document_ids_digest": {
-            "algorithm": "sha256",
-            "value": hashlib.sha256(digest_payload).hexdigest(),
-        },
+        "evaluated_document_ids_digest": document_ids_digest(evaluated_ids),
     }
     return evaluated, report
 
@@ -238,9 +293,7 @@ class SourceIdVocabularyError(RuntimeError):
 
 
 def _expect_object(value: object, context: str) -> dict[str, object]:
-    if not isinstance(value, dict) or not all(
-        isinstance(key, str) for key in value
-    ):
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
         raise ResponseValidationError(f"{context}: expected an object")
     return value
 
@@ -310,12 +363,8 @@ VALID_TRACE_COMBINATIONS = frozenset(
         ("safety_net", "fallback_redact", "redact"),
     }
 )
-BUILTIN_CANONICAL_CLASSES = frozenset(
-    {"email", "name", "location", "organization"}
-)
-SOURCE_ID_PATTERN = re.compile(
-    r"(?=.{1,128}\Z)[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*\Z"
-)
+BUILTIN_CANONICAL_CLASSES = frozenset({"email", "name", "location", "organization"})
+SOURCE_ID_PATTERN = re.compile(r"(?=.{1,128}\Z)[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*\Z")
 LEAK_SUSPECT_FIELDS = frozenset(
     {
         "clean_start",
@@ -357,9 +406,7 @@ MANIFEST_INTEGRITY_FIELDS = frozenset(
         "raw_value_mismatches",
     }
 )
-SUCCESS_TIMING_FIELDS = frozenset(
-    {"clean_ms", "restore_ms", "post_policy_scan_ms"}
-)
+SUCCESS_TIMING_FIELDS = frozenset({"clean_ms", "restore_ms", "post_policy_scan_ms"})
 SUCCESS_RESPONSE_FIELDS = frozenset(
     {
         "fixture_id",
@@ -549,9 +596,7 @@ def load_committed_source_id_vocabulary(
         if not isinstance(section, dict) or "id" not in section:
             continue
         identifiers.add(
-            _committed_vocabulary_id(
-                section["id"], f"{model_path}: {section_name}.id"
-            )
+            _committed_vocabulary_id(section["id"], f"{model_path}: {section_name}.id")
         )
         model_count += 1
     if model_count == 0:
@@ -599,13 +644,17 @@ def _validate_final_protection_trace(
             provenance["source_ids"], f"{context}.provenance.source_ids"
         )
         source_ids = [
-            _expect_string(source_id, f"{context}.provenance.source_ids[{source_index}]")
+            _expect_string(
+                source_id, f"{context}.provenance.source_ids[{source_index}]"
+            )
             for source_index, source_id in enumerate(source_values)
         ]
 
         _validate_canonical_class(pii_class, f"{context}.class")
         if action not in {"tokenize", "redact"}:
-            raise ResponseValidationError(f"{context}.action: unknown action {action!r}")
+            raise ResponseValidationError(
+                f"{context}.action: unknown action {action!r}"
+            )
         if (stage, decision, action) not in VALID_TRACE_COMBINATIONS:
             raise ResponseValidationError(
                 f"{context}.provenance: invalid stage/decision/action combination"
@@ -616,9 +665,7 @@ def _validate_final_protection_trace(
             )
         for source_index, source_id in enumerate(source_ids):
             source_context = f"{context}.provenance.source_ids[{source_index}]"
-            _validate_source_id(
-                source_id, source_context
-            )
+            _validate_source_id(source_id, source_context)
             source_identifiers.append((source_id, source_context))
         if source_ids != sorted(source_ids) or len(source_ids) != len(set(source_ids)):
             raise ResponseValidationError(
@@ -676,8 +723,16 @@ def validate_response(document: Document, value: object) -> dict[str, object]:
             f"{document.uid}: pipeline error response",
         )
         fixture_id = _expect_string(response["fixture_id"], "fixture_id")
-        _expect_string(response["pipeline_error_stage"], "pipeline_error_stage")
-        _expect_string(response["pipeline_error_code"], "pipeline_error_code")
+        stage = _expect_string(response["pipeline_error_stage"], "pipeline_error_stage")
+        reason = _expect_string(response["pipeline_error_code"], "pipeline_error_code")
+        if stage not in PIPELINE_FAILURE_STAGES:
+            raise ResponseValidationError(
+                f"pipeline_error_stage: unknown closed stage {stage!r}"
+            )
+        if reason not in PIPELINE_FAILURE_REASONS:
+            raise ResponseValidationError(
+                f"pipeline_error_code: unknown closed reason {reason!r}"
+            )
         timing = _expect_exact_keys(
             response["timing"], frozenset({"total_ms"}), "pipeline error timing"
         )
@@ -750,12 +805,16 @@ def validate_response(document: Document, value: object) -> dict[str, object]:
         _validate_final_protection_trace(
             document, response["final_protection_trace"], manifest
         )
-        if any(
-            _expect_object(item, "final_protection_trace item")["action"] == "redact"
-            for item in _expect_list(
-                response["final_protection_trace"], "final_protection_trace"
+        if (
+            any(
+                _expect_object(item, "final_protection_trace item")["action"]
+                == "redact"
+                for item in _expect_list(
+                    response["final_protection_trace"], "final_protection_trace"
+                )
             )
-        ) and _expect_object(response["restore"], "restore")["exact"] is True:
+            and _expect_object(response["restore"], "restore")["exact"] is True
+        ):
             raise ResponseValidationError(
                 "restore.exact: redact protection cannot be exactly reversible"
             )
@@ -765,8 +824,6 @@ def validate_response(document: Document, value: object) -> dict[str, object]:
             f"runner response mismatch: expected {document.uid}, received {fixture_id}"
         )
     return response
-
-
 
 
 def merge_intervals(intervals: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
@@ -807,14 +864,19 @@ def interval_is_covered(
     interval: tuple[int, int], covering: Sequence[tuple[int, int]]
 ) -> bool:
     start, end = interval
-    return any(cover_start <= start and cover_end >= end for cover_start, cover_end in covering)
+    return any(
+        cover_start <= start and cover_end >= end for cover_start, cover_end in covering
+    )
 
 
 def interval_overlaps(
     interval: tuple[int, int], candidates: Sequence[tuple[int, int]]
 ) -> bool:
     start, end = interval
-    return any(candidate_start < end and start < candidate_end for candidate_start, candidate_end in candidates)
+    return any(
+        candidate_start < end and start < candidate_end
+        for candidate_start, candidate_end in candidates
+    )
 
 
 def safe_ratio(numerator: int | float, denominator: int | float) -> float:
@@ -1012,9 +1074,7 @@ class ContractAccumulator:
         self.strict_would_reject_documents += bool(response["strict_would_reject"])
         trace = response.get("final_protection_trace", [])
         assert isinstance(trace, list)
-        actions = [
-            item["action"] for item in trace if isinstance(item, dict)
-        ]
+        actions = [item["action"] for item in trace if isinstance(item, dict)]
         self.protection_trace_items += len(actions)
         self.tokenize_actions += actions.count("tokenize")
         self.redact_actions += actions.count("redact")
@@ -1095,7 +1155,11 @@ def validate_prediction(document: Document, raw: dict[str, object]) -> Span:
     start = raw["raw_start"]
     end = raw["raw_end"]
     label = raw["class"]
-    if not isinstance(start, int) or not isinstance(end, int) or not isinstance(label, str):
+    if (
+        not isinstance(start, int)
+        or not isinstance(end, int)
+        or not isinstance(label, str)
+    ):
         raise RuntimeError(f"{document.uid}: invalid prediction shape")
     text_bytes = len(document.text.encode("utf-8"))
     if start < 0 or end <= start or end > text_bytes:
@@ -1128,9 +1192,14 @@ def run_config(
 ) -> dict[str, object]:
     if not documents:
         raise ValueError(f"{config}: cannot run an empty document cell")
+    attempted_document_ids = [document.uid for document in documents]
+    if len(set(attempted_document_ids)) != len(attempted_document_ids):
+        raise ValueError(f"{config}: document IDs must be unique within a run")
     if warmup_count < 0:
         raise ValueError("warmup_count must be non-negative")
-    environment = dict(base_environment) if base_environment is not None else os.environ.copy()
+    environment = (
+        dict(base_environment) if base_environment is not None else os.environ.copy()
+    )
     environment["GAZE_NER_MODEL_DIR"] = str(model_dir)
     environment["GAZE_NER_THRESHOLD"] = str(threshold)
     environment["GAZE_KIJI_DISTILBERT_MODEL_DIR"] = str(kiji_model_dir)
@@ -1168,8 +1237,8 @@ def run_config(
     direct = RecallAccumulator()
     contextual = RecallAccumulator()
     contract = ContractAccumulator()
-    pipeline_errors: Counter[str] = Counter()
-    pipeline_error_stages: Counter[str] = Counter()
+    scored_document_ids: list[str] = []
+    failed_closed_documents: list[dict[str, str]] = []
     success_timing: defaultdict[str, list[float]] = defaultdict(list)
     first_response_ms: float | None = None
     discarded_warmup_samples: list[dict[str, object]] = []
@@ -1230,13 +1299,10 @@ def run_config(
                     metric_result["entities"]["gold"]
                     - metric_result["entities"]["fully_covered"]
                 ),
-                "restore_failures": 1
-                - contract_result["restore_exact_documents"],
+                "restore_failures": 1 - contract_result["restore_exact_documents"],
                 "manifest_invalid_documents": 1
                 - contract_result["manifest_valid_documents"],
-                "strict_rejections": contract_result[
-                    "strict_would_reject_documents"
-                ],
+                "strict_rejections": contract_result["strict_would_reject_documents"],
                 "residual_suspects": contract_result["post_policy_suspects"],
                 "redact_actions": contract_result["redact_actions"],
             }
@@ -1253,9 +1319,15 @@ def run_config(
         for index, document in enumerate(documents):
             response, _ = exchange(document)
             if "pipeline_error_code" in response:
-                pipeline_errors[str(response["pipeline_error_code"])] += 1
-                pipeline_error_stages[str(response["pipeline_error_stage"])] += 1
+                failed_closed_documents.append(
+                    {
+                        "document_id": document.uid,
+                        "reason": str(response["pipeline_error_code"]),
+                        "stage": str(response["pipeline_error_stage"]),
+                    }
+                )
                 continue
+            scored_document_ids.append(document.uid)
             predictions = final_trace_predictions(document, response)
             overall.add(document, predictions)
             per_language[document.language].add(document, predictions)
@@ -1264,17 +1336,22 @@ def run_config(
                     document, predictions
                 )
             direct_spans = [
-                span for span in document.spans if span.label in DIRECT_IDENTIFIER_LABELS
+                span
+                for span in document.spans
+                if span.label in DIRECT_IDENTIFIER_LABELS
             ]
             contextual_spans = [
-                span for span in document.spans if span.label not in DIRECT_IDENTIFIER_LABELS
+                span
+                for span in document.spans
+                if span.label not in DIRECT_IDENTIFIER_LABELS
             ]
             direct.add(direct_spans, predictions)
             contextual.add(contextual_spans, predictions)
             contract.add(response)
             for label in {span.label for span in document.spans}:
                 per_label[label].add(
-                    [span for span in document.spans if span.label == label], predictions
+                    [span for span in document.spans if span.label == label],
+                    predictions,
                 )
             for key, value in response["timing"].items():
                 if value is not None:
@@ -1299,19 +1376,35 @@ def run_config(
         if clean_ms and measured_clean_seconds > 0.0
         else None
     )
+    failed_closed_documents.sort(key=lambda item: item["document_id"])
+    failed_closed_document_ids = [
+        item["document_id"] for item in failed_closed_documents
+    ]
+    pipeline_errors = Counter(item["reason"] for item in failed_closed_documents)
+    pipeline_error_stages = Counter(item["stage"] for item in failed_closed_documents)
+    scored_population = identified_document_population(scored_document_ids)
+    failed_closed_population = {
+        **identified_document_population(failed_closed_document_ids),
+        "excluded_documents": failed_closed_documents,
+        "reason_counts": dict(sorted(pipeline_errors.items())),
+        "stage_counts": dict(sorted(pipeline_error_stages.items())),
+    }
+    failed_closed_count = len(failed_closed_documents)
     return {
         "config": config,
+        "scored_population": scored_population,
+        "failed_closed_population": failed_closed_population,
         "metrics": overall.result(),
         "direct_identifier_recall": direct.result(),
         "contextual_pii_recall": contextual.result(),
         "pipeline_contract": contract.result(),
         "pipeline_availability": {
             "attempted_documents": len(documents),
-            "completed_documents": len(documents) - sum(pipeline_errors.values()),
+            "completed_documents": len(documents) - failed_closed_count,
             "completion_rate": safe_ratio(
-                len(documents) - sum(pipeline_errors.values()), len(documents)
+                len(documents) - failed_closed_count, len(documents)
             ),
-            "failed_closed_documents": sum(pipeline_errors.values()),
+            "failed_closed_documents": failed_closed_count,
             "errors": dict(sorted(pipeline_errors.items())),
             "error_stages": dict(sorted(pipeline_error_stages.items())),
         },
@@ -1322,12 +1415,10 @@ def run_config(
             key: value.result() for key, value in sorted(per_label.items())
         },
         "per_negative_category": {
-            key: value.result()
-            for key, value in sorted(per_negative_category.items())
+            key: value.result() for key, value in sorted(per_negative_category.items())
         },
         "latency_ms": {
-            key: timing_summary(value)
-            for key, value in sorted(success_timing.items())
+            key: timing_summary(value) for key, value in sorted(success_timing.items())
         },
         "warm_latency_ms": {
             key: timing_summary(value[1:])
@@ -1384,14 +1475,16 @@ SCORING_METADATA: dict[str, object] = {
         "A protected byte counts for safety even when its action is not reversible.",
         "Restore, manifest, pipeline, and telemetry failures remain separate hard failures.",
         "Final protection evidence contains offsets, classes, counts, and stable IDs only; never PII values.",
+        "Per-cell scored and failed-closed populations are sorted synthetic document-ID sets with SHA-256 digests.",
+        "Failed-closed reason and stage counts reconcile exactly to the identified excluded documents.",
         "Latency is considered only after correctness gates pass.",
     ],
     "comparison_gates": {
         "correctness": "zero-tolerance integer-count ratchets; ratios are diagnostics only",
         "release_readiness": "production cell must have zero correctness failures",
         "population": (
-            "candidate and baseline evaluated-population provenance and invariant "
-            "counts must match"
+            "candidate and baseline dataset provenance plus per-cell scored and "
+            "failed-closed document sets must match"
         ),
         "performance": (
             "clean_ms p95 uses a separately configured tolerance and is "
@@ -1524,6 +1617,7 @@ def _evaluated_population_provenance(
         "evaluated_population": evaluated,
         "sampling_strategy": strategy,
         "sampling_seed": seed,
+        "evaluated_document_ids": evaluated_ids,
         "evaluated_document_ids_digest": digest,
     }
 
@@ -1537,8 +1631,191 @@ def _count(value: object, context: str) -> int:
 def _count_map(value: object, context: str) -> dict[str, int]:
     if not isinstance(value, dict):
         raise ValueError(f"{context} must be an object")
+    return {str(key): _count(item, f"{context}.{key}") for key, item in value.items()}
+
+
+def _exact_object(
+    value: object, required: frozenset[str], context: str
+) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{context} must be an object")
+    if set(value) != required:
+        raise ValueError(
+            f"{context} fields disagree: "
+            f"missing={sorted(required - value.keys())}, "
+            f"unknown={sorted(value.keys() - required)}"
+        )
+    return value
+
+
+def _identified_population_ids(value: object, context: str) -> frozenset[str]:
+    population = _exact_object(
+        value,
+        frozenset({"documents", "document_ids", "document_ids_digest"}),
+        context,
+    )
+    documents = _count(population["documents"], f"{context}.documents")
+    raw_ids = population["document_ids"]
+    if not isinstance(raw_ids, list) or not all(
+        isinstance(uid, str) and uid for uid in raw_ids
+    ):
+        raise ValueError(f"{context}.document_ids must be a string array")
+    if raw_ids != sorted(raw_ids) or len(set(raw_ids)) != len(raw_ids):
+        raise ValueError(f"{context}.document_ids must be a sorted duplicate-free set")
+    if len(raw_ids) != documents:
+        raise ValueError(f"{context}.document_ids disagree with documents")
+    digest = population["document_ids_digest"]
+    if not isinstance(digest, dict) or set(digest) != {"algorithm", "value"}:
+        raise ValueError(f"{context}.document_ids_digest has an invalid shape")
+    if digest != document_ids_digest(raw_ids):
+        raise ValueError(f"{context}.document_ids_digest does not match the IDs")
+    return frozenset(raw_ids)
+
+
+def _run_population_provenance(
+    run: Mapping[str, object],
+    *,
+    context: str,
+    expected_document_ids: Iterable[str] | None = None,
+) -> dict[str, frozenset[str]]:
+    availability = run.get("pipeline_availability")
+    if not isinstance(availability, dict):
+        raise ValueError(f"{context}.pipeline_availability must be an object")
+    completed = _count(
+        availability.get("completed_documents"),
+        f"{context}.pipeline_availability.completed_documents",
+    )
+    failed = _count(
+        availability.get("failed_closed_documents"),
+        f"{context}.pipeline_availability.failed_closed_documents",
+    )
+    attempted = _count(
+        availability.get("attempted_documents"),
+        f"{context}.pipeline_availability.attempted_documents",
+    )
+    scored_ids = _identified_population_ids(
+        run.get("scored_population"), f"{context}.scored_population"
+    )
+    raw_failed_population = run.get("failed_closed_population")
+    if not isinstance(raw_failed_population, dict):
+        raise ValueError(f"{context}.failed_closed_population must be an object")
+    failed_population = _exact_object(
+        raw_failed_population,
+        frozenset(
+            {
+                "documents",
+                "document_ids",
+                "document_ids_digest",
+                "excluded_documents",
+                "reason_counts",
+                "stage_counts",
+            }
+        ),
+        f"{context}.failed_closed_population",
+    )
+    failed_ids = _identified_population_ids(
+        {
+            key: failed_population[key]
+            for key in ("documents", "document_ids", "document_ids_digest")
+        },
+        f"{context}.failed_closed_population",
+    )
+    exclusions = failed_population["excluded_documents"]
+    if not isinstance(exclusions, list):
+        raise ValueError(
+            f"{context}.failed_closed_population.excluded_documents must be an array"
+        )
+    excluded_ids: list[str] = []
+    observed_reasons: Counter[str] = Counter()
+    observed_stages: Counter[str] = Counter()
+    for index, raw_exclusion in enumerate(exclusions):
+        exclusion_context = (
+            f"{context}.failed_closed_population.excluded_documents[{index}]"
+        )
+        exclusion = _exact_object(
+            raw_exclusion,
+            frozenset({"document_id", "reason", "stage"}),
+            exclusion_context,
+        )
+        document_id = exclusion["document_id"]
+        reason = exclusion["reason"]
+        stage = exclusion["stage"]
+        if not isinstance(document_id, str) or not document_id:
+            raise ValueError(f"{exclusion_context}.document_id must be a string")
+        if not isinstance(reason, str):
+            raise ValueError(f"{exclusion_context}.reason must be a string")
+        if not isinstance(stage, str):
+            raise ValueError(f"{exclusion_context}.stage must be a string")
+        if reason not in PIPELINE_FAILURE_REASONS:
+            raise ValueError(f"{exclusion_context}.reason is not a closed reason")
+        if stage not in PIPELINE_FAILURE_STAGES:
+            raise ValueError(f"{exclusion_context}.stage is not a closed stage")
+        excluded_ids.append(document_id)
+        observed_reasons[reason] += 1
+        observed_stages[stage] += 1
+    if excluded_ids != sorted(excluded_ids) or len(set(excluded_ids)) != len(
+        excluded_ids
+    ):
+        raise ValueError(
+            f"{context}.failed_closed_population exclusions must be sorted and unique"
+        )
+    if frozenset(excluded_ids) != failed_ids:
+        raise ValueError(
+            f"{context}.failed_closed_population exclusions disagree with document IDs"
+        )
+    reason_counts = _count_map(
+        failed_population["reason_counts"],
+        f"{context}.failed_closed_population.reason_counts",
+    )
+    stage_counts = _count_map(
+        failed_population["stage_counts"],
+        f"{context}.failed_closed_population.stage_counts",
+    )
+    if set(reason_counts) - PIPELINE_FAILURE_REASONS:
+        raise ValueError(
+            f"{context}.failed_closed_population.reason_counts contains an unknown reason"
+        )
+    if set(stage_counts) - PIPELINE_FAILURE_STAGES:
+        raise ValueError(
+            f"{context}.failed_closed_population.stage_counts contains an unknown stage"
+        )
+    if reason_counts != dict(observed_reasons):
+        raise ValueError(
+            f"{context}.failed-closed reason counts do not reconcile to excluded documents"
+        )
+    if stage_counts != dict(observed_stages):
+        raise ValueError(
+            f"{context}.failed-closed stage counts do not reconcile to excluded documents"
+        )
+    availability_reasons = _count_map(
+        availability.get("errors", {}), f"{context}.pipeline_availability.errors"
+    )
+    availability_stages = _count_map(
+        availability.get("error_stages", {}),
+        f"{context}.pipeline_availability.error_stages",
+    )
+    if reason_counts != availability_reasons or stage_counts != availability_stages:
+        raise ValueError(
+            f"{context}.failed-closed breakdown disagrees with pipeline availability"
+        )
+    if len(scored_ids) != completed or len(failed_ids) != failed:
+        raise ValueError(f"{context}.population IDs disagree with availability counts")
+    if scored_ids & failed_ids:
+        raise ValueError(f"{context}.scored and failed-closed populations overlap")
+    attempted_ids = scored_ids | failed_ids
+    if len(attempted_ids) != attempted:
+        raise ValueError(
+            f"{context}.population IDs do not reconcile to attempted total"
+        )
+    if expected_document_ids is not None:
+        expected_ids = frozenset(expected_document_ids)
+        if attempted_ids != expected_ids:
+            raise ValueError(
+                f"{context}.attempted population disagrees with dataset evaluated IDs"
+            )
     return {
-        str(key): _count(item, f"{context}.{key}") for key, item in value.items()
+        "scored_document_ids": scored_ids,
+        "failed_closed_document_ids": failed_ids,
     }
 
 
@@ -1554,9 +1831,7 @@ def _run_correctness_counts(run: Mapping[str, object]) -> dict[str, int]:
         raise ValueError("scorecard metric sections must be objects")
     attempted = _count(availability["attempted_documents"], "attempted_documents")
     completed = _count(availability["completed_documents"], "completed_documents")
-    failed = _count(
-        availability["failed_closed_documents"], "failed_closed_documents"
-    )
+    failed = _count(availability["failed_closed_documents"], "failed_closed_documents")
     errors = _count_map(availability.get("errors", {}), "pipeline errors")
     error_stages = _count_map(
         availability.get("error_stages", {}), "pipeline error stages"
@@ -1655,6 +1930,7 @@ def _run_correctness_counts(run: Mapping[str, object]) -> dict[str, int]:
 
 def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, object]:
     failures: list[dict[str, object]] = []
+    evaluated_document_ids: list[str] | None = None
     try:
         candidate_runs = _scorecard_runs(candidate)
     except (KeyError, TypeError, ValueError) as error:
@@ -1672,7 +1948,8 @@ def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, obj
             }
         )
     try:
-        _evaluated_population_provenance(candidate)
+        population_provenance = _evaluated_population_provenance(candidate)
+        evaluated_document_ids = list(population_provenance["evaluated_document_ids"])
     except (KeyError, TypeError, ValueError) as error:
         failures.append(
             {
@@ -1693,6 +1970,21 @@ def evaluate_release_readiness(candidate: Mapping[str, object]) -> dict[str, obj
                 }
             )
             continue
+        if evaluated_document_ids is not None:
+            try:
+                _run_population_provenance(
+                    candidate_runs[config],
+                    context=f"candidate {config}",
+                    expected_document_ids=evaluated_document_ids,
+                )
+            except (KeyError, TypeError, ValueError) as error:
+                failures.append(
+                    {
+                        "config": config,
+                        "gate": "candidate_run_population_provenance",
+                        "reason": str(error),
+                    }
+                )
         cell_counts[config] = counts
         for gate in (
             "failed_closed_documents",
@@ -1772,31 +2064,22 @@ def _label_coverage(
     return out
 
 
+def _optional_scored_document_ids(
+    run: Mapping[str, object], context: str
+) -> frozenset[str] | None:
+    if "scored_population" not in run:
+        return None
+    return _identified_population_ids(
+        run["scored_population"], f"{context}.scored_population"
+    )
+
+
 def _class_coverage_failures(
     config: str,
     candidate_run: Mapping[str, object],
     baseline_run: Mapping[str, object],
 ) -> list[dict[str, object]]:
-    """Flags any class that LOST coverage on an unchanged population.
-
-    The discriminator is deliberately narrow: for a given class, if the gold
-    entity count is IDENTICAL between baseline and candidate, then any decrease
-    in `fully_covered` or `overlapped` means protection that existed before does
-    not exist now. Because the scorer merges every prediction class-agnostically
-    before computing coverage, an entity leaving `overlapped` means NO prediction
-    of ANY class intersects it any more -- the bytes are raw, not merely
-    mislabelled. That is an axis-1 leak introduced by a change, and it is exactly
-    the condition that three manual reviews missed.
-
-    Where the entity count DIFFERS the comparison is not like-for-like, and this
-    gate emits a NON-PASS `class_population_evaluability` entry rather than
-    staying silent. Silence there would let a change hide a coverage loss by also
-    perturbing the population -- the precise shape that disqualified an earlier
-    candidate whose leak "win" came from denominator shrinkage.
-
-    Depends on the scored population being identifiable at all (todo #2414) and
-    is the companion of typed failure reporting (todo #2413).
-    """
+    """Flags any class that lost coverage on an identical scored-document set."""
     failures: list[dict[str, object]] = []
     candidate_labels = _label_coverage(candidate_run, f"candidate {config}")
     baseline_labels = _label_coverage(baseline_run, f"baseline {config}")
@@ -1816,7 +2099,56 @@ def _class_coverage_failures(
             }
         )
         return failures
-    for label in sorted(set(candidate_labels) & set(baseline_labels)):
+    candidate_population = _optional_scored_document_ids(
+        candidate_run, f"candidate {config}"
+    )
+    baseline_population = _optional_scored_document_ids(
+        baseline_run, f"baseline {config}"
+    )
+    labels = sorted(set(candidate_labels) | set(baseline_labels))
+    if candidate_population is None or baseline_population is None:
+        for label in labels:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": CLASS_POPULATION_EVALUABILITY_GATE,
+                    "label": label,
+                    "reason": "scored_population_unidentified, cannot evaluate",
+                    "candidate_entities": candidate_labels.get(label, (0, 0, 0, 0))[0],
+                    "baseline_entities": baseline_labels.get(label, (0, 0, 0, 0))[0],
+                }
+            )
+        return failures
+    if candidate_population != baseline_population:
+        added_document_ids = sorted(candidate_population - baseline_population)
+        removed_document_ids = sorted(baseline_population - candidate_population)
+        for label in labels:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": CLASS_POPULATION_EVALUABILITY_GATE,
+                    "label": label,
+                    "reason": "population_moved, cannot evaluate",
+                    "candidate_entities": candidate_labels.get(label, (0, 0, 0, 0))[0],
+                    "baseline_entities": baseline_labels.get(label, (0, 0, 0, 0))[0],
+                    "added_document_ids": added_document_ids,
+                    "removed_document_ids": removed_document_ids,
+                }
+            )
+        return failures
+    for label in labels:
+        if label not in candidate_labels or label not in baseline_labels:
+            failures.append(
+                {
+                    "config": config,
+                    "gate": CLASS_POPULATION_EVALUABILITY_GATE,
+                    "label": label,
+                    "reason": "label_missing_on_identical_scored_population",
+                    "candidate_entities": candidate_labels.get(label, (0, 0, 0, 0))[0],
+                    "baseline_entities": baseline_labels.get(label, (0, 0, 0, 0))[0],
+                }
+            )
+            continue
         c_entities, c_full, c_overlap, c_leaked = candidate_labels[label]
         b_entities, b_full, b_overlap, b_leaked = baseline_labels[label]
         if c_entities != b_entities:
@@ -1825,13 +2157,13 @@ def _class_coverage_failures(
                     "config": config,
                     "gate": CLASS_POPULATION_EVALUABILITY_GATE,
                     "label": label,
-                    "reason": "population_moved, cannot evaluate",
+                    "reason": "gold_count_mismatch_on_identical_scored_population",
                     "candidate_entities": c_entities,
                     "baseline_entities": b_entities,
                 }
             )
             continue
-        if c_full < b_full or c_overlap < b_overlap:
+        if c_full < b_full or c_overlap < b_overlap or c_leaked > b_leaked:
             failures.append(
                 {
                     "config": config,
@@ -1940,9 +2272,13 @@ def compare_scorecards(
         and baseline_provenance is not None
         and candidate_provenance != baseline_provenance
     ):
+        candidate_ids = frozenset(candidate_provenance["evaluated_document_ids"])
+        baseline_ids = frozenset(baseline_provenance["evaluated_document_ids"])
         failure = {
             "gate": "evaluated_population_provenance_match",
             "reason": "candidate and baseline provenance differ",
+            "added_document_ids": sorted(candidate_ids - baseline_ids),
+            "removed_document_ids": sorted(baseline_ids - candidate_ids),
         }
         regression_failures.append(failure)
 
@@ -1953,7 +2289,10 @@ def compare_scorecards(
         and candidate_provenance == baseline_provenance
     )
     if prerequisites_match:
+        expected_document_ids = candidate_provenance["evaluated_document_ids"]
         for config in sorted(expected_configs):
+            candidate_values: dict[str, int] | None = None
+            baseline_values: dict[str, int] | None = None
             try:
                 candidate_values = _run_correctness_counts(candidate_runs[config])
                 baseline_values = _run_correctness_counts(baseline_runs[config])
@@ -1965,37 +2304,100 @@ def compare_scorecards(
                         "reason": str(error),
                     }
                 )
-                continue
-            for gate in invariant_counts:
-                if candidate_values[gate] != baseline_values[gate]:
+            candidate_population: dict[str, frozenset[str]] | None = None
+            baseline_population: dict[str, frozenset[str]] | None = None
+            try:
+                candidate_population = _run_population_provenance(
+                    candidate_runs[config],
+                    context=f"candidate {config}",
+                    expected_document_ids=expected_document_ids,
+                )
+            except (KeyError, TypeError, ValueError) as error:
+                regression_failures.append(
+                    {
+                        "config": config,
+                        "gate": "candidate_run_population_provenance",
+                        "reason": str(error),
+                    }
+                )
+            try:
+                baseline_population = _run_population_provenance(
+                    baseline_runs[config],
+                    context=f"baseline {config}",
+                    expected_document_ids=expected_document_ids,
+                )
+            except (KeyError, TypeError, ValueError) as error:
+                regression_failures.append(
+                    {
+                        "config": config,
+                        "gate": "baseline_run_population_provenance",
+                        "reason": str(error),
+                    }
+                )
+            populations_match = (
+                candidate_population is not None
+                and baseline_population is not None
+                and candidate_population == baseline_population
+            )
+            if candidate_population is not None and baseline_population is not None:
+                for population_name in (
+                    "scored_document_ids",
+                    "failed_closed_document_ids",
+                ):
+                    candidate_ids = candidate_population[population_name]
+                    baseline_ids = baseline_population[population_name]
+                    if candidate_ids == baseline_ids:
+                        continue
                     regression_failures.append(
                         {
                             "config": config,
-                            "gate": f"{gate}_match",
-                            "candidate": candidate_values[gate],
-                            "baseline": baseline_values[gate],
+                            "gate": (
+                                "scored_population_identity_match"
+                                if population_name == "scored_document_ids"
+                                else "failed_closed_population_identity_match"
+                            ),
+                            "reason": "candidate and baseline document sets differ",
+                            "added_document_ids": sorted(candidate_ids - baseline_ids),
+                            "removed_document_ids": sorted(
+                                baseline_ids - candidate_ids
+                            ),
                         }
                     )
-            for gate in higher_is_better:
-                if candidate_values[gate] < baseline_values[gate]:
-                    regression_failures.append(
-                        {
-                            "config": config,
-                            "gate": gate,
-                            "candidate": candidate_values[gate],
-                            "baseline": baseline_values[gate],
-                        }
-                    )
-            for gate in lower_is_better:
-                if candidate_values[gate] > baseline_values[gate]:
-                    regression_failures.append(
-                        {
-                            "config": config,
-                            "gate": gate,
-                            "candidate": candidate_values[gate],
-                            "baseline": baseline_values[gate],
-                        }
-                    )
+            if (
+                candidate_values is not None
+                and baseline_values is not None
+                and populations_match
+            ):
+                for gate in invariant_counts:
+                    if candidate_values[gate] != baseline_values[gate]:
+                        regression_failures.append(
+                            {
+                                "config": config,
+                                "gate": f"{gate}_match",
+                                "candidate": candidate_values[gate],
+                                "baseline": baseline_values[gate],
+                            }
+                        )
+                for gate in higher_is_better:
+                    if candidate_values[gate] < baseline_values[gate]:
+                        regression_failures.append(
+                            {
+                                "config": config,
+                                "gate": gate,
+                                "candidate": candidate_values[gate],
+                                "baseline": baseline_values[gate],
+                            }
+                        )
+                for gate in lower_is_better:
+                    if candidate_values[gate] > baseline_values[gate]:
+                        regression_failures.append(
+                            {
+                                "config": config,
+                                "gate": gate,
+                                "candidate": candidate_values[gate],
+                                "baseline": baseline_values[gate],
+                            }
+                        )
             try:
                 regression_failures.extend(
                     _class_coverage_failures(
@@ -2036,7 +2438,9 @@ def compare_performance(
         candidate_runs = _scorecard_runs(candidate)
         baseline_runs = _scorecard_runs(baseline)
         for config in sorted(DEFAULT_CONFIGS):
-            candidate_p95 = float(candidate_runs[config]["latency_ms"]["clean_ms"]["p95"])
+            candidate_p95 = float(
+                candidate_runs[config]["latency_ms"]["clean_ms"]["p95"]
+            )
             baseline_p95 = float(baseline_runs[config]["latency_ms"]["clean_ms"]["p95"])
             limit = baseline_p95 * (1.0 + tolerance_percent / 100.0)
             comparison = {

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -26,7 +26,8 @@ from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
 
-SCORECARD_SCHEMA_VERSION = 3
+SCORECARD_SCHEMA_VERSION = 4
+READABLE_SCORECARD_SCHEMA_VERSIONS = frozenset({3, SCORECARD_SCHEMA_VERSION})
 DEFAULT_SAMPLE_SEED = 20_260_710
 SAMPLING_STRATEGY = "deterministic-stratified-language-region-v1"
 PIPELINE_FAILURE_STAGES = frozenset({"clean", "post_policy_scan"})
@@ -285,7 +286,7 @@ def stratified_sample(
 
 
 class ResponseValidationError(RuntimeError):
-    """The Rust benchmark producer violated its closed schema-v3 wire contract."""
+    """The Rust benchmark producer violated its closed wire contract."""
 
 
 class SourceIdVocabularyError(RuntimeError):
@@ -1538,8 +1539,8 @@ def assemble_scorecard(
 
 def _scorecard_runs(scorecard: Mapping[str, object]) -> dict[str, Mapping[str, object]]:
     if type(scorecard.get("schema_version")) is not int:
-        raise ValueError("scorecard schema_version must be integer 3")
-    if scorecard["schema_version"] != SCORECARD_SCHEMA_VERSION:
+        raise ValueError("scorecard schema_version must be an integer")
+    if scorecard["schema_version"] not in READABLE_SCORECARD_SCHEMA_VERSIONS:
         raise ValueError(
             f"unsupported scorecard schema_version {scorecard['schema_version']}"
         )

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -23,9 +23,7 @@ DEFAULT_WARMUPS = 1
 DEFAULT_MEASURED_REPETITIONS = 1
 DEFAULT_PERFORMANCE_TOLERANCE_PERCENT = 20.0
 BASELINE_CONFIRMATION = "I_HAVE_REVIEWED_FULL_RESULTS"
-NEGATIVE_CORPUS = Path(
-    "crates/xtask/fixtures/negative_corpus/en_de_negative.jsonl"
-)
+NEGATIVE_CORPUS = Path("crates/xtask/fixtures/negative_corpus/en_de_negative.jsonl")
 MODEL_CONFIG = Path("crates/gaze-recognizers/benches/ner_models.toml")
 NO_OPF_MODEL_CONFIG = Path("scripts/bench/no_opf_models.toml")
 DEFAULT_DAVLAN_MODEL = Path("~/.local/share/gaze/models/davlan-mbert-ner-hrl")
@@ -106,9 +104,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--kiji-model-dir",
         type=Path,
         default=Path(
-            os.environ.get(
-                "GAZE_KIJI_DISTILBERT_MODEL_DIR", str(DEFAULT_KIJI_MODEL)
-            )
+            os.environ.get("GAZE_KIJI_DISTILBERT_MODEL_DIR", str(DEFAULT_KIJI_MODEL))
         ).expanduser(),
     )
     parser.add_argument("--threshold", type=float, default=0.3)
@@ -361,7 +357,9 @@ def load_negative_documents(
     documents: list[score.Document] = []
     languages: dict[str, int] = {}
     categories: dict[str, int] = {}
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), 1
+    ):
         try:
             row = json.loads(line)
         except json.JSONDecodeError as error:
@@ -519,16 +517,28 @@ def execute_measurements(
         )
     canonical = repetition_runs[0]
     canonical_counts = {
-        str(run["config"]): score._run_correctness_counts(run) for run in canonical
+        str(run["config"]): {
+            "counts": score._run_correctness_counts(run),
+            "scored_population": copy.deepcopy(run["scored_population"]),
+            "failed_closed_population": copy.deepcopy(run["failed_closed_population"]),
+        }
+        for run in canonical
     }
     for repetition, runs in enumerate(repetition_runs[1:], start=2):
         counts = {
-            str(run["config"]): score._run_correctness_counts(run) for run in runs
+            str(run["config"]): {
+                "counts": score._run_correctness_counts(run),
+                "scored_population": copy.deepcopy(run["scored_population"]),
+                "failed_closed_population": copy.deepcopy(
+                    run["failed_closed_population"]
+                ),
+            }
+            for run in runs
         }
         if counts != canonical_counts:
             raise RepetitionMismatchError(
                 f"measured repetition {repetition} disagrees with repetition 1 "
-                "on integer correctness counts"
+                "on integer correctness counts or identified populations"
             )
     return canonical, provenance
 
@@ -561,6 +571,8 @@ def diagnostics(scorecard: Mapping[str, object]) -> dict[str, object]:
         "runs": [
             {
                 "config": run["config"],
+                "scored_population": run["scored_population"],
+                "failed_closed_population": run["failed_closed_population"],
                 "per_language": run["per_language"],
                 "per_label": run["per_label_recall"],
                 "per_negative_category": run["per_negative_category"],
@@ -628,7 +640,9 @@ def accept_baseline(
             )
         return
     if args.profile != "full":
-        raise BaselineAcceptanceError("only a full-profile result may become a baseline")
+        raise BaselineAcceptanceError(
+            "only a full-profile result may become a baseline"
+        )
     if args.accept_baseline_confirm != BASELINE_CONFIRMATION:
         raise BaselineAcceptanceError(
             "baseline acceptance requires --accept-baseline-confirm "
@@ -663,7 +677,9 @@ def validate_cli_guards(args: argparse.Namespace) -> None:
             )
         return
     if args.profile != "full":
-        raise BaselineAcceptanceError("only a full-profile result may become a baseline")
+        raise BaselineAcceptanceError(
+            "only a full-profile result may become a baseline"
+        )
     if args.accept_baseline_confirm != BASELINE_CONFIRMATION:
         raise BaselineAcceptanceError(
             "baseline acceptance requires --accept-baseline-confirm "
@@ -694,9 +710,7 @@ def run(args: argparse.Namespace) -> int:
     davlan_model = args.model_dir.expanduser().resolve()
     kiji_model = args.kiji_model_dir.expanduser().resolve()
 
-    model_provenance = validate_required_models(
-        repo_root, davlan_model, kiji_model
-    )
+    model_provenance = validate_required_models(repo_root, davlan_model, kiji_model)
     if dataset_path.is_file():
         dataiku.verify_dataset(dataset_path)
     elif args.no_download:
@@ -733,9 +747,7 @@ def run(args: argparse.Namespace) -> int:
         warmup_count=args.warmups,
         measured_repetitions=args.measured_repetitions,
     )
-    metadata, dataset_report = composite_dataset_report(
-        dataiku_report, negative_report
-    )
+    metadata, dataset_report = composite_dataset_report(dataiku_report, negative_report)
     candidate = score.assemble_scorecard(
         repo_root=repo_root,
         dataset_metadata=metadata,

--- a/scripts/bench/run_no_opf_benchmark.py
+++ b/scripts/bench/run_no_opf_benchmark.py
@@ -824,7 +824,7 @@ def run(args: argparse.Namespace) -> int:
             **performance_result,
         }
 
-    write_json(output_dir / "scorecard-v3.json", candidate)
+    write_json(output_dir / "scorecard-v4.json", candidate)
     write_json(output_dir / "diagnostics.json", diagnostics(candidate))
     write_json(output_dir / "regression-status.json", regression)
     write_json(output_dir / "release-readiness-status.json", readiness)

--- a/scripts/bench/test_class_coverage_gate.py
+++ b/scripts/bench/test_class_coverage_gate.py
@@ -12,8 +12,12 @@ import unittest
 import gaze_bench_score as bench
 
 
-def run(label_table):
-    return {"config": "full-stack-kiji-resolve", "per_label_recall": label_table}
+def run(label_table, document_ids=("synthetic-a", "synthetic-b")):
+    return {
+        "config": "full-stack-kiji-resolve",
+        "scored_population": bench.identified_document_population(document_ids),
+        "per_label_recall": label_table,
+    }
 
 
 def label(entities, fully_covered, overlapped, leaked=100):
@@ -32,12 +36,19 @@ BASE = {
 
 
 class ClassCoverageGateTests(unittest.TestCase):
-    def failures(self, candidate_table, baseline_table=None):
+    def failures(
+        self,
+        candidate_table,
+        baseline_table=None,
+        *,
+        candidate_ids=("synthetic-a", "synthetic-b"),
+        baseline_ids=("synthetic-a", "synthetic-b"),
+    ):
         baseline_table = BASE if baseline_table is None else baseline_table
         return bench._class_coverage_failures(
             "full-stack-kiji-resolve",
-            run(candidate_table),
-            run(baseline_table),
+            run(candidate_table, candidate_ids),
+            run(baseline_table, baseline_ids),
         )
 
     def test_identical_scorecards_pass(self):
@@ -66,25 +77,46 @@ class ClassCoverageGateTests(unittest.TestCase):
         self.assertEqual(found[0]["overlapped_delta"], -1)
         self.assertEqual(found[0]["fully_covered_delta"], 0)
 
+    def test_partial_byte_loss_with_constant_entity_coverage_is_red(self):
+        candidate = copy.deepcopy(BASE)
+        candidate["SECURITYTOKEN"] = label(157, 112, 120, 797)
+        found = self.failures(candidate)
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0]["gate"], bench.CLASS_COVERAGE_LOSS_GATE)
+        self.assertEqual(found[0]["fully_covered_delta"], 0)
+        self.assertEqual(found[0]["overlapped_delta"], 0)
+        self.assertEqual(found[0]["leaked_utf8_bytes_delta"], 1)
+
     def test_coverage_gain_is_not_a_failure(self):
         candidate = copy.deepcopy(BASE)
         candidate["SECURITYTOKEN"] = label(157, 130, 140, 400)
         self.assertEqual(self.failures(candidate), [])
 
     def test_population_move_is_a_non_pass_not_a_silent_skip(self):
-        # MUTATION: this is the dodge the gate must refuse. A change that loses
-        # coverage AND perturbs the population must not slip through quietly --
-        # that is the shape that disqualified an earlier candidate whose leak
-        # "win" was denominator shrinkage.
+        # MUTATION: cardinality and gold stay constant while one scored document
+        # leaves and another enters.
+        candidate = copy.deepcopy(BASE)
+        found = self.failures(
+            candidate,
+            candidate_ids=("synthetic-b", "synthetic-c"),
+        )
+        security = next(item for item in found if item["label"] == "SECURITYTOKEN")
+        self.assertEqual(security["gate"], bench.CLASS_POPULATION_EVALUABILITY_GATE)
+        self.assertEqual(security["reason"], "population_moved, cannot evaluate")
+        self.assertEqual(security["candidate_entities"], 157)
+        self.assertEqual(security["baseline_entities"], 157)
+        self.assertEqual(security["added_document_ids"], ["synthetic-c"])
+        self.assertEqual(security["removed_document_ids"], ["synthetic-a"])
+
+    def test_gold_count_mismatch_on_identical_set_is_not_population_identity(self):
         candidate = copy.deepcopy(BASE)
         candidate["SECURITYTOKEN"] = label(150, 90, 95, 900)
         found = self.failures(candidate)
         self.assertEqual(len(found), 1, found)
-        self.assertEqual(found[0]["gate"], bench.CLASS_POPULATION_EVALUABILITY_GATE)
-        self.assertEqual(found[0]["reason"], "population_moved, cannot evaluate")
-        self.assertEqual(found[0]["candidate_entities"], 150)
-        self.assertEqual(found[0]["baseline_entities"], 157)
-        self.assertNotEqual(found, [], "population movement must never pass silently")
+        self.assertEqual(
+            found[0]["reason"],
+            "gold_count_mismatch_on_identical_scored_population",
+        )
 
     def test_absent_on_both_sides_is_comparable_as_empty(self):
         found = bench._class_coverage_failures(
@@ -112,15 +144,6 @@ class ClassCoverageGateTests(unittest.TestCase):
                 run({"SECURITYTOKEN": {"entities": "many"}}),
                 run(copy.deepcopy(BASE)),
             )
-
-    def test_gate_is_wired_into_compare_scorecards(self):
-        # Guards against the gate existing but never being invoked -- the
-        # dormant-gate failure mode. Verified through the public entry point.
-        self.assertIn(
-            "_class_coverage_failures",
-            bench.compare_scorecards.__code__.co_names,
-            "compare_scorecards must invoke the coverage gate",
-        )
 
 
 if __name__ == "__main__":

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -1153,7 +1153,7 @@ class ScorecardComparisonTests(unittest.TestCase):
             "latency_ms": {"clean_ms": {"p95": 1.0}},
         }
         return {
-            "schema_version": 3,
+            "schema_version": benchmark.SCORECARD_SCHEMA_VERSION,
             "dataset": {
                 "repository": "synthetic/comparison",
                 "revision": "synthetic-revision",
@@ -1344,7 +1344,7 @@ class DataikuSelectionTests(unittest.TestCase):
         self.assertEqual(result["dataset"]["selection"]["documents"], 1)
         self.assertEqual(result["dataset"]["available_population"]["documents"], 2)
         self.assertEqual(result["dataset"]["evaluated_population"]["documents"], 1)
-        self.assertEqual(result["schema_version"], 3)
+        self.assertEqual(result["schema_version"], 4)
 
 
 class ConfigTests(unittest.TestCase):

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -87,6 +87,7 @@ class OffsetTests(unittest.TestCase):
             [(0, 9), (12, 14)],
         )
 
+
 class MetricTests(unittest.TestCase):
     def document(self) -> benchmark.Document:
         text = "alice@example.invalid is synthetic"
@@ -201,8 +202,8 @@ class ContractTests(unittest.TestCase):
         )
         response = {
             "fixture_id": document.uid,
-            "pipeline_error_code": "POLICY_REJECTED",
-            "pipeline_error_stage": "safety_net",
+            "pipeline_error_code": "safety_net_fallback_residual_suspect",
+            "pipeline_error_stage": "clean",
             "timing": {"total_ms": 1.25},
         }
         process = mock.Mock()
@@ -241,9 +242,20 @@ class ContractTests(unittest.TestCase):
                 "completed_documents": 0,
                 "completion_rate": 0.0,
                 "failed_closed_documents": 1,
-                "errors": {"POLICY_REJECTED": 1},
-                "error_stages": {"safety_net": 1},
+                "errors": {"safety_net_fallback_residual_suspect": 1},
+                "error_stages": {"clean": 1},
             },
+        )
+        self.assertEqual(result["scored_population"]["document_ids"], [])
+        self.assertEqual(
+            result["failed_closed_population"]["excluded_documents"],
+            [
+                {
+                    "document_id": "synthetic-failure",
+                    "reason": "safety_net_fallback_residual_suspect",
+                    "stage": "clean",
+                }
+            ],
         )
         self.assertEqual(result["latency_ms"], {})
         self.assertIsNone(result["process"]["documents_per_second"])
@@ -343,31 +355,41 @@ class ResponseValidationTests(unittest.TestCase):
     def test_missing_required_field_fails_closed(self) -> None:
         response = self.success_response()
         response.pop("restore")
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "missing fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_missing_final_trace_fails_closed(self) -> None:
         response = self.success_response()
         response.pop("final_protection_trace")
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "missing fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_unknown_field_fails_closed(self) -> None:
         response = self.success_response()
         response["unratified_wire_field"] = 1
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_wrong_typed_nested_field_fails_closed(self) -> None:
         response = self.success_response()
         response["manifest_integrity"]["spans"] = True
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "expected an integer"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "expected an integer"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_success_timing_requires_the_exact_ratified_fields(self) -> None:
         response = self.success_response()
         response["timing"]["total_ms"] = 1.0
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
         for field in ("pass1_ms", "pass2_ms", "pass3_ms"):
@@ -381,7 +403,9 @@ class ResponseValidationTests(unittest.TestCase):
 
         response = self.success_response()
         response["timing"].pop("clean_ms")
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "missing fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_success_timing_only_allows_null_for_post_policy_scan(self) -> None:
@@ -415,6 +439,7 @@ class ResponseValidationTests(unittest.TestCase):
             "post_policy_scan_ms": None,
         }
         second = self.success_response()
+        second["fixture_id"] = "synthetic-response-2"
         second["timing"] = {
             "clean_ms": 3.0,
             "restore_ms": 20.0,
@@ -427,6 +452,14 @@ class ResponseValidationTests(unittest.TestCase):
         )
         process.wait.return_value = 0
         repo_root = Path(benchmark.__file__).resolve().parents[2]
+        second_document = benchmark.Document(
+            uid="synthetic-response-2",
+            text="synthetic text",
+            language="en",
+            region="US",
+            source_dataset="unit-test",
+            spans=(),
+        )
 
         with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
             with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
@@ -434,7 +467,7 @@ class ResponseValidationTests(unittest.TestCase):
                     repo_root=repo_root,
                     binary=Path(temporary) / "synthetic-runner",
                     config="production-full-stack",
-                    documents=[self.document(), self.document()],
+                    documents=[self.document(), second_document],
                     model_dir=Path(temporary),
                     kiji_model_dir=Path(temporary),
                     opf_command=None,
@@ -446,9 +479,7 @@ class ResponseValidationTests(unittest.TestCase):
 
         self.assertEqual(result["latency_ms"]["clean_ms"]["mean"], 2.5)
         self.assertEqual(result["latency_ms"]["restore_ms"]["mean"], 15.0)
-        self.assertEqual(
-            result["latency_ms"]["post_policy_scan_ms"]["mean"], 7.0
-        )
+        self.assertEqual(result["latency_ms"]["post_policy_scan_ms"]["mean"], 7.0)
         self.assertNotIn("total_ms", result["latency_ms"])
         self.assertNotIn("pass1_ms", result["latency_ms"])
         self.assertNotIn("pass2_ms", result["latency_ms"])
@@ -461,8 +492,8 @@ class ResponseValidationTests(unittest.TestCase):
         document = self.document()
         warmup_error = {
             "fixture_id": document.uid,
-            "pipeline_error_stage": "safety_net",
-            "pipeline_error_code": "POLICY_REJECTED",
+            "pipeline_error_stage": "clean",
+            "pipeline_error_code": "safety_net_fallback_residual_suspect",
             "timing": {"total_ms": 1.25},
         }
         warmup_rejection = self.success_response()
@@ -520,19 +551,50 @@ class ResponseValidationTests(unittest.TestCase):
         self.assertEqual(result["pipeline_availability"]["failed_closed_documents"], 0)
         discarded = result["process"]["discarded_warmup_samples"]
         self.assertEqual(len(discarded), 2)
-        self.assertEqual(discarded[0]["pipeline_error_code"], "POLICY_REJECTED")
-        self.assertEqual(discarded[0]["pipeline_error_stage"], "safety_net")
+        self.assertEqual(
+            discarded[0]["pipeline_error_code"],
+            "safety_net_fallback_residual_suspect",
+        )
+        self.assertEqual(discarded[0]["pipeline_error_stage"], "clean")
         self.assertEqual(discarded[1]["correctness"]["strict_rejections"], 1)
 
     def test_unknown_pipeline_error_timing_field_fails_closed(self) -> None:
         response = {
             "fixture_id": "synthetic-response",
             "pipeline_error_stage": "clean",
-            "pipeline_error_code": "pipeline_error",
+            "pipeline_error_code": "safety_net_runtime_other",
             "timing": {"total_ms": 1.0, "extra_ms": 0.1},
         }
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.document(), response)
+
+    def test_pipeline_error_reason_and_stage_are_closed_sets(self) -> None:
+        response = {
+            "fixture_id": "synthetic-response",
+            "pipeline_error_stage": "clean",
+            "pipeline_error_code": "safety_net_runtime_subprocess_timeout",
+            "timing": {"total_ms": 1.0},
+        }
+        self.assertEqual(
+            benchmark.validate_response(self.document(), copy.deepcopy(response)),
+            response,
+        )
+
+        unknown_reason = copy.deepcopy(response)
+        unknown_reason["pipeline_error_code"] = "synthetic_unknown_reason"
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown closed reason"
+        ):
+            benchmark.validate_response(self.document(), unknown_reason)
+
+        unknown_stage = copy.deepcopy(response)
+        unknown_stage["pipeline_error_stage"] = "synthetic_unknown_stage"
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown closed stage"
+        ):
+            benchmark.validate_response(self.document(), unknown_stage)
 
     def test_tokenize_trace_must_match_final_manifest_one_to_one(self) -> None:
         response = self.tokenize_response()
@@ -543,33 +605,47 @@ class ResponseValidationTests(unittest.TestCase):
     def test_trace_rejects_unknown_item_and_provenance_fields(self) -> None:
         response = self.tokenize_response()
         response["final_protection_trace"][0]["raw_value"] = "synthetic"
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
         response = self.tokenize_response()
         response["final_protection_trace"][0]["provenance"].pop("source_ids")
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "missing fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "missing fields"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
         response = self.tokenize_response()
         response["final_protection_trace"][0]["provenance"]["extra"] = "metadata"
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
-    def test_trace_rejects_wrong_types_and_invalid_closed_enum_combinations(self) -> None:
+    def test_trace_rejects_wrong_types_and_invalid_closed_enum_combinations(
+        self,
+    ) -> None:
         response = self.tokenize_response()
         response["final_protection_trace"][0]["raw_start"] = False
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "expected an integer"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "expected an integer"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
         response = self.tokenize_response()
         response["final_protection_trace"][0]["action"] = "mask"
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown action"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown action"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
         response = self.tokenize_response()
         response["final_protection_trace"][0]["provenance"]["decision"] = "resolve"
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "invalid.*combination"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "invalid.*combination"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
     def test_trace_source_ids_are_non_empty_sorted_and_duplicate_free(self) -> None:
@@ -581,13 +657,15 @@ class ResponseValidationTests(unittest.TestCase):
         ):
             with self.subTest(source_ids=source_ids):
                 response = self.tokenize_response()
-                response["final_protection_trace"][0]["provenance"][
-                    "source_ids"
-                ] = source_ids
+                response["final_protection_trace"][0]["provenance"]["source_ids"] = (
+                    source_ids
+                )
                 with self.assertRaises(benchmark.ResponseValidationError):
                     benchmark.validate_response(self.trace_document(), response)
 
-    def test_trace_rejects_noncanonical_classes_and_pii_bearing_source_ids(self) -> None:
+    def test_trace_rejects_noncanonical_classes_and_pii_bearing_source_ids(
+        self,
+    ) -> None:
         response = self.tokenize_response()
         response["manifest_spans"][0]["class"] = "not-canonical"
         response["final_protection_trace"][0]["class"] = "not-canonical"
@@ -599,9 +677,9 @@ class ResponseValidationTests(unittest.TestCase):
         for source_id in ("alice@example.invalid", "+1-555-0142", "Dr. Schmidt"):
             with self.subTest(source_id=source_id):
                 response = self.tokenize_response()
-                response["final_protection_trace"][0]["provenance"][
-                    "source_ids"
-                ] = [source_id]
+                response["final_protection_trace"][0]["provenance"]["source_ids"] = [
+                    source_id
+                ]
                 with self.assertRaisesRegex(
                     benchmark.ResponseValidationError, "metadata-only stable identifier"
                 ):
@@ -611,9 +689,7 @@ class ResponseValidationTests(unittest.TestCase):
         self,
     ) -> None:
         response = self.tokenize_response()
-        response["manifest_spans"][0][
-            "class"
-        ] = "custom:family:payment-card-or-iban"
+        response["manifest_spans"][0]["class"] = "custom:family:payment-card-or-iban"
         item = response["final_protection_trace"][0]
         item["class"] = "custom:family:payment-card-or-iban"
         item["provenance"]["source_ids"] = [
@@ -751,7 +827,9 @@ class ResponseValidationTests(unittest.TestCase):
     def test_trace_spans_use_original_utf8_boundaries_and_are_disjoint(self) -> None:
         response = self.tokenize_response()
         response["final_protection_trace"][0]["raw_end"] = 1
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "char boundaries"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "char boundaries"
+        ):
             benchmark.validate_response(self.trace_document(), response)
 
         response = self.tokenize_response()
@@ -788,7 +866,9 @@ class ResponseValidationTests(unittest.TestCase):
             "timing": {"total_ms": 1.0},
             "final_protection_trace": [],
         }
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "unknown fields"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "unknown fields"
+        ):
             benchmark.validate_response(self.document(), response)
 
     def test_telemetry_output_disagreement_fails_closed(self) -> None:
@@ -834,7 +914,9 @@ class ResponseValidationTests(unittest.TestCase):
         self.assertEqual(contract.result()["restore_exact_rate"], 0.0)
 
         response["restore"]["exact"] = True
-        with self.assertRaisesRegex(benchmark.ResponseValidationError, "cannot be exactly"):
+        with self.assertRaisesRegex(
+            benchmark.ResponseValidationError, "cannot be exactly"
+        ):
             benchmark.validate_response(document, response)
 
     def test_predictions_ignore_pre_safety_manifests_and_leak_suspects(self) -> None:
@@ -943,7 +1025,9 @@ class SamplingTests(unittest.TestCase):
         second, second_report = benchmark.stratified_sample(
             list(reversed(documents)), 3, seed=41
         )
-        self.assertEqual([document.uid for document in first], [document.uid for document in second])
+        self.assertEqual(
+            [document.uid for document in first], [document.uid for document in second]
+        )
         self.assertEqual(
             first_report["evaluated_document_ids_digest"],
             second_report["evaluated_document_ids_digest"],
@@ -1017,11 +1101,16 @@ class ScorecardComparisonTests(unittest.TestCase):
         documents = len(ids)
         fully_covered = documents if leaked == 0 else documents - 1
         digest = hashlib.sha256(
-            json.dumps(ids, ensure_ascii=False, separators=(",", ":")).encode(
-                "utf-8"
-            )
+            json.dumps(ids, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         ).hexdigest()
         run = {
+            "scored_population": benchmark.identified_document_population(ids),
+            "failed_closed_population": {
+                **benchmark.identified_document_population([]),
+                "excluded_documents": [],
+                "reason_counts": {},
+                "stage_counts": {},
+            },
             "metrics": {
                 "documents": documents,
                 "zero_leak_document_rate": recall,
@@ -1109,7 +1198,9 @@ class ScorecardComparisonTests(unittest.TestCase):
         self.assertFalse(comparison["regression"]["passed"])
         self.assertFalse(comparison["release_readiness"]["passed"])
 
-    def test_mismatched_population_fails_regression_not_candidate_readiness(self) -> None:
+    def test_mismatched_population_fails_regression_not_candidate_readiness(
+        self,
+    ) -> None:
         baseline = self.scorecard(leaked=0)
         candidate = self.scorecard(leaked=0, evaluated_ids=["synthetic-other-1"])
         comparison = benchmark.compare_scorecards(candidate, baseline)

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -84,7 +84,7 @@ def scorecard(leaked: int = 0) -> dict[str, object]:
         },
     }
     return {
-        "schema_version": 3,
+        "schema_version": score.SCORECARD_SCHEMA_VERSION,
         "dataset": {
             "repository": "synthetic/runner",
             "revision": "synthetic-v1",
@@ -138,7 +138,10 @@ def set_population_split(
 class IntegerComparatorTests(unittest.TestCase):
     def test_empty_and_missing_candidates_fail_closed(self) -> None:
         baseline = scorecard()
-        for candidate in ({}, {"schema_version": 3, "runs": []}):
+        for candidate in (
+            {},
+            {"schema_version": score.SCORECARD_SCHEMA_VERSION, "runs": []},
+        ):
             comparison = score.compare_scorecards(candidate, baseline)
             self.assertFalse(comparison["regression"]["passed"])
             self.assertFalse(comparison["release_readiness"]["passed"])
@@ -256,6 +259,7 @@ class IntegerComparatorTests(unittest.TestCase):
         self,
     ) -> None:
         legacy = scorecard()
+        legacy["schema_version"] = 3
         for run in legacy["runs"]:
             run.pop("scored_population")
             run.pop("failed_closed_population")

--- a/scripts/bench/test_run_no_opf_benchmark.py
+++ b/scripts/bench/test_run_no_opf_benchmark.py
@@ -27,9 +27,7 @@ DAVLAN_ARTIFACTS = (
 )
 DAVLAN_HF_REPO = "onnx-community/bert-base-multilingual-cased-ner-hrl-ONNX"
 DAVLAN_HF_COMMIT = "cfe67b1c1c4c91c1b26ac192955fc0971e62d8c8"
-DAVLAN_BUNDLE_SHA = (
-    "7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16"
-)
+DAVLAN_BUNDLE_SHA = "7b0b9d0d200bf7f3a39654257f8723998316600852edff8404834eb7edfc5c16"
 
 
 def scorecard(leaked: int = 0) -> dict[str, object]:
@@ -39,6 +37,13 @@ def scorecard(leaked: int = 0) -> dict[str, object]:
     ).hexdigest()
     fully_covered = 1 if leaked == 0 else 0
     run = {
+        "scored_population": score.identified_document_population([uid]),
+        "failed_closed_population": {
+            **score.identified_document_population([]),
+            "excluded_documents": [],
+            "reason_counts": {},
+            "stage_counts": {},
+        },
         "metrics": {
             "documents": 1,
             "documents_without_leaks": fully_covered,
@@ -97,10 +102,37 @@ def scorecard(leaked: int = 0) -> dict[str, object]:
             },
         },
         "runs": [
-            {"config": config, **copy.deepcopy(run)}
-            for config in score.DEFAULT_CONFIGS
+            {"config": config, **copy.deepcopy(run)} for config in score.DEFAULT_CONFIGS
         ],
     }
+
+
+def set_population_split(
+    card: dict[str, object], *, scored_id: str, failed_id: str
+) -> None:
+    document_ids = sorted([scored_id, failed_id])
+    card["dataset"]["evaluated_population"]["documents"] = 2
+    sampling = card["dataset"]["sampling"]
+    sampling["evaluated_document_ids"] = document_ids
+    sampling["evaluated_document_ids_digest"] = score.document_ids_digest(document_ids)
+    reason = "safety_net_fallback_residual_suspect"
+    for run in card["runs"]:
+        run["scored_population"] = score.identified_document_population([scored_id])
+        run["failed_closed_population"] = {
+            **score.identified_document_population([failed_id]),
+            "excluded_documents": [
+                {"document_id": failed_id, "reason": reason, "stage": "clean"}
+            ],
+            "reason_counts": {reason: 1},
+            "stage_counts": {"clean": 1},
+        }
+        run["pipeline_availability"] = {
+            "attempted_documents": 2,
+            "completed_documents": 1,
+            "failed_closed_documents": 1,
+            "errors": {reason: 1},
+            "error_stages": {"clean": 1},
+        }
 
 
 class IntegerComparatorTests(unittest.TestCase):
@@ -111,7 +143,9 @@ class IntegerComparatorTests(unittest.TestCase):
             self.assertFalse(comparison["regression"]["passed"])
             self.assertFalse(comparison["release_readiness"]["passed"])
 
-    def test_integer_leak_ratchet_catches_change_even_if_rate_is_unchanged(self) -> None:
+    def test_integer_leak_ratchet_catches_change_even_if_rate_is_unchanged(
+        self,
+    ) -> None:
         baseline = scorecard()
         candidate = copy.deepcopy(baseline)
         candidate["runs"][0]["metrics"]["utf8_bytes"]["leaked"] = 1
@@ -149,14 +183,99 @@ class IntegerComparatorTests(unittest.TestCase):
         self.assertFalse(comparison["regression"]["passed"])
         self.assertFalse(comparison["release_readiness"]["passed"])
 
+    def test_equal_cardinality_scored_membership_swap_names_added_and_removed_ids(
+        self,
+    ) -> None:
+        baseline = scorecard()
+        candidate = copy.deepcopy(baseline)
+        set_population_split(baseline, scored_id="synthetic-a", failed_id="synthetic-b")
+        set_population_split(
+            candidate, scored_id="synthetic-b", failed_id="synthetic-a"
+        )
+
+        comparison = score.compare_scorecards(candidate, baseline)
+        failures = [
+            failure
+            for failure in comparison["regression"]["failures"]
+            if failure.get("gate") == "scored_population_identity_match"
+        ]
+
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertEqual(len(failures), len(score.DEFAULT_CONFIGS), failures)
+        self.assertEqual(failures[0]["added_document_ids"], ["synthetic-b"])
+        self.assertEqual(failures[0]["removed_document_ids"], ["synthetic-a"])
+
+    def test_missing_typed_failure_reason_breaks_reconciliation(self) -> None:
+        card = scorecard()
+        set_population_split(card, scored_id="synthetic-a", failed_id="synthetic-b")
+        run = card["runs"][0]
+        run["failed_closed_population"]["reason_counts"] = {}
+
+        with self.assertRaisesRegex(
+            ValueError, "reason counts do not reconcile to excluded documents"
+        ):
+            score._run_population_provenance(
+                run,
+                context="mutation",
+                expected_document_ids=["synthetic-a", "synthetic-b"],
+            )
+
+    def test_failure_reason_counts_sum_exactly_to_failed_total(self) -> None:
+        card = scorecard()
+        set_population_split(card, scored_id="synthetic-a", failed_id="synthetic-b")
+        run = card["runs"][0]
+
+        score._run_population_provenance(
+            run,
+            context="reconciled",
+            expected_document_ids=["synthetic-a", "synthetic-b"],
+        )
+
+        self.assertEqual(
+            sum(run["failed_closed_population"]["reason_counts"].values()),
+            run["pipeline_availability"]["failed_closed_documents"],
+        )
+
+    def test_diagnostics_carries_reconciled_typed_failure_breakdown(self) -> None:
+        card = scorecard()
+        set_population_split(card, scored_id="synthetic-a", failed_id="synthetic-b")
+
+        emitted = runner.diagnostics(card)
+        failed_population = emitted["runs"][0]["failed_closed_population"]
+
+        self.assertEqual(
+            failed_population["reason_counts"],
+            {"safety_net_fallback_residual_suspect": 1},
+        )
+        self.assertEqual(
+            sum(failed_population["reason_counts"].values()),
+            failed_population["documents"],
+        )
+
+    def test_legacy_schema_v3_without_run_identity_is_readable_but_not_comparable(
+        self,
+    ) -> None:
+        legacy = scorecard()
+        for run in legacy["runs"]:
+            run.pop("scored_population")
+            run.pop("failed_closed_population")
+
+        comparison = score.compare_scorecards(legacy, copy.deepcopy(legacy))
+
+        self.assertFalse(comparison["regression"]["passed"])
+        self.assertTrue(
+            any(
+                failure.get("gate") == "candidate_run_population_provenance"
+                for failure in comparison["regression"]["failures"]
+            )
+        )
+
     def test_strict_rejections_are_bucketed_ratcheted_and_release_blocking(
         self,
     ) -> None:
         baseline = scorecard()
         candidate = copy.deepcopy(baseline)
-        candidate["runs"][0]["pipeline_contract"][
-            "strict_would_reject_documents"
-        ] = 1
+        candidate["runs"][0]["pipeline_contract"]["strict_would_reject_documents"] = 1
 
         counts = score._run_correctness_counts(candidate["runs"][0])
         comparison = score.compare_scorecards(candidate, baseline)
@@ -177,9 +296,7 @@ class IntegerComparatorTests(unittest.TestCase):
         baseline = scorecard()
         candidate = copy.deepcopy(baseline)
         candidate["runs"][0]["latency_ms"]["clean_ms"]["p95"] = 2.0
-        result = score.compare_performance(
-            candidate, baseline, tolerance_percent=10.0
-        )
+        result = score.compare_performance(candidate, baseline, tolerance_percent=10.0)
         self.assertFalse(result["passed"])
         self.assertFalse(result["gating"])
         self.assertEqual(result["disposition"], "informational")
@@ -256,9 +373,7 @@ class ModelValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             bundle = Path(tmp) / "davlan"
             pin = self.write_davlan_bundle(bundle)
-            (bundle / "model.safetensors").write_bytes(
-                b"synthetic alternate weights"
-            )
+            (bundle / "model.safetensors").write_bytes(b"synthetic alternate weights")
             with self.assertRaisesRegex(
                 runner.ModelBundleError, "unexpected bundle surface"
             ):
@@ -307,9 +422,7 @@ class ModelValidationTests(unittest.TestCase):
             target = root / "synthetic-vocab-target.txt"
             target.write_bytes(b"synthetic vocab.txt bytes")
             artifact.symlink_to(target)
-            with self.assertRaisesRegex(
-                runner.ModelBundleError, "symlink"
-            ):
+            with self.assertRaisesRegex(runner.ModelBundleError, "symlink"):
                 runner.validate_model_bundle(pin)
 
     def test_davlan_manifest_digest_mismatch_fails_closed(self) -> None:
@@ -341,9 +454,7 @@ class ModelValidationTests(unittest.TestCase):
                 pin.digest_kind,
                 score.sha256_file(manifest),
             )
-            with self.assertRaisesRegex(
-                runner.ModelBundleError, "must list exactly"
-            ):
+            with self.assertRaisesRegex(runner.ModelBundleError, "must list exactly"):
                 runner.validate_model_bundle(updated_pin)
 
     def test_davlan_malformed_manifest_line_fails_closed(self) -> None:
@@ -477,7 +588,9 @@ class ProfileIsolationTests(unittest.TestCase):
             "GAZE_OPF_DAEMON_SOCKET": "/tmp/fake.sock",
         }
         fake_run = scorecard()["runs"][0]
-        with mock.patch.object(score, "run_config", return_value=fake_run) as run_config:
+        with mock.patch.object(
+            score, "run_config", return_value=fake_run
+        ) as run_config:
             _, provenance = runner.execute_measurements(
                 repo_root=Path("/synthetic/repo"),
                 binary=Path("/synthetic/clean_for_bench"),
@@ -521,9 +634,7 @@ class ProfileIsolationTests(unittest.TestCase):
         )
 
     def test_repetitions_require_exact_strict_rejection_counts(self) -> None:
-        runs_by_config = {
-            run["config"]: run for run in scorecard()["runs"]
-        }
+        runs_by_config = {run["config"]: run for run in scorecard()["runs"]}
         call_count = 0
 
         def fake_run_config(*args: object, **kwargs: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary

- emit identified scored and failed-closed document sets per cell, including sorted IDs, stable SHA-256 digests, and per-document typed exclusion reasons
- require scored/failed population set identity before comparing metrics, and name added/removed document IDs when membership differs
- derive per-label evaluability from scored-set identity instead of gold-count equality
- replace the benchmark producer's opaque `pipeline_error` bucket with a closed typed reason classifier and reconcile reason/stage counts into `diagnostics.json`
- bump the scorecard contract to schema v4 because legacy v3 never recorded per-cell population identity

This is harness/scorer-only work. It changes no recognizer, rulepack, policy, or detection behavior.

## Exact 660-document breakdown

I ran the quick profile over the entire available 2,910-document population at clean commit `053809d` (`git_dirty=false`). This keeps the requested quick-profile mode while measuring every document:

| Kiji clean-stage reason | Documents |
| --- | ---: |
| `safety_net_fallback_residual_suspect` | 513 |
| `unknown_token` | 147 |
| **Total failed closed** | **660** |

Kiji attempted 2,910 documents, scored 2,250, and failed closed on 660. The reason sum is exactly 660; `stage_counts` is `{"clean": 660}`; the scorecard and `diagnostics.json` population blocks match exactly. Rule-floor and pass2 each scored all 2,910 documents with zero failures.

The subprocess-timeout class from todo #2404 accounts for **0/660** here. Subprocess non-zero exit, malformed backend output, label/decode mismatch, oversized input, and all other typed categories also account for zero documents in this run. The old `pipeline_error=660` bucket was therefore hiding 513 genuine policy fail-closed outcomes and 147 `UnknownToken` outcomes, not Kiji subprocess measurement noise.

## Archived PR #404 replay

I copied, rather than edited, the archived baseline/candidate artifacts and replayed the v4 comparator over the copied schema-v3 pair:

```text
comparison_schema=4; archived_schema=3
previously_unevaluable_now_evaluable=[]
reported_losses_surviving=[]
kiji_not_evaluable_count=29; reason=scored_population_unidentified, cannot evaluate
```

None of the 17 previously unevaluable Kiji labels becomes evaluable. None of the four observed loss shapes (`LICENSEPLATENUM`, `PASSWORD`, `SURNAME`, `TAXNUM`) survives as a **confirmed** loss, because v3 cannot establish that either side scored the same documents. This does not clear those losses; it makes the missing evidence explicit instead of treating unchanged gold counts as proof of population identity.

## Executed mutation probes

### (i) Equal count, one-document membership swap

The pre-change comparator accepted the swap; the new comparator rejects it and names both IDs:

```text
before_passed=True; after_passed=False; gate=scored_population_identity_match; config=full-stack-kiji-resolve; added=['synthetic-b']; removed=['synthetic-a']
```

### (ii) Constant label gold, moved document set

```text
gold=157->157; gate=class_population_evaluability; reason=population_moved, cannot evaluate; added=['synthetic-c']; removed=['synthetic-a']
```

### (iii) Remove one typed reason from the classified breakdown

```text
removed_reason=safety_net_fallback_residual_suspect; classification_rejected=True; error=mutation.failed-closed reason counts do not reconcile to excluded documents
```

### (iv) Reason counts reconcile exactly

```text
reason_counts={'safety_net_fallback_residual_suspect': 1}; sum=1; failed_total=1; reconciled=True
```

The real full-population evidence independently exercises multi-bucket reconciliation: `513 + 147 = 660`.

## Schema compatibility

The scorecard schema is explicitly bumped from v3 to v4 and the generated artifact is now `scorecard-v4.json`.

- Existing committed v3 artifacts remain readable for aggregate historical evidence and diagnostic replay.
- V3 artifacts cannot pass the v4 per-run population provenance or per-label evaluability gates, and cannot serve as a like-for-like v4 comparison baseline.
- The committed schema-v3 evidence is not rewritten or silently reinterpreted.
- A new v4 baseline is required before metric/class deltas can be evaluated.

## Verification

```text
python3 scripts/bench/test_run_no_opf_benchmark.py
Ran 35 tests ... OK

python3 scripts/bench/test_class_coverage_gate.py
Ran 10 tests ... OK

python3 scripts/bench/test_openpii_gaze_bench.py
Ran 58 tests ... OK

CARGO_TARGET_DIR=/tmp/pop-gate-target rustup run 1.96.0 cargo test -p gaze-recognizers --example clean_for_bench --all-features
9 passed; 0 failed; 2 ignored

rustup run 1.96.0 cargo fmt --all -- --check
PASS

CARGO_TARGET_DIR=/tmp/pop-gate-target rustup run 1.96.0 cargo clippy --workspace --all-features --all-targets -- -D warnings
PASS

uvx ruff check --select E4,E7,E9,F <touched Python files>
All checks passed!

git diff --check origin/agent/current-gaze-benchmark...HEAD
PASS
```

Real v4 evidence:

```text
schema=4; profile=quick; evaluated=2910; git_revision=053809dcd5c576327de3a326aaddf906db5f0bc5; git_dirty=False
rule-floor-extended: attempted=2910; scored=2910; failed=0; reasons={}; stages={}; reason_sum=0; diagnostics_match=True
pass2-ner: attempted=2910; scored=2910; failed=0; reasons={}; stages={}; reason_sum=0; diagnostics_match=True
full-stack-kiji-resolve: attempted=2910; scored=2250; failed=660; reasons={'safety_net_fallback_residual_suspect': 513, 'unknown_token': 147}; stages={'clean': 660}; reason_sum=660; diagnostics_match=True
self_comparison_passed=True; regression_failures=0; comparison_schema=4
```

Resolves solo todo #2414

Resolves solo todo #2413
