### PR TITLE
[agent] fix(types,audit): canonical string forms for audit-row enums; audit sink no longer panics; FallbackReason JSON/SQLite agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (indexed document/fingerprint pairs). `FileCorpusIndexStore::hit_count_for_domain`
   was removed (it had no callers). The AEAD/key layer and the sealed-file
   envelope are unchanged.
+- **Audit-row enums now own one canonical string form** (audit S05-F2, solo todo
+  #2935). `Action`, `ConflictTier`, `DocumentKind`, and `FallbackReason` expose
+  matching `as_str` / `from_canonical_str` methods, and SQLite plus CLI consumers
+  delegate to them instead of maintaining panic-prone copies. `FallbackReason`
+  JSON now serializes as snake_case to match SQLite; every former PascalCase
+  spelling remains accepted as a serde alias.
 
 - **`gaze_assembly::build_pipeline` derives its `NoRecognizers` guard from
   actual registration and uses one locale predicate** (audit 7201 S10-F1,

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -729,61 +729,28 @@ impl gaze_types::RedactionLogger for SqliteLogger {
 }
 
 fn conflict_tier_to_db(tier: ConflictTier) -> &'static str {
-    match tier {
-        ConflictTier::None => "none",
-        ConflictTier::ClassPriority => "class_priority",
-        ConflictTier::RulePriority => "rule_priority",
-        ConflictTier::Score => "score",
-        ConflictTier::SpanLength => "span_length",
-        ConflictTier::Validator => "validator",
-        ConflictTier::ValidatorVeto => "validator_veto",
-        ConflictTier::CollisionPolicy => "collision_policy",
-        ConflictTier::AnchoredContext => "anchored_context",
-        ConflictTier::RecognizerId => "recognizer_id",
-        ConflictTier::Merged => "merged",
-        ConflictTier::Redact => "redact",
-        ConflictTier::Resolve => "resolve",
-        ConflictTier::Fallback => "fallback",
-        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {tier:?}"),
-    }
+    tier.as_str()
 }
 
 fn fallback_reason_to_db(reason: FallbackReason) -> &'static str {
-    match reason {
-        FallbackReason::OverlapConflict => "overlap_conflict",
-        FallbackReason::ValidatorVeto => "validator_veto",
-        FallbackReason::AnchorMissing => "anchor_missing",
-        FallbackReason::ResidualSuspect => "residual_suspect",
-        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {reason:?}"),
-    }
+    reason.as_str()
 }
 
 fn fallback_reason_from_db(value: &str) -> std::result::Result<FallbackReason, rusqlite::Error> {
-    Ok(match value {
-        "overlap_conflict" => FallbackReason::OverlapConflict,
-        "validator_veto" => FallbackReason::ValidatorVeto,
-        "anchor_missing" => FallbackReason::AnchorMissing,
-        "residual_suspect" => FallbackReason::ResidualSuspect,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                18,
-                rusqlite::types::Type::Text,
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unknown fallback reason {other}"),
-                )),
-            ))
-        }
+    FallbackReason::from_canonical_str(value).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            18,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown fallback reason {value}"),
+            )),
+        )
     })
 }
 
 fn leak_kind_to_db(kind: &LeakKind) -> &'static str {
-    match kind {
-        LeakKind::Uncovered => "uncovered",
-        LeakKind::PartialBleed { .. } => "partial_bleed",
-        LeakKind::ClassMismatch { .. } => "class_mismatch",
-        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {kind:?}"),
-    }
+    kind.as_str()
 }
 
 fn leak_kind_pipeline_class(kind: &LeakKind) -> Option<&PiiClass> {
@@ -818,31 +785,15 @@ fn table_has_column(conn: &Connection, name: &str) -> Result<bool> {
 }
 
 fn conflict_tier_from_db(value: &str) -> std::result::Result<ConflictTier, rusqlite::Error> {
-    Ok(match value {
-        "none" => ConflictTier::None,
-        "class_priority" => ConflictTier::ClassPriority,
-        "rule_priority" => ConflictTier::RulePriority,
-        "score" => ConflictTier::Score,
-        "span_length" => ConflictTier::SpanLength,
-        "validator" => ConflictTier::Validator,
-        "validator_veto" => ConflictTier::ValidatorVeto,
-        "collision_policy" => ConflictTier::CollisionPolicy,
-        "anchored_context" => ConflictTier::AnchoredContext,
-        "recognizer_id" => ConflictTier::RecognizerId,
-        "merged" => ConflictTier::Merged,
-        "redact" => ConflictTier::Redact,
-        "resolve" => ConflictTier::Resolve,
-        "fallback" => ConflictTier::Fallback,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                6,
-                rusqlite::types::Type::Text,
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unknown conflict tier {other}"),
-                )),
-            ))
-        }
+    ConflictTier::from_canonical_str(value).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            6,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown conflict tier {value}"),
+            )),
+        )
     })
 }
 
