### PR TITLE
[agent] test(subprocess): load-tolerant subprocess tests — configurable test-side timeout budget + serialization; production timeouts unchanged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1446,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "signal-hook",
  "tempfile",
@@ -4239,6 +4250,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
 dependencies = [
+ "fslock",
  "futures-executor",
  "futures-util",
  "log",

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -79,4 +79,5 @@ gaze-audit = { workspace = true }
 gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
+serial_test = { version = "3", features = ["file_locks"] }
 tempfile = "3"

--- a/crates/gaze-cli/src/commands/index.rs
+++ b/crates/gaze-cli/src/commands/index.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use clap::ValueEnum;
 use gaze::{
@@ -35,6 +36,7 @@ pub(crate) struct IngestArgs {
     pub(crate) domain: String,
     pub(crate) index_path: Option<PathBuf>,
     pub(crate) on_residual: OnResidual,
+    pub(crate) safety_net_timeout_ms: u64,
 }
 
 pub(crate) struct SearchArgs {
@@ -42,6 +44,7 @@ pub(crate) struct SearchArgs {
     pub(crate) domain: String,
     pub(crate) class: Option<PiiClass>,
     pub(crate) index_path: Option<PathBuf>,
+    pub(crate) safety_net_timeout_ms: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -78,7 +81,7 @@ pub(crate) fn ingest(args: IngestArgs) -> Result<(), CliError> {
     let index_path = resolve_index_path(args.index_path);
     let docs = collect_docs(&args.dir)?;
     let classes = classes_for_docs(&docs);
-    let pipeline = build_index_pipeline(&classes)?;
+    let pipeline = build_index_pipeline(&classes, args.safety_net_timeout_ms)?;
 
     let mut store = FileCorpusIndexStore::load_or_create(&index_path, &args.domain, &classes)
         .map_err(map_bridge_error)?;
@@ -120,7 +123,7 @@ pub(crate) fn search(args: SearchArgs) -> Result<(), CliError> {
         .cloned()
         .ok_or_else(index_failed)?;
     let policy_json = store.policy_json().map_err(map_bridge_error)?;
-    let output_safety_net = build_index_output_safety_net_pipeline()?;
+    let output_safety_net = build_index_output_safety_net_pipeline(args.safety_net_timeout_ms)?;
     let mut bridge = TokenBridge::from_policy_json_and_store(&policy_json, store)
         .map_err(map_bridge_error)?
         .with_output_safety_net(output_safety_net, vec![LocaleTag::Global]);
@@ -218,13 +221,16 @@ fn classes_for_docs(docs: &[SourceDoc]) -> Vec<PiiClass> {
     classes.into_iter().collect()
 }
 
-fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
+fn build_index_pipeline(
+    classes: &[PiiClass],
+    safety_net_timeout_ms: u64,
+) -> Result<Pipeline, CliError> {
     let mut builder = Pipeline::builder()
         .detector(RegexDetector::emails().map_err(|err| {
             CliError::PolicyConfigDetail(format!("index email detector failed: {err}"))
         })?)
         .detector(FieldEntityDetector);
-    builder = builder.register_safety_net_registry(index_kiji_registry()?);
+    builder = builder.register_safety_net_registry(index_kiji_registry(safety_net_timeout_ms)?);
 
     let mut rule_classes =
         BTreeSet::from([PiiClass::Email, PiiClass::Name, PiiClass::Organization]);
@@ -239,23 +245,26 @@ fn build_index_pipeline(classes: &[PiiClass]) -> Result<Pipeline, CliError> {
         .map_err(|err| CliError::PolicyConfigDetail(format!("index pipeline build failed: {err}")))
 }
 
-fn build_index_output_safety_net_pipeline() -> Result<Pipeline, CliError> {
+fn build_index_output_safety_net_pipeline(
+    safety_net_timeout_ms: u64,
+) -> Result<Pipeline, CliError> {
     Pipeline::builder()
-        .register_safety_net_registry(index_kiji_registry()?)
+        .register_safety_net_registry(index_kiji_registry(safety_net_timeout_ms)?)
         .build()
         .map_err(|err| {
             CliError::PolicyConfigDetail(format!("index output safety-net build failed: {err}"))
         })
 }
 
-fn index_kiji_registry() -> Result<LocaleAwareModelRegistry, CliError> {
+fn index_kiji_registry(safety_net_timeout_ms: u64) -> Result<LocaleAwareModelRegistry, CliError> {
     let mut registry = LocaleAwareModelRegistry::new();
-    registry.register(index_kiji_safety_net()?);
+    registry.register(index_kiji_safety_net(safety_net_timeout_ms)?);
     Ok(registry)
 }
 
 #[cfg(feature = "safety-net-kiji")]
 fn index_kiji_safety_net(
+    safety_net_timeout_ms: u64,
 ) -> Result<gaze_recognizers::safety_net::kiji_distilbert::KijiDistilbertSafetyNet, CliError> {
     use gaze_recognizers::safety_net::kiji_distilbert::{
         KijiDistilbertConfig, KijiDistilbertSafetyNet, OrtKijiConfig, SubprocessKijiConfig,
@@ -269,7 +278,8 @@ fn index_kiji_safety_net(
 
     if let Some(command) = std::env::var_os(KIJI_COMMAND_ENV) {
         return Ok(KijiDistilbertSafetyNet::new(KijiDistilbertConfig::from(
-            SubprocessKijiConfig::new(command),
+            SubprocessKijiConfig::new(command)
+                .with_timeout(Duration::from_millis(safety_net_timeout_ms)),
         )));
     }
 
@@ -279,7 +289,9 @@ fn index_kiji_safety_net(
 }
 
 #[cfg(not(feature = "safety-net-kiji"))]
-fn index_kiji_safety_net() -> Result<impl gaze_recognizers::LocaleAwareModel, CliError> {
+fn index_kiji_safety_net(
+    _safety_net_timeout_ms: u64,
+) -> Result<impl gaze_recognizers::LocaleAwareModel, CliError> {
     Err(CliError::SafetyNetConfigDetail(
         "gaze index requires gaze-cli feature safety-net-kiji".to_string(),
     ))

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -276,6 +276,9 @@ enum Cmd {
     /// Requires the binary to be built with `--features index`.
     #[cfg(feature = "index")]
     Index {
+        /// Safety-net subprocess timeout in milliseconds.
+        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
+        safety_net_timeout_ms: u64,
         #[command(subcommand)]
         command: IndexCmd,
     },
@@ -1064,7 +1067,10 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             }),
         },
         #[cfg(feature = "index")]
-        Cmd::Index { command } => match command {
+        Cmd::Index {
+            safety_net_timeout_ms,
+            command,
+        } => match command {
             IndexCmd::Ingest {
                 dir,
                 domain,
@@ -1075,6 +1081,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 domain,
                 index_path,
                 on_residual,
+                safety_net_timeout_ms,
             }),
             IndexCmd::Search {
                 entity,
@@ -1086,6 +1093,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 domain,
                 class,
                 index_path,
+                safety_net_timeout_ms,
             }),
         },
         #[cfg(feature = "mcp")]

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -13,6 +13,7 @@ use base64::Engine;
 use regex::Regex;
 use rusqlite::{params, params_from_iter, Connection};
 use serde_json::{json, Value};
+use serial_test::file_serial;
 use tempfile::tempdir;
 
 use gaze::{PiiClass, Scope, Session};
@@ -4106,6 +4107,7 @@ fn t_kiji_distilbert_backend_without_artifact_emits_typed_envelope() {
 
 #[cfg(all(feature = "safety-net-openai", feature = "safety-net-kiji"))]
 #[test]
+#[file_serial(gaze_subprocess)]
 fn t_safety_net_registry_selects_locale_backend() {
     let dir = tempdir().unwrap();
     let opf = dir.path().join("opf");

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -18,6 +18,18 @@ use tempfile::tempdir;
 use gaze::{PiiClass, Scope, Session};
 use gaze_audit::{build_audit_query_sql, AuditFilter, SqliteLogger, AUDIT_RESTRICTED_COLUMNS};
 
+fn test_subprocess_timeout_ms() -> u64 {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    seconds.saturating_mul(1_000)
+}
+
 /// Run `gaze clean` on the given stdin and parse the JSON response.
 fn clean_ok(input: &str) -> (String, String, u64) {
     clean_ok_with_args(&[], input)
@@ -4126,6 +4138,7 @@ fn t_safety_net_registry_selects_locale_backend() {
             "--safety-net-registry",
             "--safety-net-add=openai-filter",
             "--safety-net-add=kiji-distilbert",
+            &format!("--safety-net-timeout-ms={}", test_subprocess_timeout_ms()),
             &format!("--opf-command={}", opf.display()),
             &format!("--opf-checkpoint={}", checkpoint.display()),
             "--opf-locales=en-US,en-GB",
@@ -4150,6 +4163,7 @@ fn t_safety_net_registry_selects_locale_backend() {
             "--safety-net-registry",
             "--safety-net-add=openai-filter",
             "--safety-net-add=kiji-distilbert",
+            &format!("--safety-net-timeout-ms={}", test_subprocess_timeout_ms()),
             &format!("--opf-command={}", opf.display()),
             &format!("--opf-checkpoint={}", checkpoint.display()),
             "--opf-locales=en-US,en-GB",

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -4,6 +4,7 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
+use serial_test::file_serial;
 use tempfile::tempdir;
 
 fn write_policy() -> (tempfile::TempDir, std::path::PathBuf) {
@@ -37,6 +38,7 @@ action = "preserve"
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn daemon_processes_jsonl_and_isolates_sessions() {
     let (_dir, policy) = write_policy();
     let audit_dir = tempdir().unwrap();
@@ -133,6 +135,7 @@ fn daemon_processes_jsonl_and_isolates_sessions() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn daemon_malformed_json_fails_closed_and_continues() {
     let (_dir, policy) = write_policy();
     let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -10,6 +10,18 @@ const DOMAIN: &str = "local_owner/support_notes/v1";
 const TEST_INDEX_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 const WRONG_INDEX_KEY: &str = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
 
+fn test_subprocess_timeout_ms() -> String {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    seconds.saturating_mul(1_000).to_string()
+}
+
 #[test]
 fn index_ingest_then_search_returns_tokenized_hits_without_raw_values() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -41,7 +53,7 @@ Second support note for search isolation.
     .expect("write beta");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -54,7 +66,7 @@ Second support note for search isolation.
     );
 
     let search = gaze_index_command(&fake_kiji)
-        .args(["index", "search", "alice@example.invalid"])
+        .args(["search", "alice@example.invalid"])
         .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
         .output()
@@ -103,7 +115,7 @@ Support summary mentions Dr. Schmidt after triage.
     .expect("write safety-net-only");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -116,7 +128,7 @@ Support summary mentions Dr. Schmidt after triage.
     );
 
     let search = gaze_index_command(&fake_kiji)
-        .args(["index", "search", "Dr. Schmidt"])
+        .args(["search", "Dr. Schmidt"])
         .args(["--class", "name", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
         .output()
@@ -160,7 +172,7 @@ Support summary mentions Dr. Schmidt marker after triage.
     .expect("write residual");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -173,7 +185,7 @@ Support summary mentions Dr. Schmidt marker after triage.
     );
 
     let search = gaze_index_command(&fake_kiji)
-        .args(["index", "search", "alice@example.invalid"])
+        .args(["search", "alice@example.invalid"])
         .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
         .output()
@@ -222,7 +234,7 @@ Support summary mentions Dr. Schmidt marker after triage.
     .expect("write strict");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args([
             "--on-residual",
@@ -265,7 +277,7 @@ fn index_search_wrong_key_surfaces_decrypt_reason() {
     fs::write(corpus.join("alpha.md"), "Email: alice@example.invalid\n").expect("write alpha");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -278,7 +290,7 @@ fn index_search_wrong_key_surfaces_decrypt_reason() {
     );
 
     let search = gaze_index_command_with_key(&fake_kiji, WRONG_INDEX_KEY)
-        .args(["index", "search", "alice@example.invalid"])
+        .args(["search", "alice@example.invalid"])
         .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
         .output()
@@ -317,7 +329,7 @@ Support summary: Alice Mueller from Globex GmbH wrote from alice@example.invalid
     .expect("write prose");
 
     let ingest = gaze_index_command(&fake_kiji)
-        .args(["index", "ingest"])
+        .arg("ingest")
         .arg(&corpus)
         .args(["--domain", DOMAIN, "--index-path"])
         .arg(&index)
@@ -335,7 +347,7 @@ Support summary: Alice Mueller from Globex GmbH wrote from alice@example.invalid
     );
 
     let search = gaze_index_command(&fake_kiji)
-        .args(["index", "search", "alice@example.invalid"])
+        .args(["search", "alice@example.invalid"])
         .args(["--class", "email", "--domain", DOMAIN, "--index-path"])
         .arg(&index)
         .output()
@@ -396,6 +408,10 @@ fn gaze_index_command(fake_kiji: &Path) -> Command {
 fn gaze_index_command_with_key(fake_kiji: &Path, index_key: &str) -> Command {
     let mut command = Command::cargo_bin("gaze").expect("gaze bin");
     command
+        .args([
+            "index",
+            &format!("--safety-net-timeout-ms={}", test_subprocess_timeout_ms()),
+        ])
         .env("GAZE_KIJI_DISTILBERT_COMMAND", fake_kiji)
         .env_remove("GAZE_KIJI_DISTILBERT_MODEL_DIR")
         .env("GAZE_INDEX_KEY", index_key);

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -5,6 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
+use serial_test::file_serial;
 
 const DOMAIN: &str = "local_owner/support_notes/v1";
 const TEST_INDEX_KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
@@ -23,6 +24,7 @@ fn test_subprocess_timeout_ms() -> String {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_ingest_then_search_returns_tokenized_hits_without_raw_values() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -100,6 +102,7 @@ Second support note for search isolation.
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_ingest_redacts_safety_net_only_prose_by_default_without_raw_persistence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -156,6 +159,7 @@ Support summary mentions Dr. Schmidt after triage.
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_ingest_redacts_residual_suspects_by_default_without_raw_persistence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -219,6 +223,7 @@ Support summary mentions Dr. Schmidt marker after triage.
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_ingest_strict_residual_mode_fails_closed_with_reason() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -268,6 +273,7 @@ Support summary mentions Dr. Schmidt marker after triage.
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_search_wrong_key_surfaces_decrypt_reason() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -314,6 +320,7 @@ fn index_search_wrong_key_surfaces_decrypt_reason() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn realistic_prose_name_org_email_regression_never_returns_raw_values() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");
@@ -371,6 +378,7 @@ Support summary: Alice Mueller from Globex GmbH wrote from alice@example.invalid
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn index_ingest_fails_closed_without_kiji_model_or_command() {
     let temp = tempfile::tempdir().expect("tempdir");
     let corpus = temp.path().join("corpus");

--- a/crates/gaze-cli/tests/safety_net_cli.rs
+++ b/crates/gaze-cli/tests/safety_net_cli.rs
@@ -7,6 +7,7 @@ use assert_cmd::Command;
 use gaze::{LeakKind, LeakSuspect, PiiClass};
 use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 use serde_json::Value;
+use serial_test::file_serial;
 use tempfile::{tempdir, TempDir};
 
 fn test_subprocess_timeout_ms() -> String {
@@ -112,6 +113,7 @@ fn safety_args(command: &Path, checkpoint: &Path) -> Vec<String> {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn explicit_openai_filter_device_reaches_opf_argv() {
     let arg_dir = tempdir().unwrap();
     let arg_log = arg_dir.path().join("opf.args");
@@ -134,6 +136,7 @@ fn explicit_openai_filter_device_reaches_opf_argv() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn auto_openai_filter_device_does_not_inject_opf_device_arg() {
     let arg_dir = tempdir().unwrap();
     let arg_log = arg_dir.path().join("opf.args");
@@ -155,6 +158,7 @@ fn auto_openai_filter_device_does_not_inject_opf_device_arg() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn missing_checkpoint_fails_closed_with_sanitized_error() {
     let (_opf_dir, opf) = write_mock_opf("[]");
     let missing = tempdir().unwrap().path().join("missing-checkpoint");
@@ -169,6 +173,7 @@ fn missing_checkpoint_fails_closed_with_sanitized_error() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn uncovered_suspect_exits_three_in_strict_mode_without_stdout() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_person","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
@@ -184,6 +189,7 @@ fn uncovered_suspect_exits_three_in_strict_mode_without_stdout() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn default_safety_net_mode_resolves_with_redact_fallback() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
@@ -203,6 +209,7 @@ fn default_safety_net_mode_resolves_with_redact_fallback() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn tolerant_mode_requires_env_opt_in() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
@@ -217,6 +224,7 @@ fn tolerant_mode_requires_env_opt_in() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn tolerant_fallback_requires_env_opt_in() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
@@ -231,6 +239,7 @@ fn tolerant_fallback_requires_env_opt_in() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn class_mismatch_warns_and_reports_without_failing() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_person","start":8,"end":17}]"#);
     let checkpoint = checkpoint_dir();
@@ -264,6 +273,7 @@ fn class_mismatch_warns_and_reports_without_failing() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn tolerant_uncovered_outputs_report_and_logs_audit_row() {
     let (_opf_dir, opf) = write_mock_opf(r#"[{"label":"private_email","start":0,"end":5}]"#);
     let checkpoint = checkpoint_dir();
@@ -303,6 +313,7 @@ fn tolerant_uncovered_outputs_report_and_logs_audit_row() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn safety_net_audit_query_filters_structured_field_path() {
     let dir = tempdir().unwrap();
     let db = dir.path().join("audit.sqlite");

--- a/crates/gaze-cli/tests/safety_net_cli.rs
+++ b/crates/gaze-cli/tests/safety_net_cli.rs
@@ -9,6 +9,18 @@ use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 use serde_json::Value;
 use tempfile::{tempdir, TempDir};
 
+fn test_subprocess_timeout_ms() -> String {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    seconds.saturating_mul(1_000).to_string()
+}
+
 fn write_mock_opf(body: &str) -> (TempDir, PathBuf) {
     let dir = tempdir().unwrap();
     let path = dir.path().join("mock-opf");
@@ -95,7 +107,7 @@ fn safety_args(command: &Path, checkpoint: &Path) -> Vec<String> {
         "--openai-filter-checkpoint".to_string(),
         checkpoint.display().to_string(),
         "--safety-net-timeout-ms".to_string(),
-        "30000".to_string(),
+        test_subprocess_timeout_ms(),
     ]
 }
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -52,7 +52,7 @@ unicode-normalization = "0.1"
 criterion = "0.5"
 gaze = { path = "../gaze", package = "gaze-pii", default-features = false, features = ["test-support"] }
 gaze-assembly = { path = "../gaze-assembly" }
-serial_test = "3"
+serial_test = { version = "3", features = ["file_locks"] }
 tempfile = "3"
 
 [[test]]

--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -834,9 +834,12 @@ fn empty_context() -> Context {
 
 #[cfg(feature = "safety-net-kiji")]
 fn register_kiji(pipeline: Pipeline) -> Result<Pipeline, Box<dyn std::error::Error>> {
-    use gaze_recognizers::safety_net::kiji_distilbert::KijiDistilbertSafetyNet;
+    use gaze_recognizers::safety_net::kiji_distilbert::{
+        KijiDistilbertSafetyNet, SubprocessKijiConfig,
+    };
 
-    Ok(pipeline.with_safety_net(KijiDistilbertSafetyNet::from_env()?))
+    let config = SubprocessKijiConfig::from_env()?.with_timeout(benchmark_subprocess_timeout()?);
+    Ok(pipeline.with_safety_net(KijiDistilbertSafetyNet::new(config)))
 }
 
 #[cfg(feature = "safety-net-kiji")]
@@ -867,7 +870,7 @@ fn register_opf(pipeline: Pipeline) -> Result<Pipeline, Box<dyn std::error::Erro
     let checkpoint = std::env::var_os("OPF_CHECKPOINT").ok_or("OPF_CHECKPOINT is not set")?;
     let config = SubprocessOpenAiFilterConfig::new(command)
         .with_checkpoint_path(checkpoint)
-        .with_timeout(std::time::Duration::from_secs(30))
+        .with_timeout(benchmark_subprocess_timeout()?)
         .with_args([
             "--format",
             "json",
@@ -902,13 +905,14 @@ fn register_locale_aware(pipeline: Pipeline) -> Result<Pipeline, Box<dyn std::er
     let opf_command =
         std::env::var_os("GAZE_OPENAI_FILTER_OPF").ok_or("GAZE_OPENAI_FILTER_OPF is not set")?;
     let opf_checkpoint = std::env::var_os("OPF_CHECKPOINT").ok_or("OPF_CHECKPOINT is not set")?;
+    let subprocess_timeout = benchmark_subprocess_timeout()?;
 
     Ok(pipeline
         .with_safety_net(
             OpenAiFilterSafetyNet::new(
                 SubprocessOpenAiFilterConfig::new(opf_command)
                     .with_checkpoint_path(opf_checkpoint)
-                    .with_timeout(std::time::Duration::from_secs(30))
+                    .with_timeout(subprocess_timeout)
                     .with_args([
                         "--format",
                         "json",
@@ -925,10 +929,22 @@ fn register_locale_aware(pipeline: Pipeline) -> Result<Pipeline, Box<dyn std::er
             KijiDistilbertSafetyNet::new(
                 SubprocessKijiConfig::new(kiji_command)
                     .with_model_dir(kiji_model_dir)
-                    .with_timeout(std::time::Duration::from_secs(30)),
+                    .with_timeout(subprocess_timeout),
             )
             .with_locales(vec![LocaleTag::DeDe]),
         ))
+}
+
+fn benchmark_subprocess_timeout() -> Result<std::time::Duration, Box<dyn std::error::Error>> {
+    let seconds = match std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS") {
+        Ok(value) => value.parse::<u64>()?,
+        Err(std::env::VarError::NotPresent) => 60,
+        Err(error) => return Err(error.into()),
+    };
+    if seconds == 0 {
+        return Err("benchmark subprocess timeout must be positive".into());
+    }
+    Ok(std::time::Duration::from_secs(seconds))
 }
 
 #[cfg(not(all(feature = "safety-net-kiji", feature = "safety-net-openai")))]

--- a/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/subprocess.rs
@@ -703,3 +703,10 @@ mod tests {
         assert!(matches!(error, SafetyNetError::ModelUnavailable { .. }));
     }
 }
+#[test]
+fn production_default_timeout_remains_five_seconds() {
+    assert_eq!(
+        SubprocessKijiConfig::new("kiji").timeout,
+        Duration::from_secs(5)
+    );
+}

--- a/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
+++ b/crates/gaze-recognizers/src/safety_net/openai_filter/backend/subprocess.rs
@@ -975,3 +975,10 @@ mod tests {
         assert!(matches!(error, SafetyNetError::ModelUnavailable { .. }));
     }
 }
+#[test]
+fn production_default_timeout_remains_five_seconds() {
+    assert_eq!(
+        SubprocessOpenAiFilterConfig::new("opf").timeout,
+        Duration::from_secs(5)
+    );
+}

--- a/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
+++ b/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
@@ -17,6 +17,7 @@ use gaze_recognizers::safety_net::kiji_distilbert::{
     SubprocessKijiBackend, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
 };
 use gaze_types::{DocumentKind, LocaleTag, Manifest, SafetyNet, SafetyNetContext, SafetyNetError};
+use serial_test::file_serial;
 use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
 
@@ -109,6 +110,7 @@ fn missing_sha256sums_is_weights_missing() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn subprocess_span_round_trips_through_manifest_diff() {
     // Mock-kiji emits one person span at [0,11] over "Alice Smith". The default
     // empty manifest classifies that as Uncovered.
@@ -140,6 +142,7 @@ fn subprocess_span_round_trips_through_manifest_diff() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn ort_matches_subprocess_for_fixture_inputs_when_real_kiji_is_configured() {
     let Some(command) = std::env::var_os("GAZE_KIJI_DISTILBERT_COMMAND") else {
         eprintln!("skipping parity test: GAZE_KIJI_DISTILBERT_COMMAND is not set");

--- a/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
+++ b/crates/gaze-recognizers/tests/kiji_distilbert_subprocess.rs
@@ -10,6 +10,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use gaze_recognizers::safety_net::kiji_distilbert::{
     KijiDistilbertBackend, KijiDistilbertSafetyNet, OrtKijiBackend, OrtKijiConfig,
@@ -18,6 +19,18 @@ use gaze_recognizers::safety_net::kiji_distilbert::{
 use gaze_types::{DocumentKind, LocaleTag, Manifest, SafetyNet, SafetyNetContext, SafetyNetError};
 use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
+
+fn test_subprocess_timeout() -> Duration {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    Duration::from_secs(seconds)
+}
 
 fn write_mock_kiji(body: &str) -> (TempDir, PathBuf) {
     let dir = tempdir().unwrap();
@@ -105,6 +118,7 @@ fn subprocess_span_round_trips_through_manifest_diff() {
 
     let config = SubprocessKijiConfig::new(&kiji)
         .with_model_dir(model.path())
+        .with_timeout(test_subprocess_timeout())
         .with_expected_bundle_sha256_for_tests(expected_sha);
     let net = KijiDistilbertSafetyNet::new(config);
     let manifest = Manifest::default();
@@ -137,7 +151,9 @@ fn ort_matches_subprocess_for_fixture_inputs_when_real_kiji_is_configured() {
     };
 
     let subprocess = SubprocessKijiBackend::new(
-        SubprocessKijiConfig::new(command).with_model_dir(PathBuf::from(&model_dir)),
+        SubprocessKijiConfig::new(command)
+            .with_model_dir(PathBuf::from(&model_dir))
+            .with_timeout(test_subprocess_timeout()),
     )
     .unwrap();
     let ort = OrtKijiBackend::new(OrtKijiConfig::new(PathBuf::from(model_dir))).unwrap();

--- a/crates/gaze-recognizers/tests/locale_aware_trait.rs
+++ b/crates/gaze-recognizers/tests/locale_aware_trait.rs
@@ -12,6 +12,7 @@ use gaze_recognizers::safety_net::kiji_distilbert::{
 };
 use gaze_recognizers::{LocaleAwareModel, ModelHints, ModelInput, ModelStage};
 use gaze_types::{LocaleTag, PiiClass};
+use serial_test::file_serial;
 use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
 
@@ -82,6 +83,7 @@ fn kiji_locale_aware_model_reports_configured_native_locales() {
 }
 
 #[test]
+#[file_serial(gaze_subprocess)]
 fn kiji_infer_round_trips_spans_through_locale_aware_trait() {
     let (_kiji_dir, kiji) =
         write_mock_kiji(r#"[{"label":"person","start":0,"end":11,"score":0.97}]"#);

--- a/crates/gaze-recognizers/tests/locale_aware_trait.rs
+++ b/crates/gaze-recognizers/tests/locale_aware_trait.rs
@@ -5,6 +5,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use gaze_recognizers::safety_net::kiji_distilbert::{
     KijiDistilbertSafetyNet, SubprocessKijiConfig, REQUIRED_KIJI_ARTIFACTS,
@@ -13,6 +14,18 @@ use gaze_recognizers::{LocaleAwareModel, ModelHints, ModelInput, ModelStage};
 use gaze_types::{LocaleTag, PiiClass};
 use sha2::{Digest, Sha256};
 use tempfile::{tempdir, TempDir};
+
+fn test_subprocess_timeout() -> Duration {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    Duration::from_secs(seconds)
+}
 
 fn write_mock_kiji(body: &str) -> (TempDir, PathBuf) {
     let dir = tempdir().unwrap();
@@ -76,6 +89,7 @@ fn kiji_infer_round_trips_spans_through_locale_aware_trait() {
     let net = KijiDistilbertSafetyNet::new(
         SubprocessKijiConfig::new(&kiji)
             .with_model_dir(model_dir.path())
+            .with_timeout(test_subprocess_timeout())
             .with_expected_bundle_sha256_for_tests(expected_sha),
     );
     let model: &dyn LocaleAwareModel = &net;

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -16,7 +16,7 @@ use gaze_types::{
     DocumentKind, LeakKind, LocaleTag, Manifest, PiiClass, SafetyNet, SafetyNetContext,
     SafetyNetError,
 };
-use serial_test::serial;
+use serial_test::file_serial;
 
 fn test_subprocess_timeout() -> Duration {
     let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
@@ -31,7 +31,7 @@ fn test_subprocess_timeout() -> Duration {
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn official_json_private_fields_are_dropped_at_boundary() {
     let clean = "Dr. Schmidt uses alice@example.invalid";
     let opf = script(
@@ -67,7 +67,7 @@ printf '%s\n' '{"schema_version":1,"summary":{"output_mode":"typed","span_count"
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn all_official_labels_map_exactly_to_gaze_classes() {
     let cases = [
         ("private_person", PiiClass::Name),
@@ -103,7 +103,7 @@ fn all_official_labels_map_exactly_to_gaze_classes() {
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn openai_filter_locale_aware_model_reports_configured_native_locales() {
     let net = OpenAiFilterSafetyNet::new(SubprocessOpenAiFilterConfig::new("opf"))
         .with_locales(vec![LocaleTag::EnUs]);
@@ -114,7 +114,7 @@ fn openai_filter_locale_aware_model_reports_configured_native_locales() {
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn openai_filter_infer_round_trips_spans_through_locale_aware_trait() {
     let opf = script(
         "opf-locale-aware",
@@ -151,7 +151,7 @@ printf '%s\n' '[{"label":"private_person","start":0,"end":11,"score":0.97},{"lab
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn unknown_valid_label_fails_closed() {
     let opf = script(
         "opf-unknown-label",
@@ -168,7 +168,7 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private_bank","st
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn invalid_label_characters_fail_invalid_output() {
     let opf = script(
         "opf-invalid-label",
@@ -184,7 +184,7 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private-email","s
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn sleeping_child_times_out_and_returns_sanitized_runtime_error() {
     let opf = script(
         "opf-sleep",
@@ -206,7 +206,7 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[],"text":"","redacted_text"
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn stdin_blocked_child_times_out_and_kills_subprocess() {
     let dir = tempfile::tempdir().unwrap();
     let pidfile = dir.path().join("opf.pid");
@@ -245,7 +245,7 @@ exec sleep 30
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn oversized_input_returns_before_spawn() {
     let dir = tempfile::tempdir().unwrap();
     let marker = dir.path().join("spawned");
@@ -272,7 +272,7 @@ printf '%s\n' '{{"schema_version":1,"detected_spans":[],"text":"","redacted_text
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn verbose_stderr_is_stripped_and_capped() {
     let opf = script(
         "opf-stderr",
@@ -299,7 +299,7 @@ exit 7
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn missing_checkpoint_fails_closed_without_spawn_or_download() {
     let dir = tempfile::tempdir().unwrap();
     let marker = dir.path().join("spawned");
@@ -323,7 +323,7 @@ printf '%s\n' '{{"schema_version":1,"detected_spans":[],"text":"","redacted_text
 }
 
 #[test]
-#[serial]
+#[file_serial(gaze_subprocess)]
 fn safety_net_correlates_raw_spans_with_manifest_without_source_text() {
     let clean = "<Email_1>";
     let opf = script(

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -18,6 +18,18 @@ use gaze_types::{
 };
 use serial_test::serial;
 
+fn test_subprocess_timeout() -> Duration {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    Duration::from_secs(seconds)
+}
+
 #[test]
 #[serial]
 fn official_json_private_fields_are_dropped_at_boundary() {
@@ -40,9 +52,10 @@ printf '%s\n' '{"schema_version":1,"summary":{"output_mode":"typed","span_count"
     let debug = format!("{spans:?} {backend:?}");
     assert_private_payload_absent(&debug);
 
-    let net = OpenAiFilterSafetyNet::new(SubprocessOpenAiFilterConfig::new(
-        backend.config().command().to_path_buf(),
-    ));
+    let net = OpenAiFilterSafetyNet::new(
+        SubprocessOpenAiFilterConfig::new(backend.config().command().to_path_buf())
+            .with_timeout(test_subprocess_timeout()),
+    );
     let manifest = Manifest::default();
     let context = context(&manifest, Some("$.profile.email"));
     let suspects = net.check(clean, context).unwrap();
@@ -112,7 +125,7 @@ printf '%s\n' '[{"label":"private_person","start":0,"end":11,"score":0.97},{"lab
     )
     .unwrap();
     let net = OpenAiFilterSafetyNet::new(
-        SubprocessOpenAiFilterConfig::new(opf).with_timeout(Duration::from_secs(120)),
+        SubprocessOpenAiFilterConfig::new(opf).with_timeout(test_subprocess_timeout()),
     );
     let model: &dyn LocaleAwareModel = &net;
 
@@ -272,7 +285,7 @@ exit 7
     .unwrap();
     let backend = SubprocessOpenAiFilterBackend::new(
         SubprocessOpenAiFilterConfig::new(opf)
-            .with_timeout(Duration::from_secs(120))
+            .with_timeout(test_subprocess_timeout())
             .with_stderr_diagnostics(true),
     )
     .unwrap();
@@ -322,7 +335,7 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private_email","s
     )
     .unwrap();
     let net = OpenAiFilterSafetyNet::new(
-        SubprocessOpenAiFilterConfig::new(opf).with_timeout(Duration::from_secs(120)),
+        SubprocessOpenAiFilterConfig::new(opf).with_timeout(test_subprocess_timeout()),
     );
     let manifest = Manifest::from_spans(vec![gaze_types::EmittedTokenSpan::new(
         0..9,
@@ -342,7 +355,7 @@ printf '%s\n' '{"schema_version":1,"detected_spans":[{"label":"private_email","s
 
 fn backend(command: PathBuf) -> SubprocessOpenAiFilterBackend {
     SubprocessOpenAiFilterBackend::new(
-        SubprocessOpenAiFilterConfig::new(command).with_timeout(Duration::from_secs(120)),
+        SubprocessOpenAiFilterConfig::new(command).with_timeout(test_subprocess_timeout()),
     )
     .unwrap()
 }


### PR DESCRIPTION
## What & why

Subprocess-backed tests inherited production's fail-closed 5 s deadline, so ordinary CPU and macOS Gatekeeper contention produced false-red Timeout failures. This change gives test and benchmark harnesses one explicit, generous budget and serializes subprocess tests across integration-test binaries.

Resolves solo todo #2916.
Resolves solo todo #2404.
Related solo todo #2487; no proxy flake path changed.

## Fixed-deadline subprocess inventory

| Path | Before | Where set | Timeout asserted? | After |
| --- | --- | --- | --- | --- |
| gaze-recognizers Kiji subprocess backend | 5 s | production DEFAULT_TIMEOUT | runtime behavior is covered; default was not pinned | unchanged 5 s, now pinned by a unit test |
| gaze-recognizers OpenAI Filter subprocess backend | 5 s | production DEFAULT_TIMEOUT | runtime behavior is covered; default was not pinned | unchanged 5 s, now pinned by a unit test |
| tests/kiji_distilbert_subprocess.rs | inherited 5 s | production config default | no | GAZE_TEST_SUBPROCESS_TIMEOUT_SECS, default 60 s |
| tests/locale_aware_trait.rs | inherited 5 s | production config default | no | same test env budget |
| tests/openai_filter_subprocess.rs | inherited 5 s or ad hoc 120 s | test constructors/helpers | only dedicated 100 ms and 15 s timeout/kill tests assert timeout behavior | ordinary cases use the test env budget; dedicated timeout-contract cases stay fixed |
| gaze-cli/tests/safety_net_cli.rs | 30 s | existing --safety-net-timeout-ms test args | no | same test env budget |
| gaze-cli/tests/cli_pipe.rs locale registry test | production CLI default 5 s | existing CLI flag default | no | test passes the env-derived CLI flag |
| gaze-cli/tests/index_cli.rs, fake-Kiji Python runner and six safety-net cases | production backend default 5 s; no index flag existed | index runtime constructed SubprocessKijiConfig directly | no | public gaze index --safety-net-timeout-ms keeps a 5 s default; tests pass the env-derived 60 s budget |
| gaze-cli/tests/daemon_smoke.rs | 30 s process idle timeout; one 10 s throughput assertion | test CLI args/assertion | yes, the throughput bound is part of the test | unchanged; subprocess tests join the shared serialization lane |
| examples/clean_for_bench.rs | inherited 5 s for one Kiji path; explicit 30 s for OPF/locale-aware paths | benchmark harness | no | same env budget, default 60 s |

The only remaining short fixed deadlines are the OPF tests whose purpose is to prove timeout and child-kill semantics. They remain fail-closed and serialized.

## Implementation

- GAZE_TEST_SUBPROCESS_TIMEOUT_SECS is read only by integration-test and benchmark harness code; default 60 s, invalid/zero values fail loudly.
- gaze index now exposes --safety-net-timeout-ms for ingest and search. Its production default remains 5,000 ms.
- Cross-binary tests use serial_test::file_serial(gaze_subprocess). The file_locks feature and the CLI dev-dependency are necessary because Cargo runs separate integration-test binaries in separate processes; an in-process mutex cannot serialize that class.
- No production timeout or fail-closed semantics changed.

## Before/after proof

Uncontended baseline before the change:

- locale-aware Kiji: 0.15 s test time
- Kiji manifest-diff: 1.57 s test time
- CLI locale registry: 4.85 s test time, close to the 5 s production deadline
- index CLI: 73.92 s cold wall time including compilation

Artificial load: nine yes processes on an 18-logical-core host. Each formerly flaky group passed 5/5:

- locale-aware Kiji: 0.16–0.34 s
- Kiji manifest-diff: 0.18–0.28 s
- CLI locale registry: 3.34–3.46 s
- all seven index CLI tests: 4.79–5.58 s

Unloaded, each group again passed 5/5:

- locale-aware Kiji: 0.17–0.34 s
- Kiji manifest-diff: 0.15–0.27 s
- CLI locale registry: 3.50–3.66 s
- all seven index CLI tests: 5.00–5.42 s

Warm uncontended times did not regress; the former 4.85 s near-timeout CLI case now completes in 3.50–3.66 s while retaining a larger failure budget.

## Local gates

- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings (exit 0, 1m02s)
- [x] cargo test --workspace --all-features --no-fail-fast under nine CPU burners (exit 0, 10m45s)
- [x] final-tree cargo test --workspace --all-features --no-fail-fast unloaded (exit 0, 5m57s)
- [x] production Kiji and OPF defaults pinned at 5 s (2/2)
- [x] cargo check -p gaze-recognizers --all-features --example clean_for_bench

## North-star impact

- Reliability: production subprocesses still fail closed on the same 5 s deadline with the same typed timeout behavior.
- Reversibility and agentic behavior: unchanged.
- Trust: deterministic test budgets and cross-binary serialization remove load-sensitive false reds.
- Adopter ergonomics: index users gain an explicit timeout flag with the existing production default.

## Fixtures & PII hygiene

- [x] No real PII added; existing synthetic fixtures only.

## DCO and commit discipline

- [x] All commits use the [agent] prefix and are signed off.
- [x] Files were staged by name; no force-push, amend, --no-verify, git add ., or git add -A.
