### PR TITLE
[agent] Make proxy rejection identifiers actionable

### DIFF
--- a/crates/gaze-proxy/src/codec.rs
+++ b/crates/gaze-proxy/src/codec.rs
@@ -75,6 +75,7 @@ pub enum CodecErrorCode {
 
 /// Closed carrier schemes that may safely identify an opaque request carrier.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum OpaqueCarrierScheme {
     Data,
     File,
@@ -97,6 +98,7 @@ impl OpaqueCarrierScheme {
 
 /// Structural location of an opaque carrier, never its bytes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct OpaqueCarrierLocation {
     scheme: OpaqueCarrierScheme,
     byte_offset: usize,

--- a/crates/gaze-proxy/src/codec.rs
+++ b/crates/gaze-proxy/src/codec.rs
@@ -73,16 +73,96 @@ pub enum CodecErrorCode {
     ProviderErrorEvent,
 }
 
+/// Closed carrier schemes that may safely identify an opaque request carrier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OpaqueCarrierScheme {
+    Data,
+    File,
+    Http,
+    Https,
+}
+
+impl OpaqueCarrierScheme {
+    /// Returns the normalized scheme identifier without any carrier payload.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Data => "data:",
+            Self::File => "file:",
+            Self::Http => "http:",
+            Self::Https => "https:",
+        }
+    }
+}
+
+/// Structural location of an opaque carrier, never its bytes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OpaqueCarrierLocation {
+    scheme: OpaqueCarrierScheme,
+    byte_offset: usize,
+    byte_length: usize,
+    content_block_index: Option<usize>,
+}
+
+impl OpaqueCarrierLocation {
+    pub(crate) const fn new(
+        scheme: OpaqueCarrierScheme,
+        byte_offset: usize,
+        byte_length: usize,
+        content_block_index: Option<usize>,
+    ) -> Self {
+        Self {
+            scheme,
+            byte_offset,
+            byte_length,
+            content_block_index,
+        }
+    }
+
+    #[must_use]
+    pub const fn scheme(self) -> OpaqueCarrierScheme {
+        self.scheme
+    }
+
+    #[must_use]
+    pub const fn byte_offset(self) -> usize {
+        self.byte_offset
+    }
+
+    #[must_use]
+    pub const fn byte_length(self) -> usize {
+        self.byte_length
+    }
+
+    #[must_use]
+    pub const fn content_block_index(self) -> Option<usize> {
+        self.content_block_index
+    }
+}
+
 /// Sanitized codec failure. It never retains parser, body, key, value, or provider error text.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct CodecError {
     code: CodecErrorCode,
     phase: CodecPhase,
+    opaque_carrier: Option<OpaqueCarrierLocation>,
 }
 
 impl CodecError {
     pub(crate) const fn new(code: CodecErrorCode, phase: CodecPhase) -> Self {
-        Self { code, phase }
+        Self {
+            code,
+            phase,
+            opaque_carrier: None,
+        }
+    }
+
+    pub(crate) const fn with_opaque_carrier(
+        mut self,
+        opaque_carrier: Option<OpaqueCarrierLocation>,
+    ) -> Self {
+        self.opaque_carrier = opaque_carrier;
+        self
     }
 
     #[must_use]
@@ -94,15 +174,22 @@ impl CodecError {
     pub const fn phase(self) -> CodecPhase {
         self.phase
     }
+
+    /// Returns only the carrier's structural location, never its bytes.
+    #[must_use]
+    pub const fn opaque_carrier(self) -> Option<OpaqueCarrierLocation> {
+        self.opaque_carrier
+    }
 }
 
 impl fmt::Debug for CodecError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("CodecError")
-            .field("code", &self.code)
-            .field("phase", &self.phase)
-            .finish()
+        let mut debug = formatter.debug_struct("CodecError");
+        debug.field("code", &self.code).field("phase", &self.phase);
+        if let Some(opaque_carrier) = self.opaque_carrier {
+            debug.field("opaque_carrier", &opaque_carrier);
+        }
+        debug.finish()
     }
 }
 
@@ -313,6 +400,8 @@ pub struct RequestTransformContext<'a> {
     format: WireFormat,
     limits: CodecLimits,
     inspection_projection_requested: bool,
+    content_block_index: Option<usize>,
+    opaque_carrier: Option<OpaqueCarrierLocation>,
 }
 
 impl<'a> RequestTransformContext<'a> {
@@ -327,6 +416,8 @@ impl<'a> RequestTransformContext<'a> {
             format,
             limits,
             inspection_projection_requested: false,
+            content_block_index: None,
+            opaque_carrier: None,
         }
     }
 