@@ -884,58 +835,36 @@ fn deserialize_json_column<T: DeserializeOwned>(
 }
 
 fn action_to_db(action: Action) -> &'static str {
-    match action {
-        Action::Tokenize => "tokenize",
-        Action::Redact => "redact",
-        Action::FormatPreserve => "format_preserve",
-        Action::Generalize => "generalize",
-        Action::Preserve => "preserve",
-        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {action:?}"),
-    }
+    action.as_str()
 }
 
 fn action_from_db(value: &str) -> std::result::Result<Action, rusqlite::Error> {
-    Ok(match value {
-        "tokenize" => Action::Tokenize,
-        "redact" => Action::Redact,
-        "format_preserve" => Action::FormatPreserve,
-        "generalize" => Action::Generalize,
-        "preserve" => Action::Preserve,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                2,
-                rusqlite::types::Type::Text,
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unknown action {other}"),
-                )),
-            ))
-        }
+    Action::from_canonical_str(value).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown action {value}"),
+            )),
+        )
     })
 }
 
 fn document_kind_to_db(kind: &DocumentKind) -> &'static str {
-    match kind {
-        DocumentKind::Structured => "structured",
-        DocumentKind::Text => "text",
-        _ => panic!("unknown variant in audit serialization - update sqlite.rs for new {kind:?}"),
-    }
+    kind.as_str()
 }
 
 fn document_kind_from_db(value: &str) -> std::result::Result<DocumentKind, rusqlite::Error> {
-    Ok(match value {
-        "structured" => DocumentKind::Structured,
-        "text" => DocumentKind::Text,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                3,
-                rusqlite::types::Type::Text,
-                Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("unknown document kind {other}"),
-                )),
-            ))
-        }
+    DocumentKind::from_canonical_str(value).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            3,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown document kind {value}"),
+            )),
+        )
     })
 }
 
@@ -946,6 +875,136 @@ mod tests {
         RestoreDecision, RestorePolicy, RestoreTelemetry, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
         RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
     };
