### PR TITLE
[agent] fix(proxy): stop pinning a contended non-answer in the inspection purge/disable test

### DIFF
--- a/crates/gaze-proxy/src/inspection.rs
+++ b/crates/gaze-proxy/src/inspection.rs
@@ -517,6 +517,35 @@ mod tests {
         parked
     }
 
+    // `QueueContended` is not a lifecycle verdict: it means the runtime declined to block on its
+    // own mutex to read that verdict. A registration's dispatcher thread re-acquires that mutex
+    // when `begin_purge`/`disable` notify it, so an emission issued in that window gets the
+    // non-answer instead of `Purging`/`Disabled`. Retrying is idempotent — a dropped emission
+    // advances no sequence and exhausts no emitter — so ask again rather than weaken the
+    // assertion, the same treatment `begin_for_test` and `park_dispatcher_for_test` already give
+    // contention.
+    fn settled_stages(
+        mut emit: impl FnMut() -> [InspectionAdmissionOutcomeV1; 2],
+    ) -> [InspectionAdmissionOutcomeV1; 2] {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let outcomes = emit();
+            if !outcomes.iter().any(|outcome| {
+                matches!(
+                    outcome,
+                    InspectionAdmissionOutcomeV1::Dropped(InspectionDropCodeV1::QueueContended)
+                )
+            }) {
+                return outcomes;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "inspection stages stayed contended: {outcomes:?}"
+            );
+            std::thread::yield_now();
+        }
+    }
+
     #[test]
     fn parked_dispatcher_releases_sink_during_unwind() {
         let sink = Arc::new(BlockingSink::default());
@@ -800,7 +829,7 @@ mod tests {
         let mut logical = begin_for_test(&producer);
         let purge = consumer.begin_purge().unwrap();
         assert_eq!(
-            logical.emit_request_stages(b"owner", b"provider", None, false),
+            settled_stages(|| logical.emit_request_stages(b"owner", b"provider", None, false)),
             [
                 InspectionAdmissionOutcomeV1::Dropped(InspectionDropCodeV1::Purging),
                 InspectionAdmissionOutcomeV1::Dropped(InspectionDropCodeV1::Purging),
@@ -809,7 +838,13 @@ mod tests {
         purge.complete().unwrap();
         consumer.disable();
         assert_eq!(
-            logical.emit_response_stages(b"provider", b"owner", WireFormat::Json, None, false,),
+            settled_stages(|| logical.emit_response_stages(
+                b"provider",
+                b"owner",
+                WireFormat::Json,
+                None,
+                false,
+            )),
             [
                 InspectionAdmissionOutcomeV1::Dropped(InspectionDropCodeV1::Disabled),
                 InspectionAdmissionOutcomeV1::Dropped(InspectionDropCodeV1::Disabled),


### PR DESCRIPTION
## What reddened main

`main` at `8872c43`, run 32072207668, job `xtask gates`:

```
---- inspection::tests::purge_and_disable_report_closed_outcomes_without_building_projection stdout ----
thread '...' panicked at crates/gaze-proxy/src/inspection.rs:811:9:
assertion `left == right` failed
  left: [Dropped(QueueContended), Dropped(Disabled)]
 right: [Dropped(Disabled), Dropped(Disabled)]
error: test failed, to rerun pass `-p gaze-proxy --lib`
Error: ci_feature_matrix: command failed: cargo test --workspace --all-features
```

This is **not** the `daemon_smoke` `100 daemon requests took 10.845s` failure — that one belongs to PR #435 (run 32073443722) and was fixed separately in PR #442 / solo #2981. There is no `daemon requests took` line anywhere in run 32072207668. `daemon_smoke.rs` is untouched here.

## The decision: legitimate outcome, over-specified test — NOT a production defect

**`QueueContended` during the disable window is a legitimate production outcome. `inspection.rs` and `gaze-inspection` production paths are unchanged.**

### Mechanism

`RegistrationState::try_inner` (`crates/gaze-inspection/src/lib.rs:667`) is a **`try_lock`**, and `TryLockError::WouldBlock` maps to `QueueContended`. The contender is **the registration's own dispatcher thread**:

1. `ActivatedInspectionConsumerV1::begin_purge` (L1204) and `RegistrationState::disable` (L689) both end with `changed.notify_all()`.
2. That wakes `dispatcher_loop` (L835), which re-acquires `inner` to re-evaluate its `while inner.queue.is_empty() && !inner.closed` condition.
3. If the test's next `emit_*` lands inside that window, `try_lock` fails and the emission drops as `QueueContended` instead of `Purging`/`Disabled`.

This matches both observed signatures exactly — in each, the **first** of the two stages is contended and the second gets the real code (`[QueueContended, Disabled]` in #2983, `[QueueContended, Purging]` in #2980).

### Why this is legitimate and not a mis-attribution

1. **It is truthful.** The code reports "I could not read my lifecycle state without blocking". It does not claim the queue was full, and it does not claim the data was captured.
2. **The alternative violates the design.** Returning `Disabled` at that instant would require *blocking* on the mutex. Non-blocking admission is a stated contract of this runtime — see the sibling test `bounded_queue_reports_queue_full_without_blocking_enforcement` and the dedicated `gaze-inspection` test `queue_contention_drops_before_projection_without_waiting` (L2161), which asserts precisely that a contended emission drops *before* building the projection.
3. **The north-star property is identical under both outcomes.** Both are `Dropped(_)`: no event admitted, no projection built. `pre_projection` (L1080) calls `try_inner` **before** the build closure runs (L1065), so the contended drop does strictly *less* work than the `Disabled` drop. Axis 1 (nothing enters the projection) holds either way, and `QueueContended` is the safer of the two.
4. **Operator impact is bounded and transient.** After `disable()` the dispatcher acquires the mutex exactly once more, then returns. Every subsequent emission reports `Disabled` deterministically. An operator sees at most a brief contended blip before the steady-state code, never a wrong claim about whether data was captured.

So the defect is in the test: it pinned a lifecycle verdict that the runtime had explicitly declined to compute.

## The fix

`settled_stages` re-asks until the runtime actually answers, then asserts the **exact** drop codes as before. This is the treatment `QueueContended` already gets twice in this same test module:

- `begin_for_test` (`crates/gaze-proxy/src/inspection.rs:470`) retries while `begin_logical` is contended.
- `park_dispatcher_for_test` (L495-515) retries on `Dropped(QueueContended)` and panics on any other unexpected outcome.

The failing test simply never got it.

Retrying is **idempotent**, which is what makes this safe rather than a papering-over: `self.sequence` advances only on successful admission (`gaze-inspection` L1166) and `exhausted` is set only on genuine overflow (L1055 / L1145), so a fully-dropped emission leaves the emitter untouched. Once lifecycle is `Purging`/`Disabled` it cannot return to `Running` inside the assertion window, so a retry can only ever produce the terminal code.

Nothing is loosened: the assertions still pin `[Purging, Purging]` and `[Disabled, Disabled]`. No `#[ignore]`, no deleted coverage, no sleep. The 2s deadline is a hang-failsafe, not a timing assertion — the loop's exit condition is a state-machine fact ("the runtime answered"), which is what keeps this out of the `daemon_smoke` stopwatch class.

## Evidence

### 1. Mechanism proof — deterministic red, not a hoped-for flake

Temporary probe in `dispatcher_loop`: after the condvar `wait` returns, sleep 50ms **while still holding `inner`**, widening exactly the window the race needs.

| | result |
|---|---|
| **unfixed** test under probe | **8/10 RED** |
| **fixed** test under identical probe | **10/10 GREEN** |

Representative red:

```
panicked at crates/gaze-proxy/src/inspection.rs:802:9:
assertion `left == right` failed
  left: [Dropped(QueueContended), Dropped(QueueContended)]
 right: [Dropped(Purging), Dropped(Purging)]
```

The probe contends both lifecycle sites, so the green runs exercise the helper at the purge assertion *and* the disable assertion. Probe fully reverted.

### 2. Vacuity — the test can still fail

**Mutation A — mis-attribute the disable drop** (`pre_projection`: `Disabled => QueueClosed`):

```
panicked at crates/gaze-proxy/src/inspection.rs:840:9:
assertion `left == right` failed
  left: [Dropped(QueueClosed), Dropped(QueueClosed)]
 right: [Dropped(Disabled), Dropped(Disabled)]
```

RED. The helper absorbs only `QueueContended`; a wrong terminal code still reds.

**Mutation B — contention that never resolves** (`try_inner` always returns `Err(QueueContended)`):

```
panicked at crates/gaze-proxy/src/inspection.rs:480:13:
inspection begin stayed contended
test result: FAILED. finished in 2.00s
```

RED in 2.00s. The retry cannot silently swallow unresolving contention, and cannot hang.

Both mutations reverted; the committed diff is test-only.

### 3. Repeat runs

```
20x UNLOADED:                          pass=20 fail=0
20x LOADED (6x `yes > /dev/null`):     pass=20 fail=0
```

Burners killed afterwards (`pgrep -x yes` = 0).

### 4. Gates

```
cargo fmt --all -- --check                                          OK
cargo clippy --workspace --all-features --all-targets -- -D warnings clean
cargo test -p gaze-proxy --all-features                             51 lib + all integration bins green
cargo test --workspace --all-features --no-fail-fast                exit 0 — 1489 passed, 0 failed, across 132 test binaries
```

## Duplicate resolution: #2969, #2980

**Both #2969 and #2980 name the same test as this one, and their shared stated root cause is wrong.**

They both propose that `install_proxy_inspection_v1` installs into a **process-global slot** that ~12 parallel tests in the binary race on, with `serial_test` as the fix. `install_inspection_v1` (`gaze-inspection` L768) builds a **fresh `Arc<RegistrationState>` with its own `Mutex<RuntimeInner>` on every call**. The only process-globals are the `NEXT_REGISTRATION_ID` / `NEXT_LOGICAL_ID` / `NEXT_EMISSION_ID` atomic counters, which cannot contend `inner`.

The race is **intra-test** — the test thread against its own dispatcher thread. `#[serial]` would have fixed nothing; it would only have lowered machine load and so narrowed the scheduling window, hiding the flake without addressing it. Worth recording, because that is the failure mode this repo keeps paying for.

- **#2969** — same test, same root cause (its report had an empty panic block, which is why it looked opaque). **Resolved by this PR.**
- **#2980** — has two halves:
  - the `gaze-proxy` `inspection` half (`[QueueContended, Purging]`) is the same root cause. **Resolved by this PR.**
  - the `gaze-proxy-dashboard` `dashboard_child_helper` half (`crates/gaze-proxy-dashboard/tests/runtime_lifecycle.rs:20`, `/bin/kill: No such process`) is a **distinct mechanism** — a subprocess-lifecycle harness in a different crate, no shared code with the inspection runtime. **Not fixed here; that half of #2980 should stay open.**

## North star

Axis 4 (trust). A gate that reds for non-correctness reasons trains everyone to ignore red, which is how real defects ship. This one had already cost a rerun-on-red on #438 and two misdiagnoses. Axis 1 is unaffected: the change is test-only, and the contended path was already the fail-closed one.

Resolves solo todo #2983.

Class history: solo #2404, #2916, #2981 (PR #442), #430.
