### PR TITLE
[agent] fix(proxy): daemonized proxy start honours the policy instead of running policy-less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A detached `gaze proxy start --policy prod.toml` now runs the policy instead
+  of the bundled `core` pipeline** (solo todo #2965). `start` persisted the
+  policy into its daemon config and then spawned the serving child with only
+  `--bind` and `--session-ttl`, so the detached daemon resolved
+  `build_pipeline(None, "core")`: no policy rules, no custom recognizers, no
+  dictionaries, and no policy locale tier. The configured `--rulepack` and all
+  three `--upstream-*` overrides were dropped the same way, which is why
+  `gaze proxy status` could print upstreams the running daemon never used. The
+  child's argument list is now derived from the daemon config as a whole, so the
+  daemonized proxy resolves the same pipeline as `gaze clean`. **The previous
+  entry for `gaze proxy` (solo todo #2937, PR #437) covered `gaze proxy serve`
+  only**; adopters running the daemon were unaffected by that fix. `restart`
+  carried the same defect and is fixed by the same change.
+
+- **`gaze proxy start` now fails when the daemon dies during startup instead of
+  reporting success** (found by the red test for #2965). The liveness probe used
+  `kill(pid, 0)`, which cannot distinguish a running child from one that exited
+  and has not been reaped, so a child that failed closed on an unloadable policy
+  was reported as `gaze-proxy started` with exit code 0. `start` now reports the
+  new `ProxyError::DaemonExitedEarly`, naming the child's exit code and the
+  stderr log to read, and removes the empty pidfile that would otherwise fail
+  every later start as stale. A startup failure slower than the 250 ms probe
+  window is still reported as started; that daemon is dead rather than serving
+  unprotected.
+
 - **`custom:family:*` policy classes now preserve the collision-family namespace**
   (audit S05-F1, solo todo #2934). `PiiClass::from_policy_name` previously
   normalized the reserved `family:` separator and hyphenated family name, so a

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -836,4 +836,8 @@ fn daemonized_proxy_start_fails_closed_when_the_policy_cannot_be_loaded() {
         "a policy-less daemon is serving at {bind}{}",
         daemon_log_tail(home.path())
     );
+    assert!(
+        find_under(home.path(), "proxy.pid").is_none(),
+        "a failed start must not leave the pidfile that bricks the next one"
+    );
 }

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -554,5 +555,285 @@ fn daemon_auto_activate_derives_locale_gated_locales_from_loaded_rulepacks() {
     assert!(
         clean.contains(":Custom:es_test_id_"),
         "es-ES locale-gated recognizer must auto-activate in the daemon: {clean}"
+    );
+}
+
+// solo todo #2965. `gaze proxy start` spawns a detached child, and nothing here
+// drove traffic through that child before this test — `proxy_dashboard.rs` only
+// asserted the `proxy start --help` flag surface. The daemonized path is the one
+// adopters run in production, so it has to resolve the same pipeline as
+// `gaze clean`; whatever it silently drops is policy the chokepoint ignores.
+
+/// A `gaze` invocation whose daemon state (pidfile, config, logs) is redirected
+/// into `home`, so a test daemon can never collide with the developer's real
+/// `gaze proxy`. `XDG_*` is cleared because `dirs` prefers those over `HOME`.
+fn gaze_with_home(home: &Path) -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin("gaze"));
+    command
+        .env("HOME", home)
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_STATE_HOME")
+        .env_remove("XDG_CACHE_HOME");
+    command
+}
+
+/// Finds `name` anywhere under `root`. The daemon's state layout is
+/// platform-specific, and the test only needs to prove that state landed inside
+/// the redirected `HOME`; a walk stays correct if the mapping ever changes.
+fn find_under(root: &Path, name: &str) -> Option<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.file_name().is_some_and(|found| found == name) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// Daemon log tail for assertion messages, so a failure reports what the
+/// detached child did instead of only that it never answered.
+fn daemon_log_tail(home: &Path) -> String {
+    ["proxy.log", "proxy-stderr.log"]
+        .into_iter()
+        .filter_map(|name| {
+            let text = fs::read_to_string(find_under(home, name)?).ok()?;
+            (!text.trim().is_empty()).then(|| format!("\n--- {name} ---\n{text}"))
+        })
+        .collect()
+}
+
+/// Stops the detached daemon however the test ended, so a failed assertion
+/// cannot leave a proxy running on the developer's machine.
+struct DaemonGuard {
+    home: PathBuf,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = gaze_with_home(&self.home)
+            .args(["proxy", "stop", "--force", "--timeout", "5s"])
+            .output();
+        // Backstop for a `stop` that never reached the child: the pidfile is
+        // written before the daemon serves anything.
+        if let Some(pid) = find_under(&self.home, "proxy.pid")
+            .and_then(|pidfile| fs::read_to_string(pidfile).ok())
+            .and_then(|text| text.lines().next()?.trim().parse::<u32>().ok())
+        {
+            let _ = Command::new("kill").arg("-9").arg(pid.to_string()).output();
+        }
+    }
+}
+
+/// Drives one request through the *daemonized* proxy (`gaze proxy start`, the
+/// path that spawns a detached child) and returns the body the loopback
+/// upstream actually received.
+fn daemonized_proxy_body(policy: &Path) -> String {
+    let upstream = TcpListener::bind("127.0.0.1:0").unwrap();
+    let upstream_addr = upstream.local_addr().unwrap();
+    let (capture_tx, capture_rx) = mpsc::sync_channel(1);
+    // Deliberately not joined: a daemon that ignores the configured upstream
+    // never connects, and this thread would then block `accept` forever.
+    thread::spawn(move || {
+        let Ok((mut stream, _)) = upstream.accept() else {
+            return;
+        };
+        let request = read_http_request(&mut stream);
+        let _ = capture_tx.send(request);
+        let body = r#"{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{"type":"text","text":"synthetic-safe"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#;
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+    });
+
+    let home = tempdir().unwrap();
+    let _guard = DaemonGuard {
+        home: home.path().to_path_buf(),
+    };
+    let proxy_addr = unused_local_addr();
+    let upstream_url = format!("http://{upstream_addr}");
+    let start = gaze_with_home(home.path())
+        .args([
+            "proxy",
+            "start",
+            "--bind",
+            &proxy_addr.to_string(),
+            "--upstream-anthropic",
+            &upstream_url,
+            "--policy",
+            policy.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        start.status.success(),
+        "proxy start failed: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    assert!(
+        find_under(home.path(), "proxy.pid").is_some(),
+        "daemon state escaped the redirected HOME"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if TcpStream::connect(proxy_addr).is_ok() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "daemonized proxy never bound {proxy_addr}{}",
+            daemon_log_tail(home.path())
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    let request_body = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": PARITY_INPUT}],
+        "stream": false
+    })
+    .to_string();
+    let mut stream = TcpStream::connect(proxy_addr).unwrap();
+    write!(
+        stream,
+        "POST /v1/messages HTTP/1.1\r\nhost: {proxy_addr}\r\nx-api-key: synthetic-test-key\r\nanthropic-version: 2023-06-01\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        request_body.len(),
+        request_body
+    )
+    .unwrap();
+    // A daemon that dropped `--upstream-anthropic` reaches for the real API, so
+    // this read must time out rather than hang the suite.
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .unwrap();
+    let mut response = Vec::new();
+    let _ = stream.read_to_end(&mut response);
+
+    let captured = capture_rx
+        .recv_timeout(Duration::from_secs(5))
+        .unwrap_or_else(|_| {
+            panic!(
+                "the loopback upstream captured no request: the daemonized proxy ignored the \
+                 configured --upstream-anthropic{}",
+                daemon_log_tail(home.path())
+            )
+        });
+    assert!(
+        response.starts_with(b"HTTP/1.1 200"),
+        "proxy response was not 200: {}",
+        String::from_utf8_lossy(&response)
+    );
+    let body_start = captured
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    String::from_utf8(captured[body_start..].to_vec()).unwrap()
+}
+
+/// Token classes `gaze clean` produces under `policy` — the reference every
+/// other verb has to match.
+fn clean_classes(policy: &Path) -> BTreeSet<&'static str> {
+    let mut clean = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args(["clean", "--policy", policy.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    clean
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(PARITY_INPUT.as_bytes())
+        .unwrap();
+    drop(clean.stdin.take());
+    let clean = clean.wait_with_output().unwrap();
+    assert!(
+        clean.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    let clean: Value = serde_json::from_slice(&clean.stdout).unwrap();
+    parity_classes(clean["clean_text"].as_str().unwrap())
+}
+
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemonized_proxy_start_honours_policy_recognizers_and_dictionaries() {
+    let (_dir, policy) = write_cross_verb_parity_policy();
+    let clean = clean_classes(&policy);
+    assert_eq!(
+        clean,
+        BTreeSet::from(["Custom:catalog_title", "Custom:es_test_id"]),
+        "reference verb stopped tokenizing the policy classes"
+    );
+
+    let proxy = daemonized_proxy_body(&policy);
+
+    assert_eq!(
+        parity_classes(&proxy),
+        clean,
+        "`gaze proxy start` must tokenize the same classes as `gaze clean` under one policy: {proxy}"
+    );
+    assert!(
+        !proxy.contains("ES-TEST-123456"),
+        "raw policy-detected id reached the upstream: {proxy}"
+    );
+    assert!(
+        !proxy.contains("Sonnenlied"),
+        "raw dictionary term reached the upstream: {proxy}"
+    );
+}
+
+/// The deterministic half of the same contract: if the policy the adopter named
+/// cannot be loaded, the daemon must refuse to come up. A `start` that reports
+/// success here is a chokepoint serving with the bundled `core` pipeline while
+/// the adopter believes their policy is enforced.
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemonized_proxy_start_fails_closed_when_the_policy_cannot_be_loaded() {
+    let home = tempdir().unwrap();
+    let _guard = DaemonGuard {
+        home: home.path().to_path_buf(),
+    };
+    let bind = unused_local_addr();
+    let missing = home.path().join("absent-policy.toml");
+
+    let start = gaze_with_home(home.path())
+        .args([
+            "proxy",
+            "start",
+            "--bind",
+            &bind.to_string(),
+            "--policy",
+            missing.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !start.status.success(),
+        "`proxy start` reported success with an unloadable policy: stdout={} stderr={}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr)
+    );
+    assert!(
+        TcpStream::connect(bind).is_err(),
+        "a policy-less daemon is serving at {bind}{}",
+        daemon_log_tail(home.path())
     );
 }

--- a/crates/gaze-proxy/src/daemon.rs
+++ b/crates/gaze-proxy/src/daemon.rs
@@ -1,8 +1,9 @@
+use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
@@ -208,6 +209,59 @@ pub fn write_config(paths: &DaemonPaths, config: &DaemonConfig) -> Result<(), Pr
     })
 }
 