+
+    #[test]
+    fn sqlite_sink_uses_each_audit_enums_canonical_spelling() {
+        let temp_db = tempfile::NamedTempFile::new().expect("temp db");
+        let logger = SqliteLogger::new(temp_db.path()).expect("logger");
+
+        for action in [
+            Action::Tokenize,
+            Action::Redact,
+            Action::FormatPreserve,
+            Action::Generalize,
+            Action::Preserve,
+        ] {
+            assert_logged_column(
+                &logger,
+                temp_db.path(),
+                RedactionEntry::new(
+                    format!("action:{}", action.as_str()),
+                    PiiClass::Email,
+                    action,
+                    None,
+                    DocumentKind::Text,
+                    false,
+                    ConflictTier::None,
+                    0,
+                    None,
+                ),
+                "action",
+                action.as_str(),
+            );
+        }
+        for tier in [
+            ConflictTier::None,
+            ConflictTier::ClassPriority,
+            ConflictTier::RulePriority,
+            ConflictTier::Score,
+            ConflictTier::SpanLength,
+            ConflictTier::Validator,
+            ConflictTier::ValidatorVeto,
+            ConflictTier::CollisionPolicy,
+            ConflictTier::AnchoredContext,
+            ConflictTier::RecognizerId,
+            ConflictTier::Merged,
+            ConflictTier::Redact,
+            ConflictTier::Resolve,
+            ConflictTier::Fallback,
+        ] {
+            assert_logged_column(
+                &logger,
+                temp_db.path(),
+                RedactionEntry::new(
+                    format!("tier:{}", tier.as_str()),
+                    PiiClass::Email,
+                    Action::Tokenize,
+                    None,
+                    DocumentKind::Text,
+                    false,
+                    tier,
+                    0,
+                    None,
+                ),
+                "decided_by",
+                tier.as_str(),
+            );
+        }
+        for kind in [DocumentKind::Structured, DocumentKind::Text] {
+            assert_logged_column(
+                &logger,
+                temp_db.path(),
+                RedactionEntry::new(
+                    format!("kind:{}", kind.as_str()),
+                    PiiClass::Email,
+                    Action::Tokenize,
+                    None,
+                    kind,
+                    false,
+                    ConflictTier::None,
+                    0,
+                    None,
+                ),
+                "document_kind",
+                kind.as_str(),
+            );
+        }
+        for reason in [
+            FallbackReason::OverlapConflict,
+            FallbackReason::ValidatorVeto,
+            FallbackReason::AnchorMissing,
+            FallbackReason::ResidualSuspect,
+        ] {
+            assert_logged_column(
+                &logger,
+                temp_db.path(),
+                RedactionEntry::new(
+                    format!("fallback:{}", reason.as_str()),
+                    PiiClass::Email,
+                    Action::Tokenize,
+                    None,
+                    DocumentKind::Text,
+                    false,
+                    ConflictTier::None,
+                    0,
+                    None,
+                )
+                .with_fallback_triggered(reason),
+                "fallback_triggered",
+                reason.as_str(),
+            );
+        }
+    }
+
+    fn assert_logged_column(
+        logger: &SqliteLogger,
+        path: &Path,
+        entry: RedactionEntry,
+        column: &str,
+        expected: &str,
+    ) {
+        let source = entry.source.clone();
+        logger.log(&entry).expect("write audit row");
+        let conn = Connection::open(path).expect("open audit db");
+        let actual: String = conn
+            .query_row(
+                &format!("SELECT {column} FROM redaction_log WHERE source = ?1"),
+                [&source],
+                |row| row.get(0),
+            )
+            .expect("read canonical enum column");
+        assert_eq!(actual, expected);
+    }
 
     fn create_legacy_redaction_log(path: &Path) {
         let conn = Connection::open(path).expect("legacy sqlite");

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -1064,11 +1064,7 @@ impl From<&LeakReportTelemetry> for LeakTelemetryResponse {
 }
 
 fn document_kind_label(kind: DocumentKind) -> &'static str {
-    match kind {
-        DocumentKind::Structured => "structured",
-        DocumentKind::Text => "text",
-        _ => "unknown",
-    }
+    kind.as_str()
 }
 
 pub(crate) fn enforce_safety_net_mode(

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1451,6 +1451,17 @@ pub enum LeakKind {
     },
 }
 
+impl LeakKind {
+    /// Returns the canonical audit-row spelling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Uncovered => "uncovered",
+            Self::PartialBleed { .. } => "partial_bleed",
+            Self::ClassMismatch { .. } => "class_mismatch",
+        }
+    }
+}
+
 /// Bytes-free telemetry emitted by safety-net orchestration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1964,6 +1975,31 @@ pub enum Action {
     Preserve,
 }
 
+impl Action {
+    /// Returns the canonical audit-row spelling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Tokenize => "tokenize",
+            Self::Redact => "redact",
+            Self::FormatPreserve => "format_preserve",
+            Self::Generalize => "generalize",
+            Self::Preserve => "preserve",
+        }
+    }
+
+    /// Parses a canonical audit-row spelling.
+    pub fn from_canonical_str(value: &str) -> Option<Self> {
+        match value {
+            "tokenize" => Some(Self::Tokenize),
+            "redact" => Some(Self::Redact),
+            "format_preserve" => Some(Self::FormatPreserve),
+            "generalize" => Some(Self::Generalize),
+            "preserve" => Some(Self::Preserve),
+            _ => None,
+        }
+    }
+}
+
 /// Conflict resolution tier that selected or rejected a candidate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1998,18 +2034,89 @@ pub enum ConflictTier {
     Fallback,
 }
 
