### PR TITLE
[agent] refactor(audit): present-column set + allowlist-generated select list; one redaction_log schema declaration

### DIFF
--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -73,14 +73,15 @@ and the version each column landed.
 
 ## Audit-query API surface
 
-Adopters building dashboards, exports, or compliance views interact with four
+Adopters building dashboards, exports, or compliance views interact with five
 public items beyond `SqliteLogger`:
 
 | Item | Role |
 |------|------|
 | `AuditFilter` | Plain-struct filter builder. All fields are `Option<_>` and default to `None`, so `AuditFilter::default()` returns every row. Narrow by `class`, `source`, `action`, `document_kind`, `field_path`, `session_id`, `from_epoch_ms` / `to_epoch_ms`, snapshot scheme / alg / key version, plus the v0.7.x ambiguity columns described below. |
 | `AuditLogRow` | Shape returned by `SqliteLogger::query`. Metadata only — `class`, `action`, `field_name`, `document_kind`, `conflict_loser`, `decided_by`, `created_at`, `session_id`, snapshot metadata, and the four v0.7.x ambiguity columns. No raw PII, no token values, no restore material. |
-| `build_audit_query_sql` | Lower-level helper that constructs the `(SQL, params)` pair used by `SqliteLogger::query`. Takes column-presence booleans so callers querying older databases project `NULL AS <missing_column>` rather than failing. Exposed so external readers can run the same projection logic against a read replica without re-implementing the filter compiler. |
+| `PresentColumns` | Column-name set discovered from `PRAGMA table_info(redaction_log)`. It lets cross-version readers describe an older database shape without a positional boolean list. |
+| `build_audit_query_sql` | Lower-level helper that constructs the `(SQL, params)` pair used by `SqliteLogger::query`. Takes `PresentColumns` so callers querying older databases project `NULL AS <missing_column>` rather than failing. Exposed so external readers can run the same projection logic against a read replica without re-implementing the filter compiler. |
 | `AUDIT_RESTRICTED_COLUMNS` | Canonical allowlist of columns the audit-query path may project. `audit export` and `SqliteLogger::query` select only from this set. `redaction_log` may grow columns over time (e.g. snapshot locators, replay hashes); restricting projection here is defense in depth so future schema additions never accidentally leak raw PII, token bytes, or document content. The clean path is forbidden from touching audit storage by the `gaze_module_isolation` Dylint lint; this constant is the matching read-side guard. |
 
 Safety-net writes use the `LeakSuspectLogger` trait:

--- a/crates/gaze-audit/src/lib.rs
+++ b/crates/gaze-audit/src/lib.rs
@@ -10,7 +10,7 @@ mod sqlite;
 
 pub use query::{
     build_audit_query_sql, build_safety_net_query_sql, AuditFilter, AuditLogRow, LeakSuspectRow,
-    AUDIT_RESTRICTED_COLUMNS, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
+    PresentColumns, AUDIT_RESTRICTED_COLUMNS, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
     SAFETY_NET_RESTRICTED_COLUMNS,
 };
 pub use sqlite::{AuditError, LeakSuspectLogEntry, LeakSuspectLogger, Result, SqliteLogger};

--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -1,3 +1,6 @@
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+
 use rusqlite::types::Value;
 
 pub const DEFAULT_SNAPSHOT_SCHEME: &str = "gaze.snapshot.v1.sha256-salted";
@@ -175,150 +178,70 @@ pub const SAFETY_NET_RESTRICTED_COLUMNS: &[&str] = &[
     "telemetry_kind",
 ];
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PresentColumns(BTreeSet<String>);
+
+impl PresentColumns {
+    pub fn new(columns: BTreeSet<String>) -> Self {
+        Self(columns)
+    }
+
+    pub fn contains(&self, column: &str) -> bool {
+        self.0.contains(column)
+    }
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct Predicates<'a>(Vec<Cow<'a, str>>);
+
+impl<'a> Predicates<'a> {
+    fn push(&mut self, predicate: impl Into<Cow<'a, str>>) {
+        self.0.push(predicate.into());
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn join(&self, separator: &str) -> String {
+        self.0
+            .iter()
+            .map(Cow::as_ref)
+            .collect::<Vec<_>>()
+            .join(separator)
+    }
+}
+
+fn audit_select_expression<'a>(column: &'a str, present_columns: &PresentColumns) -> Cow<'a, str> {
+    if present_columns.contains(column) {
+        return Cow::Borrowed(column);
+    }
+
+    match column {
+        "source" | "class" | "action" | "field_name" | "document_kind" | "conflict_loser" => {
+            Cow::Borrowed(column)
+        }
+        "decided_by" => Cow::Borrowed("'none' AS decided_by"),
+        "snapshot_scheme" => Cow::Owned(format!("'{DEFAULT_SNAPSHOT_SCHEME}' AS snapshot_scheme")),
+        "snapshot_alg" => Cow::Owned(format!("'{DEFAULT_SNAPSHOT_ALG}' AS snapshot_alg")),
+        _ => Cow::Owned(format!("NULL AS {column}")),
+    }
+}
+
 /// Audit reads are defense-in-depth restricted to metadata columns that are
 /// safe to display. Do not switch this path to `SELECT *`; future schema
 /// additions may include restore material or other sensitive payloads.
