### PR TITLE
[agent] tier-0 fail-closed batch: OPF euid, fetch root, CI and lint hardening

### DIFF
--- a/.github/workflows/dylint.yml
+++ b/.github/workflows/dylint.yml
@@ -36,4 +36,6 @@ jobs:
         working-directory: lint/dylint
         run: cargo test --test ui
       - name: Run dylint gate
+        env:
+          GAZE_DYLINT_REQUIRED: "1"
         run: cargo run -p xtask -- dylint-gate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,5 +216,7 @@ jobs:
         run: cargo run -p xtask -- safety-net-sanity
       - name: xtask dashboard-isolation
         run: cargo run -p xtask -- dashboard-isolation
+      - name: xtask mcp-tier-isolation
+        run: cargo run -p xtask -- mcp-tier-isolation
       - name: xtask ci-feature-matrix
         run: cargo run -p xtask -- ci-feature-matrix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6021,6 +6021,7 @@ dependencies = [
  "sha3",
  "syn",
  "tempfile",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
@@ -838,25 +838,6 @@ fn sanitize_path(path: &Path) -> String {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
-    struct CurrentDirGuard(std::path::PathBuf);
-
-    #[cfg(unix)]
-    impl CurrentDirGuard {
-        fn enter(path: &Path) -> Self {
-            let original = std::env::current_dir().unwrap();
-            std::env::set_current_dir(path).unwrap();
-            Self(original)
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for CurrentDirGuard {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.0).unwrap();
-        }
-    }
-
     #[test]
     fn private_fields_do_not_debug() {
         let span: PrivateOpfSpan = serde_json::from_str(
@@ -934,16 +915,47 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[serial_test::serial]
     fn owner_check_uses_process_euid_not_cwd_owner() {
-        let dir = tempfile::tempdir().unwrap();
         let expected = unsafe { libc::geteuid() };
-
-        assert_eq!(current_euid(), expected);
-        {
-            let _guard = CurrentDirGuard::enter(dir.path());
-            assert_eq!(current_euid(), expected);
+        if expected == 0 {
+            eprintln!("skipping different-owner CWD check because the test runner is root");
+            return;
         }
+
+        let module = module_path!()
+            .strip_prefix(concat!(env!("CARGO_CRATE_NAME"), "::"))
+            .unwrap_or(module_path!());
+        let helper = format!("{module}::owner_check_different_owner_cwd_helper");
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", &helper, "--nocapture"])
+            .env("GAZE_EUID_OWNER_CHECK_HELPER", "1")
+            .current_dir("/")
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "different-owner CWD helper failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_check_different_owner_cwd_helper() {
+        use std::os::unix::fs::MetadataExt;
+
+        if std::env::var_os("GAZE_EUID_OWNER_CHECK_HELPER").is_none() {
+            return;
+        }
+
+        let expected = unsafe { libc::geteuid() };
+        let cwd_owner = std::fs::metadata(".").unwrap().uid();
+        assert_ne!(
+            cwd_owner, expected,
+            "helper CWD owner must differ from euid"
+        );
         assert_eq!(current_euid(), expected);
     }
 

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
@@ -750,7 +750,7 @@ fn verify_one_sensitive_path(path: &Path) -> Result<std::fs::Metadata, SafetyNet
         });
     }
 
-    let uid = current_uid();
+    let uid = current_euid();
     if metadata.uid() != uid {
         return Err(SafetyNetError::ModelUnavailable {
             reason: "opf sensitive path owner mismatch".to_string(),
@@ -790,13 +790,10 @@ fn set_private_dir_permissions(path: &Path) -> Result<(), SafetyNetError> {
 }
 
 #[cfg(unix)]
-fn current_uid() -> u32 {
-    std::fs::metadata(".")
-        .map(|metadata| {
-            use std::os::unix::fs::MetadataExt;
-            metadata.uid()
-        })
-        .unwrap_or(0)
+fn current_euid() -> u32 {
+    // Verification must depend on who runs the process, not on the current
+    // directory's owner.
+    unsafe { libc::geteuid() }
 }
 
 #[cfg(windows)]
@@ -840,6 +837,25 @@ fn sanitize_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    struct CurrentDirGuard(std::path::PathBuf);
+
+    #[cfg(unix)]
+    impl CurrentDirGuard {
+        fn enter(path: &Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(original)
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).unwrap();
+        }
+    }
 
     #[test]
     fn private_fields_do_not_debug() {
@@ -914,6 +930,21 @@ mod tests {
 
         let mode = std::fs::metadata(cache_dir).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
+    fn owner_check_uses_process_euid_not_cwd_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected = unsafe { libc::geteuid() };
+
+        assert_eq!(current_euid(), expected);
+        {
+            let _guard = CurrentDirGuard::enter(dir.path());
+            assert_eq!(current_euid(), expected);
+        }
+        assert_eq!(current_euid(), expected);
     }
 
     #[cfg(unix)]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -24,3 +24,4 @@ tempfile = "3"
 fake = { version = "*", default-features = false }
 syn = { version = "2", features = ["full"] }
 tempfile = "3"
+toml = "0.8"

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -108,6 +108,11 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         program: "cargo",
         args: &["run", "-p", "xtask", "--", "dashboard-isolation"],
     },
+    MatrixCommand {
+        label: "cargo run -p xtask -- mcp-tier-isolation",
+        program: "cargo",
+        args: &["run", "-p", "xtask", "--", "mcp-tier-isolation"],
+    },
     // The removed hook called `xtask ci-feature-matrix`; omit it here to avoid
     // recursive self-execution while preserving the actual gate coverage.
     MatrixCommand {
@@ -194,6 +199,7 @@ const REQUIRED_README_VERSION_CHECK_TASK: &str = "readme-version-check";
 const REQUIRED_TOKENBRIDGE_ENCRYPTED_INDEX_TASK: &str = "tokenbridge-encrypted-index";
 const REQUIRED_TRYBUILD_FIXTURE_HYGIENE_TASK: &str = "trybuild-fixture-hygiene";
 const REQUIRED_DASHBOARD_ISOLATION_TASK: &str = "dashboard-isolation";
+const REQUIRED_MCP_TIER_ISOLATION_TASK: &str = "mcp-tier-isolation";
 const NO_PHONE_PARSER_FAIL_CLOSED_GUARD: MatrixCommand = MatrixCommand {
     label:
         "cargo test -p gaze-recognizers --no-default-features --test no_phone_parser_fail_closed",
@@ -296,6 +302,16 @@ fn ensure_matrix_contract() -> Result<()> {
         bail!(
             "ci_feature_matrix: feature matrix must run xtask {}",
             REQUIRED_DASHBOARD_ISOLATION_TASK
+        );
+    }
+
+    if !FEATURE_MATRIX
+        .iter()
+        .any(|command| command.args.contains(&REQUIRED_MCP_TIER_ISOLATION_TASK))
+    {
+        bail!(
+            "ci_feature_matrix: feature matrix must run xtask {}",
+            REQUIRED_MCP_TIER_ISOLATION_TASK
         );
     }
 

--- a/crates/xtask/src/ci_feature_matrix.rs
+++ b/crates/xtask/src/ci_feature_matrix.rs
@@ -174,7 +174,7 @@ const FEATURE_MATRIX: &[MatrixCommand] = &[
         ],
     },
     MatrixCommand {
-        label: "cargo run -p xtask -- dylint-gate",
+        label: "cargo run -p xtask -- dylint-gate  # ui-fixture-shape only in PR CI; cargo-dylint runs in dylint.yml",
         program: "cargo",
         args: &["run", "-p", "xtask", "--", "dylint-gate"],
     },

--- a/crates/xtask/src/dylint_gate.rs
+++ b/crates/xtask/src/dylint_gate.rs
@@ -18,8 +18,7 @@ pub fn run() -> Result<()> {
         println!("dylint_gate: passed");
         return Ok(());
     }
-    if !cargo_dylint_available() {
-        eprintln!("cargo-dylint not installed; skipping dylint gate. CI installs it explicitly.");
+    if !cargo_dylint_requirement(running_in_ci(), cargo_dylint_available())? {
         return Ok(());
     }
     run_cargo_dylint(&root)?;
@@ -28,7 +27,22 @@ pub fn run() -> Result<()> {
 }
 
 fn should_run_cargo_dylint() -> bool {
-    env_flag("CI") || env_flag("GITHUB_ACTIONS") || env_flag(RUN_DYLINT_ENV)
+    running_in_ci() || env_flag(RUN_DYLINT_ENV)
+}
+
+fn running_in_ci() -> bool {
+    env_flag("CI") || env_flag("GITHUB_ACTIONS")
+}
+
+fn cargo_dylint_requirement(running_in_ci: bool, available: bool) -> Result<bool> {
+    if available {
+        return Ok(true);
+    }
+    if running_in_ci {
+        bail!("dylint_gate: cargo-dylint is required in CI but was not found");
+    }
+    eprintln!("cargo-dylint not installed; skipping dylint gate outside CI.");
+    Ok(false)
 }
 
 fn env_flag(var: &str) -> bool {
@@ -110,4 +124,24 @@ fn run_cargo_dylint(root: &Path) -> Result<()> {
         bail!("dylint_gate: cargo dylint --workspace --all failed");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_cargo_dylint_fails_closed_in_ci() {
+        let error = cargo_dylint_requirement(true, false).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "dylint_gate: cargo-dylint is required in CI but was not found"
+        );
+    }
+
+    #[test]
+    fn missing_cargo_dylint_still_skips_locally() {
+        assert!(!cargo_dylint_requirement(false, false).unwrap());
+    }
 }

--- a/crates/xtask/src/dylint_gate.rs
+++ b/crates/xtask/src/dylint_gate.rs
@@ -1,3 +1,7 @@
+//! The scheduled `dylint.yml` workflow sets `GAZE_DYLINT_REQUIRED=1` and must
+//! fail closed if cargo-dylint is unavailable. Other callers still verify the
+//! UI fixture shape, but report that the compiled lint run is deferred.
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -6,43 +10,36 @@ use std::process::Command;
 use anyhow::{bail, Context, Result};
 
 const EXPECTED_UI_FIXTURES: usize = 18;
-const RUN_DYLINT_ENV: &str = "GAZE_RUN_DYLINT";
+const DYLINT_REQUIRED_ENV: &str = "GAZE_DYLINT_REQUIRED";
+const DEFERRED_MESSAGE: &str = "dylint_gate: ui-fixture-shape passed; cargo-dylint DEFERRED to the scheduled dylint.yml workflow (solo todo #1870)";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DylintDisposition {
+    Run,
+    Deferred,
+}
 
 pub fn run() -> Result<()> {
     let root = std::env::current_dir().context("failed to resolve current directory")?;
     assert_ui_fixture_shape(&root)?;
-    if !should_run_cargo_dylint() {
-        eprintln!(
-            "dylint_gate: cargo-dylint skipped outside CI; set {RUN_DYLINT_ENV}=1 to run it locally."
-        );
-        println!("dylint_gate: passed");
-        return Ok(());
+    match cargo_dylint_requirement(env_flag(DYLINT_REQUIRED_ENV), cargo_dylint_available())? {
+        DylintDisposition::Run => {
+            run_cargo_dylint(&root)?;
+            println!("dylint_gate: passed");
+        }
+        DylintDisposition::Deferred => println!("{DEFERRED_MESSAGE}"),
     }
-    if !cargo_dylint_requirement(running_in_ci(), cargo_dylint_available())? {
-        return Ok(());
-    }
-    run_cargo_dylint(&root)?;
-    println!("dylint_gate: passed");
     Ok(())
 }
 
-fn should_run_cargo_dylint() -> bool {
-    running_in_ci() || env_flag(RUN_DYLINT_ENV)
-}
-
-fn running_in_ci() -> bool {
-    env_flag("CI") || env_flag("GITHUB_ACTIONS")
-}
-
-fn cargo_dylint_requirement(running_in_ci: bool, available: bool) -> Result<bool> {
+fn cargo_dylint_requirement(required: bool, available: bool) -> Result<DylintDisposition> {
     if available {
-        return Ok(true);
+        return Ok(DylintDisposition::Run);
     }
-    if running_in_ci {
-        bail!("dylint_gate: cargo-dylint is required in CI but was not found");
+    if required {
+        bail!("dylint_gate: cargo-dylint is required by {DYLINT_REQUIRED_ENV}=1 but was not found");
     }
-    eprintln!("cargo-dylint not installed; skipping dylint gate outside CI.");
-    Ok(false)
+    Ok(DylintDisposition::Deferred)
 }
 
 fn env_flag(var: &str) -> bool {
@@ -131,17 +128,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn missing_cargo_dylint_fails_closed_in_ci() {
+    fn missing_cargo_dylint_fails_closed_when_required() {
         let error = cargo_dylint_requirement(true, false).unwrap_err();
 
         assert_eq!(
             error.to_string(),
-            "dylint_gate: cargo-dylint is required in CI but was not found"
+            "dylint_gate: cargo-dylint is required by GAZE_DYLINT_REQUIRED=1 but was not found"
         );
     }
 
     #[test]
-    fn missing_cargo_dylint_still_skips_locally() {
-        assert!(!cargo_dylint_requirement(false, false).unwrap());
+    fn missing_cargo_dylint_reports_deferred_when_not_required() {
+        assert_eq!(
+            cargo_dylint_requirement(false, false).unwrap(),
+            DylintDisposition::Deferred
+        );
+        assert_eq!(
+            DEFERRED_MESSAGE,
+            "dylint_gate: ui-fixture-shape passed; cargo-dylint DEFERRED to the scheduled dylint.yml workflow (solo todo #1870)"
+        );
+    }
+
+    #[test]
+    fn available_cargo_dylint_runs_even_when_not_required() {
+        assert_eq!(
+            cargo_dylint_requirement(false, true).unwrap(),
+            DylintDisposition::Run
+        );
     }
 }

--- a/crates/xtask/tests/ci_feature_matrix.rs
+++ b/crates/xtask/tests/ci_feature_matrix.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+const REQUIRED_XTASK_GATES: &[&str] = &[
+    "symmetric-potemkin",
+    "class-map-override-safety",
+    "recognizer-composition-validator",
+    "no-tenant-knowledge",
+    "bundle-tokenization-drift --verify-ack",
+    "family-policy-table-coherence",
+    "locale-cue-bundle-coherence",
+    "fixture-citation-lint",
+    "trybuild-fixture-hygiene",
+    "cargo-metadata-audit-isolation",
+    "readme-version-check",
+    "safety-net-sanity",
+    "dashboard-isolation",
+    "mcp-tier-isolation",
+    "ci-feature-matrix",
+];
+
+#[test]
+fn test_workflow_runs_every_required_xtask_gate() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .unwrap();
+    let workflow = std::fs::read_to_string(repo_root.join(".github/workflows/test.yml")).unwrap();
+
+    for gate in REQUIRED_XTASK_GATES {
+        let command = format!("run: cargo run -p xtask -- {gate}");
+        assert!(
+            workflow.lines().any(|line| line.trim() == command),
+            "test.yml must run `{command}`"
+        );
+    }
+}

--- a/crates/xtask/tests/dylint_config_drift.rs
+++ b/crates/xtask/tests/dylint_config_drift.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+#[path = "../../../lint/dylint/src/default_config.rs"]
+mod default_config;
+
+#[derive(Debug, Deserialize)]
+struct RootConfig {
+    gaze_dylint: DylintConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct DylintConfig {
+    protected_paths: Vec<String>,
+    forbidden_crates: Vec<String>,
+    forbidden_items: Vec<String>,
+}
+
+fn owned(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+}
+
+#[test]
+fn compiled_default_matches_repository_dylint_config() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .unwrap();
+    let source = std::fs::read_to_string(repo_root.join("dylint.toml")).unwrap();
+    let parsed: RootConfig = toml::from_str(&source).unwrap();
+
+    assert_eq!(
+        parsed.gaze_dylint.protected_paths,
+        owned(default_config::PROTECTED_PATHS)
+    );
+    assert_eq!(
+        parsed.gaze_dylint.forbidden_crates,
+        owned(default_config::FORBIDDEN_CRATES)
+    );
+    assert_eq!(
+        parsed.gaze_dylint.forbidden_items,
+        owned(default_config::FORBIDDEN_ITEMS)
+    );
+}

--- a/crates/xtask/tests/fetch_ner_model_script.rs
+++ b/crates/xtask/tests/fetch_ner_model_script.rs
@@ -1,0 +1,86 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempTree(PathBuf);
+
+impl TempTree {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "gaze-fetch-ner-test-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0).unwrap();
+    }
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn fetch_ner_model_resolves_repository_root_from_nested_script_dir() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .unwrap()
+        .to_path_buf();
+    let temp = TempTree::new();
+    let fake_bin = temp.0.join("bin");
+    let destination = temp.0.join("model");
+    fs::create_dir(&fake_bin).unwrap();
+
+    write_executable(
+        &fake_bin.join("curl"),
+        r#"#!/usr/bin/env bash
+set -eu
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$output" ]; then
+  : > "$output"
+fi
+"#,
+    );
+    write_executable(&fake_bin.join("shasum"), "#!/usr/bin/env bash\nexit 0\n");
+
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![fake_bin];
+    paths.extend(std::env::split_paths(&original_path));
+    let path = std::env::join_paths(paths).unwrap();
+    let output = Command::new("bash")
+        .arg(repo_root.join("scripts/fetch/fetch-ner-model.sh"))
+        .args(["--gaze-version", "v0.0.0"])
+        .arg(&destination)
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "fetch script failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(destination.join("labels.json").is_file());
+    assert!(repo_root.join("Cargo.toml").is_file());
+}

--- a/lint/dylint/src/default_config.rs
+++ b/lint/dylint/src/default_config.rs
@@ -1,0 +1,15 @@
+pub const PROTECTED_PATHS: &[&str] = &[
+    "crates/gaze-cli/src/restore",
+    "crates/gaze/src",
+    "crates/gaze-mcp-core/src",
+];
+
+pub const FORBIDDEN_CRATES: &[&str] = &["gaze_audit"];
+
+pub const FORBIDDEN_ITEMS: &[&str] = &[
+    "gaze_audit::SqliteLogger",
+    "gaze_audit::AuditFilter",
+    "gaze_audit::AuditLogRow",
+    "gaze_audit::build_audit_query_sql",
+    "gaze_audit::AUDIT_RESTRICTED_COLUMNS",
+];

--- a/lint/dylint/src/lib.rs
+++ b/lint/dylint/src/lib.rs
@@ -6,6 +6,8 @@ extern crate rustc_span;
 
 use std::collections::HashSet;
 
+mod default_config;
+
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX};
@@ -33,18 +35,18 @@ struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            protected_paths: vec![
-                "crates/gaze-cli/src/restore".to_owned(),
-                "crates/gaze/src".to_owned(),
-            ],
-            forbidden_crates: vec!["gaze_audit".to_owned()],
-            forbidden_items: vec![
-                "gaze_audit::SqliteLogger".to_owned(),
-                "gaze_audit::AuditFilter".to_owned(),
-                "gaze_audit::AuditLogRow".to_owned(),
-                "gaze_audit::build_audit_query_sql".to_owned(),
-                "gaze_audit::AUDIT_RESTRICTED_COLUMNS".to_owned(),
-            ],
+            protected_paths: default_config::PROTECTED_PATHS
+                .iter()
+                .map(|path| (*path).to_owned())
+                .collect(),
+            forbidden_crates: default_config::FORBIDDEN_CRATES
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+            forbidden_items: default_config::FORBIDDEN_ITEMS
+                .iter()
+                .map(|item| (*item).to_owned())
+                .collect(),
         }
     }
 }

--- a/scripts/fetch/fetch-ner-model.sh
+++ b/scripts/fetch/fetch-ner-model.sh
@@ -119,7 +119,7 @@ require_cmd() {
 require_cmd curl
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 LABELS_SOURCE="${REPO_ROOT}/crates/gaze-recognizers/assets/ner/labels.davlan-mbert.json"
 
 if [ ! -f "$LABELS_SOURCE" ]; then


### PR DESCRIPTION
## Summary

This Tier-0 hardening batch closes five fail-open or drift risks without weakening any project axis. It strengthens reliability and trust while preserving reversibility, agentic behavior, and adopter ergonomics.

## Defects, fixes, and behavioral coverage

1. **OPF owner validation depended on the current working directory.** The subprocess backend now compares model ownership with the process effective UID. The regression test re-invokes the test binary from `/`, whose owner differs from the non-root runner euid, and proves validation stays tied to process identity without changing the parent test process CWD.
2. **`fetch-ner-model.sh` resolved `REPO_ROOT` one level too shallow.** The script now resolves from `scripts/fetch` to the repository root. A no-network behavioral test runs the complete script with fake `curl` and `shasum` executables, then verifies artifacts land under the repository root.
3. **`mcp-tier-isolation` existed but was absent from the CI workflow and feature-matrix contract.** The workflow and matrix roster now run it. A workflow-contract test parses `test.yml` and verifies every required gate command, including MCP tier isolation.
4. **The compiled Dylint audit-isolation defaults omitted `gaze-mcp-core`.** Shared default constants now include the MCP core crate. A stable integration test parses `dylint.toml` and fails on drift across all three default arrays.
5. **A missing `cargo-dylint` could produce a dishonest gate result.** `GAZE_DYLINT_REQUIRED=1` now makes missing cargo-dylint fail closed, and the owning scheduled `dylint.yml` workflow sets it. PR CI still performs the real 18-fixture shape check, then reports cargo-dylint as `DEFERRED` to the scheduled workflow, never `passed`. Per Solo todo #1870, the per-PR nightly/cargo-dylint install remains deferred until its CI-minute cost is acceptable.

## Review-blocker follow-up

- **Euid mutation proof:** temporarily restored `current_euid()` to `std::fs::metadata(".").uid()` and ran the exact owner-check test. It failed as required (`left: 0`, `right: 501`, exit 101). Restoring `libc::geteuid()` made the same test pass (`1 passed`).
- **Dylint ownership proof:** with cargo-dylint absent, `GAZE_DYLINT_REQUIRED=1 cargo run -p xtask -- dylint-gate` exits 1 after the fixture check. Without the requirement flag, it verifies 18 UI fixtures and prints exactly `dylint_gate: ui-fixture-shape passed; cargo-dylint DEFERRED to the scheduled dylint.yml workflow (solo todo #1870)`.

## Verification

- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: passed
- `cargo test -p xtask dylint_gate`: passed, 3 tests
- `cargo test -p xtask --test ci_feature_matrix`: passed
- `cargo test -p gaze-recognizers --all-features safety_net::openai_filter`: passed, 14 tests
- GitHub PR checks: all green, including `xtask gates` in 50m13s
- Earlier focused behavioral tests for the original five changes: passed
- `cargo run -p xtask -- mcp-tier-isolation`: passed across four core feature graphs and three transport feature graphs
- `cargo test --workspace --all-features`: reached an untouched Kiji subprocess test and failed its fixed 5-second startup deadline, reproducible in isolation; tracked as Solo todo #2917

Audit: solo scratchpad 7201 S08-F2 (euid part), S20-F1 (minimal), S22 evidence notes

Resolves solo todo #2901
Resolves solo todo #2128