+impl ConflictTier {
+    /// Returns the canonical audit-row spelling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::ClassPriority => "class_priority",
+            Self::RulePriority => "rule_priority",
+            Self::Score => "score",
+            Self::SpanLength => "span_length",
+            Self::Validator => "validator",
+            Self::ValidatorVeto => "validator_veto",
+            Self::CollisionPolicy => "collision_policy",
+            Self::AnchoredContext => "anchored_context",
+            Self::RecognizerId => "recognizer_id",
+            Self::Merged => "merged",
+            Self::Redact => "redact",
+            Self::Resolve => "resolve",
+            Self::Fallback => "fallback",
+        }
+    }
+
+    /// Parses a canonical audit-row spelling.
+    pub fn from_canonical_str(value: &str) -> Option<Self> {
+        match value {
+            "none" => Some(Self::None),
+            "class_priority" => Some(Self::ClassPriority),
+            "rule_priority" => Some(Self::RulePriority),
+            "score" => Some(Self::Score),
+            "span_length" => Some(Self::SpanLength),
+            "validator" => Some(Self::Validator),
+            "validator_veto" => Some(Self::ValidatorVeto),
+            "collision_policy" => Some(Self::CollisionPolicy),
+            "anchored_context" => Some(Self::AnchoredContext),
+            "recognizer_id" => Some(Self::RecognizerId),
+            "merged" => Some(Self::Merged),
+            "redact" => Some(Self::Redact),
+            "resolve" => Some(Self::Resolve),
+            "fallback" => Some(Self::Fallback),
+            _ => None,
+        }
+    }
+}
+
 /// Safety-net fallback reason recorded in metadata-only audit rows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(rename_all = "snake_case")]
 pub enum FallbackReason {
     /// The suspect overlapped an existing emitted token in a way that could not be promoted.
+    #[serde(alias = "OverlapConflict")]
     OverlapConflict,
     /// A validator rejected the promoted candidate.
+    #[serde(alias = "ValidatorVeto")]
     ValidatorVeto,
     /// A mandatory anchor was missing for the promoted candidate.
+    #[serde(alias = "AnchorMissing")]
     AnchorMissing,
     /// A follow-up safety-net pass still observed a suspect.
+    #[serde(alias = "ResidualSuspect")]
     ResidualSuspect,
+}
+
+impl FallbackReason {
+    /// Returns the canonical audit-row and JSON spelling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::OverlapConflict => "overlap_conflict",
+            Self::ValidatorVeto => "validator_veto",
+            Self::AnchorMissing => "anchor_missing",
+            Self::ResidualSuspect => "residual_suspect",
+        }
+    }
+
+    /// Parses a canonical audit-row spelling.
+    pub fn from_canonical_str(value: &str) -> Option<Self> {
+        match value {
+            "overlap_conflict" => Some(Self::OverlapConflict),
+            "validator_veto" => Some(Self::ValidatorVeto),
+            "anchor_missing" => Some(Self::AnchorMissing),
+            "residual_suspect" => Some(Self::ResidualSuspect),
+            _ => None,
+        }
+    }
 }
 
 /// Source document kind for metadata-only audit logging.
@@ -2020,6 +2127,25 @@ pub enum DocumentKind {
     Structured,
     /// Plain text document.
     Text,
+}
+
+impl DocumentKind {
+    /// Returns the canonical audit-row spelling.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Structured => "structured",
+            Self::Text => "text",
+        }
+    }
+
+    /// Parses a canonical audit-row spelling.
+    pub fn from_canonical_str(value: &str) -> Option<Self> {
+        match value {
+            "structured" => Some(Self::Structured),
+            "text" => Some(Self::Text),
+            _ => None,
+        }
+    }
 }
 
 /// One row of redaction metadata emitted to a [`RedactionLogger`].
@@ -2143,17 +2269,11 @@ impl Serialize for RedactionEntry {
             state.serialize_field("recognizer_version_id", recognizer_version_id)?;
         }
         state.serialize_field("class", &self.class.to_canonical_str())?;
-        state.serialize_field("action", redaction_action_as_str(self.action))?;
+        state.serialize_field("action", self.action.as_str())?;
         state.serialize_field("field_name", &self.field_name)?;
-        state.serialize_field(
-            "document_kind",
-            redaction_document_kind_as_str(self.document_kind),
-        )?;
+        state.serialize_field("document_kind", self.document_kind.as_str())?;
         state.serialize_field("conflict_loser", &self.conflict_loser)?;