+/// Rebuilds the daemon's configured surface as `gaze proxy serve` flags.
+///
+/// The persisted [`DaemonConfig`] is the single source of truth for a detached
+/// proxy: `start` and `restart` write it, and the child is handed nothing but
+/// what this derives from it, so `serve` keeps exactly one policy input whether
+/// it runs in the foreground or as the daemon child. The exhaustive
+/// destructuring is load-bearing — a new `DaemonConfig` field stops compiling
+/// here instead of silently never reaching the daemon, which is how `--policy`,
+/// `--rulepack`, and the adapter upstreams went missing (solo todo #2965).
+fn serve_args(config: &DaemonConfig) -> Vec<OsString> {
+    let DaemonConfig {
+        bind,
+        session_ttl,
+        policy,
+        rulepack,
+        adapters,
+    } = config;
+    let AdapterConfig {
+        openai,
+        anthropic,
+        gemini,
+    } = adapters;
+
+    let mut args: Vec<OsString> = vec![
+        "--bind".into(),
+        bind.to_string().into(),
+        "--session-ttl".into(),
+        session_ttl.into(),
+    ];
+    // The policy path travels, not its resolved contents: the child loads it
+    // through the same sequence as `gaze clean`, and a path that has moved since
+    // `start` fails the child closed instead of quietly demoting the chokepoint
+    // to the bundled floor. Serializing resolved inputs into the config would
+    // make that file a second, staleable copy of the policy.
+    if let Some(policy) = policy {
+        args.push("--policy".into());
+        args.push(policy.into());
+    }
+    if let Some(rulepack) = rulepack {
+        args.push("--rulepack".into());
+        args.push(rulepack.into());
+    }
+    for (flag, ProviderConfig { upstream }) in [
+        ("--upstream-openai", openai),
+        ("--upstream-anthropic", anthropic),
+        ("--upstream-gemini", gemini),
+    ] {
+        args.push(flag.into());
+        args.push(upstream.to_string().into());
+    }
+    args
+}
+
 pub fn start(options: StartOptions) -> Result<u32, ProxyError> {
     cleanup_stale(&options.paths)?;
     if let Some(status) = status(&options.paths)? {
@@ -248,24 +302,53 @@ pub fn start(options: StartOptions) -> Result<u32, ProxyError> {
         );
     command
         .args(["proxy", "serve", "--_foreground-daemon"])
-        .arg("--bind")
-        .arg(options.config.bind.to_string())
-        .arg("--session-ttl")
-        .arg(&options.config.session_ttl)
+        .args(serve_args(&options.config))
         .args(options.extra_args)
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
     drop(lock);
-    let child = command.spawn().map_err(|source| ProxyError::DaemonIo {
+    let mut child = command.spawn().map_err(|source| ProxyError::DaemonIo {
         path: PathBuf::from("gaze proxy serve"),
         source,
     })?;
-    std::thread::sleep(Duration::from_millis(250));
-    if process_exists(child.id()) {
-        Ok(child.id())
-    } else {
-        Err(ProxyError::DaemonNotRunning)
+    confirm_started(&mut child, &options.paths)
+}
+
+/// Confirms the spawned child is still alive after a short probe window and
+/// returns its pid.
+///
+/// The child resolves the configured policy, so a fail-closed load error
+/// surfaces as an immediate exit. `kill(pid, 0)` cannot see that: an unreaped
+/// child is a zombie and still answers as alive, which reported a dead daemon as
+/// started (solo todo #2965). `try_wait` reaps and reports the real status
+/// within the same 250ms budget, returning early on failure.
+///
+/// A failure slower than the probe window still reports success; that daemon is
+/// dead rather than serving unprotected, and `gaze proxy status` shows it.
+fn confirm_started(child: &mut Child, paths: &DaemonPaths) -> Result<u32, ProxyError> {
+    let deadline = Instant::now() + Duration::from_millis(250);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                // The parent created this pidfile before spawning and the child
+                // never filled it in; leaving the empty file behind would fail
+                // every later start as stale.
+                let _ = fs::remove_file(&paths.pidfile);
+                return Err(ProxyError::DaemonExitedEarly {
+                    code: status.code(),
+                    stderr_file: paths.stderr_file.clone(),
+                });
+            }
+            Ok(None) if Instant::now() >= deadline => return Ok(child.id()),
+            Ok(None) => std::thread::sleep(Duration::from_millis(25)),
+            Err(source) => {
+                return Err(ProxyError::DaemonIo {
+                    path: PathBuf::from("gaze proxy serve"),
+                    source,
+                })
+            }
+        }
     }
 }
 
@@ -522,6 +605,53 @@ mod tests {
         .unwrap();
         cleanup_stale(&paths).unwrap();
         assert!(!paths.pidfile.exists());
+    }
+
+    // solo todo #2965: every field the adopter can configure has to reach the
+    // detached child, because the child's argv is all it ever sees.
+    #[test]
+    fn serve_args_forward_every_configured_field_to_the_daemon_child() {
+        let config = DaemonConfig {
+            policy: Some(PathBuf::from("/etc/gaze/prod.toml")),
+            rulepack: Some("core-extended".to_string()),
+            adapters: AdapterConfig::new(
+                Url::parse("http://127.0.0.1:4001").unwrap(),
+                Url::parse("http://127.0.0.1:4002").unwrap(),
+                Url::parse("http://127.0.0.1:4003").unwrap(),
+            ),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serve_args(&config),
+            [
+                "--bind",
+                "127.0.0.1:8787",
+                "--session-ttl",
+                "30m",
+                "--policy",
+                "/etc/gaze/prod.toml",
+                "--rulepack",
+                "core-extended",
+                "--upstream-openai",
+                "http://127.0.0.1:4001/",
+                "--upstream-anthropic",
+                "http://127.0.0.1:4002/",
+                "--upstream-gemini",
+                "http://127.0.0.1:4003/",
+            ]
+            .map(OsString::from)
+        );
+    }
+
+    #[test]
+    fn serve_args_omit_policy_when_the_daemon_has_none() {
+        let args = serve_args(&DaemonConfig::default());
+
+        assert!(!args.contains(&OsString::from("--policy")));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--rulepack", "core"].map(OsString::from)));
     }
 
     #[test]

--- a/crates/gaze-proxy/src/error.rs
+++ b/crates/gaze-proxy/src/error.rs
@@ -68,6 +68,20 @@ pub enum ProxyError {
     },
     #[error("daemon config failed: {detail}")]
     DaemonConfig { detail: String },
+    /// The detached daemon child exited before it could serve.
+    ///
+    /// The child resolves the configured policy, so its early exit is normally a
+    /// fail-closed policy load. Reporting that as a successful start is what let
+    /// an unloadable policy look like a running chokepoint.
+    #[error(
+        "daemon exited before serving ({code}); see {stderr_file}",
+        code = code.map_or_else(|| "terminated by signal".to_string(), |code| format!("exit code {code}")),
+        stderr_file = stderr_file.display()
+    )]
+    DaemonExitedEarly {
+        code: Option<i32>,
+        stderr_file: PathBuf,
+    },
 }
 
 /// Closed failure codes used by the direct proxy profile.