-#[allow(clippy::too_many_arguments)]
 pub fn build_audit_query_sql(
     filter: &AuditFilter,
-    has_decided_by: bool,
-    has_created_at: bool,
-    has_session_id: bool,
-    has_snapshot_scheme: bool,
-    has_snapshot_alg: bool,
-    has_snapshot_key_version: bool,
-    has_validator_fail_reason: bool,
-    has_ambiguity_record: bool,
-    has_collision_family: bool,
-    has_collision_variant: bool,
-    has_fallback_triggered: bool,
-    has_recognizer_id: bool,
-    has_recognizer_version_id: bool,
-    has_provenance_stage: bool,
-    has_provenance_model_id: bool,
-    has_provenance_model_version: bool,
-    has_provenance_artifact_sha256: bool,
-    has_provenance_tokenizer_sha256: bool,
-    has_provenance_locale_resolved: bool,
-    has_provenance_locale_match_kind: bool,
-    has_provenance_canonical_class: bool,
-    has_provenance_native_class: bool,
-    has_provenance_confidence: bool,
-    has_provenance_merged_from: bool,
-    has_restore_policy: bool,
-    has_restore_decision: bool,
-    has_restore_unknown_token_count: bool,
-    has_restore_manifest_bypass_count: bool,
-    has_restore_fresh_pii_count: bool,
-    has_restore_phase_mask: bool,
+    present_columns: &PresentColumns,
 ) -> (String, Vec<Value>) {
-    let decided_by_column = if has_decided_by {
-        "decided_by"
-    } else {
-        "'none' AS decided_by"
-    };
-    let created_at_column = if has_created_at {
-        "created_at"
-    } else {
-        "NULL AS created_at"
-    };
-    let session_id_column = if has_session_id {
-        "session_id"
-    } else {
-        "NULL AS session_id"
-    };
-    let snapshot_scheme_column = if has_snapshot_scheme {
-        "snapshot_scheme".to_string()
-    } else {
-        format!("'{DEFAULT_SNAPSHOT_SCHEME}' AS snapshot_scheme")
-    };
-    let snapshot_alg_column = if has_snapshot_alg {
-        "snapshot_alg".to_string()
-    } else {
-        format!("'{DEFAULT_SNAPSHOT_ALG}' AS snapshot_alg")
-    };
-    let snapshot_key_version_column = if has_snapshot_key_version {
-        "snapshot_key_version"
-    } else {
-        "NULL AS snapshot_key_version"
-    };
-    let validator_fail_reason_column = if has_validator_fail_reason {
-        "validator_fail_reason"
-    } else {
-        "NULL AS validator_fail_reason"
-    };
-    let ambiguity_record_column = if has_ambiguity_record {
-        "ambiguity_record"
-    } else {
-        "NULL AS ambiguity_record"
-    };
-    let collision_family_column = if has_collision_family {
-        "collision_family"
-    } else {
-        "NULL AS collision_family"
-    };
-    let collision_variant_column = if has_collision_variant {
-        "collision_variant"
-    } else {
-        "NULL AS collision_variant"
-    };
-    let fallback_triggered_column = if has_fallback_triggered {
-        "fallback_triggered"
-    } else {
-        "NULL AS fallback_triggered"
-    };
-    let recognizer_id_column = if has_recognizer_id {
-        "recognizer_id"
-    } else {
-        "NULL AS recognizer_id"
-    };
-    let recognizer_version_id_column = if has_recognizer_version_id {
-        "recognizer_version_id"
-    } else {
-        "NULL AS recognizer_version_id"
-    };
-    let provenance_stage_column = nullable_column(has_provenance_stage, "provenance_stage");
-    let provenance_model_id_column =
-        nullable_column(has_provenance_model_id, "provenance_model_id");
-    let provenance_model_version_column =
-        nullable_column(has_provenance_model_version, "provenance_model_version");
-    let provenance_artifact_sha256_column =
-        nullable_column(has_provenance_artifact_sha256, "provenance_artifact_sha256");
-    let provenance_tokenizer_sha256_column = nullable_column(
-        has_provenance_tokenizer_sha256,
-        "provenance_tokenizer_sha256",
-    );
-    let provenance_locale_resolved_column =
-        nullable_column(has_provenance_locale_resolved, "provenance_locale_resolved");
-    let provenance_locale_match_kind_column = nullable_column(
-        has_provenance_locale_match_kind,
-        "provenance_locale_match_kind",
-    );
-    let provenance_canonical_class_column =
-        nullable_column(has_provenance_canonical_class, "provenance_canonical_class");
-    let provenance_native_class_column =
-        nullable_column(has_provenance_native_class, "provenance_native_class");
-    let provenance_confidence_column =
-        nullable_column(has_provenance_confidence, "provenance_confidence");
-    let provenance_merged_from_column =
-        nullable_column(has_provenance_merged_from, "provenance_merged_from");
-    let restore_policy_column = nullable_column(has_restore_policy, "restore_policy");
-    let restore_decision_column = nullable_column(has_restore_decision, "restore_decision");
-    let restore_unknown_token_count_column = nullable_column(
-        has_restore_unknown_token_count,
-        "restore_unknown_token_count",
-    );
-    let restore_manifest_bypass_count_column = nullable_column(
-        has_restore_manifest_bypass_count,
-        "restore_manifest_bypass_count",
-    );
-    let restore_fresh_pii_count_column =
-        nullable_column(has_restore_fresh_pii_count, "restore_fresh_pii_count");
-    let restore_phase_mask_column = nullable_column(has_restore_phase_mask, "restore_phase_mask");
-    let mut sql = format!(
-        "SELECT source, {recognizer_id_column}, {recognizer_version_id_column}, class, action, field_name, document_kind, conflict_loser, {decided_by_column}, {created_at_column}, {session_id_column}, {snapshot_scheme_column}, {snapshot_alg_column}, {snapshot_key_version_column}, {validator_fail_reason_column}, {ambiguity_record_column}, {collision_family_column}, {collision_variant_column}, {fallback_triggered_column}, {provenance_stage_column}, {provenance_model_id_column}, {provenance_model_version_column}, {provenance_artifact_sha256_column}, {provenance_tokenizer_sha256_column}, {provenance_locale_resolved_column}, {provenance_locale_match_kind_column}, {provenance_canonical_class_column}, {provenance_native_class_column}, {provenance_confidence_column}, {provenance_merged_from_column}, {restore_policy_column}, {restore_decision_column}, {restore_unknown_token_count_column}, {restore_manifest_bypass_count_column}, {restore_fresh_pii_count_column}, {restore_phase_mask_column} FROM redaction_log"
-    );
-    let mut predicates = Vec::new();
+    let select_list = AUDIT_RESTRICTED_COLUMNS
+        .iter()
+        .map(|column| audit_select_expression(column, present_columns))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sql = format!("SELECT {select_list} FROM redaction_log");
+    let mut predicates = Predicates::default();
     let mut values = Vec::new();
     if let Some(class) = &filter.class {
         predicates.push("class = ?");
@@ -329,7 +252,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(source.clone()));
     }
     if let Some(recognizer_id) = &filter.recognizer_id {
-        if has_recognizer_id {
+        if present_columns.contains("recognizer_id") {
             predicates.push("recognizer_id = ?");
         } else {
             predicates.push("NULL = ?");
@@ -337,7 +260,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(recognizer_id.clone()));
     }
     if let Some(recognizer_version_id) = &filter.recognizer_version_id {
-        if has_recognizer_version_id {
+        if present_columns.contains("recognizer_version_id") {
             predicates.push("recognizer_version_id = ?");
         } else {
             predicates.push("NULL = ?");
@@ -353,7 +276,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(document_kind.clone()));
     }
     if let Some(from_epoch_ms) = filter.from_epoch_ms {
-        if has_created_at {
+        if present_columns.contains("created_at") {
             predicates.push("created_at >= ?");
         } else {
             predicates.push("NULL >= ?");
@@ -361,7 +284,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Integer(from_epoch_ms));
     }
     if let Some(to_epoch_ms) = filter.to_epoch_ms {
-        if has_created_at {
+        if present_columns.contains("created_at") {
             predicates.push("created_at <= ?");
         } else {
             predicates.push("NULL <= ?");
@@ -369,7 +292,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Integer(to_epoch_ms));
     }
     if let Some(session_id) = &filter.session_id {
-        if has_session_id {
+        if present_columns.contains("session_id") {
             predicates.push("session_id = ?");
         } else {
             predicates.push("NULL = ?");
@@ -377,7 +300,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(session_id.clone()));
     }
     if let Some(snapshot_scheme) = &filter.snapshot_scheme {
-        if has_snapshot_scheme {
+        if present_columns.contains("snapshot_scheme") {
             predicates.push("snapshot_scheme = ?");
         } else {
             predicates.push("'gaze.snapshot.v1.sha256-salted' = ?");
@@ -385,7 +308,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(snapshot_scheme.clone()));
     }
     if let Some(snapshot_alg) = &filter.snapshot_alg {
-        if has_snapshot_alg {
+        if present_columns.contains("snapshot_alg") {
             predicates.push("snapshot_alg = ?");
         } else {
             predicates.push("'SHA-256' = ?");
@@ -393,7 +316,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(snapshot_alg.clone()));
     }
     if let Some(snapshot_key_version) = filter.snapshot_key_version {
-        if has_snapshot_key_version {
+        if present_columns.contains("snapshot_key_version") {
             predicates.push("snapshot_key_version = ?");
         } else {
             predicates.push("NULL = ?");
@@ -401,7 +324,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Integer(snapshot_key_version));
     }
     if let Some(has_ambiguity) = filter.has_ambiguity {
-        if has_ambiguity_record {
+        if present_columns.contains("ambiguity_record") {
             predicates.push(if has_ambiguity {
                 "ambiguity_record IS NOT NULL"
             } else {
@@ -416,7 +339,7 @@ pub fn build_audit_query_sql(
         }
     }
     if let Some(reason) = &filter.ambiguity_reason {
-        if has_ambiguity_record {
+        if present_columns.contains("ambiguity_record") {
             predicates.push("json_extract(ambiguity_record, '$.reason') = ?");
         } else {
             predicates.push("json_extract(NULL, '$.reason') = ?");
@@ -424,7 +347,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(reason.clone()));
     }
     if let Some(family) = &filter.collision_family {
-        if has_collision_family {
+        if present_columns.contains("collision_family") {
             predicates.push("collision_family = ?");
         } else {
             predicates.push("NULL = ?");
@@ -432,7 +355,7 @@ pub fn build_audit_query_sql(
         values.push(Value::Text(family.clone()));
     }
     if let Some(variant) = &filter.collision_variant {
-        if has_collision_variant {
+        if present_columns.contains("collision_variant") {
             predicates.push("collision_variant = ?");
         } else {
             predicates.push("NULL = ?");
@@ -442,68 +365,68 @@ pub fn build_audit_query_sql(
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_stage,
+        present_columns.contains("provenance_stage"),
         "provenance_stage",
         &filter.provenance_stage,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_model_id,
+        present_columns.contains("provenance_model_id"),
         "provenance_model_id",
         &filter.provenance_model_id,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_model_version,
+        present_columns.contains("provenance_model_version"),
         "provenance_model_version",
         &filter.provenance_model_version,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_artifact_sha256,
+        present_columns.contains("provenance_artifact_sha256"),
         "provenance_artifact_sha256",
         &filter.provenance_artifact_sha256,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_tokenizer_sha256,
+        present_columns.contains("provenance_tokenizer_sha256"),
         "provenance_tokenizer_sha256",
         &filter.provenance_tokenizer_sha256,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_locale_resolved,
+        present_columns.contains("provenance_locale_resolved"),
         "provenance_locale_resolved",
         &filter.provenance_locale_resolved,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_locale_match_kind,
+        present_columns.contains("provenance_locale_match_kind"),
         "provenance_locale_match_kind",
         &filter.provenance_locale_match_kind,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_canonical_class,
+        present_columns.contains("provenance_canonical_class"),
         "provenance_canonical_class",
         &filter.provenance_canonical_class,
     );
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_native_class,
+        present_columns.contains("provenance_native_class"),
         "provenance_native_class",
         &filter.provenance_native_class,
     );
     if let Some(confidence) = filter.provenance_confidence {
-        if has_provenance_confidence {
+        if present_columns.contains("provenance_confidence") {
             predicates.push("provenance_confidence = ?");
         } else {
             predicates.push("NULL = ?");
@@ -513,12 +436,12 @@ pub fn build_audit_query_sql(
     add_optional_text_filter(
         &mut predicates,
         &mut values,
-        has_provenance_merged_from,
+        present_columns.contains("provenance_merged_from"),
         "provenance_merged_from",
         &filter.provenance_merged_from,
     );
     if filter.restore_events_only {
-        if has_restore_policy {
+        if present_columns.contains("restore_policy") {
             predicates.push("restore_policy IS NOT NULL");
         } else {
             predicates.push("NULL IS NOT NULL");
@@ -532,16 +455,8 @@ pub fn build_audit_query_sql(
     (sql, values)
 }
 
-fn nullable_column(has_column: bool, column: &'static str) -> String {
-    if has_column {
-        column.to_string()
-    } else {
-        format!("NULL AS {column}")
-    }
-}
-
 fn add_optional_text_filter<'a>(
-    predicates: &mut Vec<&'a str>,
+    predicates: &mut Predicates<'a>,
     values: &mut Vec<Value>,
     has_column: bool,
     column: &'a str,
@@ -549,27 +464,11 @@ fn add_optional_text_filter<'a>(
 ) {
     if let Some(value) = value {
         if has_column {
-            predicates.push(column_eq_predicate(column));
+            predicates.push(Cow::Owned(format!("{column} = ?")));
         } else {
             predicates.push("NULL = ?");
         }
         values.push(Value::Text(value.clone()));
-    }
-}
-
-fn column_eq_predicate(column: &str) -> &str {
-    match column {
-        "provenance_stage" => "provenance_stage = ?",
-        "provenance_model_id" => "provenance_model_id = ?",
-        "provenance_model_version" => "provenance_model_version = ?",
-        "provenance_artifact_sha256" => "provenance_artifact_sha256 = ?",
-        "provenance_tokenizer_sha256" => "provenance_tokenizer_sha256 = ?",
-        "provenance_locale_resolved" => "provenance_locale_resolved = ?",
-        "provenance_locale_match_kind" => "provenance_locale_match_kind = ?",
-        "provenance_canonical_class" => "provenance_canonical_class = ?",
-        "provenance_native_class" => "provenance_native_class = ?",
-        "provenance_merged_from" => "provenance_merged_from = ?",
-        _ => unreachable!("unsupported audit provenance filter column"),
     }
 }
 
@@ -625,4 +524,121 @@ pub fn build_safety_net_query_sql(filter: &AuditFilter) -> (String, Vec<Value>) 
     }
     sql.push_str(" ORDER BY id");
     (sql, values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OPTIONAL_COLUMNS: [&str; 30] = [
+        "decided_by",
+        "created_at",
+        "session_id",
+        "snapshot_scheme",
+        "snapshot_alg",
+        "snapshot_key_version",
+        "validator_fail_reason",
+        "ambiguity_record",
+        "collision_family",
+        "collision_variant",
+        "fallback_triggered",
+        "recognizer_id",
+        "recognizer_version_id",
+        "provenance_stage",
+        "provenance_model_id",
+        "provenance_model_version",
+        "provenance_artifact_sha256",
+        "provenance_tokenizer_sha256",
+        "provenance_locale_resolved",
+        "provenance_locale_match_kind",
+        "provenance_canonical_class",
+        "provenance_native_class",
+        "provenance_confidence",
+        "provenance_merged_from",
+        "restore_policy",
+        "restore_decision",
+        "restore_unknown_token_count",
+        "restore_manifest_bypass_count",
+        "restore_fresh_pii_count",
+        "restore_phase_mask",
+    ];
+
+    fn build_with_columns(columns: &[&str]) -> String {
+        let present_columns =
+            PresentColumns::new(columns.iter().map(|column| (*column).to_string()).collect());
+        build_audit_query_sql(&AuditFilter::default(), &present_columns).0
+    }
+
+    #[test]
+    fn generated_sql_is_byte_identical_for_column_presence_matrix() {
+        assert_eq!(
+            build_with_columns(&OPTIONAL_COLUMNS),
+            "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, snapshot_scheme, snapshot_alg, snapshot_key_version, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask FROM redaction_log ORDER BY rowid"
+        );
+        assert_eq!(
+            build_with_columns(&[]),
+            "SELECT source, NULL AS recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, NULL AS created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, 'SHA-256' AS snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, NULL AS ambiguity_record, NULL AS collision_family, NULL AS collision_variant, NULL AS fallback_triggered, NULL AS provenance_stage, NULL AS provenance_model_id, NULL AS provenance_model_version, NULL AS provenance_artifact_sha256, NULL AS provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, NULL AS provenance_locale_match_kind, NULL AS provenance_canonical_class, NULL AS provenance_native_class, NULL AS provenance_confidence, NULL AS provenance_merged_from, NULL AS restore_policy, NULL AS restore_decision, NULL AS restore_unknown_token_count, NULL AS restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, NULL AS restore_phase_mask FROM redaction_log ORDER BY rowid"
+        );
+        let mixed = [
+            "created_at",
+            "snapshot_alg",
+            "ambiguity_record",
+            "collision_variant",
+            "recognizer_id",
+            "provenance_stage",
+            "provenance_model_version",
+            "provenance_tokenizer_sha256",
+            "provenance_locale_match_kind",
+            "provenance_native_class",
+            "provenance_merged_from",
+            "restore_decision",
+            "restore_manifest_bypass_count",
+            "restore_phase_mask",
+        ];
+        assert_eq!(
+            build_with_columns(&mixed),
+            "SELECT source, recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, ambiguity_record, NULL AS collision_family, collision_variant, NULL AS fallback_triggered, provenance_stage, NULL AS provenance_model_id, provenance_model_version, NULL AS provenance_artifact_sha256, provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, provenance_locale_match_kind, NULL AS provenance_canonical_class, provenance_native_class, NULL AS provenance_confidence, provenance_merged_from, NULL AS restore_policy, restore_decision, NULL AS restore_unknown_token_count, restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, restore_phase_mask FROM redaction_log ORDER BY rowid"
+        );
+    }
+
+    #[test]
+    fn select_list_contains_each_allowlisted_column_once_in_order() {
+        let sql = build_with_columns(&[]);
+        let select_list = sql
+            .strip_prefix("SELECT ")
+            .unwrap()
+            .split_once(" FROM redaction_log")
+            .unwrap()
+            .0;
+        let aliases = select_list
+            .split(", ")
+            .map(|expression| {
+                expression
+                    .rsplit_once(" AS ")
+                    .map_or(expression, |(_, alias)| alias)
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(aliases, AUDIT_RESTRICTED_COLUMNS);
+        for column in AUDIT_RESTRICTED_COLUMNS {
+            assert_eq!(aliases.iter().filter(|alias| *alias == column).count(), 1);
+        }
+    }
+
+    #[test]
+    fn optional_text_filter_is_total_for_future_allowlisted_columns() {
+        let mut predicates = Predicates::default();
+        let mut values = Vec::new();
+
+        add_optional_text_filter(
+            &mut predicates,
+            &mut values,
+            true,
+            "future_provenance",
+            &Some("synthetic".to_string()),
+        );
+
+        assert_eq!(predicates.0, ["future_provenance = ?"]);
+        assert_eq!(values, [Value::Text("synthetic".to_string())]);
+    }
 }

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -12,7 +13,7 @@ use thiserror::Error;
 
 use crate::query::{
     build_audit_query_sql, build_safety_net_query_sql, AuditFilter, AuditLogRow, LeakSuspectRow,
-    DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
+    PresentColumns, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
 };
 
 pub type Result<T> = std::result::Result<T, AuditError>;
@@ -491,73 +492,8 @@ impl SqliteLogger {
     /// moved into a pipeline or dropped.
     pub fn query(path: &Path, filter: &AuditFilter) -> Result<Vec<AuditLogRow>> {
         let conn = open_audit_query_connection(path)?;
-        let has_decided_by = table_has_column(&conn, "decided_by")?;
-        let has_created_at = table_has_column(&conn, "created_at")?;
-        let has_session_id = table_has_column(&conn, "session_id")?;
-        let has_snapshot_scheme = table_has_column(&conn, "snapshot_scheme")?;
-        let has_snapshot_alg = table_has_column(&conn, "snapshot_alg")?;
-        let has_snapshot_key_version = table_has_column(&conn, "snapshot_key_version")?;
-        let has_validator_fail_reason = table_has_column(&conn, "validator_fail_reason")?;
-        let has_ambiguity_record = table_has_column(&conn, "ambiguity_record")?;
-        let has_collision_family = table_has_column(&conn, "collision_family")?;
-        let has_collision_variant = table_has_column(&conn, "collision_variant")?;
-        let has_fallback_triggered = table_has_column(&conn, "fallback_triggered")?;
-        let has_recognizer_id = table_has_column(&conn, "recognizer_id")?;
-        let has_recognizer_version_id = table_has_column(&conn, "recognizer_version_id")?;
-        let has_provenance_stage = table_has_column(&conn, "provenance_stage")?;
-        let has_provenance_model_id = table_has_column(&conn, "provenance_model_id")?;
-        let has_provenance_model_version = table_has_column(&conn, "provenance_model_version")?;
-        let has_provenance_artifact_sha256 = table_has_column(&conn, "provenance_artifact_sha256")?;
-        let has_provenance_tokenizer_sha256 =
-            table_has_column(&conn, "provenance_tokenizer_sha256")?;
-        let has_provenance_locale_resolved = table_has_column(&conn, "provenance_locale_resolved")?;
-        let has_provenance_locale_match_kind =
-            table_has_column(&conn, "provenance_locale_match_kind")?;
-        let has_provenance_canonical_class = table_has_column(&conn, "provenance_canonical_class")?;
-        let has_provenance_native_class = table_has_column(&conn, "provenance_native_class")?;
-        let has_provenance_confidence = table_has_column(&conn, "provenance_confidence")?;
-        let has_provenance_merged_from = table_has_column(&conn, "provenance_merged_from")?;
-        let has_restore_policy = table_has_column(&conn, "restore_policy")?;
-        let has_restore_decision = table_has_column(&conn, "restore_decision")?;
-        let has_restore_unknown_token_count =
-            table_has_column(&conn, "restore_unknown_token_count")?;
-        let has_restore_manifest_bypass_count =
-            table_has_column(&conn, "restore_manifest_bypass_count")?;
-        let has_restore_fresh_pii_count = table_has_column(&conn, "restore_fresh_pii_count")?;
-        let has_restore_phase_mask = table_has_column(&conn, "restore_phase_mask")?;
-        let (sql, values) = build_audit_query_sql(
-            filter,
-            has_decided_by,
-            has_created_at,
-            has_session_id,
-            has_snapshot_scheme,
-            has_snapshot_alg,
-            has_snapshot_key_version,
-            has_validator_fail_reason,
-            has_ambiguity_record,
-            has_collision_family,
-            has_collision_variant,
-            has_fallback_triggered,
-            has_recognizer_id,
-            has_recognizer_version_id,
-            has_provenance_stage,
-            has_provenance_model_id,
-            has_provenance_model_version,
-            has_provenance_artifact_sha256,
-            has_provenance_tokenizer_sha256,
-            has_provenance_locale_resolved,
-            has_provenance_locale_match_kind,
-            has_provenance_canonical_class,
-            has_provenance_native_class,
-            has_provenance_confidence,
-            has_provenance_merged_from,
-            has_restore_policy,
-            has_restore_decision,
-            has_restore_unknown_token_count,
-            has_restore_manifest_bypass_count,
-            has_restore_fresh_pii_count,
-            has_restore_phase_mask,
-        );
+        let present_columns = PresentColumns::new(redaction_log_column_names(&conn)?);
+        let (sql, values) = build_audit_query_sql(filter, &present_columns);
         let mut stmt = conn
             .prepare(&sql)
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -769,19 +705,18 @@ fn open_audit_query_connection(path: &Path) -> Result<Connection> {
     .map_err(|err| AuditError::Sqlite(err.to_string()))
 }
 
-fn table_has_column(conn: &Connection, name: &str) -> Result<bool> {
+fn redaction_log_column_names(conn: &Connection) -> Result<BTreeSet<String>> {
     let mut stmt = conn
         .prepare("PRAGMA table_info(redaction_log)")
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
     let columns = stmt
         .query_map([], |row| row.get::<_, String>(1))
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+    let mut names = BTreeSet::new();
     for column in columns {
-        if column.map_err(|err| AuditError::Sqlite(err.to_string()))? == name {
-            return Ok(true);
-        }
+        names.insert(column.map_err(|err| AuditError::Sqlite(err.to_string()))?);
     }
-    Ok(false)
+    Ok(names)
 }
 
 fn conflict_tier_from_db(value: &str) -> std::result::Result<ConflictTier, rusqlite::Error> {

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -131,51 +131,86 @@ pub trait LeakSuspectLogger: Send + Sync {
     fn log_leak_suspect(&self, entry: &LeakSuspectLogEntry) -> Result<()>;
 }
 
+#[derive(Clone, Copy)]
+enum ColumnConstraint {
+    NotNull,
+    Nullable,
+    Default(&'static str),
+}
+
+struct ColumnSpec {
+    name: &'static str,
+    sql_type: &'static str,
+    constraint: ColumnConstraint,
+    migrate: bool,
+    backfill: Option<&'static str>,
+}
+
+impl ColumnSpec {
+    fn declaration(&self) -> String {
+        match self.constraint {
+            ColumnConstraint::NotNull => format!("{} NOT NULL", self.sql_type),
+            ColumnConstraint::Nullable => format!("{} NULL", self.sql_type),
+            ColumnConstraint::Default(value) => {
+                format!("{} NOT NULL DEFAULT '{value}'", self.sql_type)
+            }
+        }
+    }
+}
+
+const REDACTION_LOG_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec { name: "source", sql_type: "TEXT", constraint: ColumnConstraint::NotNull, migrate: false, backfill: None },
+    ColumnSpec { name: "recognizer_id", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: Some("UPDATE redaction_log SET recognizer_id = 'legacy_unversioned' WHERE recognizer_id IS NULL") },
+    ColumnSpec { name: "recognizer_version_id", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "class", sql_type: "TEXT", constraint: ColumnConstraint::NotNull, migrate: false, backfill: None },
+    ColumnSpec { name: "action", sql_type: "TEXT", constraint: ColumnConstraint::NotNull, migrate: false, backfill: None },
+    ColumnSpec { name: "field_name", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: false, backfill: None },
+    ColumnSpec { name: "document_kind", sql_type: "TEXT", constraint: ColumnConstraint::NotNull, migrate: false, backfill: None },
+    ColumnSpec { name: "conflict_loser", sql_type: "INTEGER", constraint: ColumnConstraint::NotNull, migrate: false, backfill: None },
+    ColumnSpec { name: "decided_by", sql_type: "TEXT", constraint: ColumnConstraint::Default("none"), migrate: true, backfill: None },
+    ColumnSpec { name: "created_at", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "session_id", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "snapshot_scheme", sql_type: "TEXT", constraint: ColumnConstraint::Default(DEFAULT_SNAPSHOT_SCHEME), migrate: true, backfill: None },
+    ColumnSpec { name: "snapshot_alg", sql_type: "TEXT", constraint: ColumnConstraint::Default(DEFAULT_SNAPSHOT_ALG), migrate: true, backfill: None },
+    ColumnSpec { name: "snapshot_key_version", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "validator_fail_reason", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "ambiguity_record", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "collision_family", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "collision_variant", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "fallback_triggered", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "backend_silently_dropped", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_stage", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_model_id", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_model_version", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_artifact_sha256", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_tokenizer_sha256", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_locale_resolved", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_locale_match_kind", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_canonical_class", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_native_class", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_confidence", sql_type: "REAL", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "provenance_merged_from", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_policy", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_decision", sql_type: "TEXT", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_unknown_token_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_manifest_bypass_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_fresh_pii_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_phase_mask", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+];
 impl SqliteLogger {
     pub fn new(path: &Path) -> Result<Self> {
         let conn = Connection::open(path).map_err(|err| AuditError::Sqlite(err.to_string()))?;
+        let redaction_columns = REDACTION_LOG_COLUMNS
+            .iter()
+            .map(|column| format!("{} {}", column.name, column.declaration()))
+            .collect::<Vec<_>>()
+            .join(",\n                ");
+        conn.execute_batch(&format!(
+            "CREATE TABLE IF NOT EXISTS redaction_log (\n                {redaction_columns}\n            );"
+        ))
+        .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         conn.execute_batch(
             r#"
-            CREATE TABLE IF NOT EXISTS redaction_log (
-                source TEXT NOT NULL,
-                recognizer_id TEXT NULL,
-                recognizer_version_id TEXT NULL,
-                class TEXT NOT NULL,
-                action TEXT NOT NULL,
-                field_name TEXT NULL,
-                document_kind TEXT NOT NULL,
-                conflict_loser INTEGER NOT NULL,
-                decided_by TEXT NOT NULL DEFAULT 'none',
-                created_at INTEGER NULL,
-                session_id TEXT NULL,
-                snapshot_scheme TEXT NOT NULL DEFAULT 'gaze.snapshot.v1.sha256-salted',
-                snapshot_alg TEXT NOT NULL DEFAULT 'SHA-256',
-                snapshot_key_version INTEGER NULL,
-                validator_fail_reason TEXT NULL,
-                ambiguity_record TEXT NULL,
-                collision_family TEXT NULL,
-                collision_variant TEXT NULL,
-                fallback_triggered TEXT NULL,
-                backend_silently_dropped TEXT NULL,
-                provenance_stage TEXT NULL,
-                provenance_model_id TEXT NULL,
-                provenance_model_version TEXT NULL,
-                provenance_artifact_sha256 TEXT NULL,
-                provenance_tokenizer_sha256 TEXT NULL,
-                provenance_locale_resolved TEXT NULL,
-                provenance_locale_match_kind TEXT NULL,
-                provenance_canonical_class TEXT NULL,
-                provenance_native_class TEXT NULL,
-                provenance_confidence REAL NULL,
-                provenance_merged_from TEXT NULL,
-                restore_policy TEXT NULL,
-                restore_decision TEXT NULL,
-                restore_unknown_token_count INTEGER NULL,
-                restore_manifest_bypass_count INTEGER NULL,
-                restore_fresh_pii_count INTEGER NULL,
-                restore_phase_mask INTEGER NULL
-            );
-
             CREATE TABLE IF NOT EXISTS safety_net_log (
                 id INTEGER PRIMARY KEY,
                 safety_net_id TEXT NOT NULL,
@@ -198,167 +233,27 @@ impl SqliteLogger {
             "#,
         )
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        let columns = {
-            let mut stmt = conn
-                .prepare("PRAGMA table_info(redaction_log)")
-                .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-            let columns = stmt
-                .query_map([], |row| row.get::<_, String>(1))
-                .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-            let mut names = Vec::new();
-            for column in columns {
-                names.push(column.map_err(|err| AuditError::Sqlite(err.to_string()))?);
-            }
-            names
-        };
-        if !columns.iter().any(|column| column == "decided_by") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN decided_by TEXT NOT NULL DEFAULT 'none'",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "created_at") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN created_at INTEGER NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "session_id") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN session_id TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "snapshot_scheme") {
+
+        let columns = redaction_log_column_names(&conn)?;
+        for column in REDACTION_LOG_COLUMNS
+            .iter()
+            .filter(|column| column.migrate && !columns.contains(column.name))
+        {
             conn.execute(
                 &format!(
-                    "ALTER TABLE redaction_log ADD COLUMN snapshot_scheme TEXT NOT NULL DEFAULT '{}'",
-                    DEFAULT_SNAPSHOT_SCHEME
+                    "ALTER TABLE redaction_log ADD COLUMN {} {}",
+                    column.name,
+                    column.declaration()
                 ),
                 [],
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "snapshot_alg") {
-            conn.execute(
-                &format!(
-                    "ALTER TABLE redaction_log ADD COLUMN snapshot_alg TEXT NOT NULL DEFAULT '{}'",
-                    DEFAULT_SNAPSHOT_ALG
-                ),
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns
-            .iter()
-            .any(|column| column == "snapshot_key_version")
-        {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN snapshot_key_version INTEGER NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns
-            .iter()
-            .any(|column| column == "validator_fail_reason")
-        {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN validator_fail_reason TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "ambiguity_record") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN ambiguity_record TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "collision_family") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN collision_family TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "collision_variant") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN collision_variant TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "fallback_triggered") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN fallback_triggered TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns
-            .iter()
-            .any(|column| column == "backend_silently_dropped")
-        {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN backend_silently_dropped TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns.iter().any(|column| column == "recognizer_id") {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN recognizer_id TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-            conn.execute(
-                "UPDATE redaction_log SET recognizer_id = 'legacy_unversioned' WHERE recognizer_id IS NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        if !columns
-            .iter()
-            .any(|column| column == "recognizer_version_id")
-        {
-            conn.execute(
-                "ALTER TABLE redaction_log ADD COLUMN recognizer_version_id TEXT NULL",
-                [],
-            )
-            .map_err(|err| AuditError::Sqlite(err.to_string()))?;
-        }
-        for (column, column_type) in [
-            ("provenance_stage", "TEXT"),
-            ("provenance_model_id", "TEXT"),
-            ("provenance_model_version", "TEXT"),
-            ("provenance_artifact_sha256", "TEXT"),
-            ("provenance_tokenizer_sha256", "TEXT"),
-            ("provenance_locale_resolved", "TEXT"),
-            ("provenance_locale_match_kind", "TEXT"),
-            ("provenance_canonical_class", "TEXT"),
-            ("provenance_native_class", "TEXT"),
-            ("provenance_confidence", "REAL"),
-            ("provenance_merged_from", "TEXT"),
-            ("restore_policy", "TEXT"),
-            ("restore_decision", "TEXT"),
-            ("restore_unknown_token_count", "INTEGER"),
-            ("restore_manifest_bypass_count", "INTEGER"),
-            ("restore_fresh_pii_count", "INTEGER"),
-            ("restore_phase_mask", "INTEGER"),
-        ] {
-            if !columns.iter().any(|existing| existing == column) {
-                conn.execute(
-                    &format!("ALTER TABLE redaction_log ADD COLUMN {column} {column_type} NULL"),
-                    [],
-                )
-                .map_err(|err| AuditError::Sqlite(err.to_string()))?;
+            if let Some(backfill) = column.backfill {
+                conn.execute(backfill, [])
+                    .map_err(|err| AuditError::Sqlite(err.to_string()))?;
             }
         }
+
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -1038,6 +933,25 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM redaction_log", [], |row| row.get(0))
             .expect("row count");
         assert_eq!(row_count, 1);
+    }
+
+    #[test]
+    fn fresh_and_legacy_migrated_schemas_have_the_same_columns() {
+        let fresh_db = tempfile::NamedTempFile::new().unwrap();
+        let _fresh = SqliteLogger::new(fresh_db.path()).expect("fresh schema");
+
+        let legacy_db = tempfile::NamedTempFile::new().unwrap();
+        create_legacy_redaction_log(legacy_db.path());
+        let _migrated = SqliteLogger::new(legacy_db.path()).expect("migrated schema");
+
+        let fresh_columns = redaction_log_columns(fresh_db.path())
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let migrated_columns = redaction_log_columns(legacy_db.path())
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(migrated_columns, fresh_columns);
     }
 
     #[test]

--- a/crates/gaze-audit/tests/ner_provenance_migration.rs
+++ b/crates/gaze-audit/tests/ner_provenance_migration.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use gaze_audit::{build_audit_query_sql, AuditFilter, SqliteLogger};
+use gaze_audit::{
+    build_audit_query_sql, AuditFilter, PresentColumns, SqliteLogger, AUDIT_RESTRICTED_COLUMNS,
+};
 use rusqlite::types::Value as SqlValue;
 use rusqlite::Connection;
 
@@ -203,11 +205,13 @@ fn ner_provenance_filters_bind_expected_sql() {
 }
 
 fn build_current_audit_query_sql(filter: &AuditFilter) -> (String, Vec<SqlValue>) {
-    build_audit_query_sql(
-        filter, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true,
-    )
+    let present_columns = PresentColumns::new(
+        AUDIT_RESTRICTED_COLUMNS
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect(),
+    );
+    build_audit_query_sql(filter, &present_columns)
 }
 
 fn create_pre_provenance_redaction_log(path: &Path) {

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use gaze_audit::{
-    build_audit_query_sql, AuditFilter, DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
+    build_audit_query_sql, AuditFilter, PresentColumns, AUDIT_RESTRICTED_COLUMNS,
+    DEFAULT_SNAPSHOT_ALG, DEFAULT_SNAPSHOT_SCHEME,
 };
 use rusqlite::{types::Value as SqlValue, Connection};
 use serde_json::Value;
@@ -469,11 +470,13 @@ fn audit_sql_uses_restricted_column_set() {
         provenance_merged_from: None,
         restore_events_only: false,
     };
-    let (current_sql, values) = build_audit_query_sql(
-        &filter, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true, true,
+    let current_columns = PresentColumns::new(
+        AUDIT_RESTRICTED_COLUMNS
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect(),
     );
+    let (current_sql, values) = build_audit_query_sql(&filter, &current_columns);
     assert_eq!(
         values,
         [
@@ -507,39 +510,8 @@ fn audit_sql_uses_restricted_column_set() {
         snapshot_key_version: Some(1),
         ..AuditFilter::default()
     };
-    let (legacy_sql, legacy_values) = build_audit_query_sql(
-        &legacy_filter,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-    );
+    let legacy_columns = PresentColumns::default();
+    let (legacy_sql, legacy_values) = build_audit_query_sql(&legacy_filter, &legacy_columns);
     assert_restricted_sql(&legacy_sql);
     assert!(legacy_sql.contains("'none' AS decided_by"));
     assert!(legacy_sql.contains("NULL AS created_at"));

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -17,7 +17,18 @@ use serial_test::file_serial;
 use tempfile::tempdir;
 
 use gaze::{PiiClass, Scope, Session};
-use gaze_audit::{build_audit_query_sql, AuditFilter, SqliteLogger, AUDIT_RESTRICTED_COLUMNS};
+use gaze_audit::{
+    build_audit_query_sql, AuditFilter, PresentColumns, SqliteLogger, AUDIT_RESTRICTED_COLUMNS,
+};
+
+fn all_audit_columns() -> PresentColumns {
+    PresentColumns::new(
+        AUDIT_RESTRICTED_COLUMNS
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect(),
+    )
+}
 
 fn test_subprocess_timeout_ms() -> u64 {
     let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
@@ -1854,39 +1865,8 @@ fn s4_audit_query_columns_are_restricted() {
     let conn = Connection::open(&audit_path).unwrap();
     conn.execute("ALTER TABLE redaction_log ADD COLUMN raw_value TEXT", [])
         .unwrap();
-    let (sql, values) = build_audit_query_sql(
-        &AuditFilter::default(),
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-    );
+    let present_columns = all_audit_columns();
+    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), &present_columns);
     assert!(
         values.is_empty(),
         "default audit filter should not bind query values"
@@ -1940,39 +1920,8 @@ fn p5_audit_query_reads_structural_agent_recipient_source() {
     // `source` is intentionally present so audit reads can explain the
     // structural family without a schema change.
     assert!(AUDIT_RESTRICTED_COLUMNS.contains(&"source"));
-    let (sql, values) = build_audit_query_sql(
-        &AuditFilter::default(),
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-    );
+    let present_columns = all_audit_columns();
+    let (sql, values) = build_audit_query_sql(&AuditFilter::default(), &present_columns);
     let conn = Connection::open(&audit_path).unwrap();
     let mut stmt = conn.prepare(&sql).unwrap();
     let rows = stmt

--- a/docs/explanation/detection/ambiguity-side-channel.md
+++ b/docs/explanation/detection/ambiguity-side-channel.md
@@ -104,7 +104,7 @@ The lower-level audit query keeps raw JSON strings so `gaze-audit` does not
 interpret CLI presentation concerns. CLI JSONL parses the JSON strings back into
 typed `ValidatorFailReason` and `AmbiguityRecord` values before writing output.
 
-`build_audit_query_sql` accepts column-presence booleans for cross-version
+`build_audit_query_sql` accepts a `PresentColumns` set for cross-version
 compatibility. If a database lacks a Spike 4 column, query projection uses
 `NULL AS <column>`. Filters against missing columns naturally return no matching
 rows, except `has_ambiguity = false`, which matches legacy rows because their


### PR DESCRIPTION
## Summary

- replace 30 positional column-presence booleans and repeated `PRAGMA table_info` scans with one `PresentColumns` set
- generate the metadata-only select list from `AUDIT_RESTRICTED_COLUMNS` in allowlist order
- replace the reachable provenance-filter panic with total `Cow<str>` predicates
- drive fresh `redaction_log` creation and legacy migrations from one 37-column specification

## Safety and compatibility

- SQL output is byte-identical for all-present, none-present, and mixed column matrices
- every allowlisted projected column is asserted exactly once and in order
- legacy migration defaults and the conditional `recognizer_id` backfill are preserved
- fresh and migrated schemas are asserted to contain the same column set
- no reliability, reversibility, agentic-fit, trust, or adopter-ergonomics axis is weakened

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p gaze-audit`
- `cargo test -p gaze-cli --test audit_cross_version`
- `cargo run -p xtask -- dylint-gate` (18 UI fixture shapes passed; cargo-dylint remains CI-scheduled per todo #1870)
- `cargo test --workspace --all-features --no-fail-fast`

Audit: solo scratchpad 7201 S09-F1/S09-F2

Resolves solo todo #2954
