### PR TITLE
[agent] fix(assembly): derive the NoRecognizers guard from actual registration and unify the locale predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`gaze_assembly::build_pipeline` derives its `NoRecognizers` guard from
+  actual registration and uses one locale predicate** (audit 7201 S10-F1,
+  todo #2928). The guard now fails closed when zero recognizers were
+  registered, instead of re-deriving eligibility from policy and rulepack
+  metadata. Two behavioural consequences for adopters:
+  - Rulepack recognizers with an **empty locale list** (a pack that omits both
+    `default_locales` and per-recognizer `locales`) now register and run under
+    every document locale chain, matching the detect-time
+    `LocaleChain::intersects` semantics that already treated an empty list as
+    matching. Previously assembly silently dropped them (a missed detection).
+    Bundled rulepacks are unaffected (every bundled recognizer declares
+    locales).
+  - An `anchored_match`-only rulepack whose optional builtin cue bucket
+    (`forward_markers`, `agent_recipient_cues`, `footer_cues`) is not present
+    under the active locale chain now fails with `NoRecognizers` instead of
+    building a zero-recognizer pipeline that preserved every byte.
+  NER model loading now runs before the guard; error precedence is unchanged
+  for reachable configurations (a configured `model_dir` that fails to load
+  still surfaces as `NerLoad`).
 - `[bundle-tokenization-drift]` snapshot for bundle `core` regenerated: the new
   `url.anchored` recognizer adds one `custom:url` detection to the drift corpus
   (11 -> 12 detections). No existing detection changed class, span, or shape.

--- a/crates/gaze-assembly/src/detector_wiring.rs
+++ b/crates/gaze-assembly/src/detector_wiring.rs
@@ -1,27 +1,30 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use gaze::{
-    Context, DetectorKind, LocaleBasis, LocaleChain, LocaleTag, PiiClass, PipelineBuilder,
-    PolicyError, RawMatch, Rulepack, RulepackError, SafetyTier,
+    Context, DetectorKind, LocaleBasis, LocaleChain, LocaleTag, PiiClass, PolicyError, RawMatch,
+    Rulepack, RulepackError, SafetyTier,
 };
 use gaze_recognizers::{
     AnchoredMatchRecognizer, DictionaryRecognizer, NormalizerKind, RegexDetector, ValidatorKind,
 };
 
-use crate::{class_map::class_for_dictionary, template::lower_regex_pattern, BuildError};
+use crate::{
+    class_map::class_for_dictionary, registration::AssemblyBuilder, template::lower_regex_pattern,
+    BuildError,
+};
 
 pub(crate) fn register_policy_detectors(
-    mut builder: PipelineBuilder,
+    builder: &mut AssemblyBuilder,
     policy: &gaze::Policy,
     context: &Context,
     registered_dictionaries: &mut BTreeSet<String>,
-) -> Result<PipelineBuilder, BuildError> {
+) -> Result<(), BuildError> {
     for detector in &policy.detectors {
         let recognizer_id = match detector.kind {
             DetectorKind::Dictionary => format!("dict/{}", detector.name),
             _ => detector.name.clone(),
         };
-        builder = match &detector.kind {
+        match &detector.kind {
             DetectorKind::Regex => builder.detector(RegexDetector::with_source(
                 detector
                     .pattern
@@ -49,7 +52,7 @@ pub(crate) fn register_policy_detectors(
                     dictionary_name,
                     detector.case_sensitive,
                     detector.token_family.clone(),
-                ))
+                ));
             }
             DetectorKind::Unknown(kind) => {
                 return Err(PolicyError::BadTtl(format!("unknown detector.kind '{kind}'")).into())
@@ -61,22 +64,22 @@ pub(crate) fn register_policy_detectors(
             }
         };
         if let Some(collision) = detector.collision.clone() {
-            builder = builder.register_collision(recognizer_id, collision);
+            builder.register_collision(recognizer_id, collision);
         }
     }
 
-    Ok(builder)
+    Ok(())
 }
 
 pub(crate) fn register_rulepack_recognizers(
-    mut builder: PipelineBuilder,
+    builder: &mut AssemblyBuilder,
     policy: &gaze::Policy,
     context: &Context,
     rulepacks: &[Rulepack],
     active_locales: &LocaleChain,
     locale_vocab: &HashMap<String, Vec<String>>,
     registered_dictionaries: &mut BTreeSet<String>,
-) -> Result<PipelineBuilder, BuildError> {
+) -> Result<(), BuildError> {
     let mut rulepack_recognizers = BTreeMap::<String, (String, gaze::RecognizerSpec)>::new();
     for rulepack in rulepacks {
         for recognizer in &rulepack.recognizers {
@@ -109,7 +112,7 @@ pub(crate) fn register_rulepack_recognizers(
             continue;
         }
         if let Some(collision) = recognizer.collision.clone() {
-            builder = builder.register_collision(recognizer.id.clone(), collision);
+            builder.register_collision(recognizer.id.clone(), collision);
         }
         match recognizer.matcher {
             RawMatch::Regex {
@@ -137,7 +140,7 @@ pub(crate) fn register_rulepack_recognizers(
                     .as_ref()
                     .map(|normalizer| NormalizerKind::parse(&normalizer.kind))
                     .transpose()?;
-                builder = builder.recognizer(
+                builder.recognizer(
                     RegexDetector::with_rulepack_fields(
                         &pattern,
                         recognizer.class,
@@ -185,7 +188,7 @@ pub(crate) fn register_rulepack_recognizers(
                 registered_dictionaries.insert(dictionary_name.clone());
                 let class =
                     class_for_dictionary(policy, context, &dictionary_name, recognizer.class)?;
-                builder = builder.recognizer(
+                builder.recognizer(
                     DictionaryRecognizer::with_rulepack_fields(
                         id,
                         class,
@@ -209,11 +212,6 @@ pub(crate) fn register_rulepack_recognizers(
                 name_shape,
                 cue_position,
             } => {
-                if recognizer.locale_basis == LocaleBasis::Document
-                    && !recognizer_matches_active_locale(&recognizer.locales, active_locales)
-                {
-                    continue;
-                }
                 let Some(cues) = locale_vocab.get(&cues_bucket) else {
                     if is_optional_builtin_cue_bucket(&cues_bucket) {
                         tracing::warn!(
@@ -245,7 +243,7 @@ pub(crate) fn register_rulepack_recognizers(
                 } else {
                     recognizer.locales
                 };
-                builder = builder.recognizer(
+                builder.recognizer(
                     AnchoredMatchRecognizer::new(
                         recognizer.id,
                         cues.clone(),
@@ -265,9 +263,18 @@ pub(crate) fn register_rulepack_recognizers(
         }
     }
 
-    Ok(builder)
+    Ok(())
 }
 
+/// Whether a rulepack recognizer is admitted for registration under `policy`
+/// and `active_locales`.
+///
+/// The locale test is the detect-time canonical one (`RecognizerRegistry`
+/// gating): a `LocaleBasis::Format` recognizer runs regardless of the document
+/// locale chain, and a `LocaleBasis::Document` recognizer runs when
+/// [`LocaleChain::intersects`] admits its locale list — an empty list matches
+/// every chain. Assembly must not narrow that predicate: a recognizer the
+/// runtime would run but assembly silently dropped is a missed detection.
 pub(crate) fn recognizer_activates(
     recognizer: &gaze::RecognizerSpec,
     policy: &gaze::Policy,
@@ -277,7 +284,7 @@ pub(crate) fn recognizer_activates(
         return false;
     }
     if recognizer.locale_basis == LocaleBasis::Document
-        && !recognizer_matches_active_locale(&recognizer.locales, active_locales)
+        && !active_locales.intersects(&recognizer.locales)
     {
         return false;
     }
@@ -298,16 +305,6 @@ pub(crate) fn recognizer_activates(
         SafetyTier::OptIn => false,
         _ => false,
     }
-}
-
-fn recognizer_matches_active_locale(locales: &[LocaleTag], active_locales: &LocaleChain) -> bool {
-    locales.iter().any(|locale| {
-        *locale == LocaleTag::Global
-            || active_locales
-                .as_slice()
-                .iter()
-                .any(|active| active == locale)
-    })
 }
 
 fn is_optional_builtin_cue_bucket(bucket: &str) -> bool {
@@ -363,17 +360,17 @@ fn convert_cue_position(cue_position: &str) -> gaze_recognizers::CuePosition {
 }
 
 pub(crate) fn register_context_dictionaries(
-    mut builder: PipelineBuilder,
+    builder: &mut AssemblyBuilder,
     policy: &gaze::Policy,
     context: &Context,
     registered_dictionaries: &BTreeSet<String>,
-) -> Result<PipelineBuilder, BuildError> {
+) -> Result<(), BuildError> {
     for name in context.dictionaries.keys() {
         if registered_dictionaries.contains(name) {
             continue;
         }
         let class = class_for_dictionary(policy, context, name, PiiClass::custom(name))?;
-        builder = builder.recognizer(DictionaryRecognizer::new(
+        builder.recognizer(DictionaryRecognizer::new(
             format!("context/{name}"),
             class,
             name,
@@ -382,5 +379,5 @@ pub(crate) fn register_context_dictionaries(
         ));
     }
 
-    Ok(builder)
+    Ok(())
 }

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -44,6 +44,7 @@ mod detector_wiring;
 mod error;
 mod locale;
 mod ner;
+mod registration;
 mod template;
 
 pub use defaults::CorePipeline;
@@ -61,6 +62,13 @@ pub(crate) use locale::{merged_locale_vocab, register_anchor_cue_bundles};
 /// Use this when you load a policy file programmatically and want to mirror the
 /// exact assembly the `gaze` binary uses, including locale chain resolution and
 /// rulepack loading.
+///
+/// Fails closed with [`BuildError::NoRecognizers`] when nothing was actually
+/// registered: policy detectors, rulepack recognizers admitted by the
+/// safety-tier + locale predicate (and not skipped for a missing optional cue
+/// bucket), context dictionaries, and a loaded NER model all
+/// count. The guard reads the registration count rather than re-deriving
+/// eligibility, so a pipeline that would preserve every byte cannot build.
 pub fn build_pipeline(
     policy: &gaze::Policy,
     context: &Context,
@@ -68,18 +76,18 @@ pub fn build_pipeline(
     active_locales: &LocaleChain,
     ner_threshold: Option<f32>,
 ) -> Result<Pipeline, BuildError> {
-    let mut builder = Pipeline::builder();
+    let mut builder = registration::AssemblyBuilder::default();
     let mut registered_dictionaries = BTreeSet::<String>::new();
     let locale_vocab = merged_locale_vocab(rulepacks, active_locales);
 
-    builder = detector_wiring::register_policy_detectors(
-        builder,
+    detector_wiring::register_policy_detectors(
+        &mut builder,
         policy,
         context,
         &mut registered_dictionaries,
     )?;
-    builder = detector_wiring::register_rulepack_recognizers(
-        builder,
+    detector_wiring::register_rulepack_recognizers(
+        &mut builder,
         policy,
         context,
         rulepacks,
@@ -87,39 +95,21 @@ pub fn build_pipeline(
         &locale_vocab,
         &mut registered_dictionaries,
     )?;
-    builder = detector_wiring::register_context_dictionaries(
-        builder,
+    detector_wiring::register_context_dictionaries(
+        &mut builder,
         policy,
         context,
         &registered_dictionaries,
     )?;
-    builder = register_anchor_cue_bundles(builder, rulepacks, active_locales);
+    register_anchor_cue_bundles(&mut builder, rulepacks, active_locales);
+    ner::register_ner(&mut builder, policy, ner_threshold)?;
 
-    let has_policy_detector = !policy.detectors.is_empty();
-    let has_enabled_rulepack_recognizer = rulepacks.iter().any(|rulepack| {
-        rulepack.recognizers.iter().any(|recognizer| {
-            detector_wiring::recognizer_activates(recognizer, policy, active_locales)
-        })
-    });
-    let has_usable_ner = policy
-        .ner
-        .as_ref()
-        .is_some_and(|ner| ner.model_dir.is_some());
-    let has_context_dictionary = context
-        .dictionaries
-        .keys()
-        .any(|name| !registered_dictionaries.contains(name));
-
-    if !has_policy_detector
-        && !has_enabled_rulepack_recognizer
-        && !has_usable_ner
-        && !has_context_dictionary
-    {
+    if builder.registered_recognizers() == 0 {
         return Err(BuildError::NoRecognizers);
     }
 
     for rule in &policy.rules {
-        builder = match rule {
+        match rule {
             RuleSpec::Class { class, action } => {
                 builder.rule(ClassRule::new(class.clone(), *action))
             }
@@ -130,12 +120,10 @@ pub fn build_pipeline(
                     gaze::PolicyError::BadTtl("unsupported rule variant".to_string()).into(),
                 )
             }
-        };
+        }
     }
 
-    builder = ner::register_ner(builder, policy, ner_threshold)?;
-
-    Ok(builder.build()?)
+    Ok(builder.into_inner().build()?)
 }
 
 /// Collision-family fallback classes that loaded recognizers can emit but the

--- a/crates/gaze-assembly/src/locale.rs
+++ b/crates/gaze-assembly/src/locale.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeSet, HashMap};
 
-use gaze::{LocaleChain, PipelineBuilder, Rulepack};
+use gaze::{LocaleChain, Rulepack};
+
+use crate::registration::AssemblyBuilder;
 
 pub(crate) fn merged_locale_vocab(
     rulepacks: &[Rulepack],
@@ -35,10 +37,10 @@ pub(crate) fn merged_locale_vocab(
 }
 
 pub(crate) fn register_anchor_cue_bundles(
-    mut builder: PipelineBuilder,
+    builder: &mut AssemblyBuilder,
     rulepacks: &[Rulepack],
     active_locales: &LocaleChain,
-) -> PipelineBuilder {
+) {
     for active_locale in active_locales.as_slice() {
         for rulepack in rulepacks {
             if !rulepack.default_locales.contains(active_locale) {
@@ -48,7 +50,7 @@ pub(crate) fn register_anchor_cue_bundles(
                 continue;
             };
             for (anchor_key, bundle) in &locale.cues {
-                builder = builder.register_anchor_cue_bundle(
+                builder.register_anchor_cue_bundle(
                     active_locale.clone(),
                     anchor_key.clone(),
                     bundle.names.clone(),
@@ -57,5 +59,4 @@ pub(crate) fn register_anchor_cue_bundles(
             }
         }
     }
-    builder
 }

--- a/crates/gaze-assembly/src/ner.rs
+++ b/crates/gaze-assembly/src/ner.rs
@@ -1,13 +1,13 @@
-use gaze::{PipelineBuilder, PolicyError};
+use gaze::PolicyError;
 use gaze_recognizers::{NerOptions, NerRecognizer};
 
-use crate::BuildError;
+use crate::{registration::AssemblyBuilder, BuildError};
 
 pub(crate) fn register_ner(
-    mut builder: PipelineBuilder,
+    builder: &mut AssemblyBuilder,
     policy: &gaze::Policy,
     ner_threshold: Option<f32>,
-) -> Result<PipelineBuilder, BuildError> {
+) -> Result<(), BuildError> {
     if let Some(ner) = &policy.ner {
         if let Some(path) = &ner.model_dir {
             let detector = NerRecognizer::load_with_options(
@@ -18,9 +18,9 @@ pub(crate) fn register_ner(
                 },
             )
             .map_err(|err| PolicyError::NerLoad(err.to_string()))?;
-            builder = builder.recognizer(detector);
+            builder.recognizer(detector);
         }
     }
 
-    Ok(builder)
+    Ok(())
 }

--- a/crates/gaze-assembly/src/registration.rs
+++ b/crates/gaze-assembly/src/registration.rs
@@ -1,0 +1,77 @@
+use gaze::{CollisionMembership, Detector, LocaleTag, PipelineBuilder, Recognizer, Rule};
+
+/// [`PipelineBuilder`] wrapper that counts every recognizer it registers.
+///
+/// `build_pipeline`'s `NoRecognizers` guard reads [`Self::registered_recognizers`]
+/// instead of re-deriving "would this recognizer register" from policy and
+/// rulepack metadata. Every registration path in this crate goes through this
+/// type, so the guard cannot drift from what actually got registered — a drift
+/// that previously let a zero-recognizer pipeline build and preserve every
+/// byte (audit 7201 S10-F1).
+#[derive(Default)]
+pub(crate) struct AssemblyBuilder {
+    inner: PipelineBuilder,
+    registered_recognizers: usize,
+}
+
+impl AssemblyBuilder {
+    /// Recognizers registered so far (policy detectors, rulepack recognizers,
+    /// context dictionaries, and NER all count; collision memberships, anchor
+    /// cue bundles, and rules do not detect anything and are excluded).
+    pub(crate) fn registered_recognizers(&self) -> usize {
+        self.registered_recognizers
+    }
+
+    pub(crate) fn detector<D>(&mut self, detector: D)
+    where
+        D: Detector + 'static,
+    {
+        self.map(|builder| builder.detector(detector));
+        self.registered_recognizers += 1;
+    }
+
+    pub(crate) fn recognizer<R>(&mut self, recognizer: R)
+    where
+        R: Recognizer + 'static,
+    {
+        self.map(|builder| builder.recognizer(recognizer));
+        self.registered_recognizers += 1;
+    }
+
+    pub(crate) fn register_collision(
+        &mut self,
+        recognizer_id: impl Into<String>,
+        membership: CollisionMembership,
+    ) {
+        self.map(|builder| builder.register_collision(recognizer_id, membership));
+    }
+
+    pub(crate) fn register_anchor_cue_bundle(
+        &mut self,
+        locale: LocaleTag,
+        anchor_key: String,
+        names: Vec<String>,
+        window_chars: Option<u16>,
+    ) {
+        self.map(|builder| {
+            builder.register_anchor_cue_bundle(locale, anchor_key, names, window_chars)
+        });
+    }
+
+    pub(crate) fn rule<R>(&mut self, rule: R)
+    where
+        R: Rule + 'static,
+    {
+        self.map(|builder| builder.rule(rule));
+    }
+
+    pub(crate) fn into_inner(self) -> PipelineBuilder {
+        self.inner
+    }
+
+    // `PipelineBuilder` methods consume `self`; take it out, apply, put it back.
+    fn map(&mut self, apply: impl FnOnce(PipelineBuilder) -> PipelineBuilder) {
+        let builder = std::mem::take(&mut self.inner);
+        self.inner = apply(builder);
+    }
+}

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -160,6 +160,154 @@ pattern = '''alice@example\.invalid'''
     assert!(text.contains(":Email_"), "{text}");
 }
 
+// S10-F1 (audit 7201): the guard and registration must agree on ONE locale
+// predicate — the detect-time `LocaleChain::intersects` (empty list ⇒ matches).
+// A rulepack that omits both `default_locales` and per-recognizer `locales`
+// yields an empty locale list; the runtime would run it everywhere, so assembly
+// must register it instead of silently dropping it.
+#[test]
+fn empty_locale_rulepack_recognizer_registers_under_document_chain() {
+    let policy = name_email_policy(vec![LocaleTag::DeDe]);
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "no-locales"
+rulepack_version = "0.1.0"
+
+[[recognizers]]
+id = "unscoped.email"
+class = "Email"
+enabled = true
+
+[recognizers.match]
+kind = "regex"
+pattern = '''alice@example\.invalid'''
+"#,
+    )
+    .expect("rulepack");
+    assert!(
+        rulepack.recognizers[0].locales.is_empty(),
+        "precondition: loader keeps an empty locale list when neither default_locales nor locales is set"
+    );
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+    assert!(
+        active_locales.intersects(&rulepack.recognizers[0].locales),
+        "precondition: detect-time predicate treats an empty locale list as matching"
+    );
+
+    let text = clean_with_policy_and_rulepacks(&policy, &[rulepack], "Email alice@example.invalid");
+
+    assert!(text.contains(":Email_"), "{text}");
+}
+
+// S10-F1 (audit 7201): an anchored_match recognizer whose optional builtin cue
+// bucket is absent under the active locale chain is skipped at registration.
+// The guard must see that skip; otherwise an anchored-only rulepack builds a
+// zero-recognizer pipeline that preserves every byte (silent fail-open).
+#[test]
+fn anchored_only_rulepack_without_cue_bucket_returns_no_recognizers() {
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "anchored-only"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "forward_markers"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+"#,
+    )
+    .expect("rulepack");
+    let policy = policy();
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+
+    let err = match build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    ) {
+        Ok(_) => panic!("anchored-only rulepack without its cue bucket must fail closed"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(err, BuildError::NoRecognizers), "{err:?}");
+}
+
+// Pins #414: a format-basis recognizer registers regardless of the document
+// locale chain, so a format-only rulepack passes the guard under a chain that
+// would filter the same recognizer on document basis (compare
+// `build_pipeline_locale_filtered_rulepack_returns_no_recognizers`).
+#[test]
+fn format_basis_only_rulepack_passes_guard_under_non_matching_document_chain() {
+    let policy = empty_policy();
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "format-only"
+rulepack_version = "0.1.0"
+default_locales = ["de-DE"]
+
+[[recognizers]]
+id = "format.email"
+class = "Email"
+enabled = true
+locales = ["de-DE"]
+locale_basis = "format"
+
+[recognizers.match]
+kind = "regex"
+pattern = '''alice@example\.invalid'''
+"#,
+    )
+    .expect("rulepack");
+    let active_locales = LocaleChain::merge_policy_and_cli(Some(&[LocaleTag::EnUs]), None);
+
+    build_pipeline(
+        &policy,
+        &empty_context(),
+        &[rulepack],
+        &active_locales,
+        None,
+    )
+    .expect("format-basis recognizer must register under a non-matching document chain");
+}
+
+// A configured-but-unloadable NER model surfaces as the NER load error; the
+// guard must not mask it as `NoRecognizers` (nor pass on the mere presence of a
+// `model_dir` — see `build_pipeline_ner_without_model_dir_returns_no_recognizers`).
+#[test]
+fn ner_load_failure_is_reported_not_masked_as_no_recognizers() {
+    let mut policy = empty_policy();
+    let mut ner = NerPolicy::default();
+    ner.model_dir = Some(std::path::PathBuf::from(
+        "/nonexistent/gaze-assembly-ner-model-dir",
+    ));
+    policy.ner = Some(ner);
+    let active_locales = LocaleChain::merge_policy_and_cli(policy.locale.as_deref(), None);
+
+    let err = match build_pipeline(&policy, &empty_context(), &[], &active_locales, None) {
+        Ok(_) => panic!("unloadable NER model must not build"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, BuildError::Policy(PolicyError::NerLoad(_))),
+        "{err:?}"
+    );
+}
+
 #[test]
 fn build_pipeline_ner_without_model_dir_returns_no_recognizers() {
     let mut policy = empty_policy();

--- a/docs/explanation/policy/locale-chain.md
+++ b/docs/explanation/policy/locale-chain.md
@@ -13,7 +13,11 @@ Recognizer eligibility then depends on `locale_basis`:
 - `document` (the default when an external rulepack omits the field) treats
   `locales` as an eligibility gate. A recognizer tagged `global` is eligible for
   every document locale. Other locale tags are strict:
-  `LocaleTag::Other(_)` matches only the same opaque tag.
+  `LocaleTag::Other(_)` matches only the same opaque tag. A recognizer whose
+  locale list is empty (an external pack that omits both `default_locales` and
+  per-recognizer `locales`) is eligible for every document locale; assembly
+  (`gaze_assembly::build_pipeline`) and detection (`LocaleChain::intersects`)
+  share this one predicate.
 - `format` treats `locales` as format provenance, not a document-language gate.
   The recognizer runs once regardless of the document locale and its candidates
   join the document-basis candidates before the normal conflict resolver runs.


### PR DESCRIPTION
## Summary

`gaze_assembly::build_pipeline`'s `NoRecognizers` guard re-derived "will this recognizer register" from policy/rulepack metadata instead of reading what registration actually did. The re-derivation had drifted from the registration path in two ways, and one of them let a **zero-recognizer pipeline build successfully and preserve every byte** (silent fail-open, north-star axis 1).

This PR makes the guard read the registration count and collapses the assembly-time locale test onto the detect-time canonical predicate.

**Scope:** `gaze-assembly` only. No public API change (`build_pipeline` signature and `BuildError` variants unchanged).

## Defect

Predicates that decide "does this recognizer register" vs. what the guard checked, on `main` (`ce11278`, post-#423):

| # | Predicate | Registration path | Guard (before) | Guard (after) |
|---|---|---|---|---|
| 1 | `enabled` + `SafetyTier` activation | `recognizer_activates` | `recognizer_activates` (same fn since #423) | *count* |
| 2 | Locale match, `LocaleBasis::Document` | `recognizer_matches_active_locale` (**empty list ⇒ false**) | same narrowing fn | `LocaleChain::intersects` (**empty ⇒ true**, = detect time) |
| 3 | `LocaleBasis::Format` | registers regardless of chain (#414) | same | same (pinned by new test) |
| 4 | Anchored-match optional builtin cue bucket missing under chain | **skip** (`continue`, warn) | **invisible** → guard counted it as active | *count* |
| 5 | NER | `register_ner` (registers if `model_dir` loads) | `has_usable_ner = model_dir.is_some()` | *count* |
| 6 | Context dictionaries | `register_context_dictionaries` | `has_context_dictionary` re-derivation | *count* |
| 7 | Policy detectors | every `[[detector]]` registers or errors | `!policy.detectors.is_empty()` | *count* |

Row 4 is the reachable fail-open: an `anchored_match`-only rulepack whose cue bucket (`forward_markers` / `agent_recipient_cues` / `footer_cues`) is not provided under the active locale chain skips at registration, the guard passes, `PipelineBuilder::build()` accepts an empty registry, and the pipeline preserves every byte.

Row 2 is the audit's anti-recommendation made real by #423: the guard and registration were unified, but onto the *narrowing* predicate. A rulepack that omits both `default_locales` and per-recognizer `locales` yields an empty locale list; detection (`RecognizerRegistry`, `LocaleChain::intersects`) treats that as "matches every chain", but assembly silently dropped the recognizer (missed detection).

## Fix

- New crate-private `registration::AssemblyBuilder` wraps `PipelineBuilder` and counts every `detector()`/`recognizer()` call. Every registration path in the crate goes through it, so the guard cannot drift from registration by construction.
- `build_pipeline`: registration functions take `&mut AssemblyBuilder`; the four inlined shadow predicates are deleted; guard = `registered_recognizers() == 0 → NoRecognizers`. The guard is kept (not deleted).
- `recognizer_activates` uses `active_locales.intersects(&recognizer.locales)` for document-basis recognizers; format-basis recognizers register regardless of the document chain (exactly #414). `recognizer_matches_active_locale` and the redundant anchored-match locale re-check are removed — one predicate.
- `register_ner` runs before the guard so a loaded NER model counts. Error precedence is unchanged for reachable configurations (a configured `model_dir` that fails to load surfaced as `NerLoad` before and after; pinned by test).

## Red/green evidence

New tests in `crates/gaze-assembly/src/tests.rs`, run against **unmodified `main`** (`cargo test -p gaze-assembly --lib`):

```
test tests::anchored_only_rulepack_without_cue_bucket_returns_no_recognizers ... FAILED
    panicked: "anchored-only rulepack without its cue bucket must fail closed"  (build_pipeline returned Ok with ZERO recognizers)
test tests::empty_locale_rulepack_recognizer_registers_under_document_chain ... FAILED
    panicked: "pipeline: NoRecognizers"  (empty-locale recognizer dropped although intersects(empty)=true)
test tests::format_basis_only_rulepack_passes_guard_under_non_matching_document_chain ... ok   (pins #414)
test tests::ner_load_failure_is_reported_not_masked_as_no_recognizers ... ok   (error-order pin)
test tests::build_pipeline_{empty_inputs,all_disabled_rulepack,locale_filtered_rulepack,ner_without_model_dir,context_only}_* ... ok
test result: FAILED. 7 passed; 2 failed
```

After the fix: `cargo test -p gaze-assembly` → **47 passed; 0 failed** (+ doctest). `cargo fmt --all -- --check` clean; `cargo clippy -p gaze-assembly --all-features --all-targets -- -D warnings` clean.

Not run locally (bench machine lock 6185 was CLAIMED for the whole session; the brief forbids workspace-wide cargo while claimed): workspace `clippy`/`test --workspace --all-features`, `ci-feature-matrix`, and the `symmetric-potemkin` / `recognizer-composition-validator` / `locale-cue-bundle-coherence` xtask gates (which shell out to per-package `cargo test --exact` including `gaze-cli`). The two `gaze-assembly` tests those gates invoke (`pattern_template_lowers_correctly_under_locale_chain_de`, `format_basis_rulepack_ignores_document_locale`) pass locally. CI runs the full roster.

## Behavioural change (CHANGELOG, Unreleased / Changed)

- Rulepack recognizers with an **empty locale list** now register and run under every document locale chain (widening; leak-safe direction; matches detect-time semantics). Bundled rulepacks are unaffected — every bundled pack declares `default_locales`, so no bundled recognizer has an empty list.
- An **`anchored_match`-only rulepack whose optional builtin cue bucket is absent** under the active chain now fails with `NoRecognizers` instead of building a zero-recognizer pipeline.
- `docs/explanation/policy/locale-chain.md` gains one sentence stating the empty-list rule that assembly and detection share.

## North-star

Axis 1 (fail closed): the guard now proves "≥1 recognizer registered" rather than approximating it. Axis 4 (one source of truth): one locale predicate for assembly and detection; the count is a property of construction, not convention. Axis 5: widening disclosed in CHANGELOG.

Audit: solo scratchpad 7201 S10-F1
Resolves solo todo #2928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaaMXGxdjiJp7MxgFFJt7f