--- a/crates/gaze-proxy/src/server.rs
+++ b/crates/gaze-proxy/src/server.rs
@@ -2902,6 +2902,7 @@ fn proxy_error_name(err: &ProxyError) -> &'static str {
         ProxyError::DaemonPidfileStale { .. } => "DaemonPidfileStale",
         ProxyError::DaemonIo { .. } => "DaemonIo",
         ProxyError::DaemonConfig { .. } => "DaemonConfig",
+        ProxyError::DaemonExitedEarly { .. } => "DaemonExitedEarly",
     }
 }
 


### PR DESCRIPTION
## The defect

`gaze proxy start --policy prod.toml` persisted the policy into `DaemonConfig` and then spawned the serving child with an argv of only `--bind` and `--session-ttl` (`gaze-proxy/src/daemon.rs:249-255`). Nothing downstream rescued it: `ServeArgs.policy` is a plain `Option<PathBuf>` with no `env` or `default_value`, and `proxy::serve()` never reads the persisted config. So the detached daemon took the no-policy branch `build_pipeline(None, "core")` — **no policy rules, no custom recognizers, no dictionaries, no policy locale tier**. An adopter running the daemon got a chokepoint that ignored their entire policy.

Pre-existing on `main`, not a regression from #437, which is why that PR merged without it. It does narrow #437's reach: that CHANGELOG entry claimed `gaze proxy` resolves the same rulepacks, dictionaries, and auto-activated locales as `gaze clean` — true for `proxy serve`, not for `proxy start`.

