### PR TITLE
[agent] fix(assembly): derive locale-gated auto-activation from the loaded rulepacks (single source of truth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NER model loading now runs before the guard; error precedence is unchanged
   for reachable configurations (a configured `model_dir` that fails to load
   still surfaces as `NerLoad`).
+- **Locale-gated auto-activation is derived from the loaded rulepacks**
+  (audit 7201 S10-F2, todo #2929). The `auto_activate_locale_gated` locale set
+  (`core-extended` compatibility alias) is now computed by the new public
+  `gaze_assembly::locale_gated_activation_locales(&[Rulepack])` — the union of
+  `locales` over enabled, document-basis `safety_tier = "locale_gated"`
+  recognizers, minus `global`, ordered compatibility-first
+  (`en-US, de-DE, de-AT, de-CH`) then by canonical tag — instead of a literal
+  `[en-US, de-DE, de-AT, de-CH]` list that was triplicated across
+  `CorePipelineConfig`, `gaze clean`, and `gaze daemon`. For the bundled `core`
+  recognizers the derived set equals the old literal, so shipped behaviour is
+  unchanged (the compatibility chain stays `global, en-US, de-DE, de-AT,
+  de-CH`). Behavioural widening for adopters: a path rulepack whose
+  document-basis locale-gated recognizer declares another locale (for example
+  `es-ES`) now auto-activates under the alias without an explicit `--locale`
+  or policy locale; previously it silently never activated. Any future bundled
+  locale-gated recognizer joins the activation set automatically. The
+  `--locale`/policy locale override precedence is unchanged.
 - `[bundle-tokenization-drift]` snapshot for bundle `core` regenerated: the new
   `url.anchored` recognizer adds one `custom:url` detection to the drift corpus
   (11 -> 12 detections). No existing detection changed class, span, or shape.

--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -6,7 +6,7 @@ use gaze::{
     PolicyError, RawDocument, RuleSpec, Rulepack, RulepackSource, Session,
 };
 
-use crate::{build_pipeline, BuildError};
+use crate::{build_pipeline, locale_gated_activation_locales, BuildError};
 
 const CORE_BUNDLED_RULEPACK: &str = "core";
 
@@ -50,13 +50,8 @@ impl CorePipelineConfig {
             .any(|bundle| bundle == "core-extended");
         let mut rulepack_defaults = merged_rulepack_default_locales(&rulepacks);
         if auto_activate_locale_gated {
-            for locale in [
-                LocaleTag::EnUs,
-                LocaleTag::DeDe,
-                LocaleTag::DeAt,
-                LocaleTag::DeCh,
-            ] {
-                if !rulepack_defaults.iter().any(|existing| existing == &locale) {
+            for locale in locale_gated_activation_locales(&rulepacks) {
+                if !rulepack_defaults.contains(&locale) {
                     rulepack_defaults.push(locale);
                 }
             }

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -55,6 +55,7 @@ pub use defaults::CorePipeline;
 /// custom recognizer topology or non-bundled rulepack.
 pub use defaults::CorePipelineConfig;
 pub use error::BuildError;
+pub use locale::locale_gated_activation_locales;
 pub(crate) use locale::{merged_locale_vocab, register_anchor_cue_bundles};
 
 /// Assemble a pipeline from a loaded [`gaze::Policy`], matching the CLI code path.

--- a/crates/gaze-assembly/src/locale.rs
+++ b/crates/gaze-assembly/src/locale.rs
@@ -1,8 +1,64 @@
 use std::collections::{BTreeSet, HashMap};
 
-use gaze::{LocaleChain, Rulepack};
+use gaze::{LocaleBasis, LocaleChain, LocaleTag, Rulepack, SafetyTier};
 
 use crate::registration::AssemblyBuilder;
+
+/// Compatibility order for the activation locales the v0.6 `core-extended`
+/// alias shipped with. Ordering only: a tag listed here is NOT added to the
+/// activation set unless a loaded locale-gated recognizer declares it. Kept so
+/// per-class locale-fallback winners for the bundled `core` recognizers do not
+/// change when the set is derived instead of spelled out.
+const COMPATIBILITY_ACTIVATION_ORDER: [LocaleTag; 4] = [
+    LocaleTag::EnUs,
+    LocaleTag::DeDe,
+    LocaleTag::DeAt,
+    LocaleTag::DeCh,
+];
+
+/// Locales that `auto_activate_locale_gated` adds to the rulepack-default
+/// locale chain so every loaded `safety_tier = "locale_gated"` recognizer can
+/// activate.
+///
+/// This is the union of `locales` over the enabled, `locale_basis = "document"`
+/// locale-gated recognizers in `rulepacks`, minus `global`. It is derived from
+/// the loaded packs rather than spelled out, so a locale-gated recognizer
+/// cannot ship (bundled or adopter path pack) whose locale is missing from the
+/// activation set. Format-basis recognizers do not contribute: they run
+/// regardless of the document chain. `global` never needs pushing.
+///
+/// The push only takes effect when neither the CLI nor the policy sets a
+/// locale (see [`LocaleChain::merge_cli_policy_rulepack_default`]).
+///
+/// Ordering is deterministic and stable: the compatibility order shipped since
+/// v0.6 for the tags it named (`en-US`, `de-DE`, `de-AT`, `de-CH`) comes
+/// first; any other tag follows in canonical BCP-47 string order.
+pub fn locale_gated_activation_locales(rulepacks: &[Rulepack]) -> Vec<LocaleTag> {
+    let mut locales = Vec::<LocaleTag>::new();
+    for recognizer in rulepacks.iter().flat_map(|rulepack| &rulepack.recognizers) {
+        if !recognizer.enabled
+            || recognizer.safety_tier != SafetyTier::LocaleGated
+            || recognizer.locale_basis != LocaleBasis::Document
+        {
+            continue;
+        }
+        for locale in &recognizer.locales {
+            if *locale != LocaleTag::Global && !locales.contains(locale) {
+                locales.push(locale.clone());
+            }
+        }
+    }
+    locales.sort_by_key(activation_order_key);
+    locales
+}
+
+fn activation_order_key(locale: &LocaleTag) -> (usize, String) {
+    let rank = COMPATIBILITY_ACTIVATION_ORDER
+        .iter()
+        .position(|compatibility| compatibility == locale)
+        .unwrap_or(COMPATIBILITY_ACTIVATION_ORDER.len());
+    (rank, locale.as_str().to_string())
+}
 
 pub(crate) fn merged_locale_vocab(
     rulepacks: &[Rulepack],

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -458,6 +458,198 @@ fn core_pipeline_config_core_extended_alias_tokenizes_synthetic_phone() {
     assert!(text.contains(":Custom:phone_"), "{text}");
 }
 
+// S10-F2 (audit 7201): the auto-activate locale set is derived from the loaded
+// rulepacks, not spelled out. This adopter path rulepack declares a
+// document-basis `locale_gated` recognizer for `es-ES` under `global` defaults;
+// `core-extended` (auto-activate) must put `es-ES` on the chain so it activates.
+const ES_LOCALE_GATED_RULEPACK: &str = r#"
+schema_version = "0.1.0"
+rulepack_id = "es-locale-gated"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "es.test_id"
+class = "custom:es_test_id"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["es-ES"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''ES-TEST-[0-9]{6}'''
+"#;
+
+fn write_temp_rulepack(name: &str, contents: &str) -> std::path::PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "gaze-assembly-{name}-{}-{}.toml",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("test")
+    ));
+    std::fs::write(&path, contents).expect("write temp rulepack");
+    path
+}
+
+// The derived set for the bundled `core` recognizers equals the literal list
+// the CLI/daemon/library used to carry (`en-US, de-DE, de-AT, de-CH`) — this is
+// the derived-set == pack-union assertion; it also gates the bundle: a new
+// bundled `locale_gated` recognizer changes this set and must update the pin
+// plus the "Shipped default activation" reference table.
+#[test]
+fn locale_gated_activation_locales_for_core_bundle_match_compat_list() {
+    let core = embedded_rulepack("core");
+
+    assert_eq!(
+        locale_gated_activation_locales(&[core]),
+        vec![
+            LocaleTag::EnUs,
+            LocaleTag::DeDe,
+            LocaleTag::DeAt,
+            LocaleTag::DeCh,
+        ]
+    );
+}
+
+// Set rules: enabled + `locale_gated` + document basis contribute; `global`,
+// format-basis, disabled, and safe_default recognizers do not. Ordering:
+// compatibility tags first in their shipped order, then canonical string order.
+#[test]
+fn locale_gated_activation_locales_derive_set_and_order_from_loaded_packs() {
+    let pack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "mixed-locale-gated"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "gated.es"
+class = "custom:a"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["es-ES", "global"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''ES-A-[0-9]{6}'''
+
+[[recognizers]]
+id = "gated.gb_and_de"
+class = "custom:b"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["en-GB", "de-DE"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''GB-B-[0-9]{6}'''
+
+[[recognizers]]
+id = "gated.format_basis"
+class = "custom:c"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["fr-FR"]
+locale_basis = "format"
+
+[recognizers.match]
+kind = "regex"
+pattern = '''FR-C-[0-9]{6}'''
+
+[[recognizers]]
+id = "gated.disabled"
+class = "custom:d"
+enabled = false
+safety_tier = "locale_gated"
+locales = ["nl-NL"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''NL-D-[0-9]{6}'''
+
+[[recognizers]]
+id = "safe.default"
+class = "custom:e"
+enabled = true
+safety_tier = "safe_default"
+locales = ["pt-BR"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''BR-E-[0-9]{6}'''
+"#,
+    )
+    .expect("rulepack");
+    let core = embedded_rulepack("core");
+
+    let es = LocaleTag::parse("es-ES").expect("es-ES parses");
+    assert_eq!(
+        locale_gated_activation_locales(std::slice::from_ref(&pack)),
+        vec![LocaleTag::DeDe, LocaleTag::EnGb, es.clone()],
+        "compat tag de-DE first, then en-GB < es-ES by canonical string"
+    );
+    assert_eq!(
+        locale_gated_activation_locales(&[core, pack]),
+        vec![
+            LocaleTag::EnUs,
+            LocaleTag::DeDe,
+            LocaleTag::DeAt,
+            LocaleTag::DeCh,
+            LocaleTag::EnGb,
+            es,
+        ],
+        "shipped compat order is stable regardless of pack load order"
+    );
+}
+
+// Pins the shipped compatibility chain: for the bundled `core` recognizers the
+// derived activation set is exactly the v0.6 alias order, so S10-F2 changes no
+// shipped behaviour.
+#[test]
+fn core_extended_alias_locale_chain_is_compat_order() {
+    let core = CorePipelineConfig::new()
+        .with_bundled_rulepack("core-extended")
+        .build()
+        .expect("extended pipeline");
+
+    assert_eq!(
+        core.locale_chain().as_slice(),
+        &[
+            LocaleTag::Global,
+            LocaleTag::EnUs,
+            LocaleTag::DeDe,
+            LocaleTag::DeAt,
+            LocaleTag::DeCh,
+        ]
+    );
+}
+
+#[test]
+fn core_extended_alias_auto_activates_locale_gated_recognizer_from_path_rulepack() {
+    let path = write_temp_rulepack("es-locale-gated", ES_LOCALE_GATED_RULEPACK);
+    let built = CorePipelineConfig::new()
+        .with_bundled_rulepack("core-extended")
+        .with_rulepack_path(path.clone())
+        .build();
+    let _ = std::fs::remove_file(&path);
+    let core = built.expect("extended pipeline with path rulepack");
+
+    assert!(
+        core.locale_chain()
+            .as_slice()
+            .iter()
+            .any(|locale| locale.as_str() == "es-ES"),
+        "auto-activate chain must carry the locale-gated recognizer's locale: {:?}",
+        core.locale_chain()
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let text = clean_text(
+        core.pseudonymize_text(&session, "id ES-TEST-123456")
+            .expect("redact"),
+    );
+    assert!(text.contains(":Custom:es_test_id_"), "{text}");
+}
+
 #[test]
 fn core_pipeline_config_core_extended_alias_tokenizes_synthetic_iban() {
     let core = CorePipelineConfig::new()

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -173,16 +173,10 @@ impl Daemon {
         );
         let mut rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
         if loaded_policy.rulepacks.auto_activate_locale_gated {
-            for locale in [
-                LocaleTag::EnUs,
-                LocaleTag::DeDe,
-                LocaleTag::DeAt,
-                LocaleTag::DeCh,
-            ] {
-                if !rulepack_default_locales
-                    .iter()
-                    .any(|existing| existing == &locale)
-                {
+            // Derived from the loaded packs (audit 7201 S10-F2), same source of
+            // truth as `gaze clean` and `CorePipelineConfig`.
+            for locale in gaze_assembly::locale_gated_activation_locales(&loaded_rulepacks) {
+                if !rulepack_default_locales.contains(&locale) {
                     rulepack_default_locales.push(locale);
                 }
             }

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -136,16 +136,10 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     let dictionary_stats = dictionaries.stats();
     let mut rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
     if effective_policy.is_some_and(|policy| policy.rulepacks.auto_activate_locale_gated) {
-        for locale in [
-            LocaleTag::EnUs,
-            LocaleTag::DeDe,
-            LocaleTag::DeAt,
-            LocaleTag::DeCh,
-        ] {
-            if !rulepack_default_locales
-                .iter()
-                .any(|existing| existing == &locale)
-            {
+        // Derived from the loaded packs (audit 7201 S10-F2): every loaded
+        // locale-gated recognizer's locale joins the chain, in a stable order.
+        for locale in gaze_assembly::locale_gated_activation_locales(&loaded_rulepacks) {
+            if !rulepack_default_locales.contains(&locale) {
                 rulepack_default_locales.push(locale);
             }
         }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2619,6 +2619,91 @@ fn s2_cli_bundled_core_extended_no_policy_tokenizes_national_de_and_us_phones() 
     assert_eq!(us["stats"]["detections"], 1);
 }
 
+// S10-F2 (audit 7201) drift gate for the `gaze clean` path: the auto-activate
+// locale set must be DERIVED from the loaded rulepacks. An adopter path pack
+// with a document-basis `locale_gated` es-ES recognizer under `global` defaults
+// activates under `core-extended` (auto-activate) with no CLI/policy locale.
+// A literal `[en-US, de-DE, de-AT, de-CH]` list in the CLI fails this test.
+fn write_policy_with_es_locale_gated_path_rulepack() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("es-locale-gated.toml");
+    fs::write(
+        &rulepack_path,
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "es-locale-gated"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "es.test_id"
+class = "custom:es_test_id"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["es-ES"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''ES-TEST-[0-9]{6}'''
+"#,
+    )
+    .unwrap();
+    let policy_path = dir.path().join("policy.toml");
+    fs::write(
+        &policy_path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = ["core-extended"]
+paths = ["{}"]
+
+[[rule]]
+kind = "class"
+class = "custom:es_test_id"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            rulepack_path.display()
+        ),
+    )
+    .unwrap();
+    (dir, policy_path)
+}
+
+#[test]
+fn s10f2_auto_activate_derives_locale_gated_locales_from_loaded_rulepacks() {
+    let (_dir, policy) = write_policy_with_es_locale_gated_path_rulepack();
+    let input = "id ES-TEST-123456";
+    let value = clean_json_with_args(&[&format!("--policy={}", policy.display())], input);
+    let clean = value["clean_text"].as_str().unwrap();
+
+    assert!(
+        Regex::new(r"^id <[0-9a-f]{8}:Custom:es_test_id_1>$")
+            .unwrap()
+            .is_match(clean),
+        "es-ES locale-gated recognizer must auto-activate: {clean}"
+    );
+    assert_eq!(value["stats"]["detections"], 1);
+    let chain = value["stats"]["locale_chain"]
+        .as_array()
+        .expect("locale_chain array");
+    assert!(
+        chain.iter().any(|locale| locale == "es-ES"),
+        "auto-activate chain must carry es-ES: {chain:?}"
+    );
+    assert_eq!(
+        restore_success_text(value["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+}
+
 #[test]
 fn s4_cli_bundled_core_extended_round_trips_broadened_de_area_code_phone() {
     let input = "Phone +49 40 0000 0000";

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -172,3 +172,106 @@ fn daemon_malformed_json_fails_closed_and_continues() {
     assert_eq!(responses[1]["session_id"], "session-a");
     assert!(responses[1]["clean_text"].as_str().unwrap().contains("<"));
 }
+
+// S10-F2 (audit 7201) drift gate for the daemon path: the auto-activate locale
+// set is derived from the loaded rulepacks (same source of truth as
+// `gaze clean`). An adopter path pack with a document-basis `locale_gated`
+// es-ES recognizer activates under `core-extended` with no policy locale.
+fn write_policy_with_es_locale_gated_path_rulepack() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("es-locale-gated.toml");
+    fs::write(
+        &rulepack_path,
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "es-locale-gated"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "es.test_id"
+class = "custom:es_test_id"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["es-ES"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''ES-TEST-[0-9]{6}'''
+"#,
+    )
+    .unwrap();
+    let policy_path = dir.path().join("policy.toml");
+    fs::write(
+        &policy_path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = ["core-extended"]
+paths = ["{}"]
+
+[[rule]]
+kind = "class"
+class = "custom:es_test_id"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            rulepack_path.display()
+        ),
+    )
+    .unwrap();
+    (dir, policy_path)
+}
+
+#[test]
+fn daemon_auto_activate_derives_locale_gated_locales_from_loaded_rulepacks() {
+    let (_dir, policy) = write_policy_with_es_locale_gated_path_rulepack();
+    let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args([
+            "daemon",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--idle-timeout",
+            "30",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            json!({"session_id": "session-es", "text": "id ES-TEST-123456"})
+        )
+        .unwrap();
+    }
+
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let responses = stdout
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), 1, "{stdout}");
+    let clean = responses[0]["clean_text"].as_str().unwrap();
+    assert!(
+        clean.contains(":Custom:es_test_id_"),
+        "es-ES locale-gated recognizer must auto-activate in the daemon: {clean}"
+    );
+}

--- a/docs/reference/redaction-classes.md
+++ b/docs/reference/redaction-classes.md
@@ -255,21 +255,29 @@ The plain `core` default locale chain is `global`
 `safe_default` recognizers activate. For the CLI, `normalize_rulepack_bundles`
 rewrites the deprecated `core-extended` selection to `core` while returning an
 `auto_activate_locale_gated` bit
-(`crates/gaze-cli/src/pipeline/run.rs:700-733`). `CleanOverrides::apply_to`
+(`crates/gaze-cli/src/pipeline/run.rs:712-728`). `CleanOverrides::apply_to`
 carries that bit into `Policy::rulepacks`
 (`crates/gaze-cli/src/clean_overrides.rs:48-63`). Pipeline construction then
-adds `en-US`, `de-DE`, `de-AT`, and `de-CH` to the compatibility locale chain
-(`crates/gaze-cli/src/pipeline/run.rs:137-158`), and recognizer wiring admits
-locale-gated rows under that policy and locale intersection
-(`crates/gaze-assembly/src/detector_wiring.rs:251-285`). The library's
-`CorePipelineConfig` implements the same compatibility behavior directly from
-the requested bundle name (`crates/gaze-assembly/src/defaults.rs:45-76`).
+adds the auto-activation locales to the compatibility locale chain. That set is
+derived from the loaded rulepacks by
+`gaze_assembly::locale_gated_activation_locales`
+(`crates/gaze-assembly/src/locale.rs`): the union of `locales` over enabled,
+document-basis `safety_tier = "locale_gated"` recognizers, minus `global`,
+ordered compatibility-first (`en-US`, `de-DE`, `de-AT`, `de-CH`) then by
+canonical tag. For the bundled `core` recognizers that is exactly `en-US`,
+`de-DE`, `de-AT`, `de-CH`; an adopter path rulepack with a locale-gated
+recognizer for another locale extends the chain automatically. `gaze clean`
+(`crates/gaze-cli/src/pipeline/run.rs`), `gaze daemon`
+(`crates/gaze-cli/src/commands/daemon.rs`), and the library's
+`CorePipelineConfig` (`crates/gaze-assembly/src/defaults.rs`) all call that one
+function, and recognizer wiring admits locale-gated rows under that policy and
+locale intersection (`crates/gaze-assembly/src/detector_wiring.rs`).
 
 <!-- redaction-classes-gate:default-activation:start -->
 | Bundle selection | Effective locale chain | Auto-activate locale-gated | Active recognizer ids | Source |
 |---|---|---|---|---|
-| `core` | `global` | no | `card.structural, email.global, email.header.name, email.header.name.paren, eth.address, iban.structural, ip.v4, ip.v6, phone.e164.spaced, phone.structural, security_token.anchored, url.anchored` | `crates/gaze-recognizers/embedded/core.toml:1-847`; `crates/gaze-assembly/src/defaults.rs:45-76` |
-| `core-extended compatibility alias` | `global, en-US, de-DE, de-AT, de-CH` | yes | `card.structural, email.global, email.header.name, email.header.name.paren, eth.address, iban.structural, ip.v4, ip.v6, name.agent_recipient, name.auto_footer, name.forward_marker, phone.e164.spaced, phone.national.de, phone.national.us, phone.structural, postal.de, postal.us, security_token.anchored, ssn.us, steuer_id.de, url.anchored, vat.de` | `crates/gaze-assembly/src/defaults.rs:45-76`; `crates/gaze-cli/src/pipeline/run.rs:137-158,718-733` |
+| `core` | `global` | no | `card.structural, email.global, email.header.name, email.header.name.paren, eth.address, iban.structural, ip.v4, ip.v6, phone.e164.spaced, phone.structural, security_token.anchored, url.anchored` | `crates/gaze-recognizers/embedded/core.toml:1-847`; `crates/gaze-assembly/src/defaults.rs:45-77` |
+| `core-extended compatibility alias` | `global, en-US, de-DE, de-AT, de-CH` | yes | `card.structural, email.global, email.header.name, email.header.name.paren, eth.address, iban.structural, ip.v4, ip.v6, name.agent_recipient, name.auto_footer, name.forward_marker, phone.e164.spaced, phone.national.de, phone.national.us, phone.structural, postal.de, postal.us, security_token.anchored, ssn.us, steuer_id.de, url.anchored, vat.de` | `crates/gaze-assembly/src/locale.rs` (`locale_gated_activation_locales`); `crates/gaze-assembly/src/defaults.rs:45-77`; `crates/gaze-cli/src/pipeline/run.rs:137-146,712-728` |
 <!-- redaction-classes-gate:default-activation:end -->
 
 The v0.6+ compatibility behavior therefore does activate


### PR DESCRIPTION
## Summary

**Stacked on #428 (S10-F1)** — base branch is `agent/wave2-s10f1-registration-guard`; the diff below is only the S10-F2 commit. Will be rebased onto `main` once #428 merges.

The `auto_activate_locale_gated` locale set (what the `core-extended` compatibility alias pushes onto the rulepack-default locale chain) was a literal `[en-US, de-DE, de-AT, de-CH]` triplicated across `CorePipelineConfig` (`gaze-assembly/src/defaults.rs`), `gaze clean` (`gaze-cli/src/pipeline/run.rs`), and `gaze daemon` (`gaze-cli/src/commands/daemon.rs`). The push IS the activation mechanism for document-basis locale-gated recognizers: a locale-gated recognizer whose locale is not in the literal silently never activates under the alias (missed detection, axis 1).

Decision (plan 7202 §8 item 5, orchestrator default): **DERIVE** the set from the loaded packs — one source of truth.

## Drift evidence — what the audit found vs. what `main` carries today

The audit (scratchpad 7201 S10-F2, verified on `580db19`) found `vat.es` (es-ES), `nino.uk` (en-GB), `pan.in` (en-IN/hi-IN) as `locale_gated` recognizers whose locales were in none of the three lists. **On current `main` (`ce11278`, post-#414/#423) that value drift is gone**: those three are now `safe_default` + `locale_basis = "format"`, and only three `locale_gated` recognizers remain (`phone.national.de` de-DE/de-AT/de-CH, `postal.de` de-DE, `postal.us` en-US) whose union is exactly the literal. #427 (open) adds no locale-gated recognizers either. So the brief's "derived == literal → RED (vat.es/nino.uk/pan.in missing)" is **not red on today's main** — I say so explicitly rather than claim it.

What IS red today (and is the drift gate that matters): the literal cannot follow adopter packs or future bundled locale-gated recognizers. An adopter path rulepack with a document-basis `locale_gated` recognizer for `es-ES` under `default_locales = ["global"]` never activates under the alias, because `es-ES` is never pushed onto the chain. Red-before evidence (library path, run with the src change stashed):

```
test tests::core_extended_alias_locale_chain_is_compat_order ... ok            (pin: shipped chain unchanged)
test tests::core_extended_alias_auto_activates_locale_gated_recognizer_from_path_rulepack ... FAILED
    panicked at tests.rs:525: auto-activate chain must carry the locale-gated recognizer's locale
```

## Fix

- New public `gaze_assembly::locale_gated_activation_locales(&[Rulepack]) -> Vec<LocaleTag>` (`crates/gaze-assembly/src/locale.rs`): union of `locales` over **enabled, document-basis, `safety_tier = "locale_gated"`** recognizers, minus `global`. Format-basis recognizers do not contribute (they run regardless of the document chain, #414); `global` never needs pushing.
- **Deterministic ordering (documented in the rustdoc):** compatibility-first for the tags the v0.6 alias shipped (`en-US, de-DE, de-AT, de-CH`, in that order), then any other tag by canonical BCP-47 string. The rank table is *ordering only* — it never adds a locale to the set. Rationale: chain order decides per-class locale-fallback winners (`RecognizerRegistry::detect_all_resolved` takes the first locale in the chain that yields candidates per class), and for the bundled recognizers `postal.us` (en-US) vs `postal.de` (de-DE) is order-sensitive. Reproducing the shipped order keeps shipped behaviour byte-identical; a pure canonical sort would have flipped that precedence and changed the drift-gated "Shipped default activation" table.
- `CorePipelineConfig`, `gaze clean`, and `gaze daemon` call the one function; the three literals are deleted.

## Behavioural change (CHANGELOG, Unreleased / Changed)

- **Shipped behaviour unchanged**: for the bundled `core` recognizers the derived set equals the old literal (pinned by `locale_gated_activation_locales_for_core_bundle_match_compat_list` and `core_extended_alias_locale_chain_is_compat_order`); the compatibility chain stays `global, en-US, de-DE, de-AT, de-CH`. The gated rows of the "Shipped default activation" table are unchanged.
- **Widening (leak-safe):** an adopter path rulepack whose document-basis locale-gated recognizer declares another locale (e.g. `es-ES`) now auto-activates under the alias without an explicit `--locale`/policy locale. Any future bundled locale-gated recognizer joins the activation set automatically. `--locale` / policy-locale precedence is unchanged (the push only applies when neither is set, exactly as before).

## Tests / drift gates

| Test | Path | Status before | Status after |
|---|---|---|---|
| `locale_gated_activation_locales_for_core_bundle_match_compat_list` (gaze-assembly) | derived(core) == `[EnUs, DeDe, DeAt, DeCh]` — the derived-set == pack-union assertion; a new bundled locale-gated recognizer must update this pin **and** the reference table | n/a (fn new) | green |
| `locale_gated_activation_locales_derive_set_and_order_from_loaded_packs` | set rules (enabled / doc-basis / non-global; format-basis, disabled, safe_default excluded) + ordering rule, incl. load-order independence | n/a | green |
| `core_extended_alias_locale_chain_is_compat_order` | `CorePipelineConfig` shipped chain pin | green | green |
| `core_extended_alias_auto_activates_locale_gated_recognizer_from_path_rulepack` | library path, es-ES path pack | **red** | green |
| `s10f2_auto_activate_derives_locale_gated_locales_from_loaded_rulepacks` (`cli_pipe.rs`) | `gaze clean --policy` with `bundled=["core-extended"]` + es-ES path pack, no locale: tokenizes, `stats.locale_chain` carries `es-ES`, restore round-trips | red by construction (literal lacks es-ES) | CI |
| `daemon_auto_activate_derives_locale_gated_locales_from_loaded_rulepacks` (`daemon_smoke.rs`) | same policy through `gaze daemon` JSONL | red by construction | CI |

The two CLI tests are the behavioural gate that "the derivation is what the CLI uses": reintroducing a literal `[en-US, de-DE, de-AT, de-CH]` array in `run.rs`/`daemon.rs` fails them.

**Ran locally:** `cargo test -p gaze-assembly` → 51 passed + doctest; `cargo fmt --all -- --check` clean; `cargo clippy -p gaze-assembly --all-features --all-targets -- -D warnings` clean; `cargo check -p gaze-cli --tests` compiles (7 pre-existing dead-code warnings for ANSI color helpers under default features, unrelated).
**Not run locally** (bench machine lock 6185 CLAIMED for the whole session; brief forbids workspace-wide cargo while claimed): `cargo test -p gaze-cli --all-features` (so the two new CLI tests + the `cli_pipe` locale pins run first in CI), workspace clippy/tests, `ci-feature-matrix`, xtask gates. No existing `cli_pipe` pin was modified: the shipped chain is unchanged, so no pin encoded the old list in a way this PR changes.

## Out of scope / follow-ups (filed as Solo todos)

- `crates/gaze-recognizers/examples/clean_for_bench.rs` `BENCHMARK_ACTIVE_LOCALES` is a 4th copy of the list, but it defines the benchmark's measurement basis (also used as `.with_locale(...)`); changing it changes scorecards. Left as-is; composes with S23-F1.
- `crates/xtask/tests/redaction_classes_doc.rs` carries a 5th literal chain and its own `activates` shadow predicate that does not model `locale_basis = "format"` (so row 1 of the gated table omits format-basis recognizers that do register under `core`). xtask does not depend on `gaze-assembly`; left as-is, the core-bundle pin test keeps both consistent.
- S11-F2 (pipeline builder lift) not started, per brief.

## North-star

Axis 1: locale-gated recognizers can no longer be silently excluded from activation by a stale list. Axis 4: one source of truth (`locale_gated_activation_locales`), deterministic documented ordering, behavioural drift gates on both CLI paths. Axis 5: widening disclosed; shipped behaviour unchanged.

Audit: solo scratchpad 7201 S10-F2
Resolves solo todo #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaaMXGxdjiJp7MxgFFJt7f
