### PR TITLE
[agent] fix source-ID vocabulary and leak-guard precision

### DIFF
--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -392,6 +392,7 @@ VALID_TRACE_COMBINATIONS = frozenset(
 )
 BUILTIN_CANONICAL_CLASSES = frozenset({"email", "name", "location", "organization"})
 SOURCE_ID_PATTERN = re.compile(r"(?=.{1,128}\Z)[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*\Z")
+MIN_BOUNDED_PROTECTED_VALUE_LENGTH = 4
 LEAK_SUSPECT_FIELDS = frozenset(
     {
         "clean_start",
@@ -748,9 +749,16 @@ def _validate_final_protection_trace(
     for source_id, context in source_identifiers:
         if source_id not in COMMITTED_SOURCE_ID_VOCABULARY and any(
             raw_value
-            and re.search(
-                rf"(?:^|(?<=[._:/-])){re.escape(raw_value)}(?:$|(?=[._:/-]))",
-                source_id,
+            and (
+                source_id == raw_value
+                or (
+                    len(raw_value) >= MIN_BOUNDED_PROTECTED_VALUE_LENGTH
+                    and re.search(
+                        rf"(?:^|(?<=[._:/-])){re.escape(raw_value)}"
+                        rf"(?:$|(?=[._:/-]))",
+                        source_id,
+                    )
+                )
             )
             for raw_value in protected_raw_values
         ):

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -607,6 +607,25 @@ def load_committed_source_id_vocabulary(
                     recognizer["id"], f"{path}: recognizers[{index}].id"
                 )
             )
+            collision = recognizer.get("collision")
+            if collision is not None:
+                collision_context = f"{path}: recognizers[{index}].collision"
+                if not isinstance(collision, dict) or "family" not in collision:
+                    raise SourceIdVocabularyError(
+                        f"{collision_context} must be a table declaring a family"
+                    )
+                family = collision["family"]
+                if not isinstance(family, str):
+                    raise SourceIdVocabularyError(
+                        f"{collision_context}.family: expected a metadata-only "
+                        "stable identifier"
+                    )
+                identifiers.add(
+                    _committed_vocabulary_id(
+                        f"collision-family:{family}",
+                        f"{collision_context}.family",
+                    )
+                )
             recognizer_count += 1
     if recognizer_count == 0:
         raise SourceIdVocabularyError(

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -826,6 +826,7 @@ class ResponseValidationTests(unittest.TestCase):
         self,
     ) -> None:
         for protected_value, source_id in (
+            ("or", "or"),
             ("order-1234", "order-1234"),
             ("order-1234", "rule-order-1234-source"),
             ("davlan", "ner.davlan"),
@@ -888,27 +889,23 @@ class ResponseValidationTests(unittest.TestCase):
 
         benchmark.validate_response(document, response)
 
-    def test_trace_rejects_novel_id_with_bounded_protected_segment(self) -> None:
-        protected_value = "de"
+    def test_trace_accepts_novel_id_with_short_coincidental_segment(self) -> None:
+        protected_value = "or"
         document = benchmark.Document(
             uid="synthetic-response",
             text=protected_value,
-            language="de",
-            region="DE",
+            language="en",
+            region="US",
             source_dataset="unit-test",
-            spans=(benchmark.Span(0, len(protected_value), "POSTAL"),),
+            spans=(benchmark.Span(0, len(protected_value), "LOCATION"),),
         )
         response = self.tokenize_response()
         response["manifest_spans"][0]["raw_end"] = len(protected_value)
         item = response["final_protection_trace"][0]
         item["raw_end"] = len(protected_value)
-        item["provenance"]["source_ids"] = ["novel.de.source"]
+        item["provenance"]["source_ids"] = ["novel-payment-or-source"]
 
-        with self.assertRaisesRegex(
-            benchmark.ResponseValidationError,
-            "reproduces protected request content",
-        ):
-            benchmark.validate_response(document, response)
+        benchmark.validate_response(document, response)
 
     def test_trace_accepts_unbounded_source_id_substring(self) -> None:
         protected_value = "avl"

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -1475,6 +1475,10 @@ class ConfigTests(unittest.TestCase):
     def test_committed_source_id_vocabulary_loads_rulepack_and_model_ids(self) -> None:
         self.assertIn("postal.de", benchmark.COMMITTED_SOURCE_ID_VOCABULARY)
         self.assertIn(
+            "collision-family:payment-card-or-iban",
+            benchmark.COMMITTED_SOURCE_ID_VOCABULARY,
+        )
+        self.assertIn(
             "davlan-mbert-ner-hrl-onnx",
             benchmark.COMMITTED_SOURCE_ID_VOCABULARY,
         )
@@ -1483,6 +1487,66 @@ class ConfigTests(unittest.TestCase):
                 benchmark.COMMITTED_SOURCE_ID_VOCABULARY
             )
         )
+
+    def test_committed_source_id_vocabulary_derives_new_collision_family(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo_root = Path(temporary)
+            rulepack_dir = repo_root / "crates/gaze-recognizers/embedded"
+            rulepack_dir.mkdir(parents=True)
+            (rulepack_dir / "synthetic.toml").write_text(
+                '[[recognizers]]\n'
+                'id = "synthetic-rule"\n'
+                '[recognizers.collision]\n'
+                'family = "synthetic-new-family"\n',
+                encoding="utf-8",
+            )
+            model_path = repo_root / "scripts/bench/no_opf_models.toml"
+            model_path.parent.mkdir(parents=True)
+            model_path.write_text(
+                '[builtin_source_ids]\n'
+                'ids = ["synthetic-builtin"]\n'
+                '[synthetic_model]\n'
+                'id = "synthetic-model"\n',
+                encoding="utf-8",
+            )
+
+            vocabulary = benchmark.load_committed_source_id_vocabulary(repo_root)
+
+        self.assertIn("collision-family:synthetic-new-family", vocabulary)
+
+    def test_malformed_collision_family_metadata_fails_closed(self) -> None:
+        malformed_declarations = {
+            "not-a-table": 'collision = "synthetic-family"\n',
+            "missing-family": "collision = {}\n",
+            "non-string-family": "collision = { family = 42 }\n",
+            "invalid-family": 'collision = { family = "Not Canonical" }\n',
+        }
+        for name, declaration in malformed_declarations.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                repo_root = Path(temporary)
+                rulepack_dir = repo_root / "crates/gaze-recognizers/embedded"
+                rulepack_dir.mkdir(parents=True)
+                (rulepack_dir / "synthetic.toml").write_text(
+                    f'[[recognizers]]\nid = "synthetic-rule"\n{declaration}',
+                    encoding="utf-8",
+                )
+                model_path = repo_root / "scripts/bench/no_opf_models.toml"
+                model_path.parent.mkdir(parents=True)
+                model_path.write_text(
+                    '[builtin_source_ids]\n'
+                    'ids = ["synthetic-builtin"]\n'
+                    '[synthetic_model]\n'
+                    'id = "synthetic-model"\n',
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(
+                    benchmark.SourceIdVocabularyError,
+                    "collision|metadata-only stable identifier",
+                ):
+                    benchmark.load_committed_source_id_vocabulary(repo_root)
 
     def test_builtin_source_id_declaration_matches_committed_source_literals(
         self,


### PR DESCRIPTION
## Summary

This fixes two separable axis-4 scorer defects:

1. `load_committed_source_id_vocabulary()` harvested recognizer IDs but ignored `[recognizers.collision].family`, even though Rust emits the byte-exact provenance form `format!("collision-family:{family}")`. The loader now derives every `collision-family:<family>` ID from each committed rulepack and fails closed on malformed collision metadata.
2. The protected-content guard treated every delimiter-bounded 1–3 character coincidence in an uncommitted ID as reproduction. It now rejects exact ID/value equality at every length, and applies bounded-subsegment matching when the protected value is at least four characters.

The observed `collision-family:payment-card-or-iban` ID is therefore admitted from committed `core.toml` metadata, never from a one-off builtin allowlist entry.

## Precision and safety tradeoff

Still catches: an uncommitted producer ID exactly equal to protected request content at any length, plus any uncommitted ID containing a delimiter-bounded protected value of four or more characters, including `rule-order-1234-source` and `ner.davlan`.

Now misses: an uncommitted ID whose full value differs but contains only a delimiter-bounded 1–3-character protected value. Exact short-value IDs remain blocked. This narrow reliability tradeoff avoids chance matches on ordinary identifier fragments such as `or`, `de`, and `id`; the committed-vocabulary derivation remains the primary proof that static producer IDs are safe. No reversibility, agentic-fit, or adopter-ergonomics contract changes.

## Tests

- `test_committed_source_id_vocabulary_loads_rulepack_and_model_ids` pins the shipped payment-card/IBAN family ID.
- `test_committed_source_id_vocabulary_derives_new_collision_family` proves a synthetic new family is harvested without a code allowlist edit.
- `test_malformed_collision_family_metadata_fails_closed` pins malformed-table, missing-family, non-string, and invalid-family failures.
- `test_trace_accepts_novel_id_with_short_coincidental_segment` pins the short-fragment false-positive fix.
- `test_trace_rejects_source_id_reproducing_protected_request_content` pins exact short-value and substantive bounded-value leak rejection.

Required gate:

```
Ran 109 tests in 0.051s
OK (skipped=1)
```

108 passed, 1 skipped. No Rust files changed, so Rust-only gates were not run. No benchmark profile was run.

## Mutation probes

Vocabulary derivation removed:

```
FAIL: test_committed_source_id_vocabulary_derives_new_collision_family
AssertionError: collision-family:synthetic-new-family not found in frozenset({synthetic-model, synthetic-rule, synthetic-builtin})
Ran 1 test in 0.002s
FAILED (failures=1)
```

Derivation restored:

```
Ran 1 test in 0.002s
OK
```

Precision condition reverted to the original delimiter check:

```
ERROR: test_trace_accepts_novel_id_with_short_coincidental_segment
ResponseValidationError: final_protection_trace[0].provenance.source_ids[0]: identifier reproduces protected request content
Ran 1 test in 0.001s
FAILED (errors=1)
```

Precision condition restored, paired with the real-leak assertion:

```
Ran 2 tests in 0.001s
OK
```

Resolves solo todo #2488