### PR TITLE
[agent] fix(token-bridge): document-once persistent index with derived postings and upsert (schema v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Persistent owner-side corpus index schema v2: each document is stored
+  once, postings are derived on load, and re-ingest upserts** (audit 7201
+  S17-F1, todo #2936). `gaze_token_bridge::persistent::FileCorpusIndexStore`
+  previously wrote one record per distinct fingerprint, each carrying a full
+  copy of the document (snippet plus every entity's raw value), so a document
+  with E entities was duplicated E times on disk, and re-ingesting a `doc_id`
+  without clearing the domain left the stale copy first in scan order (the
+  stale snippet won). Raw document snippets and entity values are now persisted
+  exactly once per `(domain_id, doc_id)`; the fingerprint-to-document postings
+  map is rebuilt on load and never written to disk; `insert_hit` replaces an
+  existing `(domain_id, doc_id)` outright, and `clear_domain` + `save` leaves
+  no document bytes in the sealed payload.
+
+  **Breaking for existing local index files.** `SCHEMA_VERSION` is now `2`.
+  Loading a v1 `index.json` fails closed with the typed
+  `unsupported owner-side index schema 1; supported 2` error (the version is
+  checked before the payload shape, so there is no partial or reinterpreted
+  load), and a v2 payload carrying duplicate document keys is rejected the
+  same way. Rebuild local indexes by re-running `gaze index ingest <dir>`.
+  The `entities: N` metric printed by `gaze index ingest` keeps its meaning
+  (indexed document/fingerprint pairs). `FileCorpusIndexStore::hit_count_for_domain`
+  was removed (it had no callers). The AEAD/key layer and the sealed-file
+  envelope are unchanged.
+
 - **`gaze_assembly::build_pipeline` derives its `NoRecognizers` guard from
   actual registration and uses one locale predicate** (audit 7201 S10-F1,
   todo #2928). The guard now fails closed when zero recognizers were

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -179,7 +179,10 @@ ChaCha20-Poly1305. Default key resolution is fail-closed and headless-friendly:
 `--features os-keychain` adds OS keychain fallback for desktop use: macOS
 Keychain, Windows Credential Manager, or Linux kernel keyutils (no dbus). If no
 key source is available, `gaze index` refuses to read or write the index, and
-legacy plaintext `index.json` files are not loaded.
+legacy plaintext `index.json` files are not loaded. The sealed payload is
+schema-versioned (currently v2: one record per document, with the search
+postings derived on load); when a file's schema does not match the loader,
+`gaze index` fails closed and the index must be rebuilt with `gaze index ingest`.
 
 Search output is the bridge's agent-facing response: snippets contain only
 current-session tokens, never raw PII or index-domain aliases. The v1 ingest path

--- a/crates/gaze-token-bridge/src/persistent.rs
+++ b/crates/gaze-token-bridge/src/persistent.rs
@@ -4,8 +4,13 @@
 //! serialization for [`crate::model::IndexSearchHit`]. Raw values are sealed
 //! inside the owner-side index file; the frozen agent-visible contract stays
 //! non-serializable for owner hits.
+//!
+//! Layout (schema v2): each document is persisted exactly once, keyed by
+//! `(domain_id, doc_id)`. The fingerprint -> document postings map is derived
+//! on load and never written to disk, so raw PII exists in one place per
+//! document and re-ingesting a `doc_id` replaces (never shadows) its bytes.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -36,7 +41,7 @@ pub const LOCAL_TOOL_NAME: &str = "gaze_index_search";
 pub const LOCAL_ACTION: &str = "search_documents";
 pub const LOCAL_PURPOSE: &str = "owner_lookup";
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const DEFAULT_MAX_RESULTS: usize = 20;
 // follow-up: extract shared gaze-crypto seal/open with gaze-mcp-bridge session storage.
 // follow-up: add explicit owner-side index key rotation without plaintext migration fallback.
@@ -57,12 +62,17 @@ const INDEX_AAD_CONTEXT: &[u8] = b"gaze-token-bridge-owner-index-v1";
 static KEYCHAIN_DISABLED_FOR_TESTS: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Derived inverted index: domain -> fingerprint -> positions into
+/// `PersistentIndexFile::documents`. Rebuilt on load, never persisted.
+type Postings = HashMap<DomainId, HashMap<String, Vec<usize>>>;
+
 /// File-backed owner-side corpus index store.
 #[derive(Debug, Clone)]
 pub struct FileCorpusIndexStore {
     dir: PathBuf,
     file: PersistentIndexFile,
     index_id: [u8; INDEX_ID_LEN],
+    postings: Postings,
 }
 
 impl FileCorpusIndexStore {
@@ -80,23 +90,34 @@ impl FileCorpusIndexStore {
         let key = resolve_index_key_for_load(&dir, &envelope)?;
         let index_id = parsed_index_id(&envelope)?;
         let plaintext = decrypt_index_file(&key.material, envelope.index_id, &envelope)?;
+        // Probe the schema version before the full parse so an older layout
+        // yields the typed schema-mismatch error, not a field-shape parse error.
+        let probe: SchemaProbe = serde_json::from_slice(&plaintext).map_err(|err| {
+            BridgeError::Policy(format!(
+                "failed to parse owner-side index {}: {err}",
+                index_path.display()
+            ))
+        })?;
+        if probe.schema_version != SCHEMA_VERSION {
+            return Err(BridgeError::Policy(format!(
+                "unsupported owner-side index schema {}; supported {}; rebuild with `gaze index ingest ...`",
+                probe.schema_version, SCHEMA_VERSION
+            )));
+        }
         let file: PersistentIndexFile = serde_json::from_slice(&plaintext).map_err(|err| {
             BridgeError::Policy(format!(
                 "failed to parse owner-side index {}: {err}",
                 index_path.display()
             ))
         })?;
-        if file.schema_version != SCHEMA_VERSION {
-            return Err(BridgeError::Policy(format!(
-                "unsupported owner-side index schema {}; supported {}",
-                file.schema_version, SCHEMA_VERSION
-            )));
-        }
-        Ok(Self {
+        let mut store = Self {
             dir,
             file,
             index_id,
-        })
+            postings: Postings::new(),
+        };
+        store.rebuild_postings()?;
+        Ok(store)
     }
 
     /// Load an existing index, or create a new one with `domain_id` registered.
@@ -114,6 +135,7 @@ impl FileCorpusIndexStore {
                 dir,
                 file: PersistentIndexFile::default(),
                 index_id: random_index_id(),
+                postings: Postings::new(),
             }
         };
         store.ensure_domain(domain_id, classes)?;
@@ -178,10 +200,13 @@ impl FileCorpusIndexStore {
             .find(|domain| domain.domain_id == domain_id)
     }
 
+    /// Remove every stored document for `domain_id`. After `save`, none of
+    /// their bytes remain in the sealed payload.
     pub fn clear_domain(&mut self, domain_id: &str) {
         self.file
-            .entries
-            .retain(|entry| entry.domain_id != domain_id);
+            .documents
+            .retain(|document| document.domain_id != domain_id);
+        self.rebuild_postings_unchecked();
     }
 
     pub fn ensure_domain(
@@ -238,55 +263,126 @@ impl FileCorpusIndexStore {
             .map_err(|err| BridgeError::Policy(format!("failed to encode policy: {err}")))
     }
 
-    pub fn hit_count_for_domain(&self, domain_id: &str) -> usize {
-        self.file
-            .entries
-            .iter()
-            .filter(|entry| entry.domain_id == domain_id)
-            .map(|entry| entry.hit.doc_id.as_str())
-            .collect::<HashSet<_>>()
-            .len()
+    /// Number of `(document, fingerprint)` pairs indexed for `domain_id`
+    /// (the `entities: N` metric printed by `gaze index ingest`).
+    pub fn entity_count_for_domain(&self, domain_id: &str) -> usize {
+        self.postings
+            .get(domain_id)
+            .map(|by_fingerprint| by_fingerprint.values().map(Vec::len).sum())
+            .unwrap_or(0)
     }
 
-    pub fn entity_count_for_domain(&self, domain_id: &str) -> usize {
+    fn document_position(&self, domain_id: &str, doc_id: &str) -> Option<usize> {
         self.file
-            .entries
+            .documents
             .iter()
-            .filter(|entry| entry.domain_id == domain_id)
-            .count()
+            .position(|document| document.domain_id == domain_id && document.hit.doc_id == doc_id)
+    }
+
+    /// Rebuild the derived postings from the persisted documents, failing
+    /// closed if the payload violates the one-record-per-`(domain, doc_id)`
+    /// invariant (a hand-edited or corrupted file must not resurrect shadowed
+    /// document copies).
+    fn rebuild_postings(&mut self) -> Result<(), BridgeError> {
+        let mut seen = HashSet::new();
+        for document in &self.file.documents {
+            if !seen.insert((document.domain_id.as_str(), document.hit.doc_id.as_str())) {
+                return Err(BridgeError::Policy(
+                    "owner-side index has duplicate document keys; rebuild with `gaze index ingest ...`"
+                        .to_string(),
+                ));
+            }
+        }
+        self.rebuild_postings_unchecked();
+        Ok(())
+    }
+
+    fn rebuild_postings_unchecked(&mut self) {
+        self.postings.clear();
+        for position in 0..self.file.documents.len() {
+            self.add_postings_for(position);
+        }
+    }
+
+    /// Append `position` to every fingerprint posting list of that document.
+    /// Positions are only ever added in ascending order, so each posting list
+    /// stays sorted by document order and `hits_for_entity` is order-stable
+    /// across save + load.
+    fn add_postings_for(&mut self, position: usize) {
+        let document = &self.file.documents[position];
+        let domain_id = document.domain_id.clone();
+        let fingerprints = document_fingerprints(&domain_id, &document.hit);
+        let by_fingerprint = self.postings.entry(domain_id).or_default();
+        for fingerprint_hex in fingerprints {
+            by_fingerprint
+                .entry(fingerprint_hex)
+                .or_default()
+                .push(position);
+        }
     }
 }
 
+/// Distinct fingerprints of `hit` that live in `domain_id`, in first-seen order.
+fn document_fingerprints(domain_id: &str, hit: &StoredHit) -> Vec<String> {
+    let mut seen = HashSet::new();
+    hit.entities
+        .iter()
+        .filter(|entity| entity.index_ref.domain_id == domain_id)
+        .filter(|entity| seen.insert(entity.index_ref.fingerprint_hex.as_str()))
+        .map(|entity| entity.index_ref.fingerprint_hex.clone())
+        .collect()
+}
+
 impl CorpusIndexStore for FileCorpusIndexStore {
+    /// Upsert on `(domain_id, doc_id)`: a re-ingested document replaces its
+    /// previous copy outright, so stale snippets and raw values never survive.
+    /// A document with no fingerprint in `domain_id` is unreachable through
+    /// `hits_for_entity`, so it is not stored (and any previous copy is erased).
     fn insert_hit(&mut self, domain_id: DomainId, hit: IndexSearchHit) {
         let stored_hit = StoredHit::from(&hit);
-        let mut fingerprints = HashSet::new();
-        for entity in &hit.entities {
-            if entity.index_ref.domain_id == domain_id {
-                fingerprints.insert(entity.index_ref.fingerprint_hex.clone());
+        let reachable = !document_fingerprints(&domain_id, &stored_hit).is_empty();
+        let existing = self.document_position(&domain_id, &hit.doc_id);
+
+        match (existing, reachable) {
+            (Some(position), true) => {
+                self.file.documents[position].hit = stored_hit;
+                self.rebuild_postings_unchecked();
             }
-        }
-        for fingerprint_hex in fingerprints {
-            self.file.entries.push(StoredIndexEntry {
-                domain_id: domain_id.clone(),
-                fingerprint_hex,
-                hit: stored_hit.clone(),
-            });
+            (Some(position), false) => {
+                self.file.documents.remove(position);
+                self.rebuild_postings_unchecked();
+            }
+            (None, true) => {
+                self.file.documents.push(StoredDocument {
+                    domain_id,
+                    hit: stored_hit,
+                });
+                self.add_postings_for(self.file.documents.len() - 1);
+            }
+            (None, false) => {}
         }
     }
 
     fn hits_for_entity(&self, domain_id: &DomainId, fingerprint_hex: &str) -> Vec<IndexSearchHit> {
-        let mut seen_doc_ids = HashSet::new();
-        self.file
-            .entries
-            .iter()
-            .filter(|entry| {
-                &entry.domain_id == domain_id && entry.fingerprint_hex == fingerprint_hex
+        self.postings
+            .get(domain_id)
+            .and_then(|by_fingerprint| by_fingerprint.get(fingerprint_hex))
+            .map(|positions| {
+                positions
+                    .iter()
+                    .filter_map(|position| self.file.documents.get(*position))
+                    .map(|document| document.hit.to_index_hit())
+                    .collect()
             })
-            .filter(|entry| seen_doc_ids.insert(entry.hit.doc_id.clone()))
-            .map(|entry| entry.hit.to_index_hit())
-            .collect()
+            .unwrap_or_default()
     }
+}
+
+/// Minimal shape read before the full parse so schema drift fails closed with
+/// the typed schema-mismatch error instead of a field-shape parse error.
+#[derive(Debug, Deserialize)]
+struct SchemaProbe {
+    schema_version: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -295,7 +391,9 @@ struct PersistentIndexFile {
     domains: Vec<IndexDomain>,
     projection_keys: Vec<StoredProjectionKey>,
     rules: Vec<PolicyRule>,
-    entries: Vec<StoredIndexEntry>,
+    /// One record per `(domain_id, doc_id)`; the searchable postings are
+    /// derived from these on load.
+    documents: Vec<StoredDocument>,
 }
 
 impl Default for PersistentIndexFile {
@@ -305,7 +403,7 @@ impl Default for PersistentIndexFile {
             domains: Vec::new(),
             projection_keys: Vec::new(),
             rules: Vec::new(),
-            entries: Vec::new(),
+            documents: Vec::new(),
         }
     }
 }
@@ -317,9 +415,8 @@ struct StoredProjectionKey {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct StoredIndexEntry {
+struct StoredDocument {
     domain_id: DomainId,
-    fingerprint_hex: String,
     hit: StoredHit,
 }
 
@@ -1503,6 +1600,25 @@ mod tests {
             !text.contains("legacy"),
             "error must not echo payload contents"
         );
+    }
+
+    #[test]
+    fn schema_v2_payload_with_duplicate_document_keys_fails_closed() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = IndexKeyEnvGuard::set(TEST_KEY_1);
+        let dir = TestDir::new("duplicate-doc-keys");
+        let (mut store, _) = fixture_store(dir.path());
+        // Bypass the upsert path to forge a payload that violates the
+        // one-record-per-(domain, doc_id) invariant.
+        let duplicate = store.file.documents[0].clone();
+        store.file.documents.push(duplicate);
+        store.save().expect("save forged payload");
+
+        let err = FileCorpusIndexStore::load(dir.path())
+            .expect_err("duplicate document keys must fail closed on load");
+        let text = format!("{err:?}");
+        assert!(text.contains("duplicate document keys"), "got: {text}");
+        assert!(!text.contains(RAW_EMAIL));
     }
 
     fn synthetic_entity(key_id: &str, class: PiiClass, prefix: &str, raw: &str) -> IndexEntity {

--- a/crates/gaze-token-bridge/src/persistent.rs
+++ b/crates/gaze-token-bridge/src/persistent.rs
@@ -1226,6 +1226,328 @@ mod tests {
         assert!(!text.contains(RAW_EMAIL));
     }
 
+    // Synthetic re-ingest fixture: two revisions of the same doc_id, distinct raw
+    // values, so stale bytes from revision one are detectable in the payload.
+    const UPSERT_DOC_ID: &str = "doc:synthetic-upsert-fixture";
+    const REV1_MARKER: &str = "SNIPPET-REV1-MARKER-7f3a";
+    const REV2_MARKER: &str = "SNIPPET-REV2-MARKER-9c1e";
+    const REV1_EMAIL: &str = "rev1.stale@example.invalid";
+    const REV2_EMAIL: &str = "rev2.current@example.invalid";
+    const REV2_NAME: &str = "Rev Two Person";
+
+    #[test]
+    fn reingesting_same_doc_id_replaces_document_and_leaves_no_stale_bytes() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = IndexKeyEnvGuard::set(TEST_KEY_1);
+        let dir = TestDir::new("upsert");
+        let mut store =
+            FileCorpusIndexStore::load_or_create(dir.path(), DEFAULT_DOMAIN_ID, &[PiiClass::Email])
+                .expect("create store");
+        let key_id = store
+            .file
+            .projection_keys
+            .first()
+            .expect("projection key")
+            .key_id
+            .clone();
+
+        let rev1_email = synthetic_entity(&key_id, PiiClass::Email, "email", REV1_EMAIL);
+        let rev1_fp = rev1_email.index_ref.fingerprint_hex.clone();
+        store.insert_hit(
+            DEFAULT_DOMAIN_ID.to_string(),
+            IndexSearchHit {
+                doc_id: UPSERT_DOC_ID.to_string(),
+                snippet: format!("{REV1_MARKER} contact {}", rev1_email.domain_alias),
+                entities: vec![rev1_email],
+            },
+        );
+
+        // Revision two carries two entities so per-fingerprint duplication of the
+        // document copy would show up as two REV2_MARKER occurrences.
+        let rev2_email = synthetic_entity(&key_id, PiiClass::Email, "email", REV2_EMAIL);
+        let rev2_name = synthetic_entity(&key_id, PiiClass::Name, "name", REV2_NAME);
+        let rev2_email_fp = rev2_email.index_ref.fingerprint_hex.clone();
+        let rev2_name_fp = rev2_name.index_ref.fingerprint_hex.clone();
+        store.insert_hit(
+            DEFAULT_DOMAIN_ID.to_string(),
+            IndexSearchHit {
+                doc_id: UPSERT_DOC_ID.to_string(),
+                snippet: format!(
+                    "{REV2_MARKER} contact {} and {}",
+                    rev2_email.domain_alias, rev2_name.domain_alias
+                ),
+                entities: vec![rev2_email, rev2_name],
+            },
+        );
+        store.save().expect("save sealed index");
+
+        let domain = DEFAULT_DOMAIN_ID.to_string();
+        for (label, target) in [
+            ("in-memory", &store),
+            (
+                "reloaded",
+                &FileCorpusIndexStore::load(dir.path()).expect("reload"),
+            ),
+        ] {
+            assert!(
+                target.hits_for_entity(&domain, &rev1_fp).is_empty(),
+                "{label}: stale revision-one entity must not be searchable after upsert"
+            );
+            let email_hits = target.hits_for_entity(&domain, &rev2_email_fp);
+            assert_eq!(
+                email_hits.len(),
+                1,
+                "{label}: exactly one document for rev2 email"
+            );
+            assert_eq!(email_hits[0].doc_id, UPSERT_DOC_ID);
+            assert!(email_hits[0].snippet.starts_with(REV2_MARKER));
+            let name_hits = target.hits_for_entity(&domain, &rev2_name_fp);
+            assert_eq!(
+                name_hits.len(),
+                1,
+                "{label}: exactly one document for rev2 name"
+            );
+            assert!(name_hits[0].snippet.starts_with(REV2_MARKER));
+        }
+
+        let plaintext = decrypted_index_plaintext(dir.path());
+        assert_eq!(
+            count_occurrences(&plaintext, REV1_MARKER.as_bytes()),
+            0,
+            "stale revision-one snippet bytes must be absent from the sealed payload"
+        );
+        assert_eq!(
+            count_occurrences(&plaintext, REV1_EMAIL.as_bytes()),
+            0,
+            "stale revision-one raw value must be absent from the sealed payload"
+        );
+        assert_eq!(
+            count_occurrences(&plaintext, REV2_MARKER.as_bytes()),
+            1,
+            "current document snippet must be stored exactly once (not once per fingerprint)"
+        );
+        assert_eq!(
+            count_occurrences(&plaintext, REV2_EMAIL.as_bytes()),
+            1,
+            "current raw value must be stored exactly once"
+        );
+
+        // Erasure reachability: clearing the domain must leave no document bytes behind.
+        store.clear_domain(DEFAULT_DOMAIN_ID);
+        store.save().expect("save cleared index");
+        let cleared = decrypted_index_plaintext(dir.path());
+        assert_eq!(count_occurrences(&cleared, REV2_MARKER.as_bytes()), 0);
+        assert_eq!(count_occurrences(&cleared, REV2_EMAIL.as_bytes()), 0);
+        assert_eq!(count_occurrences(&cleared, REV2_NAME.as_bytes()), 0);
+        assert!(FileCorpusIndexStore::load(dir.path())
+            .expect("reload cleared")
+            .hits_for_entity(&domain, &rev2_email_fp)
+            .is_empty());
+    }
+
+    #[test]
+    fn postings_rebuilt_on_load_match_in_memory_and_documents_persist_once() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = IndexKeyEnvGuard::set(TEST_KEY_1);
+        let dir = TestDir::new("postings-fidelity");
+        let mut store =
+            FileCorpusIndexStore::load_or_create(dir.path(), DEFAULT_DOMAIN_ID, &[PiiClass::Email])
+                .expect("create store");
+        let key_id = store
+            .file
+            .projection_keys
+            .first()
+            .expect("projection key")
+            .key_id
+            .clone();
+
+        // Overlapping fingerprints across four documents:
+        //   fp_a -> docs 0,1,2   fp_b -> docs 1,3   fp_c -> doc 2 only
+        let entity_a = || {
+            synthetic_entity(
+                &key_id,
+                PiiClass::Email,
+                "email",
+                "shared.a@example.invalid",
+            )
+        };
+        let entity_b = || {
+            synthetic_entity(
+                &key_id,
+                PiiClass::Email,
+                "email",
+                "shared.b@example.invalid",
+            )
+        };
+        let entity_c = || synthetic_entity(&key_id, PiiClass::Name, "name", "Only In Doc Two");
+        let docs: Vec<(usize, Vec<IndexEntity>)> = vec![
+            (0, vec![entity_a()]),
+            (1, vec![entity_a(), entity_b()]),
+            (2, vec![entity_a(), entity_c()]),
+            (3, vec![entity_b()]),
+        ];
+        let fingerprints = [
+            entity_a().index_ref.fingerprint_hex,
+            entity_b().index_ref.fingerprint_hex,
+            entity_c().index_ref.fingerprint_hex,
+            "00".repeat(32),
+        ];
+        for (index, entities) in docs {
+            let aliases = entities
+                .iter()
+                .map(|entity| entity.domain_alias.clone())
+                .collect::<Vec<_>>()
+                .join(" ");
+            store.insert_hit(
+                DEFAULT_DOMAIN_ID.to_string(),
+                IndexSearchHit {
+                    doc_id: format!("doc:synthetic-{index}"),
+                    snippet: format!("doc {index} mentions {aliases}"),
+                    entities,
+                },
+            );
+        }
+        let domain = DEFAULT_DOMAIN_ID.to_string();
+        let before = fingerprints
+            .iter()
+            .map(|fingerprint| stored_hits(&store, &domain, fingerprint))
+            .collect::<Vec<_>>();
+        assert_eq!(before[0].len(), 3);
+        assert_eq!(before[1].len(), 2);
+        assert_eq!(before[2].len(), 1);
+        assert!(before[3].is_empty());
+        assert_eq!(store.entity_count_for_domain(DEFAULT_DOMAIN_ID), 6);
+
+        store.save().expect("save sealed index");
+        let loaded = FileCorpusIndexStore::load(dir.path()).expect("load sealed index");
+        let after = fingerprints
+            .iter()
+            .map(|fingerprint| stored_hits(&loaded, &domain, fingerprint))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            after, before,
+            "postings rebuilt on load must be order-stable and identical"
+        );
+        assert_eq!(loaded.entity_count_for_domain(DEFAULT_DOMAIN_ID), 6);
+
+        // On-disk shape: one document record per distinct doc, no persisted postings.
+        let plaintext = decrypted_index_plaintext(dir.path());
+        let value: serde_json::Value =
+            serde_json::from_slice(&plaintext).expect("sealed payload is json");
+        assert_eq!(value["schema_version"], serde_json::json!(SCHEMA_VERSION));
+        assert_eq!(
+            value["documents"]
+                .as_array()
+                .expect("documents array persisted")
+                .len(),
+            4,
+            "sealed payload must hold exactly one record per distinct document"
+        );
+        let mut keys = value
+            .as_object()
+            .expect("top-level object")
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            [
+                "documents",
+                "domains",
+                "projection_keys",
+                "rules",
+                "schema_version"
+            ],
+            "postings are derived on load and must not be persisted"
+        );
+    }
+
+    #[test]
+    fn schema_v1_index_fails_closed_with_typed_schema_error() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _env = IndexKeyEnvGuard::set(TEST_KEY_1);
+        let dir = TestDir::new("schema-v1");
+        // The v1 layout: per-fingerprint `entries`, each carrying a full hit copy.
+        let v1_plaintext = format!(
+            concat!(
+                r#"{{"schema_version":1,"domains":[],"projection_keys":[],"rules":[],"#,
+                r#""entries":[{{"domain_id":"{domain}","fingerprint_hex":"{fp}","#,
+                r#""hit":{{"doc_id":"doc:v1","snippet":"legacy","entities":[]}}}}]}}"#
+            ),
+            domain = DEFAULT_DOMAIN_ID,
+            fp = "ab".repeat(32),
+        );
+        let key = env_index_key().expect("env key").expect("env key set");
+        let index_id = [0x5A; INDEX_ID_LEN];
+        let sealed = encrypt_index_file(
+            &IndexKey {
+                source: IndexKeySource::Env,
+                key_id: Vec::new(),
+                material: key,
+            },
+            &index_id,
+            v1_plaintext.as_bytes(),
+        )
+        .expect("seal v1 fixture");
+        fs::write(dir.path().join(INDEX_FILE_NAME), sealed).expect("write v1 fixture");
+
+        let err = FileCorpusIndexStore::load(dir.path())
+            .expect_err("schema v1 index must fail closed on a v2 loader");
+        let text = format!("{err:?}");
+        assert!(
+            text.contains("unsupported owner-side index schema 1; supported 2"),
+            "expected typed schema-mismatch error, got: {text}"
+        );
+        assert!(
+            !text.contains("legacy"),
+            "error must not echo payload contents"
+        );
+    }
+
+    fn synthetic_entity(key_id: &str, class: PiiClass, prefix: &str, raw: &str) -> IndexEntity {
+        let fingerprint_hex = sha256_hex(&format!("{prefix}:{raw}"));
+        IndexEntity {
+            class: class.clone(),
+            raw_value: raw.to_string(),
+            index_ref: IndexedEntityRef {
+                domain_id: DEFAULT_DOMAIN_ID.to_string(),
+                key_id: key_id.to_string(),
+                entity_class: class.clone(),
+                fingerprint_hex: fingerprint_hex.clone(),
+            },
+            domain_alias: domain_alias(&class, &fingerprint_hex),
+        }
+    }
+
+    fn stored_hits(
+        store: &FileCorpusIndexStore,
+        domain: &str,
+        fingerprint: &str,
+    ) -> Vec<StoredHit> {
+        store
+            .hits_for_entity(&domain.to_string(), fingerprint)
+            .iter()
+            .map(StoredHit::from)
+            .collect()
+    }
+
+    fn decrypted_index_plaintext(dir: &Path) -> Vec<u8> {
+        let bytes = fs::read(dir.join(INDEX_FILE_NAME)).expect("read sealed index");
+        let envelope = parse_index_envelope(&bytes).expect("parse sealed envelope");
+        let key = env_index_key().expect("env key").expect("env key set");
+        decrypt_index_file(&key, envelope.index_id, &envelope)
+            .expect("decrypt sealed index")
+            .to_vec()
+    }
+
+    fn count_occurrences(haystack: &[u8], needle: &[u8]) -> usize {
+        haystack
+            .windows(needle.len())
+            .filter(|window| *window == needle)
+            .count()
+    }
+
     fn fixture_store(dir: &Path) -> (FileCorpusIndexStore, String) {
         let mut store =
             FileCorpusIndexStore::load_or_create(dir, DEFAULT_DOMAIN_ID, &[PiiClass::Email])


### PR DESCRIPTION
## Defect

`FileCorpusIndexStore` (`crates/gaze-token-bridge/src/persistent.rs`) persisted one `StoredIndexEntry` per distinct fingerprint, each carrying a **full copy of the document** (snippet + every entity's `raw_value`). Two consequences:

- **O(E²) raw-PII duplication on disk.** A document with E entities was written E times, so raw values were spread across E copies (worse erasure surface, larger sealed payload).
- **Stale-doc-wins on re-ingest.** `insert_hit` appended; `hits_for_entity` deduped by first occurrence. Re-ingesting a `doc_id` without `clear_domain` kept the stale copy first in scan order, so the stale snippet won and the stale fingerprint stayed searchable.

Also `hit_count_for_domain` was dead (no callers in the workspace).

Audit: solo scratchpad 7201 S17-F1. Resolves solo todo #2936.

## Fix (schema v2)

- Documents are stored **once**, keyed by `(domain_id, doc_id)` (`documents: Vec<StoredDocument>`).
- The fingerprint → document **postings map is derived on load** and never persisted; posting lists stay in document order so `hits_for_entity` is order-stable across save + load.
- `insert_hit` **upserts**: a re-ingested `doc_id` replaces its copy outright. A document with no fingerprint in the domain is unreachable and therefore not stored (any earlier copy is erased).
- `SCHEMA_VERSION` 1 → 2. The schema version is probed **before** the full parse, so a v1 file yields the typed `unsupported owner-side index schema 1; supported 2` error (never a partial or reinterpreted load). A v2 payload with duplicate document keys fails closed instead of resurrecting shadowed copies.
- `hit_count_for_domain` removed; `entity_count_for_domain` keeps the `entities: N` definition (document/fingerprint pairs).
- Untouched: AEAD/key layer, sealed-file envelope, `StoredHit`/`StoredEntity` private mirrors + their `compile_fail` guards, the gate-pinned `saved_index_file_is_aead_sealed_and_omits_plaintext` test, capability handle checks, output-safety-net default.

## Red / green evidence

Commit 1 (RED, a976a6f) added three tests; each failed for the intended reason on main:

| Test | Failure on main |
|---|---|
| `reingesting_same_doc_id_replaces_document_and_leaves_no_stale_bytes` | `in-memory: stale revision-one entity must not be searchable after upsert` |
| `postings_rebuilt_on_load_match_in_memory_and_documents_persist_once` | `documents array persisted` (payload had per-fingerprint `entries`) |
| `schema_v1_index_fails_closed_with_typed_schema_error` | v1 payload loaded successfully |

**Stale-bytes-absent scan.** The upsert test decrypts the sealed payload with the test key and scans plaintext bytes: rev-1 snippet marker and rev-1 raw email occur **0** times; rev-2 marker and rev-2 raw email occur **exactly 1** time (rev-2 carries two entities, so per-fingerprint duplication would have shown 2). After `clear_domain` + `save`, all rev-2 bytes are absent too (erasure reachability).

Commit 2 (fix, 9c7f0a9) turns all three green plus a fourth test (`schema_v2_payload_with_duplicate_document_keys_fails_closed`), verified with a mutation probe: disabling the duplicate check makes that test fail.

## Release note

CHANGELOG `Unreleased / Changed`: schema v2 is **breaking for existing local index files** — they fail closed on load and must be rebuilt with `gaze index ingest <dir>`. `crates/gaze-cli/README.md` index section notes the versioned payload.

## Gates (local, pinned rustc 1.96.0)

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-features --no-fail-fast` ✅ (132 test binaries, 0 failures, no #2404 flakes observed)
- `cargo run -p xtask -- tokenbridge-no-raw-index` ✅ passed
- `cargo run -p xtask -- tokenbridge-encrypted-index` ✅ passed (pinned test name unchanged)
- `cargo test -p gaze-cli --all-features --test index_cli` ✅ 7 passed
- `ci-feature-matrix` intentionally not run locally (CI is authoritative)

North star: axis 1 (raw PII on disk minimized to one copy per document; stale copies cannot survive re-ingest; erasure via `clear_domain` is complete), axis 4 (schema bump fails closed, never silently reinterprets), axis 5 (release note for the breaking local-index change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnpK921mYVHdcWKeJwJa3X