**The omission was wider than solo todo #2965 recorded.** `DaemonConfig` has five configurable fields and the child received two. `--rulepack` and all three `--upstream-*` overrides were dropped the same way, which is why `gaze proxy status` could print upstreams the running daemon never used.

## Why it escaped

No test drove traffic through a started daemon. `crates/gaze-cli/tests/proxy_dashboard.rs:245` only asserts the `proxy start --help` flag surface. The daemonized path was untestable by construction: with `--upstream-*` dropped too, a test could not point the daemon at a loopback capture server at all.

There is a pointed asymmetry here — `proxy_dashboard.rs:145` already had `relay_extra_args()`, a purpose-built complete relay for the *optional* dashboard flags. The config the chokepoint needs to be safe never got one.

## Red-first evidence (commit 1, on unmodified `main`)

Two tests, both red before the fix:

```
thread 'daemonized_proxy_start_honours_policy_recognizers_and_dictionaries' panicked at
crates/gaze-cli/tests/daemon_smoke.rs:728:13:
the loopback upstream captured no request: the daemonized proxy ignored the configured --upstream-anthropic

thread 'daemonized_proxy_start_fails_closed_when_the_policy_cannot_be_loaded' panicked at
crates/gaze-cli/tests/daemon_smoke.rs:828:5:
`proxy start` reported success with an unloadable policy: stdout=gaze-proxy started
(pid=86910, bind=127.0.0.1:61020, log=/var/folders/.../T/.tmpHjzTJ4/Library/Logs/gaze/proxy.log)

test result: FAILED. 0 passed; 2 failed
```

