### PR TITLE
[agent] fix(proxy): atomic session_for — concurrent first requests no longer orphan Sessions

### DIFF
--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1627,6 +1627,11 @@ struct SessionEntry {
     expires_at: Instant,
 }
 
+#[cfg(test)]
+static SESSION_FOR_MISS_BARRIERS: std::sync::LazyLock<
+    std::sync::Mutex<HashMap<String, Arc<tokio::sync::Barrier>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct HealthSnapshot {
@@ -2469,6 +2474,14 @@ async fn session_for(state: &AppState, headers: &HeaderMap) -> Result<Arc<Sessio
         }
     }
 
+    #[cfg(test)]
+    {
+        let barrier = SESSION_FOR_MISS_BARRIERS.lock().unwrap().get(&id).cloned();
+        if let Some(barrier) = barrier {
+            barrier.wait().await;
+        }
+    }
+
     let session = Arc::new(
         Session::new(Scope::Conversation(id.clone()))
             .map_err(|source| ProxyError::Pipeline { source })?,
@@ -3048,6 +3061,47 @@ mod tests {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             started_at: Instant::now(),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_first_requests_share_one_session() {
+        const TASK_COUNT: usize = 8;
+        const SESSION_ID: &str = "synthetic-concurrent-session";
+
+        let state = Arc::new(AppState {
+            config: Arc::new(ProxyConfig::new("127.0.0.1:0".parse().unwrap(), Vec::new())),
+            pipeline: Arc::new(Pipeline::builder().build().unwrap()),
+            client: Client::new(),
+            direct: None,
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            started_at: Instant::now(),
+        });
+        SESSION_FOR_MISS_BARRIERS.lock().unwrap().insert(
+            SESSION_ID.to_string(),
+            Arc::new(tokio::sync::Barrier::new(TASK_COUNT)),
+        );
+
+        let mut tasks = Vec::with_capacity(TASK_COUNT);
+        for _ in 0..TASK_COUNT {
+            let state = Arc::clone(&state);
+            tasks.push(tokio::spawn(async move {
+                let mut headers = HeaderMap::new();
+                headers.insert(SESSION_HEADER, HeaderValue::from_static(SESSION_ID));
+                session_for(&state, &headers).await.unwrap()
+            }));
+        }
+
+        let mut sessions = Vec::with_capacity(TASK_COUNT);
+        for task in tasks {
+            sessions.push(task.await.unwrap());
+        }
+        SESSION_FOR_MISS_BARRIERS.lock().unwrap().remove(SESSION_ID);
+
+        let first = &sessions[0];
+        assert!(
+            sessions.iter().all(|session| Arc::ptr_eq(first, session)),
+            "concurrent first requests returned orphaned Sessions"
+        );
     }
 
     fn direct_test_ingress(

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -2465,15 +2465,6 @@ async fn session_for(state: &AppState, headers: &HeaderMap) -> Result<Arc<Sessio
         .map(str::to_string)
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-    {
-        let sessions = state.sessions.read().await;
-        if let Some(entry) = sessions.get(&id) {
-            if entry.expires_at > now {
-                return Ok(entry.session.clone());
-            }
-        }
-    }
-
     #[cfg(test)]
     {
         let barrier = SESSION_FOR_MISS_BARRIERS.lock().unwrap().get(&id).cloned();
@@ -2482,20 +2473,22 @@ async fn session_for(state: &AppState, headers: &HeaderMap) -> Result<Arc<Sessio
         }
     }
 
-    let session = Arc::new(
-        Session::new(Scope::Conversation(id.clone()))
-            .map_err(|source| ProxyError::Pipeline { source })?,
-    );
     let mut sessions = state.sessions.write().await;
     sessions.retain(|_, entry| entry.expires_at > now);
-    sessions.insert(
-        id,
-        SessionEntry {
-            session: session.clone(),
-            expires_at: now + state.config.session_ttl,
-        },
-    );
-    Ok(session)
+    match sessions.entry(id) {
+        std::collections::hash_map::Entry::Occupied(entry) => Ok(entry.get().session.clone()),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let session = Arc::new(
+                Session::new(Scope::Conversation(entry.key().clone()))
+                    .map_err(|source| ProxyError::Pipeline { source })?,
+            );
+            entry.insert(SessionEntry {
+                session: session.clone(),
+                expires_at: now + state.config.session_ttl,
+            });
+            Ok(session)
+        }
+    }
 }
 
 /// Numeric request positions that are caller-authored generation controls rather than data


### PR DESCRIPTION
## Defect

`session_for` used a read-lock lookup followed by session construction and a separate write-lock insert. Concurrent first requests for the same session ID could each receive a different `Session`; all but the last inserted session became orphaned, so tokens minted through those handles could no longer restore. This is an axis-2 reversibility defect.

## Red-first evidence

Before the fix:

```text
$ cargo test -p gaze-proxy concurrent_first_requests_share_one_session -- --nocapture
running 1 test
test server::tests::concurrent_first_requests_share_one_session ... FAILED

thread 'server::tests::concurrent_first_requests_share_one_session' panicked at crates/gaze-proxy/src/server.rs:3100:9:
concurrent first requests returned orphaned Sessions

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 50 filtered out
```

The regression test uses eight tasks and a test-only barrier at the shared read-miss boundary, then asserts every returned `Arc<Session>` is pointer-identical.

## Fix

`session_for` now performs expiry cleanup and occupied/vacant selection under one write lock. Session construction and insertion happen only for the vacant entry, so concurrent callers share the canonical session.

## Verification

- `cargo fmt --all -- --check` PASS
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` PASS
- Targeted regression PASS
- `cargo test --workspace --all-features` reached and passed the new proxy regression, then stopped on the unrelated `gaze-recognizers` test `subprocess_span_round_trips_through_manifest_diff`: Kiji subprocess timed out after 5 seconds. The isolated recognizer test reproduced the same timeout.
- `cargo run -p xtask -- ci-feature-matrix` stopped twice before its first nested test because DNS could not resolve `index.crates.io`.

Audit: solo scratchpad 7201 S16-F1

Resolves solo todo #2903