@@ -346,6 +437,32 @@ impl<'a> RequestTransformContext<'a> {
 
     pub(crate) const fn inspection_projection_requested(&self) -> bool {
         self.inspection_projection_requested
+    }
+
+    pub(crate) fn replace_content_block_index(
+        &mut self,
+        content_block_index: Option<usize>,
+    ) -> Option<usize> {
+        std::mem::replace(&mut self.content_block_index, content_block_index)
+    }
+
+    pub(crate) fn record_opaque_carrier(
+        &mut self,
+        scheme: OpaqueCarrierScheme,
+        byte_offset: usize,
+        byte_length: usize,
+    ) {
+        self.opaque_carrier.get_or_insert_with(|| {
+            OpaqueCarrierLocation::new(scheme, byte_offset, byte_length, self.content_block_index)
+        });
+    }
+
+    pub(crate) fn clear_opaque_carrier(&mut self) {
+        self.opaque_carrier = None;
+    }
+
+    pub(crate) const fn opaque_carrier(&self) -> Option<OpaqueCarrierLocation> {
+        self.opaque_carrier
     }
 
     pub(crate) fn protect(&mut self, input: &str) -> Result<String, CodecErrorCode> {

--- a/crates/gaze-proxy/src/codecs/anthropic.rs
+++ b/crates/gaze-proxy/src/codecs/anthropic.rs
@@ -15,8 +15,8 @@ use gaze_types::inspection::{
 
 use crate::codec::{
     BodyCodec, CodecError, CodecErrorCode, CodecLimits, CodecPhase, InspectionParsedFactsV1,
-    InspectionStructuralProjectionV1, OutputProvenance, ProvedRequestBody, ProvedResponseBody,
-    RequestTransformContext, ResponseTransformContext, WireFormat,
+    InspectionStructuralProjectionV1, OpaqueCarrierScheme, OutputProvenance, ProvedRequestBody,
+    ProvedResponseBody, RequestTransformContext, ResponseTransformContext, WireFormat,
 };
 
 pub const ANTHROPIC_PROXY_PING_FRAME: &[u8] = b"event: ping\ndata: {\"type\":\"ping\"}\n\n";
@@ -73,6 +73,8 @@ impl BodyCodec for AnthropicMessagesCodec {
         input: &[u8],
         ctx: &mut RequestTransformContext<'_>,
     ) -> Result<ProvedRequestBody, CodecError> {
+        ctx.clear_opaque_carrier();
+        ctx.replace_content_block_index(None);
         if ctx.format() != WireFormat::Json {
             return Err(codec_error(
                 CodecErrorCode::InvalidWireFormat,
@@ -93,7 +95,7 @@ impl BodyCodec for AnthropicMessagesCodec {
         let mut document = parse_json(input, ctx.limits(), CodecPhase::RequestParse)?;
         let mut ledger = CoverageLedger::new(document.occurrence_count);
         transform_request_root(&mut document.root, input, ctx, &mut ledger)
-            .map_err(|code| codec_error(code, CodecPhase::RequestProtection))?;
+            .map_err(|code| request_codec_error(code, CodecPhase::RequestProtection, ctx))?;
         ledger
             .finish()
             .map_err(|code| codec_error(code, CodecPhase::RequestProof))?;
@@ -126,7 +128,7 @@ impl BodyCodec for AnthropicMessagesCodec {
         let mut reparsed = parse_json(&bytes, ctx.limits(), CodecPhase::RequestProof)?;
         let mut final_ledger = CoverageLedger::new(reparsed.occurrence_count);
         transform_request_root(&mut reparsed.root, &bytes, ctx, &mut final_ledger)
-            .map_err(|code| codec_error(code, CodecPhase::RequestProof))?;
+            .map_err(|code| request_codec_error(code, CodecPhase::RequestProof, ctx))?;
         final_ledger
             .finish()
             .map_err(|code| codec_error(code, CodecPhase::RequestProof))?;
@@ -235,6 +237,18 @@ impl AnthropicMessagesCodec {
 
 fn codec_error(code: CodecErrorCode, phase: CodecPhase) -> CodecError {
     CodecError::new(code, phase)
+}
+
+fn request_codec_error(
+    code: CodecErrorCode,
+    phase: CodecPhase,
+    ctx: &RequestTransformContext<'_>,
+) -> CodecError {
+    codec_error(code, phase).with_opaque_carrier(
+        (code == CodecErrorCode::OpaqueMediaUninspected)
+            .then(|| ctx.opaque_carrier())
+            .flatten(),
+    )
 }
 
 fn restore_json_response(
@@ -2031,7 +2045,7 @@ fn probe_request_view(
     view: &str,
     ctx: &mut RequestTransformContext<'_>,
 ) -> Result<RequestViewProbeOutcome, CodecErrorCode> {
-    let contains_opaque_carrier = match guard_mutable_text(view) {
+    let contains_opaque_carrier = match guard_request_mutable_text(view, ctx) {
         Ok(()) => false,
         Err(CodecErrorCode::OpaqueMediaUninspected) => true,
         Err(code) => return Err(code),
@@ -2249,8 +2263,8 @@ fn transform_request_content(
             if blocks.is_empty() {
                 return Err(CodecErrorCode::UnsupportedRequestSurface);
             }
-            for block in blocks {
-                transform_request_block(block, input, ctx, ledger)?;
+            for (index, block) in blocks.iter_mut().enumerate() {
+                transform_request_block_at_index(block, index, input, ctx, ledger)?;
             }
             Ok(())
         }
@@ -2271,16 +2285,29 @@ fn transform_request_system(
             if blocks.is_empty() {
                 return Err(CodecErrorCode::UnsupportedRequestSurface);
             }
-            for block in blocks {
+            for (index, block) in blocks.iter_mut().enumerate() {
                 if object_string(block, "type")? != "text" {
                     return Err(CodecErrorCode::UnsupportedRequestSurface);
                 }
-                transform_request_block(block, input, ctx, ledger)?;
+                transform_request_block_at_index(block, index, input, ctx, ledger)?;
             }
             Ok(())
         }
         _ => Err(CodecErrorCode::UnsupportedRequestSurface),
     }
+}
+
+fn transform_request_block_at_index(
+    node: &mut JsonNode,
+    index: usize,
+    input: &[u8],
+    ctx: &mut RequestTransformContext<'_>,
+    ledger: &mut CoverageLedger,
+) -> Result<(), CodecErrorCode> {
+    let previous = ctx.replace_content_block_index(Some(index));
+    let result = transform_request_block(node, input, ctx, ledger);
+    ctx.replace_content_block_index(previous);
+    result
 }
 
 fn transform_request_block(
@@ -2413,7 +2440,7 @@ fn validate_signed_request_block(
             }
             "thinking" if block_type == "thinking" => {
                 let text = string_value(&member.value)?;
-                guard_mutable_text(text)?;
+                guard_request_mutable_text(text, ctx)?;
                 ctx.validate_token_shapes(text)?;
                 if ctx.probe_without_prefix_cache_write(text)? != text {
                     return Err(CodecErrorCode::SignedMutationRequired);
@@ -2566,7 +2593,7 @@ fn transform_request_schema(
                     return Err(CodecErrorCode::UnsupportedRequestSurface);
                 };
                 for property in properties {
-                    guard_mutable_text(&property.key.value)?;
+                    guard_request_mutable_text(&property.key.value, ctx)?;
                     ctx.validate_token_shapes(&property.key.value)?;
                     let transformed = ctx.protect(&property.key.value)?;
                     if !transformed_property_keys.insert(transformed.clone()) {
@@ -2603,7 +2630,7 @@ fn transform_request_schema(
                         };
                         for definition in definitions {
                             ledger.mark(definition.key_occurrence)?;
-                            guard_mutable_text(&definition.key.value)?;
+                            guard_request_mutable_text(&definition.key.value, ctx)?;
                             ctx.validate_token_shapes(&definition.key.value)?;
                             if ctx.probe_without_prefix_cache_write(&definition.key.value)?
                                 != definition.key.value
@@ -2710,7 +2737,7 @@ fn transform_request_string(
     let JsonKind::String(value) = &mut node.kind else {
         return Err(CodecErrorCode::UnsupportedRequestSurface);
     };
-    guard_mutable_text(&value.value)?;
+    guard_request_mutable_text(&value.value, ctx)?;
     ctx.validate_token_shapes(&value.value)?;
     value.value = ctx.protect(&value.value)?;
     Ok(())
@@ -2720,7 +2747,7 @@ fn protect_key(
     key: &mut JsonString,
     ctx: &mut RequestTransformContext<'_>,
 ) -> Result<(), CodecErrorCode> {
-    guard_mutable_text(&key.value)?;
+    guard_request_mutable_text(&key.value, ctx)?;
     ctx.validate_token_shapes(&key.value)?;
     key.value = ctx.protect(&key.value)?;
     Ok(())
@@ -2735,7 +2762,7 @@ fn request_string_control(
     let JsonKind::String(value) = &node.kind else {
         return Err(CodecErrorCode::UnsupportedRequestSurface);
     };
-    guard_mutable_text(&value.value)?;
+    guard_request_mutable_text(&value.value, ctx)?;
     ctx.validate_token_shapes(&value.value)?;
     if ctx.probe_without_prefix_cache_write(&value.value)? == value.value {
         Ok(())
@@ -2830,7 +2857,7 @@ fn validate_cache_control_probe(
         if !valid {
             return Err(CodecErrorCode::SignedSurfaceMalformed);
         }
-        guard_mutable_text(value)?;
+        guard_request_mutable_text(value, ctx)?;
         ctx.validate_token_shapes(value)?;
         if ctx.probe_without_prefix_cache_write(value)? != value {
             return Err(CodecErrorCode::SignedMutationRequired);
@@ -3126,7 +3153,7 @@ fn guard_mutable_text(value: &str) -> Result<(), CodecErrorCode> {
                     | '\u{202a}'..='\u{202e}'
                     | '\u{2066}'..='\u{2069}'
             )
-    }) || contains_carrier_scheme(&lower)
+    }) || find_carrier_scheme(&lower).is_some()
         || inspected.as_bytes().windows(3).any(|window| {
             window[0] == b'%' && hex_value(window[1]).is_some() && hex_value(window[2]).is_some()
         })
@@ -3141,17 +3168,36 @@ fn guard_mutable_text(value: &str) -> Result<(), CodecErrorCode> {
     Ok(())
 }
 
-fn contains_carrier_scheme(value: &str) -> bool {
-    value.char_indices().any(|(index, _)| {
+fn guard_request_mutable_text(
+    value: &str,
+    ctx: &mut RequestTransformContext<'_>,
+) -> Result<(), CodecErrorCode> {
+    let result = guard_mutable_text(value);
+    if result == Err(CodecErrorCode::OpaqueMediaUninspected) {
+        let lower = value.to_ascii_lowercase();
+        if let Some((scheme, byte_offset, byte_length)) = find_carrier_scheme(&lower) {
+            ctx.record_opaque_carrier(scheme, byte_offset, byte_length);
+        }
+    }
+    result
+}
+
+fn find_carrier_scheme(value: &str) -> Option<(OpaqueCarrierScheme, usize, usize)> {
+    value.char_indices().find_map(|(index, _)| {
         let candidate = &value[index..];
-        let starts_scheme = ["data:", "file:", "http://", "https://"]
-            .iter()
-            .any(|scheme| candidate.starts_with(scheme));
-        starts_scheme
-            && (index == 0
-                || !value[..index].chars().next_back().is_some_and(|character| {
-                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
-                }))
+        let (scheme, matched) = [
+            (OpaqueCarrierScheme::Data, "data:"),
+            (OpaqueCarrierScheme::File, "file:"),
+            (OpaqueCarrierScheme::Http, "http://"),
+            (OpaqueCarrierScheme::Https, "https://"),
+        ]
+        .into_iter()
+        .find(|(_, literal)| candidate.starts_with(literal))?;
+        let boundary = index == 0
+            || !value[..index].chars().next_back().is_some_and(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+            });
+        boundary.then_some((scheme, index, matched.len()))
     })
 }
 

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -7,6 +7,8 @@ use http::Method;
 use thiserror::Error;
 use url::Url;
 
+use crate::codec::OpaqueCarrierLocation;
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ProxyError {
@@ -204,14 +206,156 @@ pub enum ProxyErrorPhase {
     Framework,
 }
 
+/// Structural reason a request header was rejected.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HeaderRejectionReason {
+    NameNotAllowlisted,
+    EmptyValue,
+    DuplicateSingleton,
+}
+
+impl HeaderRejectionReason {
+    /// Returns the stable downstream identifier for this rejection cause.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NameNotAllowlisted => "name_not_allowlisted",
+            Self::EmptyValue => "empty_value",
+            Self::DuplicateSingleton => "duplicate_singleton",
+        }
+    }
+}
+
+const MAX_STRUCTURAL_HEADER_NAME_BYTES: usize = 128;
+const PACKED_STRUCTURAL_HEADER_NAME_BYTES: usize = MAX_STRUCTURAL_HEADER_NAME_BYTES * 6 / 8;
+
+// `HeaderName::as_str()` uses the 51 lowercase HTTP token characters. Six-bit packing retains
+// every reviewed 128-byte header name exactly while keeping the closed error small and `Copy`.
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct HeaderRejectionIdentifier {
+    packed_name: [u8; PACKED_STRUCTURAL_HEADER_NAME_BYTES],
+    name_length: u8,
+    reason: HeaderRejectionReason,
+}
+
+impl HeaderRejectionIdentifier {
+    fn new(name: &str, reason: HeaderRejectionReason) -> Option<Self> {
+        let name_length = u8::try_from(name.len()).ok()?;
+        if name.len() > MAX_STRUCTURAL_HEADER_NAME_BYTES {
+            return None;
+        }
+        let mut packed_name = [0; PACKED_STRUCTURAL_HEADER_NAME_BYTES];
+        for (index, byte) in name.bytes().enumerate() {
+            let code = encode_header_name_byte(byte)?;
+            let bit_offset = index * 6;
+            let byte_offset = bit_offset / 8;
+            let shift = bit_offset % 8;
+            packed_name[byte_offset] |= code << shift;
+            if shift > 2 {
+                packed_name[byte_offset + 1] |= code >> (8 - shift);
+            }
+        }
+        Some(Self {
+            packed_name,
+            name_length,
+            reason,
+        })
+    }
+
+    fn name(self) -> String {
+        let mut name = String::with_capacity(usize::from(self.name_length));
+        for index in 0..usize::from(self.name_length) {
+            let bit_offset = index * 6;
+            let byte_offset = bit_offset / 8;
+            let shift = bit_offset % 8;
+            let mut code = self.packed_name[byte_offset] >> shift;
+            if shift > 2 {
+                code |= self.packed_name[byte_offset + 1] << (8 - shift);
+            }
+            name.push(char::from(
+                decode_header_name_byte(code & 0x3f)
+                    .expect("packed header names contain only validated token bytes"),
+            ));
+        }
+        name
+    }
+}
+
+fn encode_header_name_byte(byte: u8) -> Option<u8> {
+    match byte {
+        b'a'..=b'z' => Some(byte - b'a'),
+        b'0'..=b'9' => Some(26 + byte - b'0'),
+        b'!' => Some(36),
+        b'#' => Some(37),
+        b'$' => Some(38),
+        b'%' => Some(39),
+        b'&' => Some(40),
+        b'\'' => Some(41),
+        b'*' => Some(42),
+        b'+' => Some(43),
+        b'-' => Some(44),
+        b'.' => Some(45),
+        b'^' => Some(46),
+        b'_' => Some(47),
+        b'`' => Some(48),
+        b'|' => Some(49),
+        b'~' => Some(50),
+        _ => None,
+    }
+}
+
+fn decode_header_name_byte(code: u8) -> Option<u8> {
+    match code {
+        0..=25 => Some(b'a' + code),
+        26..=35 => Some(b'0' + code - 26),
+        36 => Some(b'!'),
+        37 => Some(b'#'),
+        38 => Some(b'$'),
+        39 => Some(b'%'),
+        40 => Some(b'&'),
+        41 => Some(b'\''),
+        42 => Some(b'*'),
+        43 => Some(b'+'),
+        44 => Some(b'-'),
+        45 => Some(b'.'),
+        46 => Some(b'^'),
+        47 => Some(b'_'),
+        48 => Some(b'`'),
+        49 => Some(b'|'),
+        50 => Some(b'~'),
+        _ => None,
+    }
+}
+
+impl fmt::Debug for HeaderRejectionIdentifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Header")
+            .field("name", &self.name())
+            .field("reason", &self.reason)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DirectProxyErrorIdentifier {
+    Header(HeaderRejectionIdentifier),
+    OpaqueCarrier(OpaqueCarrierLocation),
+}
+
 /// Sanitized direct-profile failure.
 ///
-/// `Display`, `Debug`, and the source chain deliberately expose only its closed code and phase.
+/// `Display`, `Debug`, and the source chain expose only its closed code, phase, and reviewed
+/// structural identifiers. Header values and carrier bytes are never retained.
+///
+/// This follows the field-path-only precedent established for [`ProxyError::UnsurfacedPii`] in
+/// #400: report the structural location that makes a rejection actionable, never the value.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct DirectProxyError {
     code: ProxyErrorCode,
     phase: ProxyErrorPhase,
     retry_after_seconds: Option<u32>,
+    identifier: Option<DirectProxyErrorIdentifier>,
 }
 
 impl DirectProxyError {
@@ -221,6 +365,7 @@ impl DirectProxyError {
             code,
             phase,
             retry_after_seconds: None,
+            identifier: None,
         }
     }
 
@@ -230,39 +375,82 @@ impl DirectProxyError {
         self
     }
 
+    pub(crate) fn with_header_rejection(
+        mut self,
+        name: &str,
+        reason: HeaderRejectionReason,
+    ) -> Self {
+        self.identifier =
+            HeaderRejectionIdentifier::new(name, reason).map(DirectProxyErrorIdentifier::Header);
+        self
+    }
+
+    pub(crate) fn with_opaque_carrier(mut self, opaque_carrier: OpaqueCarrierLocation) -> Self {
+        self.identifier = Some(DirectProxyErrorIdentifier::OpaqueCarrier(opaque_carrier));
+        self
+    }
+
     #[must_use]
-    pub const fn code(self) -> ProxyErrorCode {
+    pub const fn code(&self) -> ProxyErrorCode {
         self.code
     }
 
     #[must_use]
-    pub const fn phase(self) -> ProxyErrorPhase {
+    pub const fn phase(&self) -> ProxyErrorPhase {
         self.phase
     }
 
     #[must_use]
-    pub const fn http_status(self) -> StatusCode {
+    pub const fn http_status(&self) -> StatusCode {
         self.code.http_status()
     }
 
     #[must_use]
-    pub const fn retry_after_seconds(self) -> Option<u32> {
+    pub const fn retry_after_seconds(&self) -> Option<u32> {
         self.retry_after_seconds
     }
 
+    /// Returns the rejected header name without retaining or exposing its value.
     #[must_use]
-    pub const fn sse_error_frame(self) -> &'static [u8] {
+    pub fn header_name(&self) -> Option<String> {
+        match &self.identifier {
+            Some(DirectProxyErrorIdentifier::Header(identifier)) => Some(identifier.name()),
+            _ => None,
+        }
+    }
+
+    /// Returns the structural header-rejection cause.
+    #[must_use]
+    pub const fn header_rejection_reason(&self) -> Option<HeaderRejectionReason> {
+        match &self.identifier {
+            Some(DirectProxyErrorIdentifier::Header(identifier)) => Some(identifier.reason),
+            _ => None,
+        }
+    }
+
+    /// Returns only the opaque carrier's scheme and structural location.
+    #[must_use]
+    pub const fn opaque_carrier(&self) -> Option<OpaqueCarrierLocation> {
+        match &self.identifier {
+            Some(DirectProxyErrorIdentifier::OpaqueCarrier(location)) => Some(*location),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub const fn sse_error_frame(&self) -> &'static [u8] {
         crate::server::DIRECT_PROXY_ERROR_FRAME
     }
 }
 
 impl fmt::Debug for DirectProxyError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("DirectProxyError")
-            .field("code", &self.code)
-            .field("phase", &self.phase)
-            .finish()
+        let mut debug = formatter.debug_struct("DirectProxyError");
+        debug.field("code", &self.code).field("phase", &self.phase);
+        if let Some(identifier) = &self.identifier {
+            debug.field("identifier", identifier);
+        }
+        debug.finish()
     }
 }
 

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -208,6 +208,7 @@ pub enum ProxyErrorPhase {
 
 /// Structural reason a request header was rejected.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum HeaderRejectionReason {
     NameNotAllowlisted,
     EmptyValue,

--- a/crates/gaze-proxy/src/lib.rs
+++ b/crates/gaze-proxy/src/lib.rs
@@ -44,14 +44,17 @@ pub use adapter::{
     SessionRegistryConfigError, SseEvent,
 };
 pub use codec::{
-    BodyCodec, CodecError, CodecErrorCode, CodecLimits, CodecPhase, OutputProvenance,
-    ProvedRequestBody, ProvedResponseBody, RequestPseudonymizer, RequestTransformContext,
-    ResponseResidualValidator, ResponseTransformContext, WireFormat,
+    BodyCodec, CodecError, CodecErrorCode, CodecLimits, CodecPhase, OpaqueCarrierLocation,
+    OpaqueCarrierScheme, OutputProvenance, ProvedRequestBody, ProvedResponseBody,
+    RequestPseudonymizer, RequestTransformContext, ResponseResidualValidator,
+    ResponseTransformContext, WireFormat,
 };
 pub use codecs::anthropic::{
     AnthropicMessagesCodec, ANTHROPIC_PROXY_ERROR_FRAME, ANTHROPIC_PROXY_PING_FRAME,
 };
-pub use error::{DirectProxyError, ProxyError, ProxyErrorCode, ProxyErrorPhase};
+pub use error::{
+    DirectProxyError, HeaderRejectionReason, ProxyError, ProxyErrorCode, ProxyErrorPhase,
+};
 pub use inspection::{install_proxy_inspection_v1, ProxyInspectionProducerV1};
 pub use principal::{
     AuthenticatedPrincipal, ListenerScope, LocalAuthCredential, PeerScope, PrincipalContext,

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -30,7 +30,9 @@ use crate::codec::{
     ProvedRequestBody, RequestPseudonymizer, RequestTransformContext, ResponseResidualValidator,
     ResponseTransformContext, WireFormat,
 };
-use crate::error::{DirectProxyError, ProxyError, ProxyErrorCode, ProxyErrorPhase};
+use crate::error::{
+    DirectProxyError, HeaderRejectionReason, ProxyError, ProxyErrorCode, ProxyErrorPhase,
+};
 use crate::inspection::{ProxyInspectionEndpointCodesV1, ProxyInspectionLogicalV1};
 use crate::principal::{
     invoke_resolver, ListenerScope, PeerScope, PrincipalContext, PrincipalResolver,
@@ -793,15 +795,24 @@ fn validate_outbound_headers(headers: &HeaderMap) -> Result<(), DirectProxyError
     validate_header_space(headers, DirectClientConfig::default())?;
     let mut singleton_names = HashSet::new();
     for (name, value) in headers {
-        if !ALLOWED.contains(&name.as_str()) || value.is_empty() {
-            return Err(ProxyErrorCode::HeaderRejected.error(ProxyErrorPhase::RequestValidation));
+        if !ALLOWED.contains(&name.as_str()) {
+            return Err(ProxyErrorCode::HeaderRejected
+                .error(ProxyErrorPhase::RequestValidation)
+                .with_header_rejection(name.as_str(), HeaderRejectionReason::NameNotAllowlisted));
+        }
+        if value.is_empty() {
+            return Err(ProxyErrorCode::HeaderRejected
+                .error(ProxyErrorPhase::RequestValidation)
+                .with_header_rejection(name.as_str(), HeaderRejectionReason::EmptyValue));
         }
         if matches!(
             name.as_str(),
             "x-api-key" | "anthropic-version" | "anthropic-beta"
         ) && !singleton_names.insert(name.as_str())
         {
-            return Err(ProxyErrorCode::HeaderRejected.error(ProxyErrorPhase::RequestValidation));
+            return Err(ProxyErrorCode::HeaderRejected
+                .error(ProxyErrorPhase::RequestValidation)
+                .with_header_rejection(name.as_str(), HeaderRejectionReason::DuplicateSingleton));
         }
     }
     Ok(())
@@ -2331,6 +2342,7 @@ fn map_registry_error(error: RegistryError) -> DirectProxyError {
 
 fn map_codec_error(error: CodecError) -> DirectProxyError {
     let codec_phase = error.phase();
+    let opaque_carrier = error.opaque_carrier();
     let request_direction = matches!(
         codec_phase,
         CodecPhase::RequestParse | CodecPhase::RequestProtection | CodecPhase::RequestProof
@@ -2393,17 +2405,40 @@ fn map_codec_error(error: CodecError) -> DirectProxyError {
         CodecPhase::SseDecode | CodecPhase::SseLifecycle => ProxyErrorPhase::ResponseValidation,
         CodecPhase::SseReplay => ProxyErrorPhase::ResponseReplay,
     };
-    code.error(phase)
+    let direct_error = code.error(phase);
+    if let Some(opaque_carrier) = opaque_carrier {
+        direct_error.with_opaque_carrier(opaque_carrier)
+    } else {
+        direct_error
+    }
 }
 
 fn direct_error_response(error: DirectProxyError) -> Response {
+    let mut error_body = serde_json::json!({
+        "type": "api_error",
+        "message": "proxy_validation_failed",
+        "code": format!("{:?}", error.code()),
+        "phase": format!("{:?}", error.phase()),
+    });
+    if let (Some(name), Some(reason)) = (error.header_name(), error.header_rejection_reason()) {
+        error_body["header"] = serde_json::json!({
+            "name": name,
+            "reason": reason.as_str(),
+        });
+    }
+    if let Some(carrier) = error.opaque_carrier() {
+        error_body["carrier"] = serde_json::json!({
+            "scheme": carrier.scheme().as_str(),
+            "span": {
+                "byte_offset": carrier.byte_offset(),
+                "byte_length": carrier.byte_length(),
+            },
+            "content_block_index": carrier.content_block_index(),
+        });
+    }
     let body = serde_json::json!({
         "type": "error",
-        "error": {
-            "type": "api_error",
-            "message": "proxy_validation_failed",
-            "code": format!("{:?}", error.code()),
-        }
+        "error": error_body,
     });
     let mut response = Response::builder()
         .status(error.http_status())
@@ -4034,6 +4069,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn header_rejections_name_only_the_header_and_disambiguate_the_cause() {
+        const SECRET_ONE: &str = "synthetic-credential-one";
+        const SECRET_TWO: &str = "synthetic-credential-two";
+
+        let mut not_allowlisted = HeaderMap::new();
+        not_allowlisted.insert("x-synthetic-extra", HeaderValue::from_static(SECRET_ONE));
+
+        let mut empty = HeaderMap::new();
+        empty.insert("anthropic-beta", HeaderValue::from_static(""));
+
+        let mut duplicate = HeaderMap::new();
+        duplicate.append("x-api-key", HeaderValue::from_static(SECRET_ONE));
+        duplicate.append("x-api-key", HeaderValue::from_static(SECRET_TWO));
+
+        let cases = [
+            (
+                not_allowlisted,
+                "x-synthetic-extra",
+                HeaderRejectionReason::NameNotAllowlisted,
+            ),
+            (empty, "anthropic-beta", HeaderRejectionReason::EmptyValue),
+            (
+                duplicate,
+                "x-api-key",
+                HeaderRejectionReason::DuplicateSingleton,
+            ),
+        ];
+
+        for (headers, expected_name, expected_reason) in cases {
+            let error = validate_outbound_headers(&headers).unwrap_err();
+            assert_eq!(error.code(), ProxyErrorCode::HeaderRejected);
+            assert_eq!(error.phase(), ProxyErrorPhase::RequestValidation);
+            assert_eq!(error.header_name().as_deref(), Some(expected_name));
+            assert_eq!(error.header_rejection_reason(), Some(expected_reason));
+
+            let debug = format!("{error:?}");
+            assert!(debug.contains(expected_name));
+            assert!(!debug.contains(SECRET_ONE));
+            assert!(!debug.contains(SECRET_TWO));
+
+            let response = direct_error_response(error);
+            let bytes = to_bytes(response.into_body(), 4 * 1024).await.unwrap();
+            let body: Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["error"]["phase"], "RequestValidation");
+            assert_eq!(body["error"]["header"]["name"], expected_name);
+            assert_eq!(body["error"]["header"]["reason"], expected_reason.as_str());
+            let rendered = String::from_utf8(bytes.to_vec()).unwrap();
+            assert!(!rendered.contains(SECRET_ONE));
+            assert!(!rendered.contains(SECRET_TWO));
+        }
+
+        let maximum_name = format!("x-{}", "a".repeat(126));
+        let mut maximum_length = HeaderMap::new();
+        maximum_length.insert(
+            HeaderName::from_bytes(maximum_name.as_bytes()).unwrap(),
+            HeaderValue::from_static(SECRET_ONE),
+        );
+        let error = validate_outbound_headers(&maximum_length).unwrap_err();
+        assert_eq!(error.header_name().as_deref(), Some(maximum_name.as_str()));
+        assert_eq!(
+            error.header_rejection_reason(),
+            Some(HeaderRejectionReason::NameNotAllowlisted)
+        );
+    }
+
+    #[test]
+    fn actionable_header_reporting_preserves_the_rejected_request_set() {
+        let mut valid = HeaderMap::new();
+        valid.insert("content-type", HeaderValue::from_static("application/json"));
+        valid.insert("x-api-key", HeaderValue::from_static("synthetic-key"));
+        valid.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+
+        let mut not_allowlisted = valid.clone();
+        not_allowlisted.insert(
+            "x-synthetic-extra",
+            HeaderValue::from_static("synthetic-value"),
+        );
+
+        let mut empty = valid.clone();
+        empty.insert("anthropic-version", HeaderValue::from_static(""));
+
+        let mut duplicate = valid.clone();
+        duplicate.append("x-api-key", HeaderValue::from_static("synthetic-key-two"));
+
+        let rejected = [valid, not_allowlisted, empty, duplicate]
+            .iter()
+            .map(|headers| validate_outbound_headers(headers).is_err())
+            .collect::<Vec<_>>();
+        assert_eq!(rejected, vec![false, true, true, true]);
+    }
+
+    #[tokio::test]
     async fn redirects_retries_and_response_overflow_remain_disabled() {
         let target_hits = Arc::new(AtomicUsize::new(0));
         let target_hits_for_handler = Arc::clone(&target_hits);
@@ -4244,7 +4371,8 @@ mod tests {
                 "error": {
                     "type": "api_error",
                     "message": "proxy_validation_failed",
-                    "code": "RequestBodyLimitExceeded"
+                    "code": "RequestBodyLimitExceeded",
+                    "phase": "RequestValidation"
                 }
             })
         );
@@ -4279,7 +4407,8 @@ mod tests {
                 "error": {
                     "type": "api_error",
                     "message": "proxy_validation_failed",
-                    "code": "ResponseBodyLimitExceeded"
+                    "code": "ResponseBodyLimitExceeded",
+                    "phase": "ResponseValidation"
                 }
             })
         );

--- a/crates/gaze-proxy/tests/anthropic_codec.rs
+++ b/crates/gaze-proxy/tests/anthropic_codec.rs
@@ -7,7 +7,7 @@ mod codec;
 
 use anthropic::AnthropicMessagesCodec;
 use codec::{
-    BodyCodec, CodecErrorCode, CodecLimits, CodecPhase, RequestPseudonymizer,
+    BodyCodec, CodecErrorCode, CodecLimits, CodecPhase, OpaqueCarrierScheme, RequestPseudonymizer,
     RequestTransformContext, ResponseResidualValidator, ResponseTransformContext, WireFormat,
 };
 use gaze::{PiiClass, PrefixCacheWriteMode, Scope, Session, SessionTransaction};
@@ -720,6 +720,66 @@ fn request_signed_and_opaque_surfaces_are_explicit_and_fail_closed() {
         r#"{"type":"thinking","thinking":"synthetic reasoning","signature":"opaque-signature"}"#
     ));
     assert_eq!(proved.provenance().signed_opaque_ranges().len(), 1);
+}
+
+#[test]
+fn actionable_opaque_reporting_preserves_the_rejected_request_set() {
+    let cases = [
+        ("ordinary synthetic prose", None),
+        (
+            "data:text/plain,SYNTHETIC-CARRIER",
+            Some(OpaqueCarrierScheme::Data),
+        ),
+        ("file:synthetic-carrier", Some(OpaqueCarrierScheme::File)),
+        (
+            "http://synthetic.example.invalid/carrier",
+            Some(OpaqueCarrierScheme::Http),
+        ),
+        (
+            "https://synthetic.example.invalid/carrier",
+            Some(OpaqueCarrierScheme::Https),
+        ),
+    ];
+    let mut rejected = Vec::new();
+
+    for (system_text, expected_scheme) in cases {
+        let request = serde_json::json!({
+            "model": "claude-test",
+            "max_tokens": 32,
+            "system": [{"type": "text", "text": system_text}],
+            "messages": [{"role": "user", "content": "synthetic"}],
+        });
+        let input = serde_json::to_vec(&request).unwrap();
+        let codec = AnthropicMessagesCodec;
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let mut transaction = session.begin_transaction();
+        let mut pseudonymizer = SyntheticPseudonymizer {
+            transaction: &mut transaction,
+        };
+        let result = codec.protect_request(&input, &mut request_context(&mut pseudonymizer));
+        if let Err(error) = &result {
+            assert_eq!(error.code(), CodecErrorCode::OpaqueMediaUninspected);
+            let carrier = error
+                .opaque_carrier()
+                .expect("scheme carrier rejection must retain its structural location");
+            assert_eq!(carrier.scheme(), expected_scheme.unwrap());
+            assert_eq!(carrier.byte_offset(), 0);
+            assert_eq!(
+                carrier.byte_length(),
+                match carrier.scheme() {
+                    OpaqueCarrierScheme::Data | OpaqueCarrierScheme::File => 5,
+                    OpaqueCarrierScheme::Http => 7,
+                    OpaqueCarrierScheme::Https => 8,
+                }
+            );
+            assert_eq!(carrier.content_block_index(), Some(0));
+            assert!(!format!("{error:?}").contains(system_text));
+        }
+        rejected.push(result.is_err());
+        assert_eq!(result.is_err(), expected_scheme.is_some());
+    }
+
+    assert_eq!(rejected, vec![false, true, true, true, true]);
 }
 
 #[test]

--- a/crates/gaze-proxy/tests/anthropic_direct.rs
+++ b/crates/gaze-proxy/tests/anthropic_direct.rs
@@ -787,6 +787,46 @@ async fn split_logical_domain_rejects_before_upstream_io() {
 }
 
 #[tokio::test]
+async fn opaque_carrier_error_names_only_structural_location_and_phase() {
+    const CARRIER: &str = "data:text/plain,SYNTHETIC-CARRIER-SECRET";
+    let upstream = spawn_upstream().await;
+    let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "system": [
+            {"type": "text", "text": "synthetic preface"},
+            {"type": "text", "text": format!("ordinary prefix {CARRIER}")},
+        ],
+        "messages": [{"role": "user", "content": "synthetic"}],
+    });
+
+    let response = sdk_client_request(&Client::new(), &proxy, false)
+        .body(serde_json::to_vec(&request).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let bytes = response.bytes().await.unwrap();
+    let error: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(error["error"]["code"], "OpaqueMediaUninspected");
+    assert_eq!(error["error"]["phase"], "RequestTransform");
+    assert_eq!(error["error"]["carrier"]["scheme"], "data:");
+    assert_eq!(
+        error["error"]["carrier"]["span"]["byte_offset"],
+        "ordinary prefix ".len()
+    );
+    assert_eq!(error["error"]["carrier"]["span"]["byte_length"], 5);
+    assert_eq!(error["error"]["carrier"]["content_block_index"], 1);
+    let rendered = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(!rendered.contains(CARRIER));
+    assert!(!rendered.contains("SYNTHETIC-CARRIER-SECRET"));
+    assert_eq!(upstream.connections.load(Ordering::SeqCst), 0);
+    assert!(upstream.captures.lock().await.is_empty());
+}
+
+#[tokio::test]
 async fn split_opaque_carriers_reject_across_complete_request_views_without_side_effects() {
     let upstream = spawn_upstream().await;
     let logger = CountingRedactionLogger::default();


### PR DESCRIPTION
## Summary

- propagate the direct-proxy processing phase into downstream JSON errors
- make `HeaderRejected` name the header and distinguish `name_not_allowlisted`, `empty_value`, and `duplicate_singleton`
- make scheme-triggered `OpaqueMediaUninspected` report the normalized carrier scheme, matched scheme byte span, and content-block index

## Security boundary

This follows PR #400 F1’s structural-path precedent: report the location, never the value. Typed errors retain header names but never header values, and retain carrier scheme/span/index but never URI or block bytes. Scheme-free opaque image blocks intentionally receive no invented carrier metadata.

No rejection decision changes. The original fail-closed branches remain in place, and regression matrices pin the same valid/rejected request sets before and after this reporting change.

## Evidence

- `cargo fmt --all -- --check`
- `cargo clippy -p gaze-proxy --all-features --all-targets -j 2 -- -D warnings`
- `cargo test -p gaze-proxy --all-features -j 2`
- five mutation probes each produced exactly one failing test before restoration: header identifier presence, header-value absence, carrier identifier presence, carrier-byte absence, and phase presence

The requested full-workspace all-feature clippy is deferred while orchestrator 4764 owns the benchmark machine; this PR deliberately uses the narrow `gaze-proxy` gate at two Cargo jobs to avoid perturbing the fixed-deadline benchmark run tracked by todo #2404.

References todo #2428 for the `HeaderRejected` and `OpaqueMediaUninspected` error surfaces. The dashboard message from todo #2423 remains a separate follow-up.