1. **Traffic parity.** Starts the daemonized proxy with a policy carrying a synthetic custom recognizer *and* a dictionary term, drives one request through it, and asserts the token class set at the loopback upstream equals what `gaze clean` produces under the same policy, and that neither raw synthetic term (`ES-TEST-123456`, `Sonnenlied`) reaches the upstream. Mirrors the `direct_proxy_body` capture harness in `daemon_smoke.rs`.
2. **Fail-closed.** The deterministic, network-free half: `proxy start --policy <absent>` must not report success.

Daemon state is redirected into a temp `HOME` so tests never touch a developer's real `gaze proxy` state (the pidfile assertion fails loudly if that redirection ever breaks), and a `Drop` guard stops the detached child however the test ends.

## The fix (commit 2), and why it keeps one source of truth

Chose fix shape (a): the child's argv is derived from `DaemonConfig`.

The persisted `DaemonConfig` stays the single source of truth for a detached proxy — `start` and `restart` write it, and the child is handed nothing but what `serve_args()` derives from it. `serve` therefore keeps exactly one policy input (its own flags) whether it runs in the foreground or as the daemon child, and both reach `gaze clean`'s `resolve_pipeline` loader from #437 unchanged.

Shape (b) — having `serve` under `--_foreground-daemon` read the persisted config — was rejected: it would give the daemon child a different resolution sequence from plain `serve`, i.e. a second policy source, recreating exactly the drift class #437 removed. It also cannot cleanly distinguish "not passed on argv" from a clap default.

