### PR TITLE
[agent] fix(xtask): one repo root + one production-crate scope for the leak-guard gates; drift gate cwd-independent

### DIFF
--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -684,6 +684,7 @@ fn map_ocr_error_to_document_error(err: OcrError) -> DocumentError {
 pub(crate) fn build_document_pipeline() -> Result<GazePipeline, DocumentError> {
     let email = RegexDetector::emails().map_err(|err| pipeline_err("email-regex", err))?;
     // Conservative phone pattern: optional `+CC`, area, exchange, line, with
+    // fixture-cited(crates/gaze-document/src/ocr/normalize.rs:ocr::normalize::tests::already_clean_passthrough)
     // common separators. Synthetic fixture uses `+1-555-0142`-style numbers.
     let phone = RegexDetector::new(
         r"\+?\d{1,3}[-.\s]\(?\d{3}\)?[-.\s]?\d{3,4}[-.\s]?\d{0,4}",
@@ -982,6 +983,7 @@ mod tests {
                 span("Jane", 20, 36, 0.50),
                 span("Doe", 116, 36, 0.50),
                 span("Email:", 360, 10, 0.50),
+                // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_with_mock_backend_flags_low_confidence_and_columns)
                 span("alice@example.invalid", 360, 36, 0.50),
             ],
         };
@@ -1008,6 +1010,7 @@ mod tests {
             bundle.clean_markdown
         );
         assert!(
+            // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_with_mock_backend_flags_low_confidence_and_columns)
             !bundle.clean_markdown.contains("alice@example.invalid"),
             "{}",
             bundle.clean_markdown
@@ -1023,6 +1026,7 @@ mod tests {
                 span("Bill", 20, 40, 0.92),
                 span("Jane", 160, 40, 0.92),
                 span("Email", 20, 70, 0.92),
+                // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_with_mock_backend_preserves_table_cell_context)
                 span("alice@example.invalid", 160, 70, 0.92),
             ],
         };
@@ -1047,6 +1051,7 @@ mod tests {
             bundle.clean_markdown
         );
         assert!(
+            // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_with_mock_backend_preserves_table_cell_context)
             !bundle.clean_markdown.contains("alice@example.invalid"),
             "{}",
             bundle.clean_markdown
@@ -1076,6 +1081,7 @@ mod tests {
                 if decoded.width() <= decoded.height() {
                     return Ok(Vec::new());
                 }
+                // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_preprocesses_rotated_image_before_backend_ocr)
                 Ok(vec![span("alice@example.invalid", 20, 20, 0.91)])
             }
         }
@@ -1109,6 +1115,7 @@ mod tests {
             bundle.clean_markdown
         );
         assert!(
+            // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_preprocesses_rotated_image_before_backend_ocr)
             !bundle.clean_markdown.contains("alice@example.invalid"),
             "{}",
             bundle.clean_markdown
@@ -1156,6 +1163,7 @@ mod tests {
                 if horizontal_score(&image.bytes)? < self.minimum_score {
                     return Ok(Vec::new());
                 }
+                // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_deskews_image_before_backend_ocr)
                 Ok(vec![span("alice@example.invalid", 20, 20, 0.91)])
             }
         }
@@ -1212,6 +1220,7 @@ mod tests {
             bundle.clean_markdown
         );
         assert!(
+            // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_deskews_image_before_backend_ocr)
             !bundle.clean_markdown.contains("alice@example.invalid"),
             "{}",
             bundle.clean_markdown

--- a/crates/gaze-document/src/ocr/normalize.rs
+++ b/crates/gaze-document/src/ocr/normalize.rs
@@ -6,6 +6,7 @@
 //! around the `@` of an email address, e.g.:
 //!
 //! ```text
+// fixture-cited(crates/gaze-document/src/ocr/normalize.rs:ocr::normalize::tests::collapses_space_before_at)
 //! jane.doe@example.invalid   →   "jane.doe @example.invalid"
 //! ```
 //!

--- a/crates/gaze-token-bridge/src/bridge.rs
+++ b/crates/gaze-token-bridge/src/bridge.rs
@@ -392,13 +392,16 @@ pub fn synthetic_docs() -> Vec<SyntheticDoc> {
         SyntheticDoc {
             id: "cust-001",
             name: "Markus Gottschaue",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             email: "markus@example.invalid",
             customer_id: "91A",
             organization: "Globex GmbH",
         },
         SyntheticDoc {
             id: "cust-002",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             name: "Dr. Schmidt",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             email: "schmidt@example.invalid",
             customer_id: "72B",
             organization: "Initech AG",
@@ -406,6 +409,7 @@ pub fn synthetic_docs() -> Vec<SyntheticDoc> {
         SyntheticDoc {
             id: "cust-003",
             name: "Lena Torres",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             email: "lena@example.invalid",
             customer_id: "48C",
             organization: "Umbrella LLC",
@@ -413,6 +417,7 @@ pub fn synthetic_docs() -> Vec<SyntheticDoc> {
         SyntheticDoc {
             id: "cust-004",
             name: "Prof. Weber",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             email: "weber@example.invalid",
             customer_id: "54D",
             organization: "Soylent GmbH",
@@ -420,6 +425,7 @@ pub fn synthetic_docs() -> Vec<SyntheticDoc> {
         SyntheticDoc {
             id: "cust-005",
             name: "Ana Rossi",
+            // fixture-cited(crates/gaze-token-bridge/src/bridge.rs:bridge::tests::synthetic_docs_are_detected_by_demo_pipeline)
             email: "ana@example.invalid",
             customer_id: "33E",
             organization: "Vehement Capital Partners",
@@ -496,5 +502,24 @@ impl Detector for SyntheticCorpusDetector {
             }
         }
         detections
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_docs_are_detected_by_demo_pipeline() {
+        let docs = synthetic_docs();
+        let detector = SyntheticCorpusDetector::from_docs(&docs);
+
+        for doc in docs {
+            assert_eq!(
+                detector.detect(&doc.raw_text(CUSTOMER_DOMAIN)).len(),
+                4,
+                "every synthetic fixture field must remain covered by the demo detector"
+            );
+        }
     }
 }

--- a/crates/gaze-token-bridge/src/persistent.rs
+++ b/crates/gaze-token-bridge/src/persistent.rs
@@ -503,7 +503,6 @@ fn default_classes() -> Vec<PiiClass> {
         PiiClass::Organization,
         PiiClass::custom("customer_id"),
         PiiClass::custom("account_id"),
-        PiiClass::custom("order_id"),
         PiiClass::custom("case_id"),
     ]
 }

--- a/crates/xtask/src/bundle_tokenization_drift.rs
+++ b/crates/xtask/src/bundle_tokenization_drift.rs
@@ -10,6 +10,8 @@ use gaze::{PiiClass, Rulepack, RulepackSource};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::repo::repo_root;
+
 const SCHEMA_VERSION: u8 = 1;
 const FIXTURE_PATH: &str = "crates/xtask/fixtures/drift-corpus.txt";
 const EMBEDDED_RULEPACK_DIR: &str = "crates/gaze-recognizers/embedded";
@@ -26,7 +28,7 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
-    let root = std::env::current_dir().context("failed to resolve workspace root")?;
+    let root = repo_root()?;
     let bundles = discover_bundles(&root)?;
     if bundles.is_empty() {
         bail!("bundle-tokenization-drift: no bundled rulepacks discovered");
@@ -579,28 +581,18 @@ fn verify_ack(root: &Path) -> Result<()> {
 
 fn changed_snapshot_files(root: &Path) -> Result<BTreeSet<String>> {
     let mut files = BTreeSet::new();
+    let snapshot_dir = root.join(SNAPSHOT_DIR);
     for args in [
-        vec!["diff", "--name-only", "--", "crates/xtask/snapshots"],
-        vec![
-            "diff",
-            "--cached",
-            "--name-only",
-            "--",
-            "crates/xtask/snapshots",
-        ],
+        vec!["diff", "--name-only"],
+        vec!["diff", "--cached", "--name-only"],
     ] {
-        collect_changed_snapshot_files(root, &args, &mut files)?;
+        collect_changed_snapshot_files(root, &args, &snapshot_dir, &mut files)?;
     }
     if git_ref_exists(root, "origin/main")? {
         collect_changed_snapshot_files(
             root,
-            &[
-                "diff",
-                "--name-only",
-                "origin/main...HEAD",
-                "--",
-                "crates/xtask/snapshots",
-            ],
+            &["diff", "--name-only", "origin/main...HEAD"],
+            &snapshot_dir,
             &mut files,
         )?;
     }
@@ -610,11 +602,15 @@ fn changed_snapshot_files(root: &Path) -> Result<BTreeSet<String>> {
 fn collect_changed_snapshot_files(
     root: &Path,
     args: &[&str],
+    snapshot_dir: &Path,
     files: &mut BTreeSet<String>,
 ) -> Result<()> {
     let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
         .args(args)
-        .current_dir(root)
+        .arg("--")
+        .arg(snapshot_dir)
         .output()
         .with_context(|| format!("failed to run git {}", args.join(" ")))?;
     if !output.status.success() {
@@ -643,8 +639,9 @@ fn diff_contains_drift_ack(root: &Path) -> Result<bool> {
             continue;
         }
         let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
             .args(&args)
-            .current_dir(root)
             .output()
             .with_context(|| format!("failed to run git {}", args.join(" ")))?;
         if !output.status.success() {
@@ -689,8 +686,9 @@ fn section_between<'a>(text: &'a str, start_marker: &str, next_marker: &str) -> 
 
 fn git_ref_exists(root: &Path, name: &str) -> Result<bool> {
     let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
         .args(["rev-parse", "--verify", "--quiet", name])
-        .current_dir(root)
         .output()
         .with_context(|| format!("failed to check git ref {name}"))?;
     Ok(output.status.success())

--- a/crates/xtask/src/coverage_corpus/builder.rs
+++ b/crates/xtask/src/coverage_corpus/builder.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 use super::generators::GeneratorRegistry;
 use super::templates::{self, Template};
 use super::COVERAGE_CORPUS_SEED;
+use crate::repo::repo_root;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -293,14 +294,6 @@ fn tmp_path(path: &Path) -> PathBuf {
     let mut tmp = path.as_os_str().to_os_string();
     tmp.push(".tmp");
     PathBuf::from(tmp)
-}
-
-fn repo_root() -> Result<PathBuf> {
-    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .context("resolve workspace root from xtask manifest dir")?
-        .to_path_buf())
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/xtask/src/dylint_gate.rs
+++ b/crates/xtask/src/dylint_gate.rs
@@ -9,6 +9,8 @@ use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 
+use crate::repo::repo_root;
+
 const EXPECTED_UI_FIXTURES: usize = 18;
 const DYLINT_REQUIRED_ENV: &str = "GAZE_DYLINT_REQUIRED";
 const DEFERRED_MESSAGE: &str = "dylint_gate: ui-fixture-shape passed; cargo-dylint DEFERRED to the scheduled dylint.yml workflow (solo todo #1870)";
@@ -20,7 +22,7 @@ enum DylintDisposition {
 }
 
 pub fn run() -> Result<()> {
-    let root = std::env::current_dir().context("failed to resolve current directory")?;
+    let root = repo_root()?;
     assert_ui_fixture_shape(&root)?;
     match cargo_dylint_requirement(env_flag(DYLINT_REQUIRED_ENV), cargo_dylint_available())? {
         DylintDisposition::Run => {

--- a/crates/xtask/src/fixture_citation.rs
+++ b/crates/xtask/src/fixture_citation.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use crate::repo::{fixture_citation_file, production_files, PRODUCTION_CRATES};
+use crate::repo::{fixture_citation_file, production_source_dirs, repo_root, source_files};
 const MARKER_PREFIX: &str = "// fixture-cited(";
 const MARKER_SUFFIX: &str = ")";
 const FIXTURE_PATTERNS: &[&str] = &[
@@ -45,26 +45,28 @@ pub type Result<T> = std::result::Result<T, FixtureCitationError>;
 
 pub fn run() -> anyhow::Result<()> {
     let listed_tests = workspace_test_names()?;
-    scan_root_with_tests(".", &listed_tests)?;
+    let root = repo_root()?;
+    let source_dirs = production_source_dirs(&root)?;
+    scan_source_dirs_with_tests(&source_dirs, &listed_tests)?;
     println!("fixture_citation_lint: passed");
     Ok(())
 }
 
-pub fn scan_root_with_tests(root: impl AsRef<Path>, listed_tests: &HashSet<String>) -> Result<()> {
-    let root = root.as_ref();
+pub fn scan_source_dirs_with_tests(
+    source_dirs: &[PathBuf],
+    listed_tests: &HashSet<String>,
+) -> Result<()> {
     let mut missing_citation = Vec::new();
     let mut missing_test = Vec::new();
     let mut invalid_marker = Vec::new();
     let mut cases_checked = 0usize;
 
-    for file in
-        production_files(root, PRODUCTION_CRATES, fixture_citation_file).map_err(|error| {
-            FixtureCitationError::Io {
-                path: error.path,
-                message: error.message,
-            }
-        })?
-    {
+    for file in source_files(source_dirs, fixture_citation_file).map_err(|error| {
+        FixtureCitationError::Io {
+            path: error.path,
+            message: error.message,
+        }
+    })? {
         cases_checked += 1;
         let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
         let active_lines = active_production_lines(&content);

--- a/crates/xtask/src/fixture_citation.rs
+++ b/crates/xtask/src/fixture_citation.rs
@@ -6,13 +6,7 @@ use std::{
     process::Command,
 };
 
-const PRODUCTION_CRATES: &[&str] = &[
-    "gaze-pii",
-    "gaze-types",
-    "gaze-recognizers",
-    "gaze-assembly",
-    "gaze-cli",
-];
+use crate::repo::{fixture_citation_file, production_files, PRODUCTION_CRATES};
 const MARKER_PREFIX: &str = "// fixture-cited(";
 const MARKER_SUFFIX: &str = ")";
 const FIXTURE_PATTERNS: &[&str] = &[
@@ -63,7 +57,14 @@ pub fn scan_root_with_tests(root: impl AsRef<Path>, listed_tests: &HashSet<Strin
     let mut invalid_marker = Vec::new();
     let mut cases_checked = 0usize;
 
-    for file in production_files(root)? {
+    for file in
+        production_files(root, PRODUCTION_CRATES, fixture_citation_file).map_err(|error| {
+            FixtureCitationError::Io {
+                path: error.path,
+                message: error.message,
+            }
+        })?
+    {
         cases_checked += 1;
         let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
         let active_lines = active_production_lines(&content);
@@ -137,61 +138,6 @@ pub fn parse_test_list(output: &str) -> HashSet<String> {
         .filter_map(|line| line.strip_suffix(": test"))
         .map(str::to_owned)
         .collect()
-}
-
-fn production_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for crate_name in PRODUCTION_CRATES {
-        let src = root
-            .join("crates")
-            .join(package_source_dir(crate_name))
-            .join("src");
-        if !src.exists() {
-            continue;
-        }
-        collect_rs_files(&src, &mut files)?;
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn package_source_dir(package_name: &str) -> &str {
-    match package_name {
-        "gaze-pii" => "gaze",
-        _ => package_name,
-    }
-}
-
-fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    // Prevent path traversal attacks by rejecting paths containing '..'.
-    if dir
-        .components()
-        .any(|c| c == std::path::Component::ParentDir)
-    {
-        return Err(FixtureCitationError::Io {
-            path: dir.to_path_buf(),
-            message: format!("Invalid input: {}", dir.display()),
-        });
-    }
-    for entry in fs::read_dir(dir).map_err(|error| io_error(dir, error))? {
-        let entry = entry.map_err(|error| io_error(dir, error))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_rs_files(&path, files)?;
-        } else if path.extension().is_some_and(|extension| extension == "rs")
-            && !is_test_only_file(&path)
-        {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
-fn is_test_only_file(path: &Path) -> bool {
-    matches!(
-        path.file_stem().and_then(|stem| stem.to_str()),
-        Some("tests" | "test_support")
-    )
 }
 
 fn active_production_lines(content: &str) -> Vec<String> {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -19,6 +19,7 @@ mod negative_corpus;
 mod no_tenant_knowledge;
 mod publish_plan;
 mod readme_version_check;
+mod repo;
 mod safety_net_sanity;
 mod scrub_public_text;
 mod tokenbridge_encrypted_index;

--- a/crates/xtask/src/no_tenant_knowledge.rs
+++ b/crates/xtask/src/no_tenant_knowledge.rs
@@ -4,13 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const PRODUCTION_CRATES: &[&str] = &[
-    "gaze-pii",
-    "gaze-types",
-    "gaze-recognizers",
-    "gaze-assembly",
-    "gaze-cli",
-];
+use crate::repo::{production_files, tenant_knowledge_file, PRODUCTION_CRATES};
 const ALLOW_MARKER: &str = "// allow(tenant-fixture)";
 // Denylist literals split via concat!() so this source file does not contain
 // the contiguous strings the gate scans for. This is meta-Potemkin avoidance:
@@ -53,7 +47,14 @@ pub fn scan_root(root: impl AsRef<Path>) -> Result<()> {
     let mut denylist_violations = Vec::new();
     let mut cases_checked = 0usize;
 
-    for file in production_files(root)? {
+    for file in
+        production_files(root, PRODUCTION_CRATES, tenant_knowledge_file).map_err(|error| {
+            TenantKnowledgeError::Io {
+                path: error.path,
+                message: error.message,
+            }
+        })?
+    {
         cases_checked += 1;
         let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
         for (line_index, line) in content.lines().enumerate() {
@@ -92,42 +93,6 @@ pub fn scan_root(root: impl AsRef<Path>) -> Result<()> {
         });
     }
 
-    Ok(())
-}
-
-fn production_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    for crate_name in PRODUCTION_CRATES {
-        let src = root
-            .join("crates")
-            .join(package_source_dir(crate_name))
-            .join("src");
-        if !src.exists() {
-            continue;
-        }
-        collect_rs_files(&src, &mut files)?;
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn package_source_dir(package_name: &str) -> &str {
-    match package_name {
-        "gaze-pii" => "gaze",
-        _ => package_name,
-    }
-}
-
-fn collect_rs_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(dir).map_err(|error| io_error(dir, error))? {
-        let entry = entry.map_err(|error| io_error(dir, error))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_rs_files(&path, files)?;
-        } else if path.extension().is_some_and(|extension| extension == "rs") {
-            files.push(path);
-        }
-    }
     Ok(())
 }
 

--- a/crates/xtask/src/no_tenant_knowledge.rs
+++ b/crates/xtask/src/no_tenant_knowledge.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::repo::{production_files, tenant_knowledge_file, PRODUCTION_CRATES};
+use crate::repo::{production_source_dirs, repo_root, source_files, tenant_knowledge_file};
 const ALLOW_MARKER: &str = "// allow(tenant-fixture)";
 // Denylist literals split via concat!() so this source file does not contain
 // the contiguous strings the gate scans for. This is meta-Potemkin avoidance:
@@ -36,25 +36,24 @@ pub struct Violation {
 pub type Result<T> = std::result::Result<T, TenantKnowledgeError>;
 
 pub fn run() -> anyhow::Result<()> {
-    scan_root(".")?;
+    let root = repo_root()?;
+    let source_dirs = production_source_dirs(&root)?;
+    scan_source_dirs(&source_dirs)?;
     println!("no_tenant_knowledge: passed");
     Ok(())
 }
 
-pub fn scan_root(root: impl AsRef<Path>) -> Result<()> {
-    let root = root.as_ref();
+pub fn scan_source_dirs(source_dirs: &[PathBuf]) -> Result<()> {
     let mut allow_marker_violations = Vec::new();
     let mut denylist_violations = Vec::new();
     let mut cases_checked = 0usize;
 
-    for file in
-        production_files(root, PRODUCTION_CRATES, tenant_knowledge_file).map_err(|error| {
-            TenantKnowledgeError::Io {
-                path: error.path,
-                message: error.message,
-            }
-        })?
-    {
+    for file in source_files(source_dirs, tenant_knowledge_file).map_err(|error| {
+        TenantKnowledgeError::Io {
+            path: error.path,
+            message: error.message,
+        }
+    })? {
         cases_checked += 1;
         let content = fs::read_to_string(&file).map_err(|error| io_error(&file, error))?;
         for (line_index, line) in content.lines().enumerate() {

--- a/crates/xtask/src/publish_plan.rs
+++ b/crates/xtask/src/publish_plan.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -13,8 +13,13 @@ pub fn run() -> Result<()> {
 }
 
 fn cargo_metadata() -> Result<Metadata> {
+    cargo_metadata_at(Path::new("."))
+}
+
+fn cargo_metadata_at(root: &Path) -> Result<Metadata> {
     let output = Command::new("cargo")
         .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(root)
         .output()
         .context("failed to run cargo metadata")?;
     if !output.status.success() {
@@ -24,6 +29,43 @@ fn cargo_metadata() -> Result<Metadata> {
         );
     }
     serde_json::from_slice(&output.stdout).context("failed to parse cargo metadata")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceMember {
+    pub name: String,
+    pub manifest_dir: PathBuf,
+}
+
+pub(crate) fn workspace_members(root: &Path) -> Result<Vec<WorkspaceMember>> {
+    workspace_members_from_metadata(&cargo_metadata_at(root)?)
+}
+
+fn workspace_members_from_metadata(metadata: &Metadata) -> Result<Vec<WorkspaceMember>> {
+    let packages_by_id = metadata
+        .packages
+        .iter()
+        .map(|package| (package.id.as_str(), package))
+        .collect::<HashMap<_, _>>();
+    let mut members = metadata
+        .workspace_members
+        .iter()
+        .map(|id| {
+            let package = packages_by_id
+                .get(id.as_str())
+                .with_context(|| format!("workspace member {id} missing from cargo metadata"))?;
+            let manifest_dir = package
+                .manifest_path
+                .parent()
+                .with_context(|| format!("package {} manifest has no parent", package.name))?;
+            Ok(WorkspaceMember {
+                name: package.name.clone(),
+                manifest_dir: manifest_dir.to_path_buf(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    members.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(members)
 }
 
 fn build_publish_plan(metadata: &Metadata) -> Result<Vec<PublishPackage>> {

--- a/crates/xtask/src/repo.rs
+++ b/crates/xtask/src/repo.rs
@@ -5,12 +5,23 @@ use std::{
 
 use anyhow::{Context, Result};
 
-pub const PRODUCTION_CRATES: &[&str] = &[
-    "gaze-pii",
-    "gaze-types",
-    "gaze-recognizers",
-    "gaze-assembly",
-    "gaze-cli",
+use crate::publish_plan::{self, WorkspaceMember};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CrateExemption {
+    pub name: &'static str,
+    pub reason: &'static str,
+}
+
+pub const EXEMPT_CRATES: &[CrateExemption] = &[
+    CrateExemption {
+        name: "xtask",
+        reason: "repository gate runner; its denylist and synthetic-fixture definitions are not production runtime code",
+    },
+    CrateExemption {
+        name: "gaze_dylint",
+        reason: "detached compile-time Dylint crate; it is not linked into any production runtime",
+    },
 ];
 
 #[derive(Debug)]
@@ -31,20 +42,42 @@ fn repo_root_from_manifest_dir(manifest_dir: &Path) -> Result<PathBuf> {
         .to_path_buf())
 }
 
-pub fn production_files(
+pub fn production_source_dirs(root: &Path) -> Result<Vec<PathBuf>> {
+    production_source_dirs_from_members(root, &publish_plan::workspace_members(root)?)
+}
+
+fn production_source_dirs_from_members(
     root: &Path,
-    crates: &[&str],
+    members: &[WorkspaceMember],
+) -> Result<Vec<PathBuf>> {
+    let mut source_dirs = Vec::new();
+    for member in members {
+        if EXEMPT_CRATES
+            .iter()
+            .any(|exemption| exemption.name == member.name)
+        {
+            continue;
+        }
+        if !member.manifest_dir.starts_with(root) {
+            anyhow::bail!(
+                "workspace member {} resolves outside repo root: {}",
+                member.name,
+                member.manifest_dir.display()
+            );
+        }
+        source_dirs.push(member.manifest_dir.join("src"));
+    }
+    source_dirs.sort();
+    Ok(source_dirs)
+}
+
+pub fn source_files(
+    source_dirs: &[PathBuf],
     include_file: impl Fn(&Path) -> bool + Copy,
 ) -> std::result::Result<Vec<PathBuf>, WalkError> {
     let mut files = Vec::new();
-    for crate_name in crates {
-        let src = root
-            .join("crates")
-            .join(package_source_dir(crate_name))
-            .join("src");
-        if src.exists() {
-            collect_files(&src, &mut files, include_file)?;
-        }
+    for src in source_dirs {
+        collect_files(src, &mut files, include_file)?;
     }
     files.sort();
     Ok(files)
@@ -60,13 +93,6 @@ pub fn fixture_citation_file(path: &Path) -> bool {
 
 pub fn tenant_knowledge_file(path: &Path) -> bool {
     is_rust_file(path)
-}
-
-fn package_source_dir(package_name: &str) -> &str {
-    match package_name {
-        "gaze-pii" => "gaze",
-        _ => package_name,
-    }
 }
 
 fn collect_files(
@@ -109,8 +135,12 @@ fn walk_error(path: &Path, error: io::Error) -> WalkError {
 
 #[cfg(test)]
 mod tests {
-    use super::{fixture_citation_file, repo_root_from_manifest_dir, tenant_knowledge_file};
-    use std::path::Path;
+    use super::{
+        fixture_citation_file, production_source_dirs_from_members, repo_root_from_manifest_dir,
+        source_files, tenant_knowledge_file,
+    };
+    use crate::publish_plan::WorkspaceMember;
+    use std::{fs, path::Path};
 
     #[test]
     fn repo_root_resolves_from_nested_xtask_manifest_dir() {
@@ -133,5 +163,34 @@ mod tests {
             assert_eq!(fixture_citation_file(Path::new(path)), fixture_citation);
             assert_eq!(tenant_knowledge_file(Path::new(path)), tenant_knowledge);
         }
+    }
+
+    #[test]
+    fn new_workspace_member_is_scanned_unless_explicitly_exempted() {
+        let temp = tempfile::tempdir().unwrap();
+        let new_member_dir = temp.path().join("crates/gaze-new-runtime");
+        let exempt_dir = temp.path().join("crates/xtask");
+        fs::create_dir_all(new_member_dir.join("src")).unwrap();
+        fs::create_dir_all(exempt_dir.join("src")).unwrap();
+        fs::write(new_member_dir.join("src/lib.rs"), "pub fn runtime() {}\n").unwrap();
+        fs::write(exempt_dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let source_dirs = production_source_dirs_from_members(
+            temp.path(),
+            &[
+                WorkspaceMember {
+                    name: "gaze-new-runtime".to_string(),
+                    manifest_dir: new_member_dir.clone(),
+                },
+                WorkspaceMember {
+                    name: "xtask".to_string(),
+                    manifest_dir: exempt_dir,
+                },
+            ],
+        )
+        .unwrap();
+        let files = source_files(&source_dirs, tenant_knowledge_file).unwrap();
+
+        assert_eq!(files, vec![new_member_dir.join("src/lib.rs")]);
     }
 }

--- a/crates/xtask/src/repo.rs
+++ b/crates/xtask/src/repo.rs
@@ -1,0 +1,137 @@
+use std::{
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+
+pub const PRODUCTION_CRATES: &[&str] = &[
+    "gaze-pii",
+    "gaze-types",
+    "gaze-recognizers",
+    "gaze-assembly",
+    "gaze-cli",
+];
+
+#[derive(Debug)]
+pub struct WalkError {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+pub fn repo_root() -> Result<PathBuf> {
+    repo_root_from_manifest_dir(Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+fn repo_root_from_manifest_dir(manifest_dir: &Path) -> Result<PathBuf> {
+    Ok(manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .context("resolve workspace root from xtask manifest dir")?
+        .to_path_buf())
+}
+
+pub fn production_files(
+    root: &Path,
+    crates: &[&str],
+    include_file: impl Fn(&Path) -> bool + Copy,
+) -> std::result::Result<Vec<PathBuf>, WalkError> {
+    let mut files = Vec::new();
+    for crate_name in crates {
+        let src = root
+            .join("crates")
+            .join(package_source_dir(crate_name))
+            .join("src");
+        if src.exists() {
+            collect_files(&src, &mut files, include_file)?;
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+pub fn fixture_citation_file(path: &Path) -> bool {
+    is_rust_file(path)
+        && !matches!(
+            path.file_stem().and_then(|stem| stem.to_str()),
+            Some("tests" | "test_support")
+        )
+}
+
+pub fn tenant_knowledge_file(path: &Path) -> bool {
+    is_rust_file(path)
+}
+
+fn package_source_dir(package_name: &str) -> &str {
+    match package_name {
+        "gaze-pii" => "gaze",
+        _ => package_name,
+    }
+}
+
+fn collect_files(
+    dir: &Path,
+    files: &mut Vec<PathBuf>,
+    include_file: impl Fn(&Path) -> bool + Copy,
+) -> std::result::Result<(), WalkError> {
+    if dir
+        .components()
+        .any(|component| component == Component::ParentDir)
+    {
+        return Err(WalkError {
+            path: dir.to_path_buf(),
+            message: format!("Invalid input: {}", dir.display()),
+        });
+    }
+
+    for entry in fs::read_dir(dir).map_err(|error| walk_error(dir, error))? {
+        let entry = entry.map_err(|error| walk_error(dir, error))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, files, include_file)?;
+        } else if include_file(&path) {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn is_rust_file(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "rs")
+}
+
+fn walk_error(path: &Path, error: io::Error) -> WalkError {
+    WalkError {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fixture_citation_file, repo_root_from_manifest_dir, tenant_knowledge_file};
+    use std::path::Path;
+
+    #[test]
+    fn repo_root_resolves_from_nested_xtask_manifest_dir() {
+        assert_eq!(
+            repo_root_from_manifest_dir(Path::new("/workspace/crates/xtask")).unwrap(),
+            Path::new("/workspace")
+        );
+    }
+
+    #[test]
+    fn leak_guard_filters_preserve_their_exact_divergence() {
+        let cases = [
+            ("lib.rs", true, true),
+            ("tests.rs", false, true),
+            ("test_support.rs", false, true),
+            ("fixture.toml", false, false),
+        ];
+
+        for (path, fixture_citation, tenant_knowledge) in cases {
+            assert_eq!(fixture_citation_file(Path::new(path)), fixture_citation);
+            assert_eq!(tenant_knowledge_file(Path::new(path)), tenant_knowledge);
+        }
+    }
+}

--- a/crates/xtask/tests/adversarial_fixture_citation.rs
+++ b/crates/xtask/tests/adversarial_fixture_citation.rs
@@ -4,6 +4,8 @@ use std::{collections::HashSet, fs};
 
 #[path = "../src/fixture_citation.rs"]
 mod fixture_citation;
+#[path = "../src/repo.rs"]
+mod repo;
 
 use fixture_citation::{scan_root_with_tests, FixtureCitationError};
 

--- a/crates/xtask/tests/adversarial_fixture_citation.rs
+++ b/crates/xtask/tests/adversarial_fixture_citation.rs
@@ -4,10 +4,12 @@ use std::{collections::HashSet, fs};
 
 #[path = "../src/fixture_citation.rs"]
 mod fixture_citation;
+#[path = "../src/publish_plan.rs"]
+mod publish_plan;
 #[path = "../src/repo.rs"]
 mod repo;
 
-use fixture_citation::{scan_root_with_tests, FixtureCitationError};
+use fixture_citation::{scan_source_dirs_with_tests, FixtureCitationError};
 
 #[test]
 fn fixture_email_in_production_scope_without_citation_fails_with_file_and_line() {
@@ -21,7 +23,7 @@ fn fixture_email_in_production_scope_without_citation_fails_with_file_and_line()
     )
     .expect("write seeded production fixture");
 
-    let result = scan_root_with_tests(temp.path(), &HashSet::new());
+    let result = scan_source_dirs_with_tests(&[src_dir], &HashSet::new());
     fs::remove_file(&fixture).expect("remove seeded production fixture");
 
     let error = result.expect_err("uncited fixture-shaped literal must fail");
@@ -55,7 +57,7 @@ fn fixture_email_with_exact_existing_test_citation_passes() {
     .expect("write cited production fixture");
     let listed_tests = HashSet::from(["gaze::tests::email_round_trip".to_string()]);
 
-    scan_root_with_tests(temp.path(), &listed_tests)
+    scan_source_dirs_with_tests(&[src_dir], &listed_tests)
         .expect("exact cited test name should satisfy citation gate");
 }
 
@@ -74,7 +76,7 @@ fn fixture_email_with_suffix_only_test_match_fails() {
     .expect("write cited production fixture");
     let listed_tests = HashSet::from(["email_round_trip".to_string()]);
 
-    let error = scan_root_with_tests(temp.path(), &listed_tests)
+    let error = scan_source_dirs_with_tests(&[src_dir], &listed_tests)
         .expect_err("suffix-only test names must not satisfy citation gate");
     let output = error.to_string();
     assert!(
@@ -102,7 +104,7 @@ fn fixture_email_with_renamed_cited_test_fails_adversarially() {
     .expect("write cited production fixture");
     let listed_tests = HashSet::from(["gaze::tests::email_round_trip_renamed".to_string()]);
 
-    let error = scan_root_with_tests(temp.path(), &listed_tests)
+    let error = scan_source_dirs_with_tests(&[src_dir], &listed_tests)
         .expect_err("renaming the cited test must fail the citation gate");
     let output = error.to_string();
     assert!(
@@ -126,6 +128,6 @@ fn fixture_strings_inside_cfg_test_modules_are_outside_production_lint_surface()
     )
     .expect("write cfg-test fixture");
 
-    scan_root_with_tests(temp.path(), &HashSet::new())
+    scan_source_dirs_with_tests(&[src_dir], &HashSet::new())
         .expect("fixture-shaped strings in cfg(test) modules are not production code");
 }

--- a/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
+++ b/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
@@ -20,7 +20,7 @@ fn seeded_order_id_in_production_scope_fails_gate_and_mentions_literal() {
     fs::write(&fixture, "fn fixture() {\n    let _ = \"order_id\";\n}\n")
         .expect("write seeded production fixture");
 
-    let result = scan_source_dirs(&[src_dir.clone()]);
+    let result = scan_source_dirs(std::slice::from_ref(&src_dir));
     fs::remove_file(&fixture).expect("remove seeded production fixture");
 
     let error = result.expect_err("seeded tenant literal must fail");
@@ -47,7 +47,7 @@ fn allow_marker_hard_fails_in_production_but_passes_outside_production_scope() {
     )
     .expect("write production allow-marker fixture");
 
-    let result = scan_source_dirs(&[src_dir.clone()]);
+    let result = scan_source_dirs(std::slice::from_ref(&src_dir));
     fs::remove_file(&production_fixture).expect("remove production allow-marker fixture");
 
     let error = result.expect_err("production allow marker must hard-fail");

--- a/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
+++ b/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
@@ -4,10 +4,12 @@ use std::fs;
 
 #[path = "../src/no_tenant_knowledge.rs"]
 mod no_tenant_knowledge;
+#[path = "../src/publish_plan.rs"]
+mod publish_plan;
 #[path = "../src/repo.rs"]
 mod repo;
 
-use no_tenant_knowledge::{scan_root, TenantKnowledgeError};
+use no_tenant_knowledge::{scan_source_dirs, TenantKnowledgeError};
 
 #[test]
 fn seeded_order_id_in_production_scope_fails_gate_and_mentions_literal() {
@@ -18,7 +20,7 @@ fn seeded_order_id_in_production_scope_fails_gate_and_mentions_literal() {
     fs::write(&fixture, "fn fixture() {\n    let _ = \"order_id\";\n}\n")
         .expect("write seeded production fixture");
 
-    let result = scan_root(temp.path());
+    let result = scan_source_dirs(&[src_dir.clone()]);
     fs::remove_file(&fixture).expect("remove seeded production fixture");
 
     let error = result.expect_err("seeded tenant literal must fail");
@@ -45,7 +47,7 @@ fn allow_marker_hard_fails_in_production_but_passes_outside_production_scope() {
     )
     .expect("write production allow-marker fixture");
 
-    let result = scan_root(temp.path());
+    let result = scan_source_dirs(&[src_dir.clone()]);
     fs::remove_file(&production_fixture).expect("remove production allow-marker fixture");
 
     let error = result.expect_err("production allow marker must hard-fail");
@@ -73,7 +75,7 @@ fn allow_marker_hard_fails_in_production_but_passes_outside_production_scope() {
     )
     .expect("write tests allow-marker fixture");
 
-    let result = scan_root(temp.path());
+    let result = scan_source_dirs(&[src_dir]);
     fs::remove_file(&test_fixture).expect("remove tests allow-marker fixture");
 
     result.expect("allow marker outside production scope should pass");

--- a/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
+++ b/crates/xtask/tests/adversarial_no_tenant_knowledge.rs
@@ -4,6 +4,8 @@ use std::fs;
 
 #[path = "../src/no_tenant_knowledge.rs"]
 mod no_tenant_knowledge;
+#[path = "../src/repo.rs"]
+mod repo;
 
 use no_tenant_knowledge::{scan_root, TenantKnowledgeError};
 

--- a/crates/xtask/tests/bundle_tokenization_drift.rs
+++ b/crates/xtask/tests/bundle_tokenization_drift.rs
@@ -39,6 +39,35 @@ fn bundle_tokenization_drift_gate_passes_on_baseline() {
 }
 
 #[test]
+fn bundle_tokenization_drift_gate_targets_repo_snapshot_from_nested_cwd() {
+    let root = workspace_root();
+    let nested = root.join("crates/xtask/fixtures");
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "xtask",
+            "--",
+            "bundle-tokenization-drift",
+            "--verify-ack",
+        ])
+        .current_dir(&nested)
+        .output()
+        .expect("run bundle-tokenization-drift gate from nested cwd");
+
+    assert!(
+        output.status.success(),
+        "nested-cwd gate must resolve the repo-root snapshot; {}",
+        output_text(&output)
+    );
+    assert!(
+        output_text(&output).contains("bundle-tokenization-drift: passed"),
+        "nested-cwd gate must execute against the committed snapshot; {}",
+        output_text(&output)
+    );
+}
+
+#[test]
 fn bundle_tokenization_drift_gate_fails_when_enabled_recognizer_id_drifts() {
     let temp = tempfile::tempdir().expect("tempdir");
     let fixture_root = temp


### PR DESCRIPTION
## What changed

- Added one manifest-anchored `repo_root()` and one shared source walker with explicit, still-distinct filters for `fixture-citation-lint` and `no-tenant-knowledge`.
- Anchored bundle-tokenization drift Git commands with `git -C <repo-root>` and an absolute snapshot pathspec, so `--verify-ack` cannot pass vacuously from a nested cwd.
- Reused xtask's existing publish-plan cargo-metadata stack to derive leak-guard scope from every workspace member except documented non-runtime exemptions (`xtask` and detached `gaze_dylint`).

## Previous fail-open scope

Both gates previously omitted these production crates entirely:

- `gaze-audit`
- `gaze-mcp-core`
- `gaze-mcp-rmcp`
- `gaze-document`
- `gaze-proxy`
- `gaze-token-bridge`
- `gaze-mcp-bridge`

They also never covered the newer `gaze-inspection` and `gaze-proxy-dashboard` workspace members. New workspace members are now scanned by default.

## Behavioral proofs

- Filter-divergence test pins the pre-refactor semantics exactly: fixture citation excludes `tests.rs` and `test_support.rs`; tenant knowledge includes them; both include ordinary Rust source and exclude non-Rust files.
- Nested-cwd integration test runs `bundle-tokenization-drift --verify-ack` from `crates/xtask/fixtures` and requires the committed repo-root snapshot to be used.
- Workspace-member drift test injects a synthetic new member and proves it is scanned while an explicit exemption is not.

## First-time finding triage

| Finding | Resolution |
|---|---|
| `gaze-token-bridge` hard-coded `order_id` in production defaults | Fixed in this PR by removing the tenant-specific default; no current tests or policy fixtures depended on it. |
| Newly scanned synthetic fixture literals in `gaze-document` and `gaze-token-bridge` | Fixed in this PR with exact live-test citations; added a behavioral detector test for the bundled bridge corpus. |

No acknowledged exemptions or follow-up todos were needed.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p xtask -j 2`
- `cargo run -p xtask -- fixture-citation-lint`
- `cargo run -p xtask -- no-tenant-knowledge`
- `cargo run -p xtask -- bundle-tokenization-drift --verify-ack`
- `cargo run -p xtask -- dylint-gate` (18 UI fixtures verified; compiled lint deferred by the existing scheduled-workflow contract)
- `cargo test --workspace --all-features --no-fail-fast`

Audit: solo scratchpad 7201 S19-F2

Resolves solo todo #2938
