### PR TITLE
[agent] fix(safety-net): one structured walker; structured documents fail closed under Redact/Resolve instead of silently observing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Pipeline::scan_safety_nets` for a report-only pass. In-tree pipelines that
   register no safety net are unaffected.
 
+- **The three structured-document walkers are one `walk_structured` with a
+  `LeafOp`** (audit 7201 S01-F2, solo todo #2950). The pseudonymize,
+  clean-and-scan, and scan-only traversals of `RawDocument::Structured` were
+  three near-identical recursive copies that had already drifted. They are now
+  one function parameterized by `LeafOp { Pseudonymize, CleanAndScan, ScanOnly }`,
+  with every intentional difference — empty-string skipping, whether scalar
+  leaves are scanned, whether the document is rebuilt, and the root field-path
+  prefix — declared once on the op and documented there. Behaviour is unchanged
+  on all three paths, including the pre-existing divergence where
+  `scan_safety_nets_structured` reports bare-key field paths (`profile.email`)
+  and `clean_with_safety_net*` reports JSONPath-style ones (`$.profile.email`),
+  which is preserved deliberately and tracked as solo todo #2958.
+
 - **`SafetyNetMode` x `SafetyNetFallback` is lowered once to a total
   `SafetyNetDecision`** (audit 7201 S01-F1, solo todo #2949). The two public
   fields spell twelve pairs; the runtime has six behaviours, and seven pairs
@@ -275,6 +288,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FallbackReason` variant; `gaze-types` is unchanged.
 
 ### Fixed
+
+- **Structured documents no longer accept a safety-net enforcement request and
+  silently perform observation** (audit 7201 S01-F2, solo todo #2950). The
+  structured arm of `clean_with_safety_net_policy_detect_context` cleaned each
+  field, ran the nets over the result, and returned `Ok` — with no enforcement
+  stage anywhere on the path. A caller passing `SafetyNetMode::Redact` or
+  `SafetyNetMode::Resolve` with a `RawDocument::Structured` therefore got
+  observer-only behaviour and a success return, with the suspect bytes still in
+  the document. It now fails closed with the new
+  `Error::UnsupportedSafetyNetModeForStructured { mode }` before any field is
+  tokenized. **Adopters passing structured documents with an enforcing mode now
+  get an error** — the intended correction; pass `SafetyNetMode::Strict` (or
+  `Tolerant`) for the observer behaviour they were actually receiving, or use
+  `Pipeline::scan_safety_nets_structured`. Note that the policy-less
+  `clean_with_safety_net*` entry points default to `Resolve`, so structured
+  documents must go through `clean_with_safety_net_policy_detect_context`.
+  Text documents are unaffected. Axis 1.
 
 - **Safety-net `resolve` fallback acted on the primary report instead of the
   residual one, destroying tokens and shipping residual PII under the default

--- a/crates/gaze-recognizers/tests/mock_safety_net.rs
+++ b/crates/gaze-recognizers/tests/mock_safety_net.rs
@@ -60,6 +60,24 @@ fn tokenizing_pipeline(net: Option<MockSafetyNet>) -> Pipeline {
     builder.build().expect("pipeline")
 }
 
+/// Structured documents accept only an observer policy; the policy-less `clean_with_safety_net`
+/// defaults to `Resolve`, which the structured entry point refuses. See
+/// `Error::UnsupportedSafetyNetModeForStructured`.
+fn clean_structured_observing(
+    pipeline: &Pipeline,
+    session: &gaze::Session,
+    raw: RawDocument,
+    locales: &[LocaleTag],
+) -> gaze::Result<(CleanDocument, Vec<gaze::EmittedTokenSpan>, LeakReport)> {
+    pipeline.clean_with_safety_net_policy_detect_context(
+        session,
+        raw,
+        locales,
+        &gaze::DictionaryBundle::default(),
+        gaze::SafetyNetPolicy::new(gaze::SafetyNetMode::Strict, gaze::SafetyNetFallback::Redact),
+    )
+}
+
 fn precomputed_email_report(span: Range<usize>) -> LeakReport {
     LeakReport::from_parts(
         vec![LeakSuspect::new(
@@ -116,9 +134,9 @@ fn field_path_reports_drive_structured_tests() {
         ])),
     )]));
 
-    let (clean, manifest, report) = pipeline
-        .clean_with_safety_net(&session, raw, &[LocaleTag::Global])
-        .expect("structured safety-net clean");
+    let (clean, manifest, report) =
+        clean_structured_observing(&pipeline, &session, raw, &[LocaleTag::Global])
+            .expect("structured safety-net clean");
 
     assert!(manifest.is_empty());
     assert_eq!(report.stats.suspect_count, 1);
@@ -180,8 +198,7 @@ fn locale_skip_still_uses_session_level_locale_chain_for_structured_docs() {
         Value::String("alice@example.invalid".to_string()),
     )]));
 