`serve_args` destructures `DaemonConfig`, `AdapterConfig`, and `ProviderConfig` exhaustively, so a new config field is a **compile error** here rather than another silent omission. Two unit tests pin the full argv and the no-policy case.

**Path, not resolved inputs.** The child receives the policy *path* and loads it itself. The path can in principle move between `start` and a later `restart`, but that is the same contract `serve` and `clean` already have (path read at process start), and it fails closed: a policy that is gone at child exec kills the child instead of quietly demoting the chokepoint to the bundled floor. Serializing resolved pipeline inputs into the config file would make that file a second, staleable copy of the policy.

`restart` carried the same defect and is fixed by the same change, since it goes through `daemon::start`.

## Adjacent defect the red test exposed (also fixed here)

`proxy start` reported success for a child that had already died. The liveness probe was `process_exists(child.id())` → `kill(pid, 0)`, which cannot distinguish a running child from one that exited and has not been reaped — an unreaped child is a zombie and answers as alive. With the policy now actually reaching the child, an unloadable policy makes the child exit `{"error":"PolicyOpen","exit":4}`, and the old probe still printed `gaze-proxy started` with exit code 0.

`start` now uses `Child::try_wait` within the same 250 ms budget (returning early on failure, so it is never slower), reports the new `ProxyError::DaemonExitedEarly` naming the exit code and the stderr log to read, and removes the empty pidfile the parent created — which would otherwise fail every later start as `DaemonPidfileStale`. `ProxyError` is `#[non_exhaustive]`, so the added variant is not a breaking change; the closed `proxy_error_name` mapper in `server.rs` was updated.

Known limit, stated rather than hidden: a startup failure slower than the 250 ms probe window is still reported as started. That daemon is dead rather than serving unprotected.

## Class audit — other spawned children

Audited every `Command::new(current_exe)` / re-exec site in the proxy and daemon paths, not just the reported instance:

| Site | Verdict |
|---|---|
| `gaze-proxy/src/daemon.rs` `start`/`restart` → `proxy serve` child | **The defect.** Fixed: policy, rulepack, and all three upstreams now forwarded. |
| `gaze-cli/src/commands/proxy_dashboard.rs:267` `child_command` → `proxy _dashboard-child` | Clean. Forwards all four of its inputs (`--bind-addr`, `--max-events`, `--max-bytes`, `--ttl-secs`) and carries no pipeline or policy, so it has nothing to drop. |
| `proxy_dashboard.rs:145` `relay_extra_args` (dashboard flags relayed by `start`) | Clean and complete; `restart` deliberately does not relay them (per-invocation, never persisted — documented at the function). |
| `gaze daemon` | Clean. No child spawn; JSONL stdio in-process, and it receives `--policy` on its own argv. |
| `gaze mcp install` → `mcp serve` | Not this class. It writes the fixed `args: ["mcp", "serve"]`, and `mcp serve` has no policy or rulepack flag at all, so nothing is persisted-then-dropped. |

Out of scope but filed while auditing: **solo todo #2971** — `gaze mcp serve` builds its chokepoint pipeline as `gaze::Pipeline::builder().build()` (zero recognizers, zero rules) and accepts no policy input, so an adopter cannot point the MCP tier at their policy at all. Different class, same axis-1 question; filed with an evidence bar rather than fixed here.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `cargo test -p gaze-cli --all-features` — pass
- `cargo test -p gaze-proxy --all-features` — pass

Resolves solo todo #2965.