-        state.serialize_field(
-            "decided_by",
-            redaction_conflict_tier_as_str(self.decided_by),
-        )?;
+        state.serialize_field("decided_by", self.decided_by.as_str())?;
         state.serialize_field("created_at", &self.created_at)?;
         state.serialize_field("session_id", &self.session_id)?;
         state.serialize_field("validator_fail_reason", &self.validator_fail_reason)?;
@@ -2216,42 +2336,6 @@ impl Serialize for RedactionEntry {
             state.serialize_field("restore_phase_mask", &value)?;
         }
         state.end()
-    }
-}
-
-fn redaction_action_as_str(action: Action) -> &'static str {
-    match action {
-        Action::Tokenize => "tokenize",
-        Action::Redact => "redact",
-        Action::FormatPreserve => "format_preserve",
-        Action::Generalize => "generalize",
-        Action::Preserve => "preserve",
-    }
-}
-
-fn redaction_document_kind_as_str(kind: DocumentKind) -> &'static str {
-    match kind {
-        DocumentKind::Structured => "structured",
-        DocumentKind::Text => "text",
-    }
-}
-
-fn redaction_conflict_tier_as_str(tier: ConflictTier) -> &'static str {
-    match tier {
-        ConflictTier::None => "none",
-        ConflictTier::ClassPriority => "class_priority",
-        ConflictTier::RulePriority => "rule_priority",
-        ConflictTier::Score => "score",
-        ConflictTier::SpanLength => "span_length",
-        ConflictTier::Validator => "validator",
-        ConflictTier::ValidatorVeto => "validator_veto",
-        ConflictTier::CollisionPolicy => "collision_policy",
-        ConflictTier::AnchoredContext => "anchored_context",
-        ConflictTier::RecognizerId => "recognizer_id",
-        ConflictTier::Merged => "merged",
-        ConflictTier::Redact => "redact",
-        ConflictTier::Resolve => "resolve",
-        ConflictTier::Fallback => "fallback",
     }
 }
 
@@ -3030,6 +3114,94 @@ mod redaction_logger_tests {
     }
 
     fn assert_send_sync<T: Send + Sync + ?Sized>() {}
