### PR TITLE
[agent] fix(types): model the family class namespace once — PiiClass::family + shared non-normalizing parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`custom:family:*` policy classes now preserve the collision-family namespace**
+  (audit S05-F1, solo todo #2934). `PiiClass::from_policy_name` previously
+  normalized the reserved `family:` separator and hyphenated family name, so a
+  protective class rule could silently miss a family-level ambiguity token and
+  preserve the original value. `PiiClass::family` and `as_family_name` now model
+  that namespace once, and policy and rulepack parsing share the same
+  non-normalizing path. The enum and manifest wire shape are unchanged.
+
 - **The ORT NER backend now hands the BIO decoder the document text, not its
   provenance label** (audit S07-F1, solo todo #2902). `OrtBackend::detect` passed
   the constant `"ner/ort"` where `merge_bio_span_results` expected the string

--- a/crates/gaze-assembly/src/defaults.rs
+++ b/crates/gaze-assembly/src/defaults.rs
@@ -173,7 +173,7 @@ fn class_rules_from_rulepacks(rulepacks: &[Rulepack]) -> Vec<RuleSpec> {
                     .as_ref()
                     .map(|_| &collision.family)
             })
-            .map(|family| PiiClass::Custom(format!("family:{family}")))
+            .map(|family| PiiClass::family(family))
         {
             if seen.insert(family_class.clone()) {
                 rules.push(RuleSpec::Class {

--- a/crates/gaze-assembly/src/lib.rs
+++ b/crates/gaze-assembly/src/lib.rs
@@ -188,7 +188,7 @@ pub fn uncovered_collision_family_classes(
     mandatory_anchor_families(policy, rulepacks, active_locales)
         .into_iter()
         .filter(|family| {
-            let family_class = PiiClass::Custom(format!("family:{family}"));
+            let family_class = PiiClass::family(family);
             !live_rules
                 .iter()
                 .any(|rule| matches!(rule, RuleSpec::Class { class, .. } if *class == family_class))

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -784,7 +784,7 @@ fn class_rules_for_bundled_overrides(
                                 .as_ref()
                                 .map(|_| &collision.family)
                         })
-                        .map(|family| PiiClass::Custom(format!("family:{family}")))
+                        .map(|family| PiiClass::family(family))
                 }),
         );
     }

--- a/crates/gaze-recognizers/examples/clean_for_bench.rs
+++ b/crates/gaze-recognizers/examples/clean_for_bench.rs
@@ -791,7 +791,7 @@ fn benchmark_policy(rulepack: &Rulepack, auto_activate_locale_gated: bool) -> ga
             collision
                 .mandatory_anchor
                 .as_ref()
-                .map(|_| PiiClass::Custom(format!("family:{}", collision.family)))
+                .map(|_| PiiClass::family(&collision.family))
         }) {
             if seen.insert(family_class.clone()) {
                 rules.push(RuleSpec::Class {

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -233,16 +233,25 @@ impl CollisionMembership {
 impl PiiClass {
     /// Parses a policy class name into the shared class vocabulary.
     pub fn from_policy_name(input: &str) -> Option<Self> {
-        match input {
+        let trimmed = input.trim();
+        match trimmed.to_ascii_lowercase().as_str() {
             "email" => Some(Self::Email),
             "name" => Some(Self::Name),
             "location" => Some(Self::Location),
             "organization" => Some(Self::Organization),
-            custom if custom.starts_with("custom:") => {
-                let name = custom.trim_start_matches("custom:");
-                (!name.trim().is_empty()).then(|| Self::custom(name))
-            }
-            _ => None,
+            _ => trimmed
+                .split_once(':')
+                .filter(|(namespace, _)| namespace.eq_ignore_ascii_case("custom"))
+                .and_then(|(_, name)| Self::from_custom_policy_suffix(name)),
+        }
+    }
+
+    fn from_custom_policy_suffix(name: &str) -> Option<Self> {
+        let name = name.trim();
+        if let Some(family) = name.strip_prefix("family:") {
+            (!family.trim().is_empty()).then(|| Self::family(family))
+        } else {
+            (!name.is_empty()).then(|| Self::custom(name))
         }
     }
 
@@ -275,12 +284,22 @@ impl PiiClass {
         Self::Custom(normalized)
     }
 
+    /// Builds a collision-family class without normalizing its reserved namespace.
+    pub fn family(name: &str) -> Self {
+        Self::Custom(format!("family:{}", name.trim()))
+    }
+
     /// Returns the normalized custom class name for custom classes.
     pub fn as_custom_name(&self) -> Option<&str> {
         match self {
             Self::Custom(name) => Some(name.as_str()),
             Self::Email | Self::Name | Self::Location | Self::Organization => None,
         }
+    }
+
+    /// Returns the collision-family name for family classes.
+    pub fn as_family_name(&self) -> Option<&str> {
+        self.as_custom_name()?.strip_prefix("family:")
     }
 
     /// Returns the audit/token display label for this class.
@@ -317,6 +336,22 @@ impl PiiClass {
                 (!name.is_empty()).then(|| Self::Custom(name.to_string()))
             }
             _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod pii_class_tests {
+    use super::*;
+
+    #[test]
+    fn bundled_family_policy_names_round_trip_without_normalization() {
+        for family in RESERVED_BUNDLED_FAMILIES {
+            let policy_name = format!("custom:family:{family}");
+            let class = PiiClass::from_policy_name(&policy_name).expect("family policy class");
+
+            assert_eq!(class.to_canonical_str(), policy_name);
+            assert_eq!(class.as_family_name(), Some(*family));
         }
     }
 }

--- a/crates/gaze/src/conflict/hybrid_fallback.rs
+++ b/crates/gaze/src/conflict/hybrid_fallback.rs
@@ -16,7 +16,7 @@ pub(crate) fn emit(
         .recognizer_id
         .strip_prefix("collision-family:")?
         .to_string();
-    let class = PiiClass::Custom(format!("family:{family}"));
+    let class = PiiClass::family(&family);
     let mut losing_candidates = candidate
         .merged_sources
         .iter()

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -5070,6 +5070,81 @@ mod tests {
     }
 
     #[test]
+    fn policy_family_rule_matches_a_precedence_tie_candidate() {
+        struct TieRecognizer {
+            id: &'static str,
+            class: PiiClass,
+        }
+
+        impl Recognizer for TieRecognizer {
+            fn id(&self) -> &str {
+                self.id
+            }
+
+            fn supported_class(&self) -> &PiiClass {
+                &self.class
+            }
+
+            fn detect(
+                &self,
+                input: &str,
+                _ctx: &DetectContext<'_>,
+            ) -> std::result::Result<Vec<Candidate>, gaze_types::DetectError> {
+                Ok(vec![Candidate::new(
+                    0..input.len(),
+                    self.class.clone(),
+                    self.id(),
+                    1.0,
+                    0,
+                    None,
+                    self.token_family(),
+                    self.id(),
+                    ConflictTier::None,
+                    Vec::new(),
+                )])
+            }
+
+            fn token_family(&self) -> &str {
+                "document"
+            }
+        }
+
+        let family_class = PiiClass::from_policy_name("custom:family:tenant-document")
+            .expect("family policy class");
+        let pipeline = Pipeline::builder()
+            .recognizer(TieRecognizer {
+                id: "doc.alpha",
+                class: PiiClass::custom("alpha"),
+            })
+            .recognizer(TieRecognizer {
+                id: "doc.beta",
+                class: PiiClass::custom("beta"),
+            })
+            .register_collision(
+                "doc.alpha",
+                CollisionMembership::new("tenant-document", "alpha", 10, None),
+            )
+            .register_collision(
+                "doc.beta",
+                CollisionMembership::new("tenant-document", "beta", 10, None),
+            )
+            .rule(ClassRule::new(family_class, Action::Tokenize))
+            .rule(DefaultRule::new(Action::Preserve))
+            .build()
+            .expect("pipeline");
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        let clean = pipeline
+            .redact(&session, RawDocument::Text("CASE-0001".to_string()))
+            .expect("redact");
+
+        let CleanDocument::Text(text) = clean else {
+            panic!("expected text");
+        };
+        assert_ne!(text, "CASE-0001");
+    }
+
+    #[test]
     fn t21d_token_family_threads_from_recognizer_to_session() {
         struct FamilyRecognizer;
 

--- a/crates/gaze/src/policy.rs
+++ b/crates/gaze/src/policy.rs
@@ -748,29 +748,7 @@ fn expand_home(path: String) -> Result<PathBuf, PolicyError> {
 }
 
 fn parse_class(input: &str) -> Result<PiiClass, PolicyError> {
-    let lower = input.trim().to_ascii_lowercase();
-    match lower.as_str() {
-        "email" => Ok(PiiClass::Email),
-        "name" => Ok(PiiClass::Name),
-        "location" => Ok(PiiClass::Location),
-        "organization" => Ok(PiiClass::Organization),
-        custom if custom.starts_with("custom:") => {
-            let name = input
-                .trim()
-                .split_once(':')
-                .map(|(_, name)| name)
-                .unwrap_or_default();
-            if name.trim().is_empty() {
-                return Err(PolicyError::UnknownClass(input.to_string()));
-            }
-            if name.starts_with("family:") {
-                Ok(PiiClass::Custom(name.to_string()))
-            } else {
-                Ok(PiiClass::custom(name))
-            }
-        }
-        _ => Err(PolicyError::UnknownClass(input.to_string())),
-    }
+    PiiClass::from_policy_name(input).ok_or_else(|| PolicyError::UnknownClass(input.to_string()))
 }
 
 fn parse_action(input: &str) -> Result<Action, PolicyError> {
@@ -793,6 +771,19 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn bundled_family_policy_classes_preserve_the_family_namespace() {
+        for family in RESERVED_BUNDLED_FAMILIES {
+            let policy_name = format!("custom:family:{family}");
+            assert_eq!(
+                parse_class(&policy_name)
+                    .expect("family policy class")
+                    .to_canonical_str(),
+                policy_name
+            );
+        }
+    }
 
     #[test]
     fn loads_policy_and_expands_home() {

--- a/crates/gaze/src/resolver.rs
+++ b/crates/gaze/src/resolver.rs
@@ -310,7 +310,7 @@ fn family_tie_candidate(
     merged_sources.dedup();
     Some(Candidate::new(
         candidate.span.start.min(existing.span.start)..candidate.span.end.max(existing.span.end),
-        PiiClass::Custom(format!("family:{family}")),
+        PiiClass::family(family),
         format!("collision-family:{family}"),
         candidate.score.max(existing.score),
         candidate.priority.max(existing.priority),
@@ -351,7 +351,7 @@ fn family_fallback_candidate(
     let original_recognizer_id = candidate.recognizer_id.clone();
     Candidate::new(
         candidate.span,
-        PiiClass::Custom(format!("family:{family}")),
+        PiiClass::family(&family),
         format!("collision-family:{family}"),
         candidate.score,
         candidate.priority,

--- a/crates/gaze/src/rulepack.rs
+++ b/crates/gaze/src/rulepack.rs
@@ -344,7 +344,7 @@ impl Rulepack {
                         .as_ref()
                         .map(|_| &collision.family)
                 })
-                .map(|family| PiiClass::Custom(format!("family:{family}")))
+                .map(|family| PiiClass::family(family))
             {
                 classes.insert(family_class);
             }
@@ -1180,29 +1180,7 @@ fn has_regex_separator(pattern: &str) -> bool {
 }
 
 pub fn parse_class(input: &str) -> Result<PiiClass, RulepackError> {
-    let trimmed = input.trim();
-    let lower = trimmed.to_ascii_lowercase();
-    match lower.as_str() {
-        "email" => Ok(PiiClass::Email),
-        "name" => Ok(PiiClass::Name),
-        "location" => Ok(PiiClass::Location),
-        "organization" => Ok(PiiClass::Organization),
-        custom if custom.starts_with("custom:") => {
-            let name = trimmed
-                .split_once(':')
-                .map(|(_, name)| name)
-                .unwrap_or_default();
-            if name.trim().is_empty() {
-                return Err(RulepackError::UnknownClass(input.to_string()));
-            }
-            if name.starts_with("family:") {
-                Ok(PiiClass::Custom(name.to_string()))
-            } else {
-                Ok(PiiClass::custom(name))
-            }
-        }
-        _ => Err(RulepackError::UnknownClass(input.to_string())),
-    }
+    PiiClass::from_policy_name(input).ok_or_else(|| RulepackError::UnknownClass(input.to_string()))
 }
 
 fn parse_locales(locales: Vec<String>) -> Result<Vec<LocaleTag>, RulepackError> {
@@ -1906,6 +1884,19 @@ rulepack_version = "0.4.0"
             parse_class("custom:Class_Alpha").unwrap(),
             PiiClass::Custom("class_alpha".to_string())
         );
+    }
+
+    #[test]
+    fn bundled_family_rulepack_classes_preserve_the_family_namespace() {
+        for family in crate::RESERVED_BUNDLED_FAMILIES {
+            let policy_name = format!("custom:family:{family}");
+            assert_eq!(
+                parse_class(&policy_name)
+                    .expect("family rulepack class")
+                    .to_canonical_str(),
+                policy_name
+            );
+        }
     }
 
     fn unsupported_field_rulepack(extra: &str) -> String {


### PR DESCRIPTION
## Defect

`PiiClass::from_policy_name("custom:family:x")` normalized the reserved family namespace to `Custom("family_x")`, while policy and rulepack parsers carried separate bypasses that produced `Custom("family:x")`. A protective family-class rule built through the shared public parser therefore never matched a family-level ambiguity token, allowing the original value to be preserved.

## Fix

- add `PiiClass::family` and `as_family_name` without adding a wire enum variant
- make all three policy-name parser paths share one non-normalizing family suffix parser
- replace all eight crate-local `format!("family:...")` class constructions with the constructor
- document the adopter-visible fix under Unreleased

The manifest and serde shape remain unchanged. No north-star axis is weakened.

## Red / green evidence

- RED: bundled family round-trip returned `custom:family_us_9_digit_id` instead of `custom:family:us-9-digit-id`
- RED: the precedence-tie pipeline test returned unchanged `CASE-0001` under a protective family rule
- GREEN: all three parser-path tests and the end-to-end precedence-tie policy test pass

## Mutation probe

Temporarily normalizing the precedence-tie construction site made `policy_family_rule_matches_a_precedence_tie_candidate` fail with unchanged `CASE-0001`; restoring `PiiClass::family` made it pass.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`

Audit: solo scratchpad 7201 S05-F1

Resolves solo todo #2934