-    let (_, _, report) = pipeline
-        .clean_with_safety_net(&session, raw, &[LocaleTag::DeDe])
+    let (_, _, report) = clean_structured_observing(&pipeline, &session, raw, &[LocaleTag::DeDe])
         .expect("structured locale skip");
 
     assert_eq!(report.stats.locale_skipped_count, 1);

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -79,6 +79,11 @@ pub enum Error {
     UnsupportedRawDocumentVariant,
     #[error("unsupported structured value variant")]
     UnsupportedValueVariant,
+    #[error(
+        "safety-net mode {mode:?} is unsupported for structured documents; \
+         pass SafetyNetMode::Strict or SafetyNetMode::Tolerant, or use scan_safety_nets_structured"
+    )]
+    UnsupportedSafetyNetModeForStructured { mode: SafetyNetMode },
     #[error("unsupported policy action variant")]
     UnsupportedActionVariant,
 }
@@ -570,14 +575,19 @@ impl Pipeline {
         dictionaries: &DictionaryBundle,
     ) -> Result<CleanDocument> {
         match raw {
-            RawDocument::Structured(structured_fields) => redact_structured(
-                self,
-                target,
-                structured_fields,
-                DocumentKind::Structured,
-                locale_chain,
-                dictionaries,
-            ),
+            RawDocument::Structured(structured_fields) => {
+                let mut report = LeakReport::default();
+                walk_structured(
+                    self,
+                    target,
+                    &structured_fields,
+                    locale_chain,
+                    dictionaries,
+                    &mut report,
+                    LeafOp::Pseudonymize,
+                )
+                .map(CleanDocument::Structured)
+            }
             RawDocument::Text(text) => Ok(CleanDocument::Text(self.pseudonymize_text(
                 target,
                 &text,
@@ -675,15 +685,23 @@ impl Pipeline {
         let decision = policy.decision();
         match raw {
             RawDocument::Structured(structured_fields) => {
+                // Fail closed before any detection or tokenization runs. The structured path has
+                // no enforcement stage: it cleans each leaf, runs the nets over the result, and
+                // reports. Accepting an enforcing policy here and quietly performing observation
+                // is the axis-1 hole this rejects — the caller asked for the suspect bytes to be
+                // removed and would have been told, with `Ok`, that they were.
+                if !matches!(decision, SafetyNetDecision::Observe { .. }) {
+                    return Err(Error::UnsupportedSafetyNetModeForStructured { mode: policy.mode });
+                }
                 let mut report = LeakReport::default();
-                let clean = redact_structured_with_safety_net(
+                let clean = walk_structured(
                     self,
                     target,
-                    structured_fields,
+                    &structured_fields,
                     locale_chain,
                     dictionaries,
                     &mut report,
-                    decision,
+                    LeafOp::CleanAndScan(decision),
                 )?;
                 Ok((CleanDocument::Structured(clean), Vec::new(), report))
             }
@@ -819,16 +837,15 @@ impl Pipeline {
 
         let mut report = LeakReport::default();
         let mut target = ProtectionTarget::Live(session);
-        for (key, value) in document {
-            walk_value_for_safety_net_scan(
-                self,
-                &mut target,
-                value,
-                key,
-                locale_chain,
-                &mut report,
-            )?;
-        }
+        walk_structured(
+            self,
+            &mut target,
+            document,
+            locale_chain,
+            &DictionaryBundle::default(),
+            &mut report,
+            LeafOp::ScanOnly,
+        )?;
         Ok(SafetyNetResult { nets_run, report })
     }
 
@@ -2783,289 +2800,231 @@ fn model_error_to_safety_net_error(error: ModelError) -> SafetyNetError {
     }
 }
 
-fn redact_structured(
-    pipeline: &Pipeline,
-    target: &mut ProtectionTarget<'_, '_>,
-    fields: BTreeMap<String, Value>,
-    document_kind: DocumentKind,
-    locale_chain: &[crate::LocaleTag],
-    dictionaries: &DictionaryBundle,
-) -> Result<CleanDocument> {
-    let mut clean = BTreeMap::new();
-    for (key, value) in fields {
-        let path = format!("$.{key}");
-        clean.insert(
-            key.clone(),
-            redact_structured_value(
-                pipeline,
-                target,
-                value,
-                &key,
-                &path,
-                document_kind,
-                locale_chain,
-                dictionaries,
-            )?,
-        );
-    }
-    Ok(CleanDocument::Structured(clean))
+/// What a [`walk_structured_value`] traversal does at each leaf.
+///
+/// The three ops are deliberately asymmetric, and each asymmetry is contractual rather than
+/// accidental:
+///
+/// - **Empty strings.** Both safety-net ops skip them: an empty leaf cannot carry a suspect, and
+///   handing `""` to a subprocess backend is pure cost. `Pseudonymize` does not skip — every
+///   string leaf goes through the primary pipeline.
+/// - **Scalars** (`null`, `true`, `7`). `Pseudonymize` passes them through untouched; there is
+///   nothing in a scalar for the deterministic detectors to tokenize. Both safety-net ops
+///   stringify and scan them, because a net can flag a numeric leaf that never reaches the text
+///   detectors. `null` stringifies to nothing and is skipped by all three
+///   ([`Value::scalar_to_safety_net_string`]).
+/// - **Rebuilding.** [`Self::ScanOnly`] reads the document and produces no replacement; the other
+///   two rebuild it. See [`Self::rebuilds`].
+///
+/// There is no enforcing op. The structured entry point rejects an enforcing
+/// [`SafetyNetDecision`] with [`Error::UnsupportedSafetyNetModeForStructured`] before any
+/// traversal starts, so a leaf never has to decide whether to act on a suspect.
+#[derive(Debug, Clone, Copy)]
+enum LeafOp {
+    /// Tokenize each string leaf through the primary pipeline. No safety net runs.
+    Pseudonymize,
+    /// Tokenize each string leaf, then run the safety nets over the tokenized text and accumulate
+    /// the per-field reports. The decision is carried only so `run_safety_nets` can apply its
+    /// observer-only skip gating; it is always an `Observe` decision here.
+    CleanAndScan(SafetyNetDecision),
+    /// Run the safety nets over each leaf as-is, with no manifest and no mutation.
+    ScanOnly,
 }
 
-#[allow(clippy::too_many_arguments)]
-fn redact_structured_value(
-    pipeline: &Pipeline,
-    target: &mut ProtectionTarget<'_, '_>,
-    value: Value,
-    field_name: &str,
-    field_path: &str,
-    document_kind: DocumentKind,
-    locale_chain: &[crate::LocaleTag],
-    dictionaries: &DictionaryBundle,
-) -> Result<Value> {
-    match value {
-        Value::String(text) => Ok(Value::String(pipeline.pseudonymize_text(
-            target,
-            &text,
-            Some(field_name),
-            document_kind,
-            locale_chain,
-            dictionaries,
-        )?)),
-        Value::Array(values) => values
-            .into_iter()
-            .enumerate()
-            .map(|(idx, value)| {
-                redact_structured_value(
-                    pipeline,
-                    target,
-                    value,
-                    field_name,
-                    &format!("{field_path}[{idx}]"),
-                    document_kind,
-                    locale_chain,
-                    dictionaries,
-                )
-            })
-            .collect::<Result<Vec<_>>>()
-            .map(Value::Array),
-        Value::Object(fields) => {
-            let mut clean = BTreeMap::new();
-            for (key, value) in fields {
-                let child_path = format!("{field_path}.{key}");
-                clean.insert(
-                    key.clone(),
-                    redact_structured_value(
-                        pipeline,
-                        target,
-                        value,
-                        &key,
-                        &child_path,
-                        document_kind,
-                        locale_chain,
-                        dictionaries,
-                    )?,
-                );
-            }
-            Ok(Value::Object(clean))
+impl LeafOp {
+    /// Whether the traversal produces a replacement document. `ScanOnly` reads without rebuilding,
+    /// so its walk returns `None` at every level and allocates no copy of the caller's document.
+    fn rebuilds(self) -> bool {
+        !matches!(self, LeafOp::ScanOnly)
+    }
+
+    /// The root field path reported for a top-level key.
+    ///
+    /// `ScanOnly` reports a bare key (`profile.email`) where the two cleaning ops report a
+    /// JSONPath-style root (`$.profile.email`). That is a pre-existing divergence between
+    /// `Pipeline::scan_safety_nets_structured` and `Pipeline::clean_with_safety_net*`, surfaced
+    /// by folding the three walkers into one. It is preserved rather than silently unified
+    /// because `field_path` is adopter-visible telemetry that lands in the audit log; changing it
+    /// is a separate, announced change (solo todo #2958).
+    fn root_path(self, key: &str) -> String {
+        match self {
+            LeafOp::ScanOnly => key.to_string(),
+            LeafOp::Pseudonymize | LeafOp::CleanAndScan(_) => format!("$.{key}"),
         }
-        Value::Null | Value::Bool(_) | Value::I64(_) => Ok(value),
-        _ => Err(Error::UnsupportedValueVariant),
+    }
+
+    /// The decision handed to `run_safety_nets` for this op.
+    fn decision(self) -> SafetyNetDecision {
+        match self {
+            LeafOp::CleanAndScan(decision) => decision,
+            LeafOp::Pseudonymize | LeafOp::ScanOnly => SafetyNetDecision::Observe { strict: true },
+        }
     }
 }
 
+/// Walks every field of a structured document under one [`LeafOp`].
+///
+/// Returns the rebuilt document, or an empty map when the op does not rebuild.
 #[allow(clippy::too_many_arguments)]
-fn redact_structured_with_safety_net(
+fn walk_structured(
     pipeline: &Pipeline,
     target: &mut ProtectionTarget<'_, '_>,
-    fields: BTreeMap<String, Value>,
+    fields: &BTreeMap<String, Value>,
     locale_chain: &[crate::LocaleTag],
     dictionaries: &DictionaryBundle,
     report: &mut LeakReport,
-    decision: SafetyNetDecision,
+    op: LeafOp,
 ) -> Result<BTreeMap<String, Value>> {
     let mut clean = BTreeMap::new();
     for (key, value) in fields {
-        let path = format!("$.{key}");
-        clean.insert(
-            key.clone(),
-            redact_structured_value_with_safety_net(
-                pipeline,
-                target,
-                value,
-                &key,
-                &path,
-                locale_chain,
-                dictionaries,
-                report,
-                decision,
-            )?,
-        );
+        let path = op.root_path(key);
+        // A field error aborts the whole document rather than yielding a partially protected
+        // one: the caller asked for a protected document, not a best-effort one.
+        if let Some(value) = walk_structured_value(
+            pipeline,
+            target,
+            value,
+            key,
+            &path,
+            locale_chain,
+            dictionaries,
+            report,
+            op,
+        )? {
+            clean.insert(key.clone(), value);
+        }
     }
     Ok(clean)
 }
 
+/// Walks one structured value under `op`.
+///
+/// `report` is only written by the safety-net ops; [`LeafOp::Pseudonymize`] ignores it. Keeping it
+/// a separate parameter rather than a field on the op keeps `LeafOp` `Copy` through the recursion.
 #[allow(clippy::too_many_arguments)]
-fn redact_structured_value_with_safety_net(
+fn walk_structured_value(
     pipeline: &Pipeline,
     target: &mut ProtectionTarget<'_, '_>,
-    value: Value,
+    value: &Value,
     field_name: &str,
     field_path: &str,
     locale_chain: &[crate::LocaleTag],
     dictionaries: &DictionaryBundle,
     report: &mut LeakReport,
-    decision: SafetyNetDecision,
-) -> Result<Value> {
+    op: LeafOp,
+) -> Result<Option<Value>> {
     match value {
-        Value::String(text) => {
-            if text.is_empty() {
-                return Ok(Value::String(text));
-            }
-            let clean = pipeline.redact_text_with_manifest(
+        Value::String(text) => match op {
+            LeafOp::Pseudonymize => Ok(Some(Value::String(pipeline.pseudonymize_text(
                 target,
-                &text,
+                text,
                 Some(field_name),
                 DocumentKind::Structured,
                 locale_chain,
                 dictionaries,
-            )?;
-            // For RawDocument::Structured, locale gating uses the session-level
-            // locale chain across all fields; fields have no locale annotations.
-            let field_report = pipeline.run_safety_nets(
-                target,
-                &clean.text,
-                &Manifest::from_spans(clean.manifest),
-                DocumentKind::Structured,
-                locale_chain,
-                Some(field_path),
-                decision,
-            )?;
-            report.extend(field_report);
-            Ok(Value::String(clean.text))
-        }
-        Value::Array(values) => values
-            .into_iter()
-            .enumerate()
-            .map(|(idx, value)| {
-                redact_structured_value_with_safety_net(
+            )?))),
+            LeafOp::CleanAndScan(decision) => {
+                if text.is_empty() {
+                    return Ok(Some(Value::String(String::new())));
+                }
+                let clean = pipeline.redact_text_with_manifest(
+                    target,
+                    text,
+                    Some(field_name),
+                    DocumentKind::Structured,
+                    locale_chain,
+                    dictionaries,
+                )?;
+                // For RawDocument::Structured, locale gating uses the session-level
+                // locale chain across all fields; fields have no locale annotations.
+                let field_report = pipeline.run_safety_nets(
+                    target,
+                    &clean.text,
+                    &Manifest::from_spans(clean.manifest),
+                    DocumentKind::Structured,
+                    locale_chain,
+                    Some(field_path),
+                    decision,
+                )?;
+                report.extend(field_report);
+                Ok(Some(Value::String(clean.text)))
+            }
+            LeafOp::ScanOnly => {
+                if !text.is_empty() {
+                    let field_report = pipeline.run_safety_nets(
+                        target,
+                        text,
+                        &Manifest::default(),
+                        DocumentKind::Structured,
+                        locale_chain,
+                        Some(field_path),
+                        op.decision(),
+                    )?;
+                    report.extend(field_report);
+                }
+                Ok(None)
+            }
+        },
+        Value::Array(values) => {
+            let mut clean = Vec::new();
+            for (idx, child) in values.iter().enumerate() {
+                // An index is not a field name, so array elements keep the parent's.
+                if let Some(child) = walk_structured_value(
                     pipeline,
                     target,
-                    value,
+                    child,
                     field_name,
                     &format!("{field_path}[{idx}]"),
                     locale_chain,
                     dictionaries,
                     report,
-                    decision,
-                )
-            })
-            .collect::<Result<Vec<_>>>()
-            .map(Value::Array),
+                    op,
+                )? {
+                    clean.push(child);
+                }
+            }
+            Ok(op.rebuilds().then_some(Value::Array(clean)))
+        }
         Value::Object(fields) => {
             let mut clean = BTreeMap::new();
-            for (key, value) in fields {
-                let child_path = format!("{field_path}.{key}");
-                clean.insert(
-                    key.clone(),
-                    redact_structured_value_with_safety_net(
-                        pipeline,
-                        target,
-                        value,
-                        &key,
-                        &child_path,
-                        locale_chain,
-                        dictionaries,
-                        report,
-                        decision,
-                    )?,
-                );
-            }
-            Ok(Value::Object(clean))
-        }
-        Value::Null | Value::Bool(_) | Value::I64(_) => {
-            if let Some(scalar) = value.scalar_to_safety_net_string() {
-                let field_report = pipeline.run_safety_nets(
-                    target,
-                    &scalar,
-                    &Manifest::default(),
-                    DocumentKind::Structured,
-                    locale_chain,
-                    Some(field_path),
-                    decision,
-                )?;
-                report.extend(field_report);
-            }
-            Ok(value)
-        }
-        _ => Err(Error::UnsupportedValueVariant),
-    }
-}
-
-fn walk_value_for_safety_net_scan(
-    pipeline: &Pipeline,
-    target: &mut ProtectionTarget<'_, '_>,
-    value: &Value,
-    field_path: &str,
-    locale_chain: &[crate::LocaleTag],
-    report: &mut LeakReport,
-) -> Result<()> {
-    match value {
-        Value::String(text) => {
-            if !text.is_empty() {
-                let field_report = pipeline.run_safety_nets(
-                    target,
-                    text,
-                    &Manifest::default(),
-                    DocumentKind::Structured,
-                    locale_chain,
-                    Some(field_path),
-                    SafetyNetDecision::Observe { strict: true },
-                )?;
-                report.extend(field_report);
-            }
-        }
-        Value::Null => {}
-        Value::Bool(_) | Value::I64(_) => {
-            if let Some(scalar) = value.scalar_to_safety_net_string() {
-                let field_report = pipeline.run_safety_nets(
-                    target,
-                    &scalar,
-                    &Manifest::default(),
-                    DocumentKind::Structured,
-                    locale_chain,
-                    Some(field_path),
-                    SafetyNetDecision::Observe { strict: true },
-                )?;
-                report.extend(field_report);
-            }
-        }
-        Value::Array(values) => {
-            for (idx, value) in values.iter().enumerate() {
-                walk_value_for_safety_net_scan(
+            for (key, child) in fields {
+                if let Some(child) = walk_structured_value(
                     pipeline,
                     target,
-                    value,
-                    &format!("{field_path}[{idx}]"),
-                    locale_chain,
-                    report,
-                )?;
-            }
-        }
-        Value::Object(fields) => {
-            for (key, value) in fields {
-                walk_value_for_safety_net_scan(
-                    pipeline,
-                    target,
-                    value,
+                    child,
+                    key,
                     &format!("{field_path}.{key}"),
                     locale_chain,
+                    dictionaries,
                     report,
-                )?;
+                    op,
+                )? {
+                    clean.insert(key.clone(), child);
+                }
             }
+            Ok(op.rebuilds().then_some(Value::Object(clean)))
         }
-        _ => return Err(Error::UnsupportedValueVariant),
+        Value::Null | Value::Bool(_) | Value::I64(_) => {
+            if !matches!(op, LeafOp::Pseudonymize) {
+                if let Some(scalar) = value.scalar_to_safety_net_string() {
+                    let field_report = pipeline.run_safety_nets(
+                        target,
+                        &scalar,
+                        &Manifest::default(),
+                        DocumentKind::Structured,
+                        locale_chain,
+                        Some(field_path),
+                        op.decision(),
+                    )?;
+                    report.extend(field_report);
+                }
+            }
+            Ok(op.rebuilds().then(|| value.clone()))
+        }
+        // Fail closed on a value variant this build does not model. Widening this arm would let
+        // an unmodelled leaf pass through unprotected.
+        _ => Err(Error::UnsupportedValueVariant),
     }
-    Ok(())
 }
 
 fn translate_candidate(candidate: Candidate, spans: &[(usize, usize)]) -> Option<Candidate> {

--- a/crates/gaze/tests/safety_net.rs
+++ b/crates/gaze/tests/safety_net.rs
@@ -1001,9 +1001,14 @@ fn structured_safety_net_traverses_nested_fields_and_preserves_shape() {
 
     let raw = RawDocument::Structured(BTreeMap::from([("user".to_string(), Value::Object(user))]));
 
-    let (clean, manifest, report) = pipeline
-        .clean_with_safety_net(&session, raw, &[gaze::LocaleTag::Global])
-        .expect("structured safety net clean");
+    let (clean, manifest, report) = clean_with_policy(
+        &pipeline,
+        &session,
+        raw,
+        &[gaze::LocaleTag::Global],
+        observer_policy(),
+    )
+    .expect("structured safety net clean");
 
     assert!(manifest.is_empty(), "structured manifests stay field-local");
     assert_eq!(report.stats.suspect_count, 1);
@@ -1045,9 +1050,14 @@ fn structured_locale_skip_uses_session_level_locale_chain() {
         Value::String("alice@example.invalid".to_string()),
     )]));
 
-    let (_, _, report) = pipeline
-        .clean_with_safety_net(&session, raw, &[gaze::LocaleTag::DeDe])
-        .expect("structured locale skip");
+    let (_, _, report) = clean_with_policy(
+        &pipeline,
+        &session,
+        raw,
+        &[gaze::LocaleTag::DeDe],
+        observer_policy(),
+    )
+    .expect("structured locale skip");
 
     // For RawDocument::Structured, locale gating uses session-level locale
     // chain across all fields; fields do not carry per-field locale metadata.
@@ -1076,9 +1086,14 @@ fn structured_field_error_fails_closed_at_doc_level() {
         )])),
     )]));
 
-    let err = pipeline
-        .clean_with_safety_net(&session, raw, &[gaze::LocaleTag::Global])
-        .expect_err("field-level safety net errors fail closed");
+    let err = clean_with_policy(
+        &pipeline,
+        &session,
+        raw,
+        &[gaze::LocaleTag::Global],
+        observer_policy(),
+    )
+    .expect_err("field-level safety net errors fail closed");
 
     assert!(matches!(
         err,
@@ -1955,4 +1970,156 @@ fn first_pass_refusal_redacts_only_the_actionable_suspect_and_audits_the_protect
             "{refusal:?}: the protected suspect keeps its Preserve row"
         );
     }
+}
+
+/// Axis-1 contract hole: a caller asking for enforcement on a structured document was given
+/// observation. The structured arm of `clean_target_with_safety_net_policy_detect_context` ran the
+/// nets per field, collected the report, and returned `Ok` — the suspect bytes were still in the
+/// document, and nothing in the return value said the requested action had not been performed.
+#[test]
+fn structured_documents_do_not_silently_observe_when_enforcement_is_requested() {
+    let raw_email = "alice@example.invalid";
+    for mode in [gaze::SafetyNetMode::Redact, gaze::SafetyNetMode::Resolve] {
+        let net =
+            MockNet::new(Some(0..raw_email.len()), PiiClass::Email).with_field_path("$.email");
+        let pipeline = pipeline_with_net(Some(net));
+        let session = session();
+        let raw = RawDocument::Structured(BTreeMap::from([(
+            "email".to_string(),
+            Value::String(raw_email.to_string()),
+        )]));
+
+        let result = clean_with_policy(
+            &pipeline,
+            &session,
+            raw,
+            &[gaze::LocaleTag::Global],
+            gaze::SafetyNetPolicy::new(mode, gaze::SafetyNetFallback::Redact),
+        );
+
+        match result {
+            // Fail closed: the request is refused with a typed error.
+            Err(err) => assert!(
+                matches!(
+                    err,
+                    gaze::Error::UnsupportedSafetyNetModeForStructured { .. }
+                ),
+                "{mode:?}: unexpected error {err:?}"
+            ),
+            // Or the enforcement actually happened. What must never occur is Ok with the
+            // suspect bytes still present.
+            Ok((clean, _, _)) => {
+                let CleanDocument::Structured(fields) = clean else {
+                    panic!("expected structured output");
+                };
+                let Value::String(email) = &fields["email"] else {
+                    panic!("expected string leaf");
+                };
+                assert!(
+                    !email.contains(raw_email),
+                    "{mode:?}: enforcement requested, observation performed — suspect bytes shipped"
+                );
+            }
+        }
+    }
+}
+
+/// Nested-traversal parity across all three `LeafOp`s.
+///
+/// The three structured walkers were near-identical copies and had already drifted (see the
+/// root-path note below). Folding them into one `walk_structured` makes divergence a compile-time
+/// impossibility for everything except what the op deliberately varies; this pins the parts that
+/// must stay identical.
+#[test]
+fn structured_walk_has_nested_parity_across_every_leaf_op() {
+    fn document() -> BTreeMap<String, Value> {
+        let contact = BTreeMap::from([(
+            "email".to_string(),
+            Value::String("alice@example.invalid".to_string()),
+        )]);
+        let user = BTreeMap::from([
+            (
+                "contacts".to_string(),
+                Value::Array(vec![Value::Object(contact)]),
+            ),
+            ("empty".to_string(), Value::String(String::new())),
+            ("active".to_string(), Value::Bool(true)),
+            ("count".to_string(), Value::I64(7)),
+        ]);
+        BTreeMap::from([("user".to_string(), Value::Object(user))])
+    }
+
+    fn seen_paths(net: &MockNet) -> Vec<String> {
+        let mut paths = net
+            .seen
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|entry| entry.field_path.clone().unwrap_or_default())
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+
+    // Leg 1: Pseudonymize, through the plain structured entry point.
+    let pseudonymize_net = MockNet::new(None, PiiClass::Email);
+    let pseudonymized = pipeline_with_net(Some(pseudonymize_net.clone()))
+        .redact(&session(), RawDocument::Structured(document()))
+        .expect("pseudonymize structured");
+    let CleanDocument::Structured(pseudonymized) = pseudonymized else {
+        panic!("expected structured output");
+    };
+    // Pseudonymize runs no safety net at all — not even over the scalar leaves.
+    assert!(seen_paths(&pseudonymize_net).is_empty());
+
+    // Leg 2: CleanAndScan, through the observer-policy safety-net entry point.
+    let clean_net = MockNet::new(None, PiiClass::Email);
+    let (cleaned, _, _) = clean_with_policy(
+        &pipeline_with_net(Some(clean_net.clone())),
+        &session(),
+        RawDocument::Structured(document()),
+        &[gaze::LocaleTag::Global],
+        observer_policy(),
+    )
+    .expect("clean structured");
+    let CleanDocument::Structured(cleaned) = cleaned else {
+        panic!("expected structured output");
+    };
+
+    // Leg 3: ScanOnly, through the observer scan API.
+    let scan_net = MockNet::new(None, PiiClass::Email);
+    pipeline_with_net(Some(scan_net.clone()))
+        .scan_safety_nets_structured(&session(), &document(), &[gaze::LocaleTag::Global])
+        .expect("scan structured");
+
+    // Both rebuilding ops reconstruct the same document: nested objects, arrays, the empty
+    // string, and both scalar kinds survive the walk under a preserve-only rule set.
+    assert_eq!(pseudonymized, cleaned);
+    assert_eq!(pseudonymized, document());
+
+    // Both scanning ops visit the same leaves, in the same order, skipping the empty string and
+    // covering both scalars.
+    let cleaned_paths = seen_paths(&clean_net);
+    let scanned_paths = seen_paths(&scan_net);
+    assert_eq!(
+        cleaned_paths,
+        vec![
+            "$.user.active".to_string(),
+            "$.user.contacts[0].email".to_string(),
+            "$.user.count".to_string(),
+        ]
+    );
+    // Documented divergence, preserved rather than silently unified: `scan_safety_nets_structured`
+    // reports bare-key roots where the cleaning path reports JSONPath-style ones (todo #2958).
+    assert_eq!(
+        scanned_paths,
+        cleaned_paths
+            .iter()
+            .map(|path| path.trim_start_matches("$.").to_string())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !cleaned_paths.iter().any(|path| path.ends_with("empty")),
+        "empty string leaves are skipped by both scanning ops"
+    );
 }

--- a/docs/explanation/safety-net/safety-nets.md
+++ b/docs/explanation/safety-net/safety-nets.md
@@ -377,8 +377,46 @@ that field path, and the FP-adjudication query
 it. Locale-skip telemetry is also recorded per field when the session-level
 locale chain does not match.
 
+### The structured path is observer-only, and says so
+
+**A structured document accepts only an observer policy.** Passing
+`SafetyNetMode::Redact` or `SafetyNetMode::Resolve` with a
+`RawDocument::Structured` returns
+`Error::UnsupportedSafetyNetModeForStructured` before any field is
+tokenized. The traversal above has no enforcement stage: it cleans each
+leaf, runs the nets over the result, and reports. Accepting an enforcing
+policy and quietly performing observation would be the worst of both — the
+caller is told `Ok`, and the suspect bytes are still in the document.
+Failing closed is the axis-1 answer.
+
+Use `SafetyNetMode::Strict` (reject at your boundary when the report is
+non-empty) or `SafetyNetMode::Tolerant`, via
+`Pipeline::clean_with_safety_net_policy_detect_context`, or
+`Pipeline::scan_safety_nets_structured` for a read-only pass over an
+already-clean document. Note that the policy-less
+`Pipeline::clean_with_safety_net*` entry points default to `Resolve`
+(`SafetyNetPolicy::default()`), so they are text-only in practice.
+
+Enforcement for structured documents is not implemented rather than
+forbidden: per-field enforcement is a coherent future feature (each leaf
+carries its own manifest, so a leaf could be resolved or redacted in
+isolation). Until it exists, the contract says so out loud.
+
+### One walker
+
+All three structured traversals — pseudonymize, clean-and-scan, and
+scan-only — are the single `walk_structured` in
+`crates/gaze/src/pipeline.rs`, parameterized by a `LeafOp`. They were three
+near-identical copies and had already drifted. What the op varies is
+documented on `LeafOp` itself: empty-string skipping, whether scalar leaves
+are scanned, whether the document is rebuilt, and the root field-path
+prefix.
+
 The integration coverage lives in
-`crates/gaze/tests/safety_net.rs::structured_safety_net_traverses_nested_fields_and_preserves_shape`.
+`crates/gaze/tests/safety_net.rs`:
+`structured_safety_net_traverses_nested_fields_and_preserves_shape`,
+`structured_walk_has_nested_parity_across_every_leaf_op`, and
+`structured_documents_do_not_silently_observe_when_enforcement_is_requested`.
 
 ## Replay hash
 


### PR DESCRIPTION
## Summary

S01-F2. A structured document could be handed an enforcing safety-net policy and be given
observation instead — accepted, cleaned, reported, returned `Ok`, suspect bytes still in the
document. That now fails closed with a typed error. The three near-identical structured walkers
that made the hole easy to miss are now one.

#436 (S01-F1) has merged as `6ad0efe`. This branch was rebased onto it and is **no longer stacked**:
base `6ad0efe`, head `1703550`, so the diff shown is this PR's own change only. The rebase
conflicted once in `crates/gaze/tests/safety_net.rs` (both PRs append tests to the end of that
file); it was resolved three-way and independently verified by reconstructing the expected result
from both parents and byte-comparing it against the shipped file.

## 1. The contract hole (axis 1)

`clean_target_with_safety_net_policy_detect_context`'s `Structured` arm cleaned each leaf, ran the
nets over the result, aggregated a `LeakReport`, and returned. There is no enforcement stage
anywhere on that path — no resolve, no redact, no fallback. The `policy` was consulted only for the
skip-gating hint inside `run_safety_nets`.

So `SafetyNetMode::Redact` on a structured document meant: *"delete the suspect spans"* in, *"here
is your document with the suspect spans in it, and an `Ok`"* out. The caller had no way to detect
the downgrade short of diffing the bytes themselves.

RED, before the fix:

```
structured_documents_do_not_silently_observe_when_enforcement_is_requested ... FAILED
  Redact: enforcement requested, observation performed — suspect bytes shipped
```

**Fix — typed rejection** (plan 7202 §8 item 6 default). The structured entry point now returns
`Error::UnsupportedSafetyNetModeForStructured { mode }` when the lowered decision is not
`Observe`, **before any field is detected or tokenized** — so a rejected request leaves no partial
session state behind.

This is "not implemented", stated out loud, rather than "forbidden": per-field enforcement is a
coherent future feature, since each leaf already carries its own manifest. Until it exists the
contract says so.

## 2. One walker

`redact_structured_value`, `redact_structured_value_with_safety_net`, and
`walk_value_for_safety_net_scan` were three near-identical recursive traversals. They are now one
`walk_structured` / `walk_structured_value` parameterized by:

```rust
enum LeafOp {
    Pseudonymize,
    CleanAndScan(SafetyNetDecision),
    ScanOnly,
}
```

Every intentional difference is declared once on `LeafOp` and documented there:

| | `Pseudonymize` | `CleanAndScan` | `ScanOnly` |
|---|---|---|---|
| empty string leaf | pseudonymized | **skipped** | **skipped** |
| scalar leaf (`null`/`bool`/`i64`) | passed through, no net | stringified + scanned | stringified + scanned |
| rebuilds the document | yes | yes | **no** (returns `None`, allocates no copy) |
| root field path | `$.key` | `$.key` | **`key`** (see below) |
| `UnsupportedValueVariant` on unknown variant | yes | yes | yes |
| field error aborts the whole document | yes | yes | yes |

`ScanOnly` borrows rather than owns, so `scan_safety_nets_structured` still makes no copy of the
caller's document — the walk returns `Option<Value>` and `ScanOnly` returns `None` at every level.

### Naming deviation from the todo

The todo proposed `LeafOp::CleanAndEnforce`. With the typed rejection above, no structured leaf
ever enforces, so that name would assert something the code cannot do — the exact class of lie this
pair of PRs is removing. It is `CleanAndScan`.

## 3. Drift the unification surfaced

Folding the copies together exposed a real divergence: `scan_safety_nets_structured` reports
suspect `field_path` values rooted at the bare key (`profile.email`), while
`clean_with_safety_net*` reports JSONPath-style roots (`$.profile.email`). Nested segments are
identical; only the first differs.

**Preserved, not silently unified.** `field_path` is adopter-visible telemetry that lands in the
audit log and in locale-skip telemetry; changing it inside a refactor PR would move data under
adopters' BI joins with no announcement. It is now encoded and explained in exactly one place,
`LeafOp::root_path`, and tracked as **solo todo #2958** to be decided and announced on its own.

## 4. Preserved deliberately

- Empty-string skip, scalar passthrough asymmetry, doc-level abort on field error — all pinned by
  the parity test.
- The `UnsupportedValueVariant` fail-closed arm is **not** relaxed.
- The text path is untouched; it still enforces.

## Tests

- `structured_documents_do_not_silently_observe_when_enforcement_is_requested` — the RED test
  above, over both `Redact` and `Resolve`. Written to accept *either* correct outcome (typed error
  or real enforcement) and fail only on `Ok`-with-suspect-bytes, so it stays valid if per-field
  enforcement is implemented later.
- `structured_walk_has_nested_parity_across_every_leaf_op` — runs one nested fixture (object →
  array → object → string, plus an empty string and both scalar kinds) through all three ops and
  asserts the two rebuilding ops reconstruct identical documents, the two scanning ops visit
  identical leaves, and the root-prefix divergence is exactly the documented one.
- Existing structured suite green, with five call sites moved to an explicit observer policy
  because they were relying on the convenience API's default:
  `tests/safety_net.rs::{structured_safety_net_traverses_nested_fields_and_preserves_shape,
  structured_locale_skip_uses_session_level_locale_chain,
  structured_field_error_fails_closed_at_doc_level}` and
  `gaze-recognizers/tests/mock_safety_net.rs::{field_path_reports_drive_structured_tests,
  locale_skip_still_uses_session_level_locale_chain_for_structured_docs}`.
- `canary_e2e.rs:23`, `contracts.rs:115/1075`, `mock_safety_net.rs:108/178` all green.

## Adopter-visible change

`SafetyNetPolicy::default()` is `Resolve`, so the policy-less `Pipeline::clean_with_safety_net*`
entry points now return `Error::UnsupportedSafetyNetModeForStructured` for a
`RawDocument::Structured`. Pass `SafetyNetMode::Strict` (or `Tolerant`) through
`clean_with_safety_net_policy_detect_context` for the observer behaviour that was actually being
performed, or use `Pipeline::scan_safety_nets_structured`. Text documents are unaffected.
`Error` is `#[non_exhaustive]`, so the new variant is not itself a breaking change.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -D warnings`,
`cargo test --workspace --all-features`, `cargo run -p xtask -- safety-net-sanity` — all green on
the rebased head `1703550` at the CI-pinned toolchain (rustc 1.96.0), independently reproduced in
review: 132 test binaries, 0 failures; clippy 0 warnings; `safety_net_sanity: passed`.

## North star

Axis 1: an enforcement request that was silently downgraded to observation now fails closed, before
any tokenization. Axis 3: structured (tool-call JSON) documents are first-class enough to deserve a
truthful contract rather than a quiet degradation. Axis 4: one walker, one place where each
behavioural difference is declared; the surfaced field-path drift is documented rather than
quietly changed. Axis 5: the error message names the modes that do work and the API to use instead.

Audit: solo scratchpad 7201 S01-F2

Resolves solo todo #2950