+
+    #[test]
+    fn fallback_reason_serializes_snake_case_and_accepts_legacy_pascal_case() {
+        for (legacy, canonical, value) in [
+            (
+                "OverlapConflict",
+                "overlap_conflict",
+                FallbackReason::OverlapConflict,
+            ),
+            (
+                "ValidatorVeto",
+                "validator_veto",
+                FallbackReason::ValidatorVeto,
+            ),
+            (
+                "AnchorMissing",
+                "anchor_missing",
+                FallbackReason::AnchorMissing,
+            ),
+            (
+                "ResidualSuspect",
+                "residual_suspect",
+                FallbackReason::ResidualSuspect,
+            ),
+        ] {
+            let legacy_json = format!(r#""{legacy}""#);
+            assert_eq!(
+                serde_json::from_str::<FallbackReason>(&legacy_json)
+                    .expect("legacy fallback reason"),
+                value
+            );
+            assert_eq!(
+                serde_json::to_string(&value).expect("fallback reason"),
+                format!(r#""{canonical}""#)
+            );
+        }
+    }
+
+    #[test]
+    fn audit_enum_canonical_forms_round_trip() {
+        for value in [
+            Action::Tokenize,
+            Action::Redact,
+            Action::FormatPreserve,
+            Action::Generalize,
+            Action::Preserve,
+        ] {
+            assert_eq!(Action::from_canonical_str(value.as_str()), Some(value));
+        }
+        for value in [
+            ConflictTier::None,
+            ConflictTier::ClassPriority,
+            ConflictTier::RulePriority,
+            ConflictTier::Score,
+            ConflictTier::SpanLength,
+            ConflictTier::Validator,
+            ConflictTier::ValidatorVeto,
+            ConflictTier::CollisionPolicy,
+            ConflictTier::AnchoredContext,
+            ConflictTier::RecognizerId,
+            ConflictTier::Merged,
+            ConflictTier::Redact,
+            ConflictTier::Resolve,
+            ConflictTier::Fallback,
+        ] {
+            assert_eq!(
+                ConflictTier::from_canonical_str(value.as_str()),
+                Some(value)
+            );
+        }
+        for value in [DocumentKind::Structured, DocumentKind::Text] {
+            assert_eq!(
+                DocumentKind::from_canonical_str(value.as_str()),
+                Some(value)
+            );
+        }
+        for value in [
+            FallbackReason::OverlapConflict,
+            FallbackReason::ValidatorVeto,
+            FallbackReason::AnchorMissing,
+            FallbackReason::ResidualSuspect,
+        ] {
+            assert_eq!(
+                FallbackReason::from_canonical_str(value.as_str()),
+                Some(value)
+            );
+        }
+    }
 
     #[test]
     fn redaction_log_error_display_is_stable() {

--- a/docs/explanation/safety-net/safety-net-modes.md
+++ b/docs/explanation/safety-net/safety-net-modes.md
@@ -187,7 +187,7 @@ Emit one `RedactionEntry` per redacted suspect with:
 
 The audit row carries the action and the byte range. It does **not** carry the original suspect bytes — that would re-introduce the leak into the audit DB. This is consistent with the existing safety-nets contract (no raw bytes cross the adapter boundary, see [`safety-nets.md`](safety-nets.md)).
 
-Update the string mapping in `redaction_conflict_tier_as_str` at `crates/gaze-types/src/lib.rs:1559` to cover `SafetyNetRedacted` with `"safety_net_redacted"` and `Fallback` with `"fallback"`.
+Update the string mapping in `ConflictTier::as_str` to cover `SafetyNetRedacted` with `"safety_net_redacted"` and `Fallback` with `"fallback"`.
 
 ### 4.4 Restore behavior
 
@@ -437,7 +437,7 @@ pub struct RedactionEntry {
 }
 ```
 
-Also update the string mapping in `redaction_conflict_tier_as_str` at `crates/gaze-types/src/lib.rs:1559` to cover `SafetyNetRedacted` with `"safety_net_redacted"` and `Fallback` with `"fallback"`.
+Also update the string mapping in `ConflictTier::as_str` to cover `SafetyNetRedacted` with `"safety_net_redacted"` and `Fallback` with `"fallback"`.
 
 Today's `SafetyNetMode` enum at `crates/gaze-cli/src/commands/mod.rs:399` is **not** annotated `#[non_exhaustive]`. The impl PR for redact mode should add that attribute as part of the same change. This is one-time hygiene, not a contract change.
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -262,9 +262,8 @@ SafetyNet modes layer on top of the resolver (after tokenization):
 
 ### 2.2 `decided_by` audit-string values
 
-Canonical strings produced by `redaction_conflict_tier_as_str`
-(`gaze-types/src/lib.rs:1866`). These are what land in the `decided_by`
-column.
+Canonical strings produced by `ConflictTier::as_str`. These are what land in
+the `decided_by` column.
 
 | String | Variant | Landed |
 |---|---|---|


### PR DESCRIPTION
## Defect

`Action`, `ConflictTier`, `DocumentKind`, and `FallbackReason` had no type-owned canonical-string contract. JSON, SQLite, and CLI consumers maintained separate tables, including panic arms in the audit sink. `FallbackReason` had already drifted: JSON emitted `OverlapConflict` while SQLite stored `overlap_conflict`.

## Fix

- add exhaustive `as_str` / `from_canonical_str` methods to the four audit-row enums
- make `RedactionEntry`, SQLite writes/reads, and the CLI document-kind label delegate to those methods
- replace the last audit-sink serialization panic with type-owned `LeakKind::as_str`
- serialize `FallbackReason` as snake_case while retaining aliases for every legacy PascalCase spelling
- update canonical-string documentation and the Unreleased changelog

Unknown SQLite strings continue through `rusqlite::Error::FromSqlConversionFailure`; the sink no longer panics on serialization. No north-star axis is weakened.

## Red / green evidence

- RED: `FallbackReason::OverlapConflict` serialized as `"OverlapConflict"`, while the sink wrote `"overlap_conflict"`
- RED: canonical round-trip tests did not compile because the four type-owned APIs were absent
- GREEN: explicit variant lists round-trip for all four enums; the real SQLite sink writes `as_str()` for every variant; all old PascalCase fallback spellings deserialize and new output is snake_case

## Mutation probe

Changing `ConflictTier::CollisionPolicy::as_str()` to `collision-policy` made the canonical round-trip test fail (`None` versus `Some(CollisionPolicy)`); restoring `collision_policy` made it pass.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`

Audit: solo scratchpad 7201 S05-F2

Resolves solo todo #2935
