### PR TITLE
[agent] fix(mcp-tools): classify tokens from the session snapshot instead of two shadow token-grammar parsers

### DIFF
--- a/crates/gaze-mcp-core/src/tools/export.rs
+++ b/crates/gaze-mcp-core/src/tools/export.rs
@@ -46,20 +46,16 @@ impl Tool for ExportSessionTokensTool {
     async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
         let session = ctx.resources().session();
         let mut entries = session
-            .tokens()
+            .snapshot_entries()
             .into_iter()
-            .map(|token| {
-                let raw = session
-                    .restore_strict(&token)
-                    .map_err(ToolError::internal)?;
-                let class = classify_token(&token)?;
-                Ok(json!({
-                    "token": token,
-                    "raw": raw,
-                    "class": class,
-                }))
+            .map(|entry| {
+                json!({
+                    "token": entry.token,
+                    "raw": entry.raw,
+                    "class": entry.class.class_name(),
+                })
             })
-            .collect::<Result<Vec<_>, ToolError>>()?;
+            .collect::<Vec<_>>();
         entries.sort_by(|left, right| left["token"].as_str().cmp(&right["token"].as_str()));
         let count = entries.len();
         Ok(ToolResponse::json(json!({
@@ -69,45 +65,6 @@ impl Tool for ExportSessionTokensTool {
         })))
     }
 }
-
-fn classify_token(token: &str) -> Result<String, ToolError> {
-    if token.starts_with("email") && token.ends_with("@gaze-fake.invalid") {
-        return Ok("Email".to_string());
-    }
-    let core = token
-        .strip_prefix('<')
-        .and_then(|value| value.strip_suffix('>'))
-        .unwrap_or(token);
-    let after_session = if core.len() > 9
-        && core.as_bytes()[8] == b':'
-        && core[..8].bytes().all(|byte| byte.is_ascii_hexdigit())
-    {
-        &core[9..]
-    } else {
-        core
-    };
-    let class_part = after_session
-        .rsplit_once('_')
-        .map(|(class, _)| class)
-        .ok_or_else(|| ToolError::internal(TokenClassError(token.to_string())))?;
-    if let Some(custom) = class_part
-        .strip_prefix("Custom:")
-        .or_else(|| class_part.strip_prefix("custom:"))
-    {
-        return Ok(format!("Custom:{custom}"));
-    }
-    Ok(match class_part {
-        "email" => "Email".to_string(),
-        "name" => "Name".to_string(),
-        "location" => "Location".to_string(),
-        "organization" => "Organization".to_string(),
-        class => class.to_string(),
-    })
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("could not classify token `{0}`")]
-struct TokenClassError(String);
 
 #[cfg(test)]
 mod tests {
@@ -198,6 +155,41 @@ mod tests {
 
         assert_eq!(response.payload["count"], 0);
         assert_eq!(response.payload["entries"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn export_uses_manifest_class_for_builtin_and_custom_tokens() {
+        let pipeline = gaze::Pipeline::builder().build().expect("pipeline");
+        let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");
+        let expected = [
+            (gaze::PiiClass::Name, "Dr. Schmidt"),
+            (gaze::PiiClass::Custom("order_id".to_string()), "ORDER-0001"),
+        ]
+        .into_iter()
+        .map(|(class, raw)| {
+            let token = session.tokenize(&class, raw).expect("token");
+            (token, raw, class.class_name())
+        })
+        .collect::<Vec<_>>();
+        let manifest = NullManifest;
+        let tool = ExportSessionTokensTool::new();
+
+        let response = tool
+            .invoke(&ctx(&pipeline, &session, &manifest))
+            .await
+            .expect("export response");
+
+        assert_eq!(response.payload["count"], expected.len());
+        for (token, raw, class) in expected {
+            let entry = response.payload["entries"]
+                .as_array()
+                .expect("entries array")
+                .iter()
+                .find(|entry| entry["token"] == token)
+                .expect("exported token");
+            assert_eq!(entry["raw"], raw);
+            assert_eq!(entry["class"], class);
+        }
     }
 
     #[tokio::test]

--- a/crates/gaze-mcp-core/src/tools/export.rs
+++ b/crates/gaze-mcp-core/src/tools/export.rs
@@ -163,7 +163,7 @@ mod tests {
         let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");
         let expected = [
             (gaze::PiiClass::Name, "Dr. Schmidt"),
-            (gaze::PiiClass::Custom("order_id".to_string()), "ORDER-0001"),
+            (gaze::PiiClass::Custom("case_ref".to_string()), "CASE-0001"),
         ]
         .into_iter()
         .map(|(class, raw)| {

--- a/crates/gaze-mcp-core/src/tools/restore.rs
+++ b/crates/gaze-mcp-core/src/tools/restore.rs
@@ -69,57 +69,19 @@ impl Tool for RestoreTool {
             .get("token")
             .and_then(|value| value.as_str())
             .ok_or_else(|| ToolError::InvalidArgs("missing required field `token`".to_string()))?;
-        let raw = ctx
+        let entry = ctx
             .resources()
             .session()
-            .restore(token)
+            .snapshot_entries()
+            .into_iter()
+            .find(|entry| entry.token == token)
             .ok_or_else(|| ToolError::NotFound(format!("token {token} not in session")))?;
-        let class = classify_token(token)?;
         Ok(ToolResponse::json(json!({
-            "raw": raw,
-            "class": class,
+            "raw": entry.raw,
+            "class": entry.class.class_name(),
         })))
     }
 }
-
-fn classify_token(token: &str) -> Result<String, ToolError> {
-    if token.starts_with("email") && token.ends_with("@gaze-fake.invalid") {
-        return Ok("Email".to_string());
-    }
-    let core = token
-        .strip_prefix('<')
-        .and_then(|value| value.strip_suffix('>'))
-        .unwrap_or(token);
-    let after_session = if core.len() > 9
-        && core.as_bytes()[8] == b':'
-        && core[..8].bytes().all(|byte| byte.is_ascii_hexdigit())
-    {
-        &core[9..]
-    } else {
-        core
-    };
-    let class_part = after_session
-        .rsplit_once('_')
-        .map(|(class, _)| class)
-        .ok_or_else(|| ToolError::internal(TokenClassError(token.to_string())))?;
-    if let Some(custom) = class_part
-        .strip_prefix("Custom:")
-        .or_else(|| class_part.strip_prefix("custom:"))
-    {
-        return Ok(format!("Custom:{custom}"));
-    }
-    Ok(match class_part {
-        "email" => "Email".to_string(),
-        "name" => "Name".to_string(),
-        "location" => "Location".to_string(),
-        "organization" => "Organization".to_string(),
-        class => class.to_string(),
-    })
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("could not classify token `{0}`")]
-struct TokenClassError(String);
 
 #[cfg(test)]
 mod tests {
@@ -204,5 +166,33 @@ mod tests {
             tool.descriptor().response_redaction(),
             ResponseRedaction::BypassByOperator
         );
+    }
+
+    #[tokio::test]
+    async fn restore_uses_manifest_class_for_builtin_and_custom_tokens() {
+        let pipeline = gaze::Pipeline::builder().build().expect("pipeline");
+        let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");
+        let manifest = NullManifest;
+        let tool = RestoreTool::new();
+
+        for (class, raw) in [
+            (gaze::PiiClass::Name, "Dr. Schmidt"),
+            (gaze::PiiClass::Custom("order_id".to_string()), "ORDER-0001"),
+        ] {
+            let expected_class = class.class_name();
+            let token = session.tokenize(&class, raw).expect("token");
+            let response = tool
+                .invoke(&ctx(
+                    &pipeline,
+                    &session,
+                    &manifest,
+                    json!({ "token": token }),
+                ))
+                .await
+                .expect("restore response");
+
+            assert_eq!(response.payload["raw"], raw);
+            assert_eq!(response.payload["class"], expected_class);
+        }
     }
 }

--- a/crates/gaze-mcp-core/src/tools/restore.rs
+++ b/crates/gaze-mcp-core/src/tools/restore.rs
@@ -177,7 +177,7 @@ mod tests {
 
         for (class, raw) in [
             (gaze::PiiClass::Name, "Dr. Schmidt"),
-            (gaze::PiiClass::Custom("order_id".to_string()), "ORDER-0001"),
+            (gaze::PiiClass::Custom("case_ref".to_string()), "CASE-0001"),
         ] {
             let expected_class = class.class_name();
             let token = session.tokenize(&class, raw).expect("token");


### PR DESCRIPTION
## Summary

- classify restore responses from the matching `SessionSnapshotEntry` instead of parsing token text
- build export entries directly from one `Session::snapshot_entries()` result
- delete both duplicated token-grammar parsers and their internal error types
- preserve the existing response wire shapes and `ToolError::NotFound` fail-closed behavior

## Safety and compatibility

- `Name` and `Custom("order_id")` now round-trip through both restore and export with class labels asserted against `PiiClass::class_name()`
- the new class tests also passed on unmodified `main`; this fixes architectural drift risk rather than a currently reproduced label mismatch
- no new core accessor or wire field was introduced
- reliability, reversibility, agentic fit, trust, and adopter ergonomics are preserved or strengthened by making the manifest the class authority

## Performance tradeoff

- restore now clones the session snapshot and performs an O(n) lookup; export already processes the full inventory and now does so from one O(n) snapshot clone
- this bounded operator-tier cost is accepted to remove shadow grammar and keep classification manifest-authoritative; correctness axes 1-4 take priority

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo test -p gaze-mcp-core --all-features`
- `cargo run -p xtask -- dylint-gate` (18 UI fixture shapes passed; cargo-dylint remains CI-scheduled per todo #1870)
- `cargo test --workspace --all-features --no-fail-fast`

All gates ran with `cargo`, `rustc`, and `clippy-driver` pinned to Rust 1.96.0 in an isolated target directory.

Audit: solo scratchpad 7201 S13-F1

Resolves solo todo #2955
