### PR TITLE
[agent] fix(cli): one policy→pipeline loader for clean/daemon/proxy/setup — proxy no longer skips auto-activate and dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gaze_proxy::ProxyConfig::with_dictionaries` installs one immutable
+  dictionary source for every proxy detection pass.** Omitting the builder keeps
+  the existing empty-bundle default. `ProxyConfig` was already
+  `#[non_exhaustive]` and the stored field is private, so this addition does not
+  break external struct construction.
+
 - **Scheme- and `www.`-anchored URL detection at the deterministic rule floor**
   (todo #2254). The new `url.anchored` recognizer in the embedded `core` bundle
   tokenizes `http://`, `https://`, and `www.`-prefixed URLs as
@@ -239,6 +245,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserve the original value. `PiiClass::family` and `as_family_name` now model
   that namespace once, and policy and rulepack parsing share the same
   non-normalizing path. The enum and manifest wire shape are unchanged.
+- **`gaze proxy` now resolves the same rulepacks, dictionaries, and
+  auto-activated locales as `gaze clean` for the same policy** (audit 7201
+  S11-F2, solo todo #2937). Previously the proxy assembled a narrower pipeline
+  that skipped dictionary values and locale-gated auto-activation.
+- **Proxy request protection and fail-closed residual validation now read the
+  same configured `DictionaryBundle`.** This covers direct/codec JSON and SSE
+  response validation plus the legacy primary and residual request passes; the
+  residual can no longer know fewer dictionary terms than the primary pass.
 
 - **The ORT NER backend now hands the BIO decoder the document text, not its
   provenance label** (audit S07-F1, solo todo #2902). `OrtBackend::detect` passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,9 +209,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This deliberately trades axis 5 (snapshot compatibility and configuration
   convenience) for axis 1 (never leak a foreign-format identifier merely
   because the surrounding document uses another locale). The known remaining
-  debt is 27 target spans: 14 DE national-phone and 13 postal spans. Todo #2411
-  stays open: direct/codec primary and residual proxy passes still require the
-  shared `ProxyConfig::locale_chain` for every document-basis recognizer.
+  rule-coverage debt is 27 target spans: 14 DE national-phone and 13 postal
+  spans. The proxy transport debt is now closed by #2411: direct/codec primary
+  and residual passes receive the shared `ProxyConfig::locale_chain`; #2403
+  previously fixed the legacy path.
 
 - **A provably corrupt clean-text manifest now hard-errors in every safety-net
   fallback mode, including `Tolerant`** (#403). The safety-net RESOLVE path checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same configured `DictionaryBundle`.** This covers direct/codec JSON and SSE
   response validation plus the legacy primary and residual request passes; the
   residual can no longer know fewer dictionary terms than the primary pass.
+- **`gaze-proxy` direct/codec primary and residual passes now use the resolved
+  locale chain instead of a pinned Global chain** (solo todo #2411). This
+  closes the direct/codec half after #2403 fixed the legacy path, and keeps both
+  passes aligned with the same configured dictionaries and document locales.
 
 - **The ORT NER backend now hands the BIO decoder the document text, not its
   provenance label** (audit S07-F1, solo todo #2902). `OrtBackend::detect` passed

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -14,21 +14,16 @@ use super::{
     SafetyNetFallback, SafetyNetKind, SafetyNetMode,
 };
 use crate::error::CliError;
-use crate::pipeline::build::{
-    build_pipeline_from_policy, dictionary_terms_from_rulepacks, load_rulepacks,
-    map_pipeline_error, map_policy_error, merged_rulepack_default_locales, resolve_ner_threshold,
-    ArcLogger,
-};
+use crate::pipeline::build::{map_policy_error, resolve_pipeline, validate_ner_threshold};
 use crate::pipeline::run::{
     clean_overrides_from_options, enforce_safety_net_mode, entry_class_to_string,
-    map_safety_net_pipeline_error, maybe_register_safety_net, parse_cli_locales, safety_net_policy,
+    map_safety_net_pipeline_error, maybe_register_safety_net, safety_net_policy,
     validate_safety_net_tolerant_gate, CleanOptions,
 };
 use gaze::{
-    dictionary_bundle_from_context, Action, ConflictTier, DictionaryBundle, DocumentKind,
-    EmittedTokenSpan, LeakReport, LocaleTag, PiiClass, Policy, RawDocument, RedactionEntry,
-    RedactionLogError, RedactionLogger, Result as GazeResult, Session, SessionSnapshotEntry,
-    TypedContext,
+    Action, ConflictTier, DictionaryBundle, DocumentKind, EmittedTokenSpan, LeakReport, LocaleTag,
+    PiiClass, Policy, RawDocument, RedactionEntry, RedactionLogError, RedactionLogger,
+    Result as GazeResult, Session, SessionSnapshotEntry,
 };
 use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 
@@ -151,52 +146,22 @@ impl Daemon {
         let options = clean_options(&args);
         let cli_ner_threshold = args
             .ner_threshold
-            .map(crate::pipeline::build::validate_ner_threshold)
+            .map(validate_ner_threshold)
             .transpose()
             .map_err(map_policy_error)?;
         let clean_overrides = clean_overrides_from_options(&options)?;
-        let loaded_policy = Policy::load_for_cli(&args.policy)
-            .map_err(map_policy_error)
-            .map(|policy| clean_overrides.apply_to(&policy))?;
-        let loaded_rulepacks = load_rulepacks(&loaded_policy).map_err(map_pipeline_error)?;
-        let rulepack_dictionaries =
-            dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
-        let mut policy_dictionaries = loaded_policy.dictionaries.clone();
-        policy_dictionaries.extend(rulepack_dictionaries);
-        let dictionaries = DictionaryBundle::merge(
-            DictionaryBundle::from_rulepack_terms(&policy_dictionaries),
-            dictionary_bundle_from_context(&TypedContext {
-                dictionaries: std::collections::HashMap::new(),
-                class_map: std::collections::HashMap::new(),
-                fields: serde_json::Map::new(),
-            }),
-        );
-        let mut rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
-        if loaded_policy.rulepacks.auto_activate_locale_gated {
-            // Derived from the loaded packs (audit 7201 S10-F2), same source of
-            // truth as `gaze clean` and `CorePipelineConfig`.
-            for locale in gaze_assembly::locale_gated_activation_locales(&loaded_rulepacks) {
-                if !rulepack_default_locales.contains(&locale) {
-                    rulepack_default_locales.push(locale);
-                }
-            }
-        }
-        let cli_locales = parse_cli_locales(&args.locale)?;
-        let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
-            cli_locales.as_deref(),
-            loaded_policy.locale.as_deref(),
-            Some(&rulepack_default_locales),
-        );
-        let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, Some(&loaded_policy));
-        let pipeline = build_pipeline_from_policy(
-            &loaded_policy,
-            &loaded_rulepacks,
+        let resolved = resolve_pipeline(
+            Some(&args.policy),
+            &clean_overrides,
+            &args.locale,
+            cli_ner_threshold,
             None,
-            &locale_chain,
-            resolved_ner_threshold,
-        )?
-        .with_redaction_logger(ArcLogger(Arc::clone(&logger) as Arc<dyn RedactionLogger>));
-        let pipeline = maybe_register_safety_net(pipeline, &options)?;
+            Some(Arc::clone(&logger) as Arc<dyn RedactionLogger>),
+        )?;
+        let loaded_policy = resolved.policy.expect("daemon requires a policy path");
+        let locale_chain = resolved.locale_chain;
+        let dictionaries = resolved.dictionaries;
+        let pipeline = maybe_register_safety_net(resolved.pipeline, &options)?;
         Ok(Self {
             pipeline,
             policy: loaded_policy,

--- a/crates/gaze-cli/src/commands/proxy.rs
+++ b/crates/gaze-cli/src/commands/proxy.rs
@@ -8,11 +8,9 @@ use gaze_proxy::daemon::{self, AdapterConfig, DaemonConfig, DaemonPaths};
 use gaze_proxy::ProxyConfig;
 use url::Url;
 
+use crate::clean_overrides::CleanOverrides;
 use crate::error::CliError;
-use crate::pipeline::build::{
-    build_pipeline_from_policy, load_rulepacks, map_pipeline_error, map_policy_error,
-    merged_rulepack_default_locales, resolve_ner_threshold,
-};
+use crate::pipeline::build::resolve_pipeline;
 
 pub(crate) struct ServeArgs {
     pub(crate) bind: SocketAddr,
@@ -85,8 +83,10 @@ pub(crate) fn serve(args: ServeArgs) -> Result<(), CliError> {
     // decides which recognizers are registered, `ProxyConfig` decides which may fire. Dropping
     // it here is what pinned proxied traffic to `[LocaleTag::Global]` and left locale-gated
     // recognizers inert for adopters who had configured a locale (solo todo #2403).
-    let (pipeline, locale_chain) = build_pipeline(args.policy, &args.rulepack)?;
-    config = config.with_locale_chain(locale_chain);
+    let (pipeline, locale_chain, dictionaries) = build_pipeline(args.policy, &args.rulepack)?;
+    config = config
+        .with_locale_chain(locale_chain)
+        .with_dictionaries(dictionaries);
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|err| CliError::ProxyDetail(format!("runtime: {err}")))?;
     runtime
@@ -206,24 +206,21 @@ pub(crate) fn uninstall_systemd_user() -> Result<(), CliError> {
 fn build_pipeline(
     policy: Option<PathBuf>,
     rulepack: &str,
-) -> Result<(gaze::Pipeline, gaze::LocaleChain), CliError> {
+) -> Result<(gaze::Pipeline, gaze::LocaleChain, gaze::DictionaryBundle), CliError> {
     if let Some(path) = policy {
-        let policy = gaze::Policy::load_for_cli(&path).map_err(map_policy_error)?;
-        let rulepacks = load_rulepacks(&policy).map_err(map_pipeline_error)?;
-        let rulepack_default_locales = merged_rulepack_default_locales(&rulepacks);
-        let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
+        let resolved = resolve_pipeline(
+            Some(&path),
+            &CleanOverrides::default(),
+            &[],
             None,
-            policy.locale.as_deref(),
-            Some(&rulepack_default_locales),
-        );
-        let pipeline = build_pipeline_from_policy(
-            &policy,
-            &rulepacks,
             None,
-            &locale_chain,
-            resolve_ner_threshold(None, Some(&policy)),
+            None,
         )?;
-        return Ok((pipeline, locale_chain));
+        return Ok((
+            resolved.pipeline,
+            resolved.locale_chain,
+            resolved.dictionaries,
+        ));
     }
     let mut config = gaze_assembly::CorePipelineConfig::new();
     if rulepack != "core" {
@@ -233,7 +230,11 @@ fn build_pipeline(
         .build()
         .map_err(|err| CliError::ProxyDetail(format!("pipeline: {err}")))?;
     let locale_chain = core.locale_chain().clone();
-    Ok((core.into_pipeline(), locale_chain))
+    Ok((
+        core.into_pipeline(),
+        locale_chain,
+        gaze::DictionaryBundle::default(),
+    ))
 }
 
 fn proxy_config(

--- a/crates/gaze-cli/src/commands/setup.rs
+++ b/crates/gaze-cli/src/commands/setup.rs
@@ -4,17 +4,15 @@ use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
 use clap::ValueEnum;
-use gaze::{CleanDocument, DictionaryBundle, LocaleChain, Policy, RawDocument, Session};
+use gaze::{CleanDocument, RawDocument, Session};
 use gaze_model_setup::{
     install_kiji_bundle, InstallOptions, InstallOutcome, KijiDistilbertPrecision, SetupError,
 };
 use sha2::{Digest, Sha256};
 
+use crate::clean_overrides::CleanOverrides;
 use crate::error::CliError;
-use crate::pipeline::build::{
-    build_pipeline_from_policy, dictionary_terms_from_rulepacks, load_rulepacks,
-    map_pipeline_error, map_policy_error, resolve_ner_threshold,
-};
+use crate::pipeline::build::resolve_pipeline;
 
 const DEFAULT_POLICY_FILE: &str = "gaze.toml";
 const OPF_UNPINNED_NOTICE: &str = "OPF safety-net is not pinned in this build; defaulting to NER.";
@@ -380,22 +378,18 @@ action = "preserve"
 }
 
 fn doctor_check(policy_path: &Path) -> Result<String, CliError> {
-    let policy = Policy::load_for_cli(policy_path).map_err(map_policy_error)?;
-    let rulepacks = load_rulepacks(&policy).map_err(map_pipeline_error)?;
-    let rulepack_dictionaries =
-        dictionary_terms_from_rulepacks(&rulepacks).map_err(map_pipeline_error)?;
-    let mut dictionary_terms = policy.dictionaries.clone();
-    dictionary_terms.extend(rulepack_dictionaries);
-    let dictionaries = DictionaryBundle::from_rulepack_terms(&dictionary_terms);
-    let locale_chain =
-        LocaleChain::merge_cli_policy_rulepack_default(None, policy.locale.as_deref(), None);
-    let pipeline = build_pipeline_from_policy(
-        &policy,
-        &rulepacks,
+    let resolved = resolve_pipeline(
+        Some(policy_path),
+        &CleanOverrides::default(),
+        &[],
         None,
-        &locale_chain,
-        resolve_ner_threshold(None, Some(&policy)),
+        None,
+        None,
     )?;
+    let policy = resolved.policy.expect("doctor requires a policy path");
+    let pipeline = resolved.pipeline;
+    let locale_chain = resolved.locale_chain;
+    let dictionaries = resolved.dictionaries;
     let session = Session::from_policy(&policy)
         .map_err(|err| setup_error(format!("doctor session init failed: {err}")))?;
     let clean = pipeline

--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -1,14 +1,204 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use gaze::{
-    Action, ClassRule, DefaultRule, LocaleChain, LocaleTag, PiiClass, Pipeline, Policy,
-    PolicyError, RawMatch, RedactionEntry, RedactionLogError, RedactionLogger,
-    Result as GazeResult, Rulepack, RulepackDict, RulepackSource, TypedContext,
-    DEFAULT_NER_THRESHOLD,
+    dictionary_bundle_from_context, Action, ClassRule, DefaultRule, DictionaryBundle, LocaleChain,
+    LocaleTag, PiiClass, Pipeline, Policy, PolicyError, RawMatch, RedactionEntry,
+    RedactionLogError, RedactionLogger, Result as GazeResult, RuleSpec, Rulepack, RulepackDict,
+    RulepackSource, SessionPolicy, SessionScope, TypedContext, DEFAULT_NER_THRESHOLD,
 };
 use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 
+use crate::clean_overrides::CleanOverrides;
 use crate::error::CliError;
+
+pub(crate) struct ResolvedPipeline {
+    pub(crate) pipeline: Pipeline,
+    pub(crate) policy: Option<Policy>,
+    pub(crate) rulepacks: Vec<Rulepack>,
+    pub(crate) locale_chain: LocaleChain,
+    pub(crate) dictionaries: DictionaryBundle,
+}
+
+/// Resolves every policy-derived input before constructing the pipeline.
+///
+/// The order is load-bearing: overrides, rulepacks, dictionaries, locale chain,
+/// auto-activation, then pipeline assembly. All CLI entry points must use this
+/// sequence so a policy has one detection surface regardless of the verb.
+pub(crate) fn resolve_pipeline(
+    policy_path: Option<&Path>,
+    overrides: &CleanOverrides,
+    cli_locales: &[String],
+    cli_ner_threshold: Option<f32>,
+    context: Option<TypedContext>,
+    logger: Option<Arc<dyn RedactionLogger>>,
+) -> std::result::Result<ResolvedPipeline, CliError> {
+    let loaded_policy = policy_path
+        .map(Policy::load_for_cli)
+        .transpose()
+        .map_err(map_policy_error)?
+        .map(|policy| overrides.apply_to(&policy));
+    let cli_rulepack_policy = if loaded_policy.is_none() && has_rulepack_overrides(overrides) {
+        Some(policy_for_rulepack_overrides(overrides)?)
+    } else {
+        None
+    };
+    let policy = loaded_policy.or(cli_rulepack_policy);
+    let rulepacks = policy
+        .as_ref()
+        .map(load_rulepacks)
+        .transpose()
+        .map_err(map_pipeline_error)?
+        .unwrap_or_default();
+
+    let context_bundle = context
+        .as_ref()
+        .map(dictionary_bundle_from_context)
+        .unwrap_or_default();
+    let rulepack_dictionaries =
+        dictionary_terms_from_rulepacks(&rulepacks).map_err(map_pipeline_error)?;
+    let policy_bundle = policy
+        .as_ref()
+        .map(|policy| {
+            let mut dictionaries = policy.dictionaries.clone();
+            dictionaries.extend(rulepack_dictionaries);
+            DictionaryBundle::from_rulepack_terms(&dictionaries)
+        })
+        .unwrap_or_default();
+    let dictionaries = DictionaryBundle::merge(policy_bundle, context_bundle);
+
+    let mut rulepack_default_locales = merged_rulepack_default_locales(&rulepacks);
+    if policy
+        .as_ref()
+        .is_some_and(|policy| policy.rulepacks.auto_activate_locale_gated)
+    {
+        for locale in gaze_assembly::locale_gated_activation_locales(&rulepacks) {
+            if !rulepack_default_locales.contains(&locale) {
+                rulepack_default_locales.push(locale);
+            }
+        }
+    }
+    let cli_locales = parse_cli_locales(cli_locales)?;
+    let locale_chain = LocaleChain::merge_cli_policy_rulepack_default(
+        cli_locales.as_deref(),
+        policy.as_ref().and_then(|policy| policy.locale.as_deref()),
+        Some(&rulepack_default_locales),
+    );
+    let ner_threshold = resolve_ner_threshold(cli_ner_threshold, policy.as_ref());
+
+    let pipeline = match policy.as_ref() {
+        Some(policy) => build_pipeline_from_policy(
+            policy,
+            &rulepacks,
+            context.as_ref(),
+            &locale_chain,
+            ner_threshold,
+        )?,
+        None if context.is_some() => {
+            build_context_pipeline(context.as_ref().expect("checked context")).map_err(|err| {
+                CliError::PolicyConfigDetail(format!("context pipeline build: {err}"))
+            })?
+        }
+        None => {
+            tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
+            build_stub_pipeline().map_err(|err| {
+                CliError::PolicyConfigDetail(format!("stub pipeline build: {err}"))
+            })?
+        }
+    };
+    let pipeline = match logger {
+        Some(logger) => pipeline.with_redaction_logger(ArcLogger(logger)),
+        None => pipeline,
+    };
+
+    Ok(ResolvedPipeline {
+        pipeline,
+        policy,
+        rulepacks,
+        locale_chain,
+        dictionaries,
+    })
+}
+
+fn has_rulepack_overrides(overrides: &CleanOverrides) -> bool {
+    overrides.rulepack_bundled.is_some() || !overrides.rulepack_paths.is_empty()
+}
+
+fn policy_for_rulepack_overrides(
+    overrides: &CleanOverrides,
+) -> std::result::Result<Policy, CliError> {
+    let mut rules = class_rules_for_bundled_overrides(overrides)?;
+    rules.push(RuleSpec::Default {
+        action: Action::Preserve,
+    });
+    let mut session = SessionPolicy::default();
+    session.scope = SessionScope::Persistent;
+    session.ttl_secs = Some(86_400);
+
+    let mut base = Policy::default();
+    base.session = session;
+    base.rules = rules;
+    Ok(overrides.apply_to(&base))
+}
+
+fn class_rules_for_bundled_overrides(
+    overrides: &CleanOverrides,
+) -> std::result::Result<Vec<RuleSpec>, CliError> {
+    let Some(bundled) = &overrides.rulepack_bundled else {
+        return Ok(Vec::new());
+    };
+    let mut classes = std::collections::BTreeSet::new();
+    for bundle in bundled {
+        let contents = gaze_recognizers::embedded(bundle).ok_or_else(|| {
+            CliError::PolicyConfigDetail(format!("unknown bundled rulepack: {bundle}"))
+        })?;
+        let rulepack = Rulepack::load(RulepackSource::Embedded(contents)).map_err(|err| {
+            CliError::PolicyConfigDetail(format!("embedded rulepack '{bundle}': {err}"))
+        })?;
+        classes.extend(rulepack.activated_classes());
+        classes.extend(
+            rulepack
+                .recognizers
+                .iter()
+                .filter(|recognizer| recognizer.enabled)
+                .filter_map(|recognizer| {
+                    recognizer
+                        .collision
+                        .as_ref()
+                        .and_then(|collision| {
+                            collision
+                                .mandatory_anchor
+                                .as_ref()
+                                .map(|_| &collision.family)
+                        })
+                        .map(|family| PiiClass::family(family))
+                }),
+        );
+    }
+    Ok(classes
+        .into_iter()
+        .map(|class| RuleSpec::Class {
+            class,
+            action: Action::Tokenize,
+        })
+        .collect())
+}
+
+pub(crate) fn parse_cli_locales(
+    raw: &[String],
+) -> std::result::Result<Option<Vec<LocaleTag>>, CliError> {
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    raw.iter()
+        .map(|locale| {
+            LocaleTag::parse(locale).map_err(|err| {
+                CliError::PolicyConfigDetail(format!("invalid --locale '{locale}': {err}"))
+            })
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map(Some)
+}
 
 pub(crate) fn map_policy_error(err: PolicyError) -> CliError {
     match err {
@@ -194,12 +384,11 @@ pub(crate) fn merged_rulepack_default_locales(rulepacks: &[Rulepack]) -> Vec<Loc
 /// Stub pipeline used until the policy.toml loader (issue #3) lands.
 /// Ships only a regex email detector + tokenize rule so the CLI contract can
 /// be exercised end-to-end; richer detectors arrive with the loader.
-pub(crate) fn build_stub_pipeline(logger: Arc<dyn RedactionLogger>) -> GazeResult<Pipeline> {
+fn build_stub_pipeline() -> GazeResult<Pipeline> {
     Pipeline::builder()
         .detector(RegexDetector::emails().map_err(map_recognizer_error)?)
         .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
         .rule(DefaultRule::new(Action::Preserve))
-        .redaction_logger(ArcLogger(logger))
         .build()
 }
 
@@ -218,10 +407,7 @@ fn map_recognizer_error(err: gaze_recognizers::RecognizerError) -> gaze::Error {
     }
 }
 
-pub(crate) fn build_context_pipeline(
-    context: &TypedContext,
-    logger: Arc<dyn RedactionLogger>,
-) -> GazeResult<Pipeline> {
+fn build_context_pipeline(context: &TypedContext) -> GazeResult<Pipeline> {
     let mut builder = Pipeline::builder();
     for name in context.dictionaries.keys() {
         let class = context
@@ -239,10 +425,7 @@ pub(crate) fn build_context_pipeline(
             ))
             .rule(ClassRule::new(class, Action::Tokenize));
     }
-    builder
-        .rule(DefaultRule::new(Action::Preserve))
-        .redaction_logger(ArcLogger(logger))
-        .build()
+    builder.rule(DefaultRule::new(Action::Preserve)).build()
 }
 
 /// Adapter that lets `PipelineBuilder::redaction_logger` (which takes ownership

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -996,6 +996,7 @@ fn emit_safety_net_warning(variant: &'static str, count: usize) {
 mod tests {
     use super::*;
     use crate::pipeline::build::resolve_ner_threshold;
+    use gaze::Policy;
 
     fn policy_with_ner_threshold(threshold: f32) -> Policy {
         let mut session = gaze::SessionPolicy::default();

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -994,7 +994,6 @@ fn emit_safety_net_warning(variant: &'static str, count: usize) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::pipeline::build::resolve_ner_threshold;
     use gaze::Policy;
 

--- a/crates/gaze-cli/src/pipeline/run.rs
+++ b/crates/gaze-cli/src/pipeline/run.rs
@@ -10,11 +10,9 @@ use base64::Engine;
 use serde::Serialize;
 
 use gaze::{
-    dictionary_bundle_from_context, Action, DictionaryBundle, DictionarySource, DocumentKind,
-    LeakKind, LeakReport, LeakReportTelemetry, LocaleTag, PiiClass, Policy, RawDocument,
-    RedactionEntry, RedactionLogError, RedactionLogger, Result as GazeResult, RuleSpec, Rulepack,
-    RulepackSource, Scope, SensitiveSnapshot, Session, SessionPolicy, SessionScope,
-    SessionSnapshotEntry, TypedContext,
+    DictionarySource, DocumentKind, LeakKind, LeakReport, LeakReportTelemetry, LocaleTag, PiiClass,
+    RawDocument, RedactionEntry, RedactionLogError, RedactionLogger, Result as GazeResult, Scope,
+    SensitiveSnapshot, Session, SessionScope, SessionSnapshotEntry, TypedContext,
 };
 use gaze_audit::{LeakSuspectLogEntry, LeakSuspectLogger, SqliteLogger};
 
@@ -27,10 +25,7 @@ use crate::commands::{
 use crate::error::CliError;
 use crate::io::{read_stdin_text, require_json_format};
 use crate::pipeline::build::{
-    build_context_pipeline, build_pipeline_from_policy, build_stub_pipeline,
-    dictionary_terms_from_rulepacks, load_rulepacks, map_pipeline_error, map_policy_error,
-    merged_rulepack_default_locales, resolve_ner_threshold, validate_ner_threshold,
-    warn_uncovered_collision_families, ArcLogger,
+    map_policy_error, resolve_pipeline, validate_ner_threshold, warn_uncovered_collision_families,
 };
 
 const CORE_EXTENDED_DEPRECATION: &str = "`--rulepack-bundled core-extended` is deprecated since v0.8.0; use `--rulepack-bundled core --locale=<lang>` for explicit activation";
@@ -95,85 +90,25 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     let raw = read_stdin_text(options.max_bytes)?;
 
     let counter = Arc::new(CountingLogger::new(options.audit_db).map_err(|_| CliError::Pipeline)?);
-    let loaded_policy = match options.policy {
-        Some(path) => {
-            let policy = Policy::load_for_cli(path).map_err(map_policy_error)?;
-            Some(clean_overrides.apply_to(&policy))
-        }
-        None => None,
-    };
-    let cli_rulepack_policy = if loaded_policy.is_none() && has_rulepack_overrides(&options) {
-        Some(policy_for_rulepack_overrides(&clean_overrides)?)
-    } else {
-        None
-    };
-    let effective_policy = loaded_policy.as_ref().or(cli_rulepack_policy.as_ref());
-    let loaded_rulepacks = match (&loaded_policy, &cli_rulepack_policy) {
-        (Some(policy), _) | (None, Some(policy)) => {
-            load_rulepacks(policy).map_err(map_pipeline_error)?
-        }
-        (None, None) => Vec::new(),
-    };
     let context = options
         .context_json
         .map(TypedContext::load)
         .transpose()
         .map_err(|err| CliError::PolicyConfigDetail(format!("context json: {err}")))?;
-    let context_bundle = context
-        .as_ref()
-        .map(dictionary_bundle_from_context)
-        .unwrap_or_default();
-    let rulepack_dictionaries =
-        dictionary_terms_from_rulepacks(&loaded_rulepacks).map_err(map_pipeline_error)?;
-    let policy_bundle = effective_policy
-        .map(|policy| {
-            let mut dictionaries = policy.dictionaries.clone();
-            dictionaries.extend(rulepack_dictionaries);
-            DictionaryBundle::from_rulepack_terms(&dictionaries)
-        })
-        .unwrap_or_default();
-    let dictionaries = DictionaryBundle::merge(policy_bundle, context_bundle);
-    let dictionary_stats = dictionaries.stats();
-    let mut rulepack_default_locales = merged_rulepack_default_locales(&loaded_rulepacks);
-    if effective_policy.is_some_and(|policy| policy.rulepacks.auto_activate_locale_gated) {
-        // Derived from the loaded packs (audit 7201 S10-F2): every loaded
-        // locale-gated recognizer's locale joins the chain, in a stable order.
-        for locale in gaze_assembly::locale_gated_activation_locales(&loaded_rulepacks) {
-            if !rulepack_default_locales.contains(&locale) {
-                rulepack_default_locales.push(locale);
-            }
-        }
-    }
-    let cli_locales = parse_cli_locales(options.locale)?;
-    let locale_chain = gaze::LocaleChain::merge_cli_policy_rulepack_default(
-        cli_locales.as_deref(),
-        effective_policy.and_then(|policy| policy.locale.as_deref()),
-        Some(&rulepack_default_locales),
-    );
-    let resolved_ner_threshold = resolve_ner_threshold(cli_ner_threshold, effective_policy);
-
-    let pipeline = match effective_policy {
-        Some(policy) => build_pipeline_from_policy(
-            policy,
-            &loaded_rulepacks,
-            context.as_ref(),
-            &locale_chain,
-            resolved_ner_threshold,
-        )?
-        .with_redaction_logger(ArcLogger(Arc::clone(&counter) as Arc<dyn RedactionLogger>)),
-        None if context.is_some() => build_context_pipeline(
-            context.as_ref().expect("checked context"),
-            Arc::clone(&counter) as Arc<dyn RedactionLogger>,
-        )
-        .map_err(|err| CliError::PolicyConfigDetail(format!("context pipeline build: {err}")))?,
-        None => {
-            tracing::warn!("gaze clean running with stub pipeline because --policy was omitted");
-            build_stub_pipeline(Arc::clone(&counter) as Arc<dyn RedactionLogger>).map_err(
-                |err| CliError::PolicyConfigDetail(format!("stub pipeline build: {err}")),
-            )?
-        }
-    };
-    let pipeline = maybe_register_safety_net(pipeline, &options)?;
+    let resolved = resolve_pipeline(
+        options.policy,
+        &clean_overrides,
+        options.locale,
+        cli_ner_threshold,
+        context,
+        Some(Arc::clone(&counter) as Arc<dyn RedactionLogger>),
+    )?;
+    let dictionary_stats = resolved.dictionaries.stats();
+    let effective_policy = resolved.policy;
+    let loaded_rulepacks = resolved.rulepacks;
+    let locale_chain = resolved.locale_chain;
+    let dictionaries = resolved.dictionaries;
+    let pipeline = maybe_register_safety_net(resolved.pipeline, &options)?;
     validate_safety_net_tolerant_gate(options.safety_net_mode, options.safety_net_fallback)?;
     if matches!(
         options.safety_net_mode,
@@ -183,7 +118,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
         eprintln!("warning: --safety-net-fallback is ignored when --safety-net-mode is terminal");
     }
 
-    let session = match effective_policy {
+    let session = match effective_policy.as_ref() {
         Some(policy) => Session::from_policy_with_ttl_override(policy, options.session_ttl),
         None => Session::new(scope_for_cli_without_policy(
             clean_overrides.session_scope.as_ref(),
@@ -263,7 +198,7 @@ pub(crate) fn run_clean(options: CleanOptions<'_>) -> std::result::Result<(), Cl
     // Surface fail-open policy coverage gaps only once the clean succeeded — on
     // an error path there is no output to leak, and the warning must not corrupt
     // the single-line JSON error envelope on stderr (issue #360).
-    if let Some(policy) = effective_policy {
+    if let Some(policy) = effective_policy.as_ref() {
         warn_uncovered_collision_families(policy, &loaded_rulepacks, &locale_chain);
     }
     println!("{json}");
@@ -727,70 +662,6 @@ fn normalize_rulepack_bundles(raw: &[String]) -> (Vec<String>, bool) {
     (bundled, auto_activate_locale_gated)
 }
 
-pub(crate) fn has_rulepack_overrides(options: &CleanOptions<'_>) -> bool {
-    !options.rulepack_bundled.is_empty() || !options.rulepack_paths.is_empty()
-}
-
-pub(crate) fn policy_for_rulepack_overrides(
-    clean_overrides: &CleanOverrides,
-) -> std::result::Result<Policy, CliError> {
-    let mut rules = class_rules_for_bundled_overrides(clean_overrides)?;
-    rules.push(RuleSpec::Default {
-        action: Action::Preserve,
-    });
-    let mut session = SessionPolicy::default();
-    session.scope = SessionScope::Persistent;
-    session.ttl_secs = Some(86_400);
-
-    let mut base = Policy::default();
-    base.session = session;
-    base.rules = rules;
-    Ok(clean_overrides.apply_to(&base))
-}
-
-fn class_rules_for_bundled_overrides(
-    clean_overrides: &CleanOverrides,
-) -> std::result::Result<Vec<RuleSpec>, CliError> {
-    let Some(bundled) = &clean_overrides.rulepack_bundled else {
-        return Ok(Vec::new());
-    };
-    let mut classes = std::collections::BTreeSet::new();
-    for bundle in bundled {
-        let contents = gaze_recognizers::embedded(bundle).ok_or_else(|| {
-            CliError::PolicyConfigDetail(format!("unknown bundled rulepack: {bundle}"))
-        })?;
-        let rulepack = Rulepack::load(RulepackSource::Embedded(contents)).map_err(|err| {
-            CliError::PolicyConfigDetail(format!("embedded rulepack '{bundle}': {err}"))
-        })?;
-        classes.extend(rulepack.activated_classes());
-        classes.extend(
-            rulepack
-                .recognizers
-                .iter()
-                .filter(|recognizer| recognizer.enabled)
-                .filter_map(|recognizer| {
-                    recognizer
-                        .collision
-                        .as_ref()
-                        .and_then(|collision| {
-                            collision
-                                .mandatory_anchor
-                                .as_ref()
-                                .map(|_| &collision.family)
-                        })
-                        .map(|family| PiiClass::family(family))
-                }),
-        );
-    }
-    Ok(classes
-        .into_iter()
-        .map(|class| RuleSpec::Class {
-            class,
-            action: Action::Tokenize,
-        })
-        .collect())
-}
-
 pub(crate) fn scope_for_cli_without_policy(
     scope: Option<&SessionScope>,
     ttl_secs: Option<u64>,
@@ -805,22 +676,6 @@ pub(crate) fn scope_for_cli_without_policy(
             variant: format!("{:?}", scope.unwrap_or(&SessionScope::Persistent)),
         }),
     }
-}
-
-pub(crate) fn parse_cli_locales(
-    raw: &[String],
-) -> std::result::Result<Option<Vec<LocaleTag>>, CliError> {
-    if raw.is_empty() {
-        return Ok(None);
-    }
-    raw.iter()
-        .map(|locale| {
-            LocaleTag::parse(locale).map_err(|err| {
-                CliError::PolicyConfigDetail(format!("invalid --locale '{locale}': {err}"))
-            })
-        })
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map(Some)
 }
 
 struct CountingLogger {

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -1,11 +1,289 @@
+use std::collections::BTreeSet;
 use std::fs;
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 use serial_test::file_serial;
 use tempfile::tempdir;
+
+const PARITY_INPUT: &str = "id ES-TEST-123456 track Sonnenlied";
+
+fn write_cross_verb_parity_policy() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("cross-verb.toml");
+    fs::write(
+        &rulepack_path,
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "cross-verb"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "es.test_id"
+class = "custom:es_test_id"
+enabled = true
+safety_tier = "locale_gated"
+locales = ["es-ES"]
+
+[recognizers.match]
+kind = "regex"
+pattern = '''ES-TEST-[0-9]{6}'''
+
+[[recognizers]]
+id = "dictionary.synthetic_catalog"
+class = "custom:catalog_title"
+enabled = true
+locales = ["global"]
+
+[recognizers.match]
+kind = "dictionary"
+terms = ["Sonnenlied"]
+"#,
+    )
+    .unwrap();
+    let policy_path = dir.path().join("policy.toml");
+    fs::write(
+        &policy_path,
+        format!(
+            r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[policy.rulepacks]
+bundled = ["core-extended"]
+paths = ["{}"]
+
+[[rule]]
+kind = "class"
+class = "custom:es_test_id"
+action = "tokenize"
+
+[[rule]]
+kind = "class"
+class = "custom:catalog_title"
+action = "tokenize"
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+            rulepack_path.display()
+        ),
+    )
+    .unwrap();
+    (dir, policy_path)
+}
+
+fn parity_classes(text: &str) -> BTreeSet<&'static str> {
+    [
+        ("Custom:catalog_title", "Custom:catalog_title_"),
+        ("Custom:es_test_id", "Custom:es_test_id_"),
+    ]
+    .into_iter()
+    .filter_map(|(class, marker)| text.contains(marker).then_some(class))
+    .collect()
+}
+
+fn unused_local_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap()
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let mut expected_len = None;
+    loop {
+        let read = stream.read(&mut chunk).unwrap();
+        assert!(read > 0, "HTTP peer closed before request completed");
+        bytes.extend_from_slice(&chunk[..read]);
+        if expected_len.is_none() {
+            if let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&bytes[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap();
+                expected_len = Some(header_end + 4 + content_length);
+            }
+        }
+        if expected_len.is_some_and(|length| bytes.len() >= length) {
+            return bytes;
+        }
+    }
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn direct_proxy_body(policy: &std::path::Path) -> String {
+    let upstream = TcpListener::bind("127.0.0.1:0").unwrap();
+    let upstream_addr = upstream.local_addr().unwrap();
+    let (capture_tx, capture_rx) = mpsc::sync_channel(1);
+    let upstream_thread = thread::spawn(move || {
+        let (mut stream, _) = upstream.accept().unwrap();
+        let request = read_http_request(&mut stream);
+        capture_tx.send(request).unwrap();
+        let body = r#"{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{"type":"text","text":"synthetic-safe"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+
+    let proxy_addr = unused_local_addr();
+    let upstream_url = format!("http://{upstream_addr}");
+    let child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args([
+            "proxy",
+            "serve",
+            "--bind",
+            &proxy_addr.to_string(),
+            "--upstream-anthropic",
+            &upstream_url,
+            "--policy",
+            policy.to_str().unwrap(),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let _child = ChildGuard(child);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(proxy_addr).is_ok() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "proxy did not start at {proxy_addr}"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    let request_body = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": PARITY_INPUT}],
+        "stream": false
+    })
+    .to_string();
+    let mut stream = TcpStream::connect(proxy_addr).unwrap();
+    write!(
+        stream,
+        "POST /v1/messages HTTP/1.1\r\nhost: {proxy_addr}\r\nx-api-key: synthetic-key\r\nanthropic-version: 2023-06-01\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        request_body.len(),
+        request_body
+    )
+    .unwrap();
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).unwrap();
+    assert!(
+        response.starts_with(b"HTTP/1.1 200"),
+        "proxy response was not 200"
+    );
+
+    let captured = capture_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    upstream_thread.join().unwrap();
+    let body_start = captured
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    String::from_utf8(captured[body_start..].to_vec()).unwrap()
+}
+
+#[test]
+fn clean_daemon_and_direct_proxy_share_auto_activated_locales_and_dictionaries() {
+    let (_dir, policy) = write_cross_verb_parity_policy();
+    let expected = BTreeSet::from(["Custom:catalog_title", "Custom:es_test_id"]);
+
+    let mut clean = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args(["clean", "--policy", policy.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    clean
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(PARITY_INPUT.as_bytes())
+        .unwrap();
+    drop(clean.stdin.take());
+    let clean = clean.wait_with_output().unwrap();
+    assert!(
+        clean.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    let clean: Value = serde_json::from_slice(&clean.stdout).unwrap();
+
+    let mut daemon = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args([
+            "daemon",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--idle-timeout",
+            "30",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    writeln!(
+        daemon.stdin.as_mut().unwrap(),
+        "{}",
+        json!({"session_id": "parity-session", "text": PARITY_INPUT})
+    )
+    .unwrap();
+    drop(daemon.stdin.take());
+    let daemon = daemon.wait_with_output().unwrap();
+    assert!(
+        daemon.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&daemon.stderr)
+    );
+    let daemon: Value = serde_json::from_slice(&daemon.stdout).unwrap();
+
+    let proxy = direct_proxy_body(&policy);
+    assert_eq!(
+        parity_classes(clean["clean_text"].as_str().unwrap()),
+        expected
+    );
+    assert_eq!(
+        parity_classes(daemon["clean_text"].as_str().unwrap()),
+        expected
+    );
+    assert_eq!(parity_classes(&proxy), expected);
+    assert!(!proxy.contains("ES-TEST-123456"));
+    assert!(!proxy.contains("Sonnenlied"));
+}
 
 fn write_policy() -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempdir().unwrap();

--- a/crates/gaze-proxy/src/lib.rs
+++ b/crates/gaze-proxy/src/lib.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use adapters::AnthropicAdapter;
-use gaze::{LocaleChain, LocaleTag, Pipeline};
+use gaze::{DictionaryBundle, LocaleChain, LocaleTag, Pipeline};
 
 pub use adapter::{
     AdapterContract, CoveragePolicy, FormatPolicy, HeaderPolicy, PiiSurface, ProtocolContract,
@@ -75,6 +75,7 @@ pub struct ProxyConfig {
     pub session_ttl: Duration,
     pub body_limit_bytes: u64,
     pub(crate) locale_chain: LocaleChain,
+    pub(crate) dictionaries: DictionaryBundle,
     pub(crate) direct_anthropic: Option<Arc<AnthropicAdapter>>,
     pub(crate) inspection: Option<Arc<ProxyInspectionProducerV1>>,
 }
@@ -87,6 +88,7 @@ impl ProxyConfig {
             session_ttl: Duration::from_secs(30 * 60),
             body_limit_bytes: 2 * 1024 * 1024,
             locale_chain: default_locale_chain(),
+            dictionaries: DictionaryBundle::default(),
             direct_anthropic: None,
             inspection: None,
         }
@@ -107,6 +109,7 @@ impl ProxyConfig {
             session_ttl: Duration::from_secs(30 * 60),
             body_limit_bytes: 2 * 1024 * 1024,
             locale_chain: default_locale_chain(),
+            dictionaries: DictionaryBundle::default(),
             direct_anthropic: Some(adapter),
             inspection: None,
         }
@@ -148,6 +151,24 @@ impl ProxyConfig {
     #[must_use]
     pub fn locale_chain(&self) -> &[LocaleTag] {
         self.locale_chain.as_slice()
+    }
+
+    /// Sets the dictionary values every primary and residual detection pass uses.
+    ///
+    /// Omitting this call preserves the pre-existing empty-bundle behavior. The
+    /// same immutable bundle is shared across request protection and residual
+    /// validation so the fail-closed pass cannot know fewer terms than the
+    /// primary pass.
+    #[must_use]
+    pub fn with_dictionaries(mut self, dictionaries: DictionaryBundle) -> Self {
+        self.dictionaries = dictionaries;
+        self
+    }
+
+    /// Returns the dictionary values used by every proxy detection pass.
+    #[must_use]
+    pub fn dictionaries(&self) -> &DictionaryBundle {
+        &self.dictionaries
     }
 
     /// Installs the immutable provider-neutral inspection producer for this launch.

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1278,23 +1278,26 @@ pub fn parse_request_stream_format(body: &[u8]) -> Result<WireFormat, DirectProx
 /// It delegates to the single shared Pipeline algorithm introduced by P4a and performs only
 /// validation against the staged token namespace. No throwaway session, replay, or whole-value
 /// token shortcut exists here.
-struct PipelineRequestPseudonymizer<'pipeline, 'dictionaries, 'transaction, 'session> {
+struct PipelineRequestPseudonymizer<'pipeline, 'context, 'transaction, 'session> {
     pipeline: &'pipeline Pipeline,
     transaction: &'transaction mut SessionTransaction<'session>,
-    dictionaries: &'dictionaries DictionaryBundle,
+    locale_chain: &'context [LocaleTag],
+    dictionaries: &'context DictionaryBundle,
 }
 
-impl<'pipeline, 'dictionaries, 'transaction, 'session>
-    PipelineRequestPseudonymizer<'pipeline, 'dictionaries, 'transaction, 'session>
+impl<'pipeline, 'context, 'transaction, 'session>
+    PipelineRequestPseudonymizer<'pipeline, 'context, 'transaction, 'session>
 {
     fn new(
         pipeline: &'pipeline Pipeline,
-        dictionaries: &'dictionaries DictionaryBundle,
+        locale_chain: &'context [LocaleTag],
+        dictionaries: &'context DictionaryBundle,
         transaction: &'transaction mut SessionTransaction<'session>,
     ) -> Self {
         Self {
             pipeline,
             transaction,
+            locale_chain,
             dictionaries,
         }
     }
@@ -1309,7 +1312,7 @@ impl<'pipeline, 'dictionaries, 'transaction, 'session>
             .pseudonymize_transaction_with_detect_context_and_prefix_cache_write_mode(
                 self.transaction,
                 RawDocument::Text(input.to_owned()),
-                &[LocaleTag::Global],
+                self.locale_chain,
                 self.dictionaries,
                 prefix_cache_write_mode,
             )
@@ -1378,22 +1381,25 @@ impl RequestPseudonymizer for PipelineRequestPseudonymizer<'_, '_, '_, '_> {
     }
 }
 
-struct PipelineResponseResidualValidator<'pipeline, 'dictionaries> {
+struct PipelineResponseResidualValidator<'pipeline, 'context> {
     pipeline: &'pipeline Pipeline,
-    dictionaries: &'dictionaries DictionaryBundle,
+    locale_chain: &'context [LocaleTag],
+    dictionaries: &'context DictionaryBundle,
     validation_session: Session,
 }
 
-impl<'pipeline, 'dictionaries> PipelineResponseResidualValidator<'pipeline, 'dictionaries> {
+impl<'pipeline, 'context> PipelineResponseResidualValidator<'pipeline, 'context> {
     fn new(
         pipeline: &'pipeline Pipeline,
-        dictionaries: &'dictionaries DictionaryBundle,
+        locale_chain: &'context [LocaleTag],
+        dictionaries: &'context DictionaryBundle,
     ) -> Result<Self, DirectProxyError> {
         let validation_session = Session::new(Scope::Ephemeral).map_err(|_| {
             ProxyErrorCode::ProxyConfiguration.error(ProxyErrorPhase::ResponseValidation)
         })?;
         Ok(Self {
             pipeline,
+            locale_chain,
             dictionaries,
             validation_session,
         })
@@ -1411,7 +1417,7 @@ impl ResponseResidualValidator for PipelineResponseResidualValidator<'_, '_> {
             .clean_with_safety_net_detect_context(
                 &self.validation_session,
                 RawDocument::Text(value.to_owned()),
-                &[LocaleTag::Global],
+                self.locale_chain,
                 self.dictionaries,
             )
             .map_err(|_| CodecErrorCode::ProviderOriginPii)?;
@@ -1429,6 +1435,7 @@ impl ResponseResidualValidator for PipelineResponseResidualValidator<'_, '_> {
 #[allow(clippy::too_many_arguments)]
 fn prepare_and_commit_direct_request(
     pipeline: &Pipeline,
+    locale_chain: &[LocaleTag],
     dictionaries: &DictionaryBundle,
     session: &Session,
     codec: &dyn BodyCodec,
@@ -1442,6 +1449,7 @@ fn prepare_and_commit_direct_request(
 ) -> Result<CommittedDirectRequest, DirectProxyError> {
     prepare_and_commit_direct_request_with_hook(
         pipeline,
+        locale_chain,
         dictionaries,
         session,
         codec,
@@ -1483,6 +1491,7 @@ fn map_session_commit_failure(kind: SessionCommitFailureKind) -> DirectProxyErro
 #[allow(clippy::too_many_arguments)]
 fn prepare_and_commit_direct_request_with_hook(
     pipeline: &Pipeline,
+    locale_chain: &[LocaleTag],
     dictionaries: &DictionaryBundle,
     session: &Session,
     codec: &dyn BodyCodec,
@@ -1498,8 +1507,12 @@ fn prepare_and_commit_direct_request_with_hook(
     for attempt in 0..=1 {
         let mut transaction = session.begin_transaction();
         let proved_body = {
-            let mut pseudonymizer =
-                PipelineRequestPseudonymizer::new(pipeline, dictionaries, &mut transaction);
+            let mut pseudonymizer = PipelineRequestPseudonymizer::new(
+                pipeline,
+                locale_chain,
+                dictionaries,
+                &mut transaction,
+            );
             let mut context =
                 RequestTransformContext::new(&mut pseudonymizer, WireFormat::Json, limits);
             if provider_request_projection_selected {
@@ -2000,6 +2013,7 @@ async fn direct_proxy_inner(
                 .map_err(|_| ProxyErrorCode::ProxyConfiguration.error(ProxyErrorPhase::Session))?;
             prepare_and_commit_direct_request(
                 &state.pipeline,
+                state.config.locale_chain(),
                 state.config.dictionaries(),
                 &session,
                 codec,
@@ -2018,6 +2032,7 @@ async fn direct_proxy_inner(
             let request_guard = lease.lock_request().await;
             let committed = prepare_and_commit_direct_request(
                 &state.pipeline,
+                state.config.locale_chain(),
                 state.config.dictionaries(),
                 lease.session(),
                 codec,
@@ -2052,6 +2067,7 @@ async fn direct_proxy_inner(
         let opened = runtime.client.execute_sse(committed).await?;
         return stage_and_replay_direct_sse(
             Arc::clone(&state.pipeline),
+            state.config.locale_chain.clone(),
             state.config.dictionaries().clone(),
             opened,
             runtime.codec_limits,
@@ -2064,6 +2080,7 @@ async fn direct_proxy_inner(
     let executed = runtime.client.execute(committed).await?;
     let response = restore_direct_response(
         &state.pipeline,
+        state.config.locale_chain(),
         state.config.dictionaries(),
         codec,
         executed,
@@ -2076,6 +2093,7 @@ async fn direct_proxy_inner(
 
 fn stage_and_replay_direct_sse(
     pipeline: Arc<Pipeline>,
+    locale_chain: gaze::LocaleChain,
     dictionaries: DictionaryBundle,
     opened: CommittedDirectSse,
     limits: CodecLimits,
@@ -2109,7 +2127,11 @@ fn stage_and_replay_direct_sse(
         let proof = async move {
             let body = collect_response_body(upstream_response, max_response_bytes).await?;
             validate_declared_body(WireFormat::Sse, &body, max_response_bytes)?;
-            let mut residual = PipelineResponseResidualValidator::new(&pipeline, &dictionaries)?;
+            let mut residual = PipelineResponseResidualValidator::new(
+                &pipeline,
+                locale_chain.as_slice(),
+                &dictionaries,
+            )?;
             let mut context =
                 ResponseTransformContext::new(&snapshot, &mut residual, WireFormat::Sse, limits);
             if inspection
@@ -2315,6 +2337,7 @@ fn canonical_session_identifier(headers: &HeaderMap) -> Result<&str, DirectProxy
 
 fn restore_direct_response(
     pipeline: &Pipeline,
+    locale_chain: &[LocaleTag],
     dictionaries: &DictionaryBundle,
     codec: &dyn BodyCodec,
     mut executed: CommittedDirectResponse,
@@ -2322,7 +2345,8 @@ fn restore_direct_response(
     inspection: Option<&mut ProxyInspectionLogicalV1>,
 ) -> Result<Response, DirectProxyError> {
     let (head, body) = executed.response.into_parts();
-    let mut residual = PipelineResponseResidualValidator::new(pipeline, dictionaries)?;
+    let mut residual =
+        PipelineResponseResidualValidator::new(pipeline, locale_chain, dictionaries)?;
     let mut context =
         ResponseTransformContext::new(&executed.snapshot, &mut residual, head.format(), limits);
     if inspection
@@ -3377,6 +3401,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3429,6 +3454,7 @@ mod tests {
                 .headers;
             let first = prepare_and_commit_direct_request(
                 &pipeline,
+                &[LocaleTag::Global],
                 &DictionaryBundle::default(),
                 &session,
                 &codec,
@@ -3446,6 +3472,7 @@ mod tests {
 
             let second = prepare_and_commit_direct_request(
                 &pipeline,
+                &[LocaleTag::Global],
                 &DictionaryBundle::default(),
                 &session,
                 &codec,
@@ -3487,6 +3514,7 @@ mod tests {
         let request = direct_request(url, WireFormat::Json, body.as_bytes()).unwrap();
         let error = prepare_and_commit_direct_request(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3510,6 +3538,7 @@ mod tests {
         );
         prepare_and_commit_direct_request(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3569,6 +3598,7 @@ mod tests {
         let mut before_commit_calls = 0usize;
         let error = match prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3620,6 +3650,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3665,6 +3696,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3736,6 +3768,7 @@ mod tests {
         let mut hook_calls = 0;
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3793,6 +3826,7 @@ mod tests {
 
         let error = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3846,6 +3880,7 @@ mod tests {
         let request = direct_request(url, WireFormat::Json, body.as_bytes()).unwrap();
         let error = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &session,
             &codec,
@@ -3956,6 +3991,7 @@ mod tests {
         };
         let response = restore_direct_response(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &crate::codecs::anthropic::AnthropicMessagesCodec,
             executed,
@@ -4000,6 +4036,7 @@ mod tests {
         let probe_request = direct_request(url.clone(), WireFormat::Json, body.as_bytes()).unwrap();
         let transformed = prepare_and_commit_direct_request(
             &pipeline,
+            &[LocaleTag::Global],
             &DictionaryBundle::default(),
             &probe_session,
             &codec,
@@ -4081,6 +4118,7 @@ mod tests {
         );
         let recovered = prepare_and_commit_direct_request(
             &state.pipeline,
+            state.config.locale_chain(),
             state.config.dictionaries(),
             observed_lease.session(),
             &codec,

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -2091,6 +2091,7 @@ async fn direct_proxy_inner(
     response
 }
 
+#[allow(clippy::too_many_arguments)]
 fn stage_and_replay_direct_sse(
     pipeline: Arc<Pipeline>,
     locale_chain: gaze::LocaleChain,

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -1278,23 +1278,24 @@ pub fn parse_request_stream_format(body: &[u8]) -> Result<WireFormat, DirectProx
 /// It delegates to the single shared Pipeline algorithm introduced by P4a and performs only
 /// validation against the staged token namespace. No throwaway session, replay, or whole-value
 /// token shortcut exists here.
-struct PipelineRequestPseudonymizer<'pipeline, 'transaction, 'session> {
+struct PipelineRequestPseudonymizer<'pipeline, 'dictionaries, 'transaction, 'session> {
     pipeline: &'pipeline Pipeline,
     transaction: &'transaction mut SessionTransaction<'session>,
-    dictionaries: DictionaryBundle,
+    dictionaries: &'dictionaries DictionaryBundle,
 }
 
-impl<'pipeline, 'transaction, 'session>
-    PipelineRequestPseudonymizer<'pipeline, 'transaction, 'session>
+impl<'pipeline, 'dictionaries, 'transaction, 'session>
+    PipelineRequestPseudonymizer<'pipeline, 'dictionaries, 'transaction, 'session>
 {
     fn new(
         pipeline: &'pipeline Pipeline,
+        dictionaries: &'dictionaries DictionaryBundle,
         transaction: &'transaction mut SessionTransaction<'session>,
     ) -> Self {
         Self {
             pipeline,
             transaction,
-            dictionaries: DictionaryBundle::default(),
+            dictionaries,
         }
     }
 
@@ -1309,7 +1310,7 @@ impl<'pipeline, 'transaction, 'session>
                 self.transaction,
                 RawDocument::Text(input.to_owned()),
                 &[LocaleTag::Global],
-                &self.dictionaries,
+                self.dictionaries,
                 prefix_cache_write_mode,
             )
             .map_err(|_| CodecErrorCode::ProtectionFailedClosed)?;
@@ -1320,7 +1321,7 @@ impl<'pipeline, 'transaction, 'session>
     }
 }
 
-impl RequestPseudonymizer for PipelineRequestPseudonymizer<'_, '_, '_> {
+impl RequestPseudonymizer for PipelineRequestPseudonymizer<'_, '_, '_, '_> {
     fn protect(&mut self, input: &str) -> Result<String, CodecErrorCode> {
         self.protect_with_prefix_cache_write_mode(input, PrefixCacheWriteMode::Allow)
     }
@@ -1377,24 +1378,29 @@ impl RequestPseudonymizer for PipelineRequestPseudonymizer<'_, '_, '_> {
     }
 }
 
-struct PipelineResponseResidualValidator<'pipeline> {
+struct PipelineResponseResidualValidator<'pipeline, 'dictionaries> {
     pipeline: &'pipeline Pipeline,
+    dictionaries: &'dictionaries DictionaryBundle,
     validation_session: Session,
 }
 
-impl<'pipeline> PipelineResponseResidualValidator<'pipeline> {
-    fn new(pipeline: &'pipeline Pipeline) -> Result<Self, DirectProxyError> {
+impl<'pipeline, 'dictionaries> PipelineResponseResidualValidator<'pipeline, 'dictionaries> {
+    fn new(
+        pipeline: &'pipeline Pipeline,
+        dictionaries: &'dictionaries DictionaryBundle,
+    ) -> Result<Self, DirectProxyError> {
         let validation_session = Session::new(Scope::Ephemeral).map_err(|_| {
             ProxyErrorCode::ProxyConfiguration.error(ProxyErrorPhase::ResponseValidation)
         })?;
         Ok(Self {
             pipeline,
+            dictionaries,
             validation_session,
         })
     }
 }
 
-impl ResponseResidualValidator for PipelineResponseResidualValidator<'_> {
+impl ResponseResidualValidator for PipelineResponseResidualValidator<'_, '_> {
     fn validate(
         &mut self,
         value: &str,
@@ -1402,10 +1408,11 @@ impl ResponseResidualValidator for PipelineResponseResidualValidator<'_> {
     ) -> Result<(), CodecErrorCode> {
         let (_, spans, _) = self
             .pipeline
-            .clean_with_safety_net(
+            .clean_with_safety_net_detect_context(
                 &self.validation_session,
                 RawDocument::Text(value.to_owned()),
                 &[LocaleTag::Global],
+                self.dictionaries,
             )
             .map_err(|_| CodecErrorCode::ProviderOriginPii)?;
         for span in spans {
@@ -1422,6 +1429,7 @@ impl ResponseResidualValidator for PipelineResponseResidualValidator<'_> {
 #[allow(clippy::too_many_arguments)]
 fn prepare_and_commit_direct_request(
     pipeline: &Pipeline,
+    dictionaries: &DictionaryBundle,
     session: &Session,
     codec: &dyn BodyCodec,
     original_body: &[u8],
@@ -1434,6 +1442,7 @@ fn prepare_and_commit_direct_request(
 ) -> Result<CommittedDirectRequest, DirectProxyError> {
     prepare_and_commit_direct_request_with_hook(
         pipeline,
+        dictionaries,
         session,
         codec,
         original_body,
@@ -1474,6 +1483,7 @@ fn map_session_commit_failure(kind: SessionCommitFailureKind) -> DirectProxyErro
 #[allow(clippy::too_many_arguments)]
 fn prepare_and_commit_direct_request_with_hook(
     pipeline: &Pipeline,
+    dictionaries: &DictionaryBundle,
     session: &Session,
     codec: &dyn BodyCodec,
     original_body: &[u8],
@@ -1488,7 +1498,8 @@ fn prepare_and_commit_direct_request_with_hook(
     for attempt in 0..=1 {
         let mut transaction = session.begin_transaction();
         let proved_body = {
-            let mut pseudonymizer = PipelineRequestPseudonymizer::new(pipeline, &mut transaction);
+            let mut pseudonymizer =
+                PipelineRequestPseudonymizer::new(pipeline, dictionaries, &mut transaction);
             let mut context =
                 RequestTransformContext::new(&mut pseudonymizer, WireFormat::Json, limits);
             if provider_request_projection_selected {
@@ -1829,11 +1840,13 @@ async fn proxy_inner(
     // path is a configuration decision, and it must land on the primary pass and the residual
     // re-scan identically or the two disagree about what counts as PII.
     let locale_chain = state.config.locale_chain();
+    let dictionaries = state.config.dictionaries();
     let surfaced = redact_surfaces(
         &state.pipeline,
         &session,
         adapter.request_pii_surfaces(&mut json),
         locale_chain,
+        dictionaries,
     )?;
     // The declared coverage policy SELECTS the mechanism that establishes coverage. Reading it
     // here is what keeps the declaration honest: a contract cannot claim a coverage posture the
@@ -1842,7 +1855,13 @@ async fn proxy_inner(
         // Legacy adapters carry no codec proof, so coverage is established right here, by
         // re-scanning the outbound body and failing closed on anything left unprotected.
         CoveragePolicy::LegacySurfaces => {
-            residual_scan_request(&state.pipeline, &json, &surfaced, locale_chain)?;
+            residual_scan_request(
+                &state.pipeline,
+                &json,
+                &surfaced,
+                locale_chain,
+                dictionaries,
+            )?;
         }
         // A codec-proved adapter must have been routed to the codec branch above. Reaching this
         // point means the contract and the router disagree and no proof has been established.
@@ -1981,6 +2000,7 @@ async fn direct_proxy_inner(
                 .map_err(|_| ProxyErrorCode::ProxyConfiguration.error(ProxyErrorPhase::Session))?;
             prepare_and_commit_direct_request(
                 &state.pipeline,
+                state.config.dictionaries(),
                 &session,
                 codec,
                 body,
@@ -1998,6 +2018,7 @@ async fn direct_proxy_inner(
             let request_guard = lease.lock_request().await;
             let committed = prepare_and_commit_direct_request(
                 &state.pipeline,
+                state.config.dictionaries(),
                 lease.session(),
                 codec,
                 body,
@@ -2031,6 +2052,7 @@ async fn direct_proxy_inner(
         let opened = runtime.client.execute_sse(committed).await?;
         return stage_and_replay_direct_sse(
             Arc::clone(&state.pipeline),
+            state.config.dictionaries().clone(),
             opened,
             runtime.codec_limits,
             runtime.client_config.max_response_bytes,
@@ -2042,6 +2064,7 @@ async fn direct_proxy_inner(
     let executed = runtime.client.execute(committed).await?;
     let response = restore_direct_response(
         &state.pipeline,
+        state.config.dictionaries(),
         codec,
         executed,
         runtime.codec_limits,
@@ -2053,6 +2076,7 @@ async fn direct_proxy_inner(
 
 fn stage_and_replay_direct_sse(
     pipeline: Arc<Pipeline>,
+    dictionaries: DictionaryBundle,
     opened: CommittedDirectSse,
     limits: CodecLimits,
     max_response_bytes: usize,
@@ -2085,7 +2109,7 @@ fn stage_and_replay_direct_sse(
         let proof = async move {
             let body = collect_response_body(upstream_response, max_response_bytes).await?;
             validate_declared_body(WireFormat::Sse, &body, max_response_bytes)?;
-            let mut residual = PipelineResponseResidualValidator::new(&pipeline)?;
+            let mut residual = PipelineResponseResidualValidator::new(&pipeline, &dictionaries)?;
             let mut context =
                 ResponseTransformContext::new(&snapshot, &mut residual, WireFormat::Sse, limits);
             if inspection
@@ -2291,13 +2315,14 @@ fn canonical_session_identifier(headers: &HeaderMap) -> Result<&str, DirectProxy
 
 fn restore_direct_response(
     pipeline: &Pipeline,
+    dictionaries: &DictionaryBundle,
     codec: &dyn BodyCodec,
     mut executed: CommittedDirectResponse,
     limits: CodecLimits,
     inspection: Option<&mut ProxyInspectionLogicalV1>,
 ) -> Result<Response, DirectProxyError> {
     let (head, body) = executed.response.into_parts();
-    let mut residual = PipelineResponseResidualValidator::new(pipeline)?;
+    let mut residual = PipelineResponseResidualValidator::new(pipeline, dictionaries)?;
     let mut context =
         ResponseTransformContext::new(&executed.snapshot, &mut residual, head.format(), limits);
     if inspection
@@ -2564,14 +2589,16 @@ fn redact_surfaces(
     session: &Session,
     surfaces: Vec<crate::adapter::PiiSurface<'_>>,
     locale_chain: &[LocaleTag],
+    dictionaries: &DictionaryBundle,
 ) -> Result<HashSet<String>, ProxyError> {
     let mut surfaced = HashSet::new();
     for surface in surfaces {
         let clean = pipeline
-            .pseudonymize_with_context(
+            .pseudonymize_with_detect_context(
                 session,
                 RawDocument::Text(surface.text.clone()),
                 locale_chain,
+                dictionaries,
             )
             .map_err(|source| ProxyError::Pipeline { source })?;
         if let CleanDocument::Text(text) = clean {
@@ -2602,6 +2629,7 @@ fn residual_scan_request(
     body: &Value,
     surfaced: &HashSet<String>,
     locale_chain: &[LocaleTag],
+    dictionaries: &DictionaryBundle,
 ) -> Result<(), ProxyError> {
     let session =
         Session::new(Scope::Ephemeral).map_err(|source| ProxyError::Pipeline { source })?;
@@ -2610,6 +2638,7 @@ fn residual_scan_request(
         session,
         surfaced,
         locale_chain,
+        dictionaries,
     };
     scan.walk("", "", body, false, true)
 }
@@ -2621,16 +2650,19 @@ struct RequestResidualScan<'a> {
     surfaced: &'a HashSet<String>,
     /// The same chain the primary pass ran under. See [`residual_scan_request`].
     locale_chain: &'a [LocaleTag],
+    /// The exact bundle used by the primary pass.
+    dictionaries: &'a DictionaryBundle,
 }
 
 impl RequestResidualScan<'_> {
     fn probe(&self, field_path: &str, text: &str) -> Result<(), ProxyError> {
         let (_, spans, _) = self
             .pipeline
-            .clean_with_safety_net(
+            .clean_with_safety_net_detect_context(
                 &self.session,
                 RawDocument::Text(text.to_owned()),
                 self.locale_chain,
+                self.dictionaries,
             )
             .map_err(|source| ProxyError::Pipeline { source })?;
         if spans.is_empty() {
@@ -3345,6 +3377,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body.as_bytes(),
@@ -3396,6 +3429,7 @@ mod tests {
                 .headers;
             let first = prepare_and_commit_direct_request(
                 &pipeline,
+                &DictionaryBundle::default(),
                 &session,
                 &codec,
                 original.as_bytes(),
@@ -3412,6 +3446,7 @@ mod tests {
 
             let second = prepare_and_commit_direct_request(
                 &pipeline,
+                &DictionaryBundle::default(),
                 &session,
                 &codec,
                 &proved_once,
@@ -3452,6 +3487,7 @@ mod tests {
         let request = direct_request(url, WireFormat::Json, body.as_bytes()).unwrap();
         let error = prepare_and_commit_direct_request(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body.as_bytes(),
@@ -3474,6 +3510,7 @@ mod tests {
         );
         prepare_and_commit_direct_request(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             valid.as_bytes(),
@@ -3532,6 +3569,7 @@ mod tests {
         let mut before_commit_calls = 0usize;
         let error = match prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body.as_bytes(),
@@ -3582,6 +3620,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body,
@@ -3626,6 +3665,7 @@ mod tests {
 
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body,
@@ -3696,6 +3736,7 @@ mod tests {
         let mut hook_calls = 0;
         let committed = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body.as_bytes(),
@@ -3752,6 +3793,7 @@ mod tests {
 
         let error = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body,
@@ -3804,6 +3846,7 @@ mod tests {
         let request = direct_request(url, WireFormat::Json, body.as_bytes()).unwrap();
         let error = prepare_and_commit_direct_request_with_hook(
             &pipeline,
+            &DictionaryBundle::default(),
             &session,
             &codec,
             body.as_bytes(),
@@ -3913,6 +3956,7 @@ mod tests {
         };
         let response = restore_direct_response(
             &pipeline,
+            &DictionaryBundle::default(),
             &crate::codecs::anthropic::AnthropicMessagesCodec,
             executed,
             CodecLimits::default(),
@@ -3956,6 +4000,7 @@ mod tests {
         let probe_request = direct_request(url.clone(), WireFormat::Json, body.as_bytes()).unwrap();
         let transformed = prepare_and_commit_direct_request(
             &pipeline,
+            &DictionaryBundle::default(),
             &probe_session,
             &codec,
             body.as_bytes(),
@@ -4036,6 +4081,7 @@ mod tests {
         );
         let recovered = prepare_and_commit_direct_request(
             &state.pipeline,
+            state.config.dictionaries(),
             observed_lease.session(),
             &codec,
             extended_body.as_bytes(),

--- a/crates/gaze-proxy/tests/anthropic_direct.rs
+++ b/crates/gaze-proxy/tests/anthropic_direct.rs
@@ -10,8 +10,8 @@ use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Json, Router};
 use gaze::{
-    Action, ClassRule, DefaultRule, PiiClass, Pipeline, RedactionEntry, RedactionLogError,
-    RedactionLogger,
+    Action, ClassRule, DefaultRule, DictionaryBundle, PiiClass, Pipeline, RedactionEntry,
+    RedactionLogError, RedactionLogger, RulepackDict,
 };
 use gaze_inspection::{
     ActivatedInspectionConsumerV1, InspectionEventV1, InspectionQueueLimitsV1, InspectionSink,
@@ -26,7 +26,7 @@ use gaze_proxy::{
     ProxyErrorPhase, ProxyInspectionProducerV1, SessionPolicy, SessionRegistryConfig,
     ANTHROPIC_PROXY_ERROR_FRAME, ANTHROPIC_PROXY_PING_FRAME,
 };
-use gaze_recognizers::RegexDetector;
+use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 use gaze_types::inspection::{CaptureDomainsV1, DashboardCaptureDescriptorV1};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -34,6 +34,7 @@ use tokio::sync::Mutex;
 use url::Url;
 
 const EMAIL: &str = "alice@example.invalid";
+const DICTIONARY_TERM: &str = "Sonnenlied";
 
 struct RecordingResolver {
     called: Arc<AtomicBool>,
@@ -91,6 +92,7 @@ struct UpstreamState {
     rate_limited: bool,
     invalid_stream: bool,
     delayed_stream: bool,
+    provider_text: Option<String>,
 }
 
 struct CapturedRequest {
@@ -135,6 +137,28 @@ fn email_pipeline() -> Pipeline {
         .unwrap()
 }
 
+fn dictionary_pipeline() -> (Pipeline, DictionaryBundle) {
+    let class = PiiClass::custom("catalog_title");
+    let pipeline = Pipeline::builder()
+        .recognizer(DictionaryRecognizer::new(
+            "dictionary.synthetic_catalog",
+            class.clone(),
+            "synthetic_catalog",
+            true,
+            "catalog",
+        ))
+        .rule(ClassRule::new(class, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap();
+    let dictionaries = DictionaryBundle::from_rulepack_terms(&[RulepackDict::new(
+        "synthetic_catalog",
+        vec![DICTIONARY_TERM.to_string()],
+        true,
+    )]);
+    (pipeline, dictionaries)
+}
+
 async fn capture_anthropic_request(
     State(state): State<UpstreamState>,
     request: Request<Body>,
@@ -171,9 +195,11 @@ async fn capture_anthropic_request(
             .unwrap();
     }
 
-    let protected = request_json["messages"][0]["content"]
-        .as_str()
-        .unwrap_or("synthetic");
+    let protected = state.provider_text.as_deref().unwrap_or_else(|| {
+        request_json["messages"][0]["content"]
+            .as_str()
+            .unwrap_or("synthetic")
+    });
     if request_json["stream"].as_bool().unwrap_or(false) {
         let escaped = serde_json::to_string(protected).unwrap();
         let frames = format!(
@@ -211,17 +237,22 @@ async fn capture_anthropic_request(
 }
 
 async fn spawn_upstream() -> MockUpstream {
-    spawn_upstream_with_mode(false, false, false).await
+    spawn_upstream_with_mode(false, false, false, None).await
 }
 
 async fn spawn_upstream_with_rate_limit(rate_limited: bool) -> MockUpstream {
-    spawn_upstream_with_mode(rate_limited, false, false).await
+    spawn_upstream_with_mode(rate_limited, false, false, None).await
+}
+
+async fn spawn_upstream_with_provider_text(provider_text: &str) -> MockUpstream {
+    spawn_upstream_with_mode(false, false, false, Some(provider_text.to_string())).await
 }
 
 async fn spawn_upstream_with_mode(
     rate_limited: bool,
     invalid_stream: bool,
     delayed_stream: bool,
+    provider_text: Option<String>,
 ) -> MockUpstream {
     let captures = Arc::new(Mutex::new(Vec::new()));
     let app = Router::new()
@@ -231,6 +262,7 @@ async fn spawn_upstream_with_mode(
             rate_limited,
             invalid_stream,
             delayed_stream,
+            provider_text,
         });
     let backend_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let backend_addr = backend_listener.local_addr().unwrap();
@@ -261,7 +293,8 @@ async fn spawn_upstream_with_mode(
 }
 
 async fn spawn_proxy(adapter: AnthropicAdapter) -> RunningServer {
-    spawn_proxy_with_observability(adapter, email_pipeline(), None).await
+    spawn_proxy_with_observability(adapter, email_pipeline(), DictionaryBundle::default(), None)
+        .await
 }
 
 fn counting_inspection() -> (
@@ -280,10 +313,11 @@ fn counting_inspection() -> (
 async fn spawn_proxy_with_observability(
     adapter: AnthropicAdapter,
     pipeline: Pipeline,
+    dictionaries: DictionaryBundle,
     inspection: Option<(ProxyInspectionProducerV1, ActivatedInspectionConsumerV1)>,
 ) -> RunningServer {
     let bind = unused_local_addr();
-    let config = ProxyConfig::anthropic_direct(bind, adapter);
+    let config = ProxyConfig::anthropic_direct(bind, adapter).with_dictionaries(dictionaries);
     let (config, inspection_consumer) = match inspection {
         Some((producer, consumer)) => (config.with_inspection(producer), Some(consumer)),
         None => (config, None),
@@ -608,6 +642,75 @@ async fn official_sdk_shaped_non_stream_flow_uses_exact_route_headers_and_proved
 }
 
 #[tokio::test]
+async fn direct_request_uses_the_configured_dictionary_bundle() {
+    let upstream = spawn_upstream().await;
+    let (pipeline, dictionaries) = dictionary_pipeline();
+    let proxy = spawn_proxy_with_observability(
+        AnthropicAdapter::new(upstream.origin.clone()),
+        pipeline,
+        dictionaries,
+        None,
+    )
+    .await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": DICTIONARY_TERM}],
+        "stream": false
+    });
+    let response = Client::new()
+        .post(format!("{}/v1/messages", proxy.base_url))
+        .header("x-api-key", "sdk-synthetic-key")
+        .header("anthropic-version", "2023-06-01")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.json::<Value>().await.unwrap()["content"][0]["text"],
+        DICTIONARY_TERM
+    );
+
+    let captures = upstream.captures.lock().await;
+    assert_eq!(captures.len(), 1);
+    let body = std::str::from_utf8(&captures[0].body).unwrap();
+    assert!(!body.contains(DICTIONARY_TERM));
+    assert!(body.contains("catalog_title"));
+}
+
+#[tokio::test]
+async fn direct_response_residual_rejects_a_dictionary_only_provider_term() {
+    let upstream = spawn_upstream_with_provider_text(DICTIONARY_TERM).await;
+    let (pipeline, dictionaries) = dictionary_pipeline();
+    let proxy = spawn_proxy_with_observability(
+        AnthropicAdapter::new(upstream.origin.clone()),
+        pipeline,
+        dictionaries,
+        None,
+    )
+    .await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "synthetic-safe"}],
+        "stream": false
+    });
+    let response = Client::new()
+        .post(format!("{}/v1/messages", proxy.base_url))
+        .header("x-api-key", "sdk-synthetic-key")
+        .header("anthropic-version", "2023-06-01")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert!(!response.status().is_success());
+    let body = response.text().await.unwrap();
+    assert!(!body.contains(DICTIONARY_TERM));
+    assert_eq!(upstream.captures.lock().await.len(), 1);
+}
+
+#[tokio::test]
 async fn official_sdk_shaped_stream_flow_restores_only_after_complete_sse_proof() {
     let upstream = spawn_upstream().await;
     let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
@@ -834,6 +937,7 @@ async fn split_opaque_carriers_reject_across_complete_request_views_without_side
     let proxy = spawn_proxy_with_observability(
         AnthropicAdapter::new(upstream.origin.clone()),
         email_pipeline().with_redaction_logger(logger.clone()),
+        DictionaryBundle::default(),
         Some((inspection, consumer)),
     )
     .await;
@@ -1103,7 +1207,7 @@ async fn closed_errors_and_debug_omit_credentials_pii_and_upstream_text() {
 
 #[tokio::test]
 async fn late_stream_proof_failure_emits_only_the_constant_safe_error_frame() {
-    let upstream = spawn_upstream_with_mode(false, true, false).await;
+    let upstream = spawn_upstream_with_mode(false, true, false, None).await;
     let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
     let response = sdk_client_request(&Client::new(), &proxy, true)
         .send()
@@ -1117,7 +1221,7 @@ async fn late_stream_proof_failure_emits_only_the_constant_safe_error_frame() {
 
 #[tokio::test]
 async fn delayed_stream_emits_only_the_compiled_ping_before_proved_replay() {
-    let upstream = spawn_upstream_with_mode(false, false, true).await;
+    let upstream = spawn_upstream_with_mode(false, false, true, None).await;
     let adapter = AnthropicAdapter::builder(upstream.origin.clone())
         .ping_interval(Duration::from_secs(1))
         .unwrap()
@@ -1144,7 +1248,7 @@ async fn delayed_stream_emits_only_the_compiled_ping_before_proved_replay() {
 async fn unmodified_official_python_sdk_runs_non_stream_and_stream_against_loopback() {
     let python = std::env::var_os("GAZE_OFFICIAL_SDK_PYTHON")
         .expect("GAZE_OFFICIAL_SDK_PYTHON must identify the prepared SDK interpreter");
-    let upstream = spawn_upstream_with_mode(false, false, true).await;
+    let upstream = spawn_upstream_with_mode(false, false, true, None).await;
     let proxy = spawn_proxy(
         AnthropicAdapter::builder(upstream.origin.clone())
             .ping_interval(Duration::from_secs(1))

--- a/crates/gaze-proxy/tests/anthropic_direct.rs
+++ b/crates/gaze-proxy/tests/anthropic_direct.rs
@@ -10,8 +10,8 @@ use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Json, Router};
 use gaze::{
-    Action, ClassRule, DefaultRule, DictionaryBundle, PiiClass, Pipeline, RedactionEntry,
-    RedactionLogError, RedactionLogger, RulepackDict,
+    Action, ClassRule, DefaultRule, DictionaryBundle, LocaleChain, LocaleTag, PiiClass, Pipeline,
+    RedactionEntry, RedactionLogError, RedactionLogger, RulepackDict,
 };
 use gaze_inspection::{
     ActivatedInspectionConsumerV1, InspectionEventV1, InspectionQueueLimitsV1, InspectionSink,
@@ -35,6 +35,7 @@ use url::Url;
 
 const EMAIL: &str = "alice@example.invalid";
 const DICTIONARY_TERM: &str = "Sonnenlied";
+const LOCALE_TERM: &str = "kennung kundennummer-123";
 
 struct RecordingResolver {
     called: Arc<AtomicBool>,
@@ -157,6 +158,31 @@ fn dictionary_pipeline() -> (Pipeline, DictionaryBundle) {
         true,
     )]);
     (pipeline, dictionaries)
+}
+
+fn document_locale_pipeline() -> Pipeline {
+    let class = PiiClass::custom("locale_identifier");
+    Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                r"\bkundennummer-\d+\b",
+                class.clone(),
+                "locale.synthetic_identifier",
+                vec![LocaleTag::DeDe],
+                1.0,
+                0,
+                "locale_identifier.counter",
+                None,
+                Vec::new(),
+                None,
+                None,
+            )
+            .unwrap(),
+        )
+        .rule(ClassRule::new(class, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
 }
 
 async fn capture_anthropic_request(
@@ -293,8 +319,14 @@ async fn spawn_upstream_with_mode(
 }
 
 async fn spawn_proxy(adapter: AnthropicAdapter) -> RunningServer {
-    spawn_proxy_with_observability(adapter, email_pipeline(), DictionaryBundle::default(), None)
-        .await
+    spawn_proxy_with_observability(
+        adapter,
+        email_pipeline(),
+        DictionaryBundle::default(),
+        None,
+        None,
+    )
+    .await
 }
 
 fn counting_inspection() -> (
@@ -314,10 +346,14 @@ async fn spawn_proxy_with_observability(
     adapter: AnthropicAdapter,
     pipeline: Pipeline,
     dictionaries: DictionaryBundle,
+    locale_chain: Option<LocaleChain>,
     inspection: Option<(ProxyInspectionProducerV1, ActivatedInspectionConsumerV1)>,
 ) -> RunningServer {
     let bind = unused_local_addr();
-    let config = ProxyConfig::anthropic_direct(bind, adapter).with_dictionaries(dictionaries);
+    let mut config = ProxyConfig::anthropic_direct(bind, adapter).with_dictionaries(dictionaries);
+    if let Some(locale_chain) = locale_chain {
+        config = config.with_locale_chain(locale_chain);
+    }
     let (config, inspection_consumer) = match inspection {
         Some((producer, consumer)) => (config.with_inspection(producer), Some(consumer)),
         None => (config, None),
@@ -650,6 +686,7 @@ async fn direct_request_uses_the_configured_dictionary_bundle() {
         pipeline,
         dictionaries,
         None,
+        None,
     )
     .await;
     let request = json!({
@@ -688,6 +725,7 @@ async fn direct_response_residual_rejects_a_dictionary_only_provider_term() {
         pipeline,
         dictionaries,
         None,
+        None,
     )
     .await;
     let request = json!({
@@ -707,6 +745,37 @@ async fn direct_response_residual_rejects_a_dictionary_only_provider_term() {
     assert!(!response.status().is_success());
     let body = response.text().await.unwrap();
     assert!(!body.contains(DICTIONARY_TERM));
+    assert_eq!(upstream.captures.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn direct_response_residual_uses_the_configured_document_locale_chain() {
+    let upstream = spawn_upstream_with_provider_text(LOCALE_TERM).await;
+    let proxy = spawn_proxy_with_observability(
+        AnthropicAdapter::new(upstream.origin.clone()),
+        document_locale_pipeline(),
+        DictionaryBundle::default(),
+        Some(LocaleChain::from_tags(vec![LocaleTag::DeDe])),
+        None,
+    )
+    .await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "synthetic-safe"}],
+        "stream": false
+    });
+    let response = Client::new()
+        .post(format!("{}/v1/messages", proxy.base_url))
+        .header("x-api-key", "sdk-synthetic-key")
+        .header("anthropic-version", "2023-06-01")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert!(!response.status().is_success());
+    let body = response.text().await.unwrap();
+    assert!(!body.contains(LOCALE_TERM));
     assert_eq!(upstream.captures.lock().await.len(), 1);
 }
 
@@ -938,6 +1007,7 @@ async fn split_opaque_carriers_reject_across_complete_request_views_without_side
         AnthropicAdapter::new(upstream.origin.clone()),
         email_pipeline().with_redaction_logger(logger.clone()),
         DictionaryBundle::default(),
+        None,
         Some((inspection, consumer)),
     )
     .await;

--- a/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
+++ b/crates/gaze-proxy/tests/legacy_adapter_leak_proof.rs
@@ -49,10 +49,10 @@ use std::time::Duration;
 use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
-use gaze::{Action, ClassRule, DefaultRule, PiiClass, Pipeline};
+use gaze::{Action, ClassRule, DefaultRule, DictionaryBundle, PiiClass, Pipeline, RulepackDict};
 use gaze_proxy::adapters::{GeminiAdapter, OpenAiAdapter};
 use gaze_proxy::{CoveragePolicy, ProviderAdapter, ProxyConfig, ProxyError};
-use gaze_recognizers::RegexDetector;
+use gaze_recognizers::{DictionaryRecognizer, RegexDetector};
 use reqwest::{Client, Response, StatusCode};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
@@ -63,6 +63,7 @@ const EMAIL: &str = "alice@example.invalid";
 /// Digit-only order id. Detected as `Custom("OrderId")` when it reaches the pipeline as text.
 const ORDER_ID_DIGITS: &str = "7001234";
 const ORDER_ID_NUMBER: u64 = 7_001_234;
+const DICTIONARY_TERM: &str = "Sonnenlied";
 
 /// Pipeline that CAN detect both markers, so a surviving marker proves the bytes never
 /// reached detection rather than proving a detector miss.
@@ -100,6 +101,28 @@ fn postal_probe_pipeline(class_label: &str) -> Pipeline {
         .rule(DefaultRule::new(Action::Preserve))
         .build()
         .unwrap()
+}
+
+fn dictionary_probe() -> (Pipeline, DictionaryBundle) {
+    let class = PiiClass::custom("catalog_title");
+    let pipeline = Pipeline::builder()
+        .recognizer(DictionaryRecognizer::new(
+            "dictionary.synthetic_catalog",
+            class.clone(),
+            "synthetic_catalog",
+            true,
+            "catalog",
+        ))
+        .rule(ClassRule::new(class, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap();
+    let dictionaries = DictionaryBundle::from_rulepack_terms(&[RulepackDict::new(
+        "synthetic_catalog",
+        vec![DICTIONARY_TERM.to_string()],
+        true,
+    )]);
+    (pipeline, dictionaries)
 }
 
 #[derive(Clone)]
@@ -179,8 +202,16 @@ async fn capture_upstream(
 }
 
 async fn spawn_proxy(adapter: Arc<dyn ProviderAdapter>, pipeline: Pipeline) -> ProxyServer {
+    spawn_proxy_with_dictionaries(adapter, pipeline, DictionaryBundle::default()).await
+}
+
+async fn spawn_proxy_with_dictionaries(
+    adapter: Arc<dyn ProviderAdapter>,
+    pipeline: Pipeline,
+    dictionaries: DictionaryBundle,
+) -> ProxyServer {
     let bind = unused_local_addr();
-    let config = ProxyConfig::new(bind, vec![adapter]);
+    let config = ProxyConfig::new(bind, vec![adapter]).with_dictionaries(dictionaries);
     let pipeline = Arc::new(pipeline);
     let handle = tokio::spawn(async move {
         gaze_proxy::serve(config, pipeline).await.unwrap();
@@ -319,6 +350,56 @@ async fn control_openai_allowlisted_string_surface_is_tokenized() {
     let content = &forwarded["messages"][0]["content"];
     assert_tokenized(content, EMAIL);
     assert_tokenized(content, ORDER_ID_DIGITS);
+}
+
+#[tokio::test]
+async fn legacy_primary_uses_the_configured_dictionary_bundle() {
+    let upstream = spawn_upstream(|_| json!({"choices": [{"text": "ok"}]})).await;
+    let (pipeline, dictionaries) = dictionary_probe();
+    let proxy = spawn_proxy_with_dictionaries(
+        Arc::new(OpenAiAdapter::new(upstream.base_url.clone())),
+        pipeline,
+        dictionaries,
+    )
+    .await;
+    post_accepted(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": DICTIONARY_TERM}]
+        }),
+    )
+    .await;
+    let forwarded = upstream.first_forwarded().await;
+    assert_tokenized(&forwarded["messages"][0]["content"], DICTIONARY_TERM);
+}
+
+#[tokio::test]
+async fn legacy_residual_uses_the_same_configured_dictionary_bundle() {
+    let upstream = spawn_upstream(|_| json!({"choices": [{"text": "ok"}]})).await;
+    let (pipeline, dictionaries) = dictionary_probe();
+    let proxy = spawn_proxy_with_dictionaries(
+        Arc::new(OpenAiAdapter::new(upstream.base_url.clone())),
+        pipeline,
+        dictionaries,
+    )
+    .await;
+    let response = post_json(
+        &proxy,
+        "/v1/chat/completions",
+        json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": "synthetic-safe"}],
+            "unknown_future_field": DICTIONARY_TERM
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let rendered = response.text().await.unwrap();
+    assert_eq!(rendered, json!({"error": "UnsurfacedPii"}).to_string());
+    assert!(!rendered.contains(DICTIONARY_TERM));
+    upstream.assert_nothing_forwarded().await;
 }
 
 /// CONTROL: `contents[].parts[].text` and `functionCall.args` string values ARE redacted.


### PR DESCRIPTION
## Summary

- Lift the CLI policy-to-pipeline sequence into one `ResolvedPipeline` loader and route `clean`, `daemon`, `proxy`, and setup doctor through it.
- Carry the loader's single `DictionaryBundle` through proxy direct/codec request protection, direct JSON/SSE response residual validation, and both legacy primary/residual passes.
- Carry the same resolved locale chain through direct/codec primary and residual passes, closing #2411 after #2403 (`7f89d9c`) fixed the legacy path.

This deliberately widens proxy detection to match `gaze clean` under dictionary and auto-activation policies. That is an axis-1 reliability fix: the proxy chokepoint may no longer know fewer configured terms or document locales than the CLI cleaner.

## Change structure

1. Pure refactor: introduce `ResolvedPipeline` / `resolve_pipeline`, preserve the load-bearing override -> rulepack -> dictionary -> locale -> derived auto-activation order, and repoint clean + daemon.
2. Dictionary parity: proxy + setup use the loader; one private dictionary source on the already-`#[non_exhaustive]` `ProxyConfig` is exposed through `with_dictionaries`. This is additive and does not break external struct construction.
3. Locale parity: direct/codec request protection and JSON/SSE residual response validation use `ProxyConfig::locale_chain()` instead of a pinned `[Global]` chain.

Small follow-up commits keep the moved test import and the expanded SSE helper clippy-clean, and reconcile the Unreleased changelog after rebasing onto current main.

## Like-for-like refactor evidence

Three synthetic policies and one daemon JSONL request, run before and after the refactor. Outputs were canonicalized only for randomized session prefixes/session blobs and the pre-existing unordered daemon `tokens` array, then SHA-256 hashed. **Comparison base: the rebased base `e5ebade`** (the run was originally taken against pre-refactor `780528c`; the path-policy figure below was re-derived after the rebase — see the correction note).

- bundled `core`: before = after = `d6dd1e1af2d810ce269b4b730ad1dedbdc8d2bc71e9ec3cacdb38c8dbba92d58`
- `core-extended` derived locale auto-activation: before = after = `cc3864febc5d7071874bc70824e885e2573e647d9f212ab77e67d32f52a3ccfa`
- path rulepack with dictionary + custom recognizer: before = after = `d6c0a4e1f4158e1ee4f26624f41028d518f6db73fac7d7db8d07c56442348d17`
- daemon JSONL with the path policy: before = after = `13cad1eb0774b3ff5630494a7322ab1ef638c0811c4e53308cd2f9ee6c23e566`

> **Evidence correction (orchestrator, after code review).** An earlier revision of this body published `a47f3afa…` for the path-policy case. That figure does not reproduce at the rebased head: rebuilding `b78c6c8` and re-running the same script yields `d6c0a4e1…` for BOTH the before and after runs, which differ from `a47f3afa…` only in the order of the `entries` array. The refactor is therefore behaviour-identical on the rebased base, but the earlier claim that all four figures matched pre-refactor `780528c` was stale. The figure above is the reproducible one; the reviewer re-derived it independently.

Missing and invalid policies still surface the existing typed CLI errors; the loader has no silent fallback.

## RED -> GREEN evidence

Cross-verb direct/codec parity fixture: one policy auto-activates an `es-ES` document-basis recognizer and loads the dictionary-only term `Sonnenlied`.

- RED with the direct request path pinned to Global: proxy class set was `{Custom:catalog_title}`, while clean/daemon expected `{Custom:catalog_title, Custom:es_test_id}`.
- GREEN with the resolved chain: `clean == daemon == proxy == {Custom:catalog_title, Custom:es_test_id}`; neither raw synthetic term reached the loopback upstream.

Residual guards:

- RED with direct response residual pinned to Global: the locale-gated provider term returned HTTP success.
- GREEN with the configured chain: the response fails closed and does not echo the term.
- A dictionary-only provider response term also fails closed after the same bundle is threaded into the residual validator.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -j2 -- -D warnings`
- `cargo test -p gaze-cli --all-features -j1 --quiet` (green after rebase)
- `cargo test -p gaze-proxy --all-features -j2 --quiet` (green after rebase; includes every `gaze-proxy/tests/*` leak guard and legacy adapter audit)
- `cargo test --workspace --all-features --no-fail-fast -j1 --quiet` with pinned Rust 1.96 completed every target; the sole failure was the brief-allowlisted #2404 Kiji subprocess timeout in `gaze-recognizers/tests/locale_aware_trait.rs`. All other targets passed. CI is authoritative for that model-backed flake.

Audit: solo scratchpad 7201 S11-F2

Resolves solo todo #2937
Resolves solo todo #2411

