### PR TITLE
[agent] test(daemon): move the daemon throughput budget out of the correctness test and behind an opt-in

### DIFF
--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -315,12 +315,17 @@ action = "preserve"
     (dir, path)
 }
 
-#[test]
-#[file_serial(gaze_subprocess)]
-fn daemon_processes_jsonl_and_isolates_sessions() {
-    let (_dir, policy) = write_policy();
-    let audit_dir = tempdir().unwrap();
-    let audit_db = audit_dir.path().join("audit.db");
+/// Drives `count` JSONL requests through one `gaze daemon` process, alternating
+/// between two session ids so per-session manifest isolation is exercised.
+///
+/// Returns the wall-clock duration next to the output instead of asserting on
+/// it: throughput is a performance property, and only the opt-in throughput
+/// test below looks at the duration (solo #2981).
+fn run_daemon_batch(
+    policy: &std::path::Path,
+    audit_db: &std::path::Path,
+    count: usize,
+) -> (Duration, Output) {
     let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
         .args([
             "daemon",
@@ -342,7 +347,7 @@ fn daemon_processes_jsonl_and_isolates_sessions() {
     let started = Instant::now();
     {
         let stdin = child.stdin.as_mut().unwrap();
-        for idx in 0..100 {
+        for idx in 0..count {
             let session_id = if idx % 2 == 0 {
                 "session-a"
             } else {
@@ -357,15 +362,40 @@ fn daemon_processes_jsonl_and_isolates_sessions() {
     }
 
     let output = child.wait_with_output().unwrap();
+    (started.elapsed(), output)
+}
+
+/// Budget for the opt-in throughput test, mirroring the
+/// `GAZE_TEST_SUBPROCESS_TIMEOUT_SECS` helper #430 introduced: generous by
+/// default, tightenable when a run deliberately hunts a perf regression.
+fn daemon_throughput_budget() -> Duration {
+    let seconds = std::env::var("GAZE_TEST_DAEMON_THROUGHPUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("daemon throughput budget must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "daemon throughput budget must be positive");
+    Duration::from_secs(seconds)
+}
+
+// What this guarantees: every one of the 100 JSONL requests is answered, each
+// answer is tokenized and carries a non-empty manifest, `session-a` and
+// `session-b` never share a token (per-session manifest isolation), and every
+// audit row is attributed to the daemon stage. How *fast* the daemon got there
+// is not one of those properties - see the opt-in throughput test below.
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemon_processes_jsonl_and_isolates_sessions() {
+    let (_dir, policy) = write_policy();
+    let audit_dir = tempdir().unwrap();
+    let audit_db = audit_dir.path().join("audit.db");
+    let (_elapsed, output) = run_daemon_batch(&policy, &audit_db, 100);
     assert!(
         output.status.success(),
         "stderr={}",
         String::from_utf8_lossy(&output.stderr)
-    );
-    let elapsed = started.elapsed();
-    assert!(
-        elapsed < Duration::from_secs(10),
-        "100 daemon requests took {elapsed:?}"
     );
 
     let stdout = String::from_utf8(output.stdout).unwrap();
@@ -410,6 +440,37 @@ fn daemon_processes_jsonl_and_isolates_sessions() {
     assert!(stages
         .iter()
         .all(|stage| stage.as_deref() == Some("daemon")));
+}
+
+// Throughput used to be asserted inside the correctness test above with a hard
+// `elapsed < 10s`. A busy runner measured 10.845s and took main's `xtask gates`
+// run down with it (solo #2981) - the same fixed-budget-loses-its-race class as
+// solo #2404 / #2916, which #430 fixed for subprocess timeouts. A stopwatch
+// proves nothing about correctness, so it lives here instead: `#[ignore]` keeps
+// it out of every CI invocation (`cargo test` never passes `--include-ignored`
+// in this repo) while it stays runnable on demand with
+// `cargo test -p gaze-cli --all-features --test daemon_smoke -- --ignored`.
+#[test]
+#[ignore = "throughput budget, not a correctness property; run explicitly with --ignored"]
+#[file_serial(gaze_subprocess)]
+fn daemon_throughput_stays_within_opt_in_budget() {
+    let (_dir, policy) = write_policy();
+    let audit_dir = tempdir().unwrap();
+    let (elapsed, output) = run_daemon_batch(&policy, &audit_dir.path().join("audit.db"), 100);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let answered = String::from_utf8(output.stdout).unwrap().lines().count();
+    assert_eq!(answered, 100, "throughput run must answer every request");
+
+    let budget = daemon_throughput_budget();
+    assert!(
+        elapsed < budget,
+        "100 daemon requests took {elapsed:?} against a {budget:?} budget; \
+         override with GAZE_TEST_DAEMON_THROUGHPUT_SECS"
+    );
 }
 
 #[test]

--- a/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
+++ b/crates/gaze-recognizers/tests/openai_filter_subprocess.rs
@@ -234,8 +234,14 @@ exec sleep 30
 
     assert!(matches!(error, SafetyNetError::Runtime { .. }));
     assert!(error.to_string().contains("timed out"));
+    // The failure mode this bounds is "the write blocked instead of timing
+    // out", which returns only when the child's own `sleep 30` exits - so any
+    // bound comfortably under 30s still discriminates it. The old 17s left the
+    // configured 15s timeout just 2s of slack, which is the same
+    // fixed-budget-loses-its-race shape as solo #2981; sit halfway between the
+    // two instead so a loaded runner cannot turn this into a false red.
     assert!(
-        elapsed < Duration::from_secs(17),
+        elapsed < Duration::from_secs(25),
         "blocked stdin timeout took {elapsed:?}"
     );
 


### PR DESCRIPTION
## What this is

`crates/gaze-cli/tests/daemon_smoke.rs` asserted `elapsed < Duration::from_secs(10)` for 100 daemon requests, inside a test whose actual job is proving per-session manifest isolation. On a busy runner that stopwatch measured **10.845s** and turned a correctness gate red. This moves the stopwatch out of the correctness path and keeps the throughput coverage as an explicit, runnable, opt-in test.

Resolves solo todo #2981.

## Evidence, and a correction to the todo's framing

Solo #2981 says main's last completed run failed on this assertion. **It did not** — verified against the CI logs, and worth stating plainly because it changes what merging this PR does and does not fix:

| Run | Commit / PR | `xtask gates` | Actual failure |
|---|---|---|---|
| [32072207668](https://github.com/CertaMesh/gaze/actions/runs/32072207668) | main `8872c43` | failure, 31m22s | `gaze-proxy` `inspection::tests::purge_and_disable_report_closed_outcomes_without_building_projection`, `inspection.rs:811` — `left: [Dropped(QueueContended), Dropped(Disabled)]`, `right: [Dropped(Disabled), Dropped(Disabled)]`. **No `daemon requests took` line anywhere in that run.** |
| [32073443722](https://github.com/CertaMesh/gaze/actions/runs/32073443722) | PR #435 | failure, 32m50s | `daemon_smoke.rs:366` — `100 daemon requests took 10.8453462s`. **This is the one this PR fixes.** |

So the honest characterisation is: **an intermittent, load-dependent assertion that has been observed failing exactly once, on one PR** — not a deterministic block, and not the thing that took main's last completed run down. Current main `ec3b450` was still `in_progress` while this was written, so main's present state is unknown rather than proven red. The separate `gaze-proxy` inspection failure is filed as **solo todo #2983** — it is a *different* load-dependent flake (a queue-contention race rather than a stopwatch) and it, not this, is what needs fixing to explain main's red.

That lower hit rate does not weaken the case:

- A stopwatch in a correctness test is wrong at **any** hit rate. It cannot fail for a reason a reviewer should act on, so every red it produces is noise, and noise is how teams learn to shrug at red. (North-star axis 4, trust.)
- `xtask gates` takes **31–54 minutes** per run on recent main commits (31m22s, 48m52s, 53m57s, 50m36s, 47m52s). A flaky assertion near its tail burns most of an hour before it tells you anything, and then tells you something untrue.
- The same test passed in the sibling `test` job on the identical commit, which is the signature of a load race rather than a logic failure. Same class as solo #2404 and #2916; PR #430 fixed that class for *subprocess timeouts*, but this throughput budget was never covered by that work.

The measured window was never a clean throughput number either: it opens before the first write and closes after `wait_with_output()`, so it also swallows daemon startup (policy load, rulepack compile) and shutdown. It was a performance assertion smuggled into a correctness test, and not a well-posed one.

## What the correctness test guarantees now

`daemon_processes_jsonl_and_isolates_sessions` keeps **every** assertion it had, minus the stopwatch:

- all 100 JSONL requests are answered (`responses.len() == 100`),
- every response is tokenized and carries a non-empty manifest,
- `session-a` and `session-b` never share a token — per-session manifest isolation, the assertion that actually matters here,
- every audit row is attributed to `provenance_stage = "daemon"`,
- the daemon exits successfully.

None of those depended on how fast the machine was. The list is now written above the test so the next person does not have to re-derive it.

## What changed

**Option chosen: keep the throughput coverage, move it out of the correctness path** (todo option 1, the preferred shape).

- Extracted `run_daemon_batch(policy, audit_db, count) -> (Duration, Output)`. It *returns* the duration instead of asserting on it, so the correctness test can ignore it and the perf test can use it, with no duplicated request-driving loop.
- Added `daemon_throughput_stays_within_opt_in_budget`, `#[ignore]`d and `#[file_serial(gaze_subprocess)]`. `#[ignore]` is what guarantees it can never gate CI: no `cargo test` invocation in this repo passes `--include-ignored` (`.github/workflows/test.yml` runs `cargo test --workspace --all-features --no-fail-fast`; the `--ignored` flags elsewhere in the tree are parents invoking named subprocess helpers). It stays runnable on demand:

      cargo test -p gaze-cli --all-features --test daemon_smoke -- --ignored

- Its budget comes from `GAZE_TEST_DAEMON_THROUGHPUT_SECS`, mirroring the `GAZE_TEST_SUBPROCESS_TIMEOUT_SECS` helper #430 introduced — same shape, same generous 60s default, same positive-integer validation. A deliberate perf hunt can tighten it; CI can never trip over it.
- The test was already in the `#[file_serial(gaze_subprocess)]` group, so that half of todo option 2 was already in place and is preserved.

Test-only change; no production code touched, so no CHANGELOG entry.

## Load proof

Host: Apple M5 Max, 18 cores, macOS 25.5.0, rustc 1.96.0. Burners are `yes` processes at 2× ncpu (36).

**Vacuity check first** — an assertion that cannot go red proves nothing, so the new opt-in budget was pinned to 1s to confirm it is live and env-driven:

    vacuity (budget=1s): rc=101 | 100 daemon requests took 4.591499334s | test result: FAILED. 0 passed; 1 failed

**Correctness test, 5× under load (36 burners), all green:**

    loaded run 1: rc=0 | test result: ok. 1 passed; 0 failed ... finished in 4.66s
    loaded run 2: rc=0 | test result: ok. 1 passed; 0 failed ... finished in 4.81s
    loaded run 3: rc=0 | test result: ok. 1 passed; 0 failed ... finished in 4.70s
    loaded run 4: rc=0 | test result: ok. 1 passed; 0 failed ... finished in 4.70s
    loaded run 5: rc=0 | test result: ok. 1 passed; 0 failed ... finished in 4.79s

**Correctness test, 5× unloaded, all green and no slower:**

    unloaded run 1: rc=0 | test result: ok ... finished in 4.33s
    unloaded run 2: rc=0 | test result: ok ... finished in 4.34s
    unloaded run 3: rc=0 | test result: ok ... finished in 4.40s
    unloaded run 4: rc=0 | test result: ok ... finished in 4.31s
    unloaded run 5: rc=0 | test result: ok ... finished in 4.32s

**Opt-in throughput test:** 4.74s under load and 4.43s unloaded, both against the old 10s bound; 4.19s against the shipped 60s default. Burner count back to 0 after every phase.

**Stated limitation, so nobody over-reads this:** 36 burners on an 18-core M5 Max still leaves the daemon ~4.7s, so these runs **did not reproduce** the 10.845s CI failure and are not offered as a reproduction. What they show is that the correctness test is now indifferent to load, and that the opt-in assertion works. The reproduction lives in the CI log linked above, on a 2–4 core runner also executing `xtask ci-feature-matrix`.

## Sibling audit

Swept the workspace for `Instant::now` / `.elapsed()` / `Duration::from_secs` in tests, ranked by whether the timing gates correctness:

**Gates correctness — fixed:**
- `crates/gaze-cli/tests/daemon_smoke.rs:366` — this PR.
- `crates/gaze-recognizers/tests/openai_filter_subprocess.rs:238` — `stdin_blocked_child_times_out_and_kills_subprocess` asserted `elapsed < 17s` against a configured 15s timeout: 2s of slack. Widened to 25s. The failure mode it bounds ("the write blocked instead of timing out") only returns when the child's own `sleep 30` exits, so any bound comfortably under 30s discriminates it just as well — the tight 17s bought nothing but flake risk. One line plus the reasoning in a comment.

**Gates correctness — too large to fix here, filed as solo #2982:**
- `crates/gaze-cli/src/restore/session.rs:175` — `pass2_cursor_scan_handles_dense_substitution_spans` guards against an O(n²) regression with a 50ms stopwatch over 1000 iterations in a debug build. It cannot simply be deleted (that stopwatch is the only anti-quadratic guard: a from-scratch rescan would still leave the cursor correct and pass the other assertions) and it cannot simply be widened (at n=1000 a quadratic implementation is still only single-digit milliseconds, so a load-robust budget destroys the signal). The real fix is to scale n to ~100k so the complexity classes separate by orders of magnitude, or to count cursor advances instead of timing them. Latent, never observed failing.

**Not siblings — bounded waits, left alone:** the `deadline = Instant::now() + …` readiness loops in `gaze-proxy`, `gaze-proxy-dashboard`, and `daemon_smoke.rs:175` bound *waiting for something to become ready*; failing means it never did, which is a real signal.

**Not siblings — injected clock, left alone:** `crates/gaze-proxy/tests/session_registry.rs` passes an explicit `now` into `acquire_at(...)` rather than racing the wall clock. That is the pattern the other two should converge on.

**Also found, out of scope:** solo #2983 — the `gaze-proxy` inspection failure that actually took main's last completed run down. Same meta-class (a test assuming a quiet machine), different mechanism.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo test -p gaze-cli --all-features` — all green locally under the CI-pinned rustc 1.96.0.

## Class history

solo #2404, solo #2916 (fixed budgets losing a race under load) · PR #430 (env-configurable subprocess timeouts — the helper idiom reused here) · solo #2982, #2983 (follow-ups from this audit).
