### PR TITLE
refactor(cli): one clap Args declaration per shared flag group (S11-F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`gaze-cli` declares each shared flag group once** (audit 7201 S11-F1, solo
+  todo #2368). `gaze clean` and `gaze daemon` each declared their flags inline
+  in `Cmd`, restated them in a 33- and 23-field destructure, and rebuilt them
+  into a runtime `Args` struct — five mirrors of one list. `gaze proxy serve`
+  and `gaze proxy start` carried two byte-identical 31-line dashboard blocks
+  plus two hand-written 10-field mappings. The flags now live in one
+  `#[derive(clap::Args)]` struct per group, flattened with `#[command(flatten)]`,
+  and the OpenAI-filter subprocess group and the safety-net budget group
+  (`--safety-net-timeout-ms`, `--safety-net-input-limit-bytes`,
+  `--safety-net-mode`, `--safety-net-fallback`) are owned once in
+  `commands::shared_args` and shared by `clean` and `daemon`, so a verb cannot
+  quietly lose one and run a weaker Pass-3 safety net than its sibling.
+
+  **The published CLI surface is unchanged.** `scripts/verify/cli-help-surface.sh`
+  builds the base revision and the working tree in one run and diffs `--help`
+  for the root command and all 32 subcommands; all 33 captures are byte-identical
+  across the change, and the captures are committed under
+  `crates/gaze-cli/tests/fixtures/cli-help/`.
+
+  `gaze daemon` still accepts fewer flags than `gaze clean`: no
+  `--safety-net-registry`, `--safety-net-add`, `--kiji-distilbert-precision`,
+  `--opf-locales`, `--opf-command`, `--opf-checkpoint`, `--rulepack-bundled`,
+  or `--rulepack-path`. That gap is unchanged by this release and is now pinned
+  by a test rather than left implicit; passing one of those to `gaze daemon` is
+  rejected, not ignored.
+
 - **One documented safety-net default across the library and the CLI** (audit
   7201 S01-F1, solo todo #2949). `Pipeline::clean_with_safety_net` and
   `clean_with_safety_net_detect_context` — the policy-less convenience entry

--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -1,46 +1,107 @@
 use std::path::PathBuf;
 
+use clap::Args as ClapArgs;
+
+use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
 use super::{
-    KijiBackend, KijiDistilbertPrecision, OpenAiFilterDevice, OpenAiFilterOperatingPoint,
-    SafetyNetBackend, SafetyNetFallback, SafetyNetKind, SafetyNetMode,
+    KijiBackend, KijiDistilbertPrecision, OpenAiFilterDevice, SafetyNetBackend, SafetyNetKind,
 };
 use crate::error::CliError;
+use crate::io::DEFAULT_MAX_BYTES;
 use crate::pipeline::{run_clean, CleanOptions};
 
+/// The complete `gaze clean` flag surface.
+///
+/// This struct is the only declaration of these flags: `Cmd::Clean` flattens
+/// it, so parsing and the runtime call share one definition instead of a
+/// declaration plus a hand-written destructure/restructure pair.
+#[derive(ClapArgs, Debug)]
 pub(crate) struct Args {
+    /// Path to policy.toml. Required once the policy loader lands (issue #3).
+    #[arg(long)]
     pub(crate) policy: Option<PathBuf>,
+    /// Output format. Only `json` is supported today.
+    #[arg(long, default_value = "json")]
     pub(crate) format: String,
+    /// Override the persistent session TTL in seconds.
+    #[arg(long)]
     pub(crate) session_ttl: Option<u64>,
+    /// Override policy \[session].scope.
+    #[arg(long)]
     pub(crate) session_scope: Option<String>,
+    /// Active locale fallback chain, comma separated and priority ordered.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) locale: Vec<String>,
+    /// Override policy \[ner] threshold. Must be between 0.0 and 1.0 inclusive.
+    #[arg(long)]
     pub(crate) ner_threshold: Option<f32>,
+    /// Override policy \[ner].model_dir.
+    #[arg(long)]
     pub(crate) ner_model_dir: Option<PathBuf>,
+    /// Override policy \[ner].locale.
+    #[arg(long)]
     pub(crate) ner_locale: Option<String>,
+    /// Override policy.rulepacks.bundled. Comma-separated and repeatable.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) rulepack_bundled: Vec<String>,
+    /// Override policy.rulepacks.paths. Repeatable.
+    #[arg(long = "rulepack-path")]
     pub(crate) rulepack_paths: Vec<PathBuf>,
+    /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
+    #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
     pub(crate) max_bytes: u64,
+    /// Path to a typed Context JSON envelope. stdin remains raw text.
+    #[arg(long)]
     pub(crate) context_json: Option<PathBuf>,
+    /// Optional SQLite redaction-log database path.
+    #[arg(long)]
     pub(crate) audit_db: Option<PathBuf>,
+    /// Optional observer-only privacy safety net.
+    #[arg(long, value_enum)]
     pub(crate) safety_net: Option<SafetyNetKind>,
+    /// v0.8 backend selector. When set with
+    /// `--safety-net=<kind>`, this flag wins. Lets adopters swap the
+    /// Pass-3 backend without re-typing the legacy `--safety-net` value.
+    #[arg(long, value_enum)]
     pub(crate) safety_net_backend: Option<SafetyNetBackend>,
+    /// Enable locale-aware Pass-3 safety-net registry dispatch.
+    #[arg(long)]
     pub(crate) safety_net_registry: bool,
+    /// Add one backend to the locale-aware safety-net registry. Repeatable.
+    #[arg(long, value_enum)]
     pub(crate) safety_net_add: Vec<SafetyNetBackend>,
-    pub(crate) openai_filter_command: Option<PathBuf>,
-    pub(crate) openai_filter_checkpoint: Option<PathBuf>,
-    pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+    #[command(flatten)]
+    pub(crate) openai_filter: OpenAiFilterSubprocessArgs,
+    /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
+    #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    /// Kiji DistilBERT runtime backend. Default: subprocess for compatibility.
+    #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
     pub(crate) kiji_backend: KijiBackend,
+    /// Kiji DistilBERT ONNX precision. Default: fp32.
+    #[arg(long, value_enum, default_value_t = KijiDistilbertPrecision::Fp32)]
     pub(crate) kiji_distilbert_precision: KijiDistilbertPrecision,
+    /// Locale list for the OpenAI Privacy Filter registry entry.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) opf_locales: Vec<String>,
+    /// Alias for --openai-filter-command in registry examples.
+    #[arg(long)]
     pub(crate) opf_command: Option<PathBuf>,
+    /// Alias for --openai-filter-checkpoint in registry examples.
+    #[arg(long)]
     pub(crate) opf_checkpoint: Option<PathBuf>,
+    /// Path to the local Kiji DistilBERT subprocess command.
+    #[arg(long)]
     pub(crate) kiji_distilbert_command: Option<PathBuf>,
+    /// Path to the pinned Kiji DistilBERT model directory (must contain
+    /// SHA256SUMS, labels.json, model.onnx, tokenizer.json).
+    #[arg(long)]
     pub(crate) kiji_distilbert_model_dir: Option<PathBuf>,
+    /// Locale list for the Kiji DistilBERT registry entry.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) kiji_distilbert_locales: Vec<String>,
-    pub(crate) safety_net_timeout_ms: u64,
-    pub(crate) safety_net_input_limit_bytes: usize,
-    pub(crate) safety_net_mode: SafetyNetMode,
-    pub(crate) safety_net_fallback: SafetyNetFallback,
+    #[command(flatten)]
+    pub(crate) safety_net_limits: SafetyNetLimitArgs,
 }
 
 pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
@@ -62,9 +123,9 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         safety_net_backend: args.safety_net_backend,
         safety_net_registry: args.safety_net_registry,
         safety_net_add: &args.safety_net_add,
-        openai_filter_command: args.openai_filter_command.as_deref(),
-        openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
-        openai_filter_operating_point: args.openai_filter_operating_point,
+        openai_filter_command: args.openai_filter.openai_filter_command.as_deref(),
+        openai_filter_checkpoint: args.openai_filter.openai_filter_checkpoint.as_deref(),
+        openai_filter_operating_point: args.openai_filter.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
         kiji_distilbert_precision: args.kiji_distilbert_precision,
@@ -74,9 +135,9 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
         kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
         kiji_distilbert_locales: &args.kiji_distilbert_locales,
-        safety_net_timeout_ms: args.safety_net_timeout_ms,
-        safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
-        safety_net_mode: args.safety_net_mode,
-        safety_net_fallback: args.safety_net_fallback,
+        safety_net_timeout_ms: args.safety_net_limits.safety_net_timeout_ms,
+        safety_net_input_limit_bytes: args.safety_net_limits.safety_net_input_limit_bytes,
+        safety_net_mode: args.safety_net_limits.safety_net_mode,
+        safety_net_fallback: args.safety_net_limits.safety_net_fallback,
     })
 }

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -9,9 +9,10 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
 use super::{
-    KijiBackend, OpenAiFilterDevice, OpenAiFilterOperatingPoint, SafetyNetBackend,
-    SafetyNetFallback, SafetyNetKind, SafetyNetMode,
+    KijiBackend, OpenAiFilterDevice, SafetyNetBackend, SafetyNetFallback, SafetyNetKind,
+    SafetyNetMode,
 };
 use crate::error::CliError;
 use crate::pipeline::build::{map_policy_error, resolve_pipeline, validate_ner_threshold};
@@ -31,30 +32,65 @@ const DEFAULT_PROCESS_IDLE_TIMEOUT_SECS: u64 = 1_800;
 const DEFAULT_SESSION_IDLE_TIMEOUT_SECS: u64 = 3_600;
 const DEFAULT_SESSION_CAP: usize = 1_000;
 
+/// The complete `gaze daemon` flag surface.
+///
+/// Declared once and flattened into `Cmd::Daemon`. The safety-net groups it
+/// shares with `gaze clean` come from [`super::shared_args`], so the two verbs
+/// cannot drift apart on those flags without a compile error.
+#[derive(clap::Args, Debug)]
 pub(crate) struct Args {
+    /// Path to policy.toml.
+    #[arg(long)]
     pub(crate) policy: PathBuf,
+    /// Optional observer-only privacy safety net.
+    #[arg(long, value_enum)]
     pub(crate) safety_net: Option<SafetyNetKind>,
+    /// v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins.
+    #[arg(long, value_enum)]
     pub(crate) safety_net_backend: Option<SafetyNetBackend>,
-    pub(crate) idle_timeout_secs: u64,
-    pub(crate) session_idle_timeout_secs: u64,
+    /// Exit when stdin is idle for this many seconds.
+    #[arg(long, default_value_t = default_process_idle_timeout_secs())]
+    pub(crate) idle_timeout: u64,
+    /// Evict sessions idle for this many seconds.
+    #[arg(long, default_value_t = default_session_idle_timeout_secs())]
+    pub(crate) session_idle_timeout: u64,
+    /// Maximum live sessions before LRU eviction.
+    #[arg(long, default_value_t = default_session_cap())]
     pub(crate) session_cap: usize,
+    /// Optional SQLite redaction-log database path.
+    #[arg(long)]
     pub(crate) audit_db: Option<PathBuf>,
+    /// Active locale fallback chain, comma separated and priority ordered.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) locale: Vec<String>,
+    /// Override policy \[ner\] threshold. Must be between 0.0 and 1.0 inclusive.
+    #[arg(long)]
     pub(crate) ner_threshold: Option<f32>,
+    /// Override policy \[ner\].model_dir.
+    #[arg(long)]
     pub(crate) ner_model_dir: Option<PathBuf>,
+    /// Override policy \[ner\].locale.
+    #[arg(long)]
     pub(crate) ner_locale: Option<String>,
-    pub(crate) openai_filter_command: Option<PathBuf>,
-    pub(crate) openai_filter_checkpoint: Option<PathBuf>,
-    pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+    #[command(flatten)]
+    pub(crate) openai_filter: OpenAiFilterSubprocessArgs,
+    /// Device selection for the OpenAI safety-net subprocess.
+    #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
     pub(crate) openai_filter_device: OpenAiFilterDevice,
+    /// Kiji DistilBERT runtime backend.
+    #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
     pub(crate) kiji_backend: KijiBackend,
+    /// Path to the local Kiji DistilBERT subprocess command.
+    #[arg(long)]
     pub(crate) kiji_distilbert_command: Option<PathBuf>,
+    /// Path to the pinned Kiji DistilBERT model directory.
+    #[arg(long)]
     pub(crate) kiji_distilbert_model_dir: Option<PathBuf>,
+    /// Locale list for the Kiji DistilBERT backend.
+    #[arg(long, value_delimiter = ',')]
     pub(crate) kiji_distilbert_locales: Vec<String>,
-    pub(crate) safety_net_timeout_ms: u64,
-    pub(crate) safety_net_input_limit_bytes: usize,
-    pub(crate) safety_net_mode: SafetyNetMode,
-    pub(crate) safety_net_fallback: SafetyNetFallback,
+    #[command(flatten)]
+    pub(crate) safety_net_limits: SafetyNetLimitArgs,
 }
 
 pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
@@ -140,7 +176,10 @@ impl Daemon {
                 "--session-cap must be greater than zero".to_string(),
             ));
         }
-        validate_safety_net_tolerant_gate(args.safety_net_mode, args.safety_net_fallback)?;
+        validate_safety_net_tolerant_gate(
+            args.safety_net_limits.safety_net_mode,
+            args.safety_net_limits.safety_net_fallback,
+        )?;
         let logger =
             Arc::new(DaemonLogger::new(args.audit_db.as_deref()).map_err(|_| CliError::Pipeline)?);
         let options = clean_options(&args);
@@ -168,14 +207,14 @@ impl Daemon {
             locale_chain: locale_chain.as_slice().to_vec(),
             dictionaries,
             safety_net_active: args.safety_net.is_some(),
-            safety_net_mode: args.safety_net_mode,
-            safety_net_fallback: args.safety_net_fallback,
+            safety_net_mode: args.safety_net_limits.safety_net_mode,
+            safety_net_fallback: args.safety_net_limits.safety_net_fallback,
             logger,
             sessions: HashMap::new(),
             lru: VecDeque::new(),
             session_cap: args.session_cap,
-            session_idle_timeout: Duration::from_secs(args.session_idle_timeout_secs),
-            process_idle_timeout: Duration::from_secs(args.idle_timeout_secs),
+            session_idle_timeout: Duration::from_secs(args.session_idle_timeout),
+            process_idle_timeout: Duration::from_secs(args.idle_timeout),
             last_stdin_activity: Instant::now(),
         })
     }
@@ -322,9 +361,9 @@ fn clean_options(args: &Args) -> CleanOptions<'_> {
         safety_net_backend: args.safety_net_backend,
         safety_net_registry: false,
         safety_net_add: &[],
-        openai_filter_command: args.openai_filter_command.as_deref(),
-        openai_filter_checkpoint: args.openai_filter_checkpoint.as_deref(),
-        openai_filter_operating_point: args.openai_filter_operating_point,
+        openai_filter_command: args.openai_filter.openai_filter_command.as_deref(),
+        openai_filter_checkpoint: args.openai_filter.openai_filter_checkpoint.as_deref(),
+        openai_filter_operating_point: args.openai_filter.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
         kiji_distilbert_precision: super::KijiDistilbertPrecision::Fp32,
@@ -334,10 +373,10 @@ fn clean_options(args: &Args) -> CleanOptions<'_> {
         kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
         kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
         kiji_distilbert_locales: &args.kiji_distilbert_locales,
-        safety_net_timeout_ms: args.safety_net_timeout_ms,
-        safety_net_input_limit_bytes: args.safety_net_input_limit_bytes,
-        safety_net_mode: args.safety_net_mode,
-        safety_net_fallback: args.safety_net_fallback,
+        safety_net_timeout_ms: args.safety_net_limits.safety_net_timeout_ms,
+        safety_net_input_limit_bytes: args.safety_net_limits.safety_net_input_limit_bytes,
+        safety_net_mode: args.safety_net_limits.safety_net_mode,
+        safety_net_fallback: args.safety_net_limits.safety_net_fallback,
     }
 }
 

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod proxy_dashboard;
 mod restore;
 #[cfg(feature = "setup")]
 mod setup;
+mod shared_args;
 
 use std::path::PathBuf;
 
@@ -41,180 +42,13 @@ pub(crate) struct Cli {
 enum Cmd {
     /// Read raw text from stdin; emit `{clean_text, session_blob, stats}` JSON to stdout.
     Clean {
-        /// Path to policy.toml. Required once the policy loader lands (issue #3).
-        #[arg(long)]
-        policy: Option<PathBuf>,
-        /// Output format. Only `json` is supported today.
-        #[arg(long, default_value = "json")]
-        format: String,
-        /// Override the persistent session TTL in seconds.
-        #[arg(long)]
-        session_ttl: Option<u64>,
-        /// Override policy \[session].scope.
-        #[arg(long)]
-        session_scope: Option<String>,
-        /// Active locale fallback chain, comma separated and priority ordered.
-        #[arg(long, value_delimiter = ',')]
-        locale: Vec<String>,
-        /// Override policy \[ner] threshold. Must be between 0.0 and 1.0 inclusive.
-        #[arg(long)]
-        ner_threshold: Option<f32>,
-        /// Override policy \[ner].model_dir.
-        #[arg(long)]
-        ner_model_dir: Option<PathBuf>,
-        /// Override policy \[ner].locale.
-        #[arg(long)]
-        ner_locale: Option<String>,
-        /// Override policy.rulepacks.bundled. Comma-separated and repeatable.
-        #[arg(long, value_delimiter = ',')]
-        rulepack_bundled: Vec<String>,
-        /// Override policy.rulepacks.paths. Repeatable.
-        #[arg(long = "rulepack-path")]
-        rulepack_paths: Vec<PathBuf>,
-        /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
-        #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
-        max_bytes: u64,
-        /// Path to a typed Context JSON envelope. stdin remains raw text.
-        #[arg(long)]
-        context_json: Option<PathBuf>,
-        /// Optional SQLite redaction-log database path.
-        #[arg(long)]
-        audit_db: Option<PathBuf>,
-        /// Optional observer-only privacy safety net.
-        #[arg(long, value_enum)]
-        safety_net: Option<SafetyNetKind>,
-        /// v0.8 backend selector. When set with
-        /// `--safety-net=<kind>`, this flag wins. Lets adopters swap the
-        /// Pass-3 backend without re-typing the legacy `--safety-net` value.
-        #[arg(long, value_enum)]
-        safety_net_backend: Option<SafetyNetBackend>,
-        /// Enable locale-aware Pass-3 safety-net registry dispatch.
-        #[arg(long)]
-        safety_net_registry: bool,
-        /// Add one backend to the locale-aware safety-net registry. Repeatable.
-        #[arg(long, value_enum)]
-        safety_net_add: Vec<SafetyNetBackend>,
-        /// Path to the local OpenAI Privacy Filter `opf` command.
-        #[arg(long)]
-        openai_filter_command: Option<PathBuf>,
-        /// Path to the local OpenAI Privacy Filter checkpoint or model directory.
-        #[arg(long)]
-        openai_filter_checkpoint: Option<PathBuf>,
-        /// OpenAI Privacy Filter operating point, when supported by the command.
-        #[arg(long, value_enum)]
-        openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
-        /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
-        #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
-        openai_filter_device: OpenAiFilterDevice,
-        /// Kiji DistilBERT runtime backend. Default: subprocess for compatibility.
-        #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
-        kiji_backend: KijiBackend,
-        /// Kiji DistilBERT ONNX precision. Default: fp32.
-        #[arg(long, value_enum, default_value_t = KijiDistilbertPrecision::Fp32)]
-        kiji_distilbert_precision: KijiDistilbertPrecision,
-        /// Locale list for the OpenAI Privacy Filter registry entry.
-        #[arg(long, value_delimiter = ',')]
-        opf_locales: Vec<String>,
-        /// Alias for --openai-filter-command in registry examples.
-        #[arg(long)]
-        opf_command: Option<PathBuf>,
-        /// Alias for --openai-filter-checkpoint in registry examples.
-        #[arg(long)]
-        opf_checkpoint: Option<PathBuf>,
-        /// Path to the local Kiji DistilBERT subprocess command.
-        #[arg(long)]
-        kiji_distilbert_command: Option<PathBuf>,
-        /// Path to the pinned Kiji DistilBERT model directory (must contain
-        /// SHA256SUMS, labels.json, model.onnx, tokenizer.json).
-        #[arg(long)]
-        kiji_distilbert_model_dir: Option<PathBuf>,
-        /// Locale list for the Kiji DistilBERT registry entry.
-        #[arg(long, value_delimiter = ',')]
-        kiji_distilbert_locales: Vec<String>,
-        /// Safety-net subprocess timeout in milliseconds.
-        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
-        safety_net_timeout_ms: u64,
-        /// Maximum clean-text bytes submitted to the safety net.
-        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES)]
-        safety_net_input_limit_bytes: usize,
-        /// Safety-net handling mode for suspected leaks.
-        #[arg(long, value_enum, default_value_t = SafetyNetMode::Resolve)]
-        safety_net_mode: SafetyNetMode,
-        /// Fallback when safety-net resolve or redact cannot complete.
-        #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
-        safety_net_fallback: SafetyNetFallback,
+        #[command(flatten)]
+        args: clean::Args,
     },
     /// Run a long-lived JSON-lines stdio cleaning daemon.
     Daemon {
-        /// Path to policy.toml.
-        #[arg(long)]
-        policy: PathBuf,
-        /// Optional observer-only privacy safety net.
-        #[arg(long, value_enum)]
-        safety_net: Option<SafetyNetKind>,
-        /// v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins.
-        #[arg(long, value_enum)]
-        safety_net_backend: Option<SafetyNetBackend>,
-        /// Exit when stdin is idle for this many seconds.
-        #[arg(long, default_value_t = daemon::default_process_idle_timeout_secs())]
-        idle_timeout: u64,
-        /// Evict sessions idle for this many seconds.
-        #[arg(long, default_value_t = daemon::default_session_idle_timeout_secs())]
-        session_idle_timeout: u64,
-        /// Maximum live sessions before LRU eviction.
-        #[arg(long, default_value_t = daemon::default_session_cap())]
-        session_cap: usize,
-        /// Optional SQLite redaction-log database path.
-        #[arg(long)]
-        audit_db: Option<PathBuf>,
-        /// Active locale fallback chain, comma separated and priority ordered.
-        #[arg(long, value_delimiter = ',')]
-        locale: Vec<String>,
-        /// Override policy \[ner\] threshold. Must be between 0.0 and 1.0 inclusive.
-        #[arg(long)]
-        ner_threshold: Option<f32>,
-        /// Override policy \[ner\].model_dir.
-        #[arg(long)]
-        ner_model_dir: Option<PathBuf>,
-        /// Override policy \[ner\].locale.
-        #[arg(long)]
-        ner_locale: Option<String>,
-        /// Path to the local OpenAI Privacy Filter `opf` command.
-        #[arg(long)]
-        openai_filter_command: Option<PathBuf>,
-        /// Path to the local OpenAI Privacy Filter checkpoint or model directory.
-        #[arg(long)]
-        openai_filter_checkpoint: Option<PathBuf>,
-        /// OpenAI Privacy Filter operating point, when supported by the command.
-        #[arg(long, value_enum)]
-        openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
-        /// Device selection for the OpenAI safety-net subprocess.
-        #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
-        openai_filter_device: OpenAiFilterDevice,
-        /// Kiji DistilBERT runtime backend.
-        #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
-        kiji_backend: KijiBackend,
-        /// Path to the local Kiji DistilBERT subprocess command.
-        #[arg(long)]
-        kiji_distilbert_command: Option<PathBuf>,
-        /// Path to the pinned Kiji DistilBERT model directory.
-        #[arg(long)]
-        kiji_distilbert_model_dir: Option<PathBuf>,
-        /// Locale list for the Kiji DistilBERT backend.
-        #[arg(long, value_delimiter = ',')]
-        kiji_distilbert_locales: Vec<String>,
-        /// Safety-net subprocess timeout in milliseconds.
-        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_TIMEOUT_MS)]
-        safety_net_timeout_ms: u64,
-        /// Maximum clean-text bytes submitted to the safety net.
-        #[arg(long, default_value_t = DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES)]
-        safety_net_input_limit_bytes: usize,
-        /// Safety-net handling mode for suspected leaks.
-        #[arg(long, value_enum, default_value_t = SafetyNetMode::Resolve)]
-        safety_net_mode: SafetyNetMode,
-        /// Fallback when safety-net resolve or redact cannot complete.
-        #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
-        safety_net_fallback: SafetyNetFallback,
+        #[command(flatten)]
+        args: daemon::Args,
     },
     /// Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout.
     Restore {
@@ -438,42 +272,9 @@ enum ProxyCmd {
         #[cfg(feature = "dashboard")]
         #[arg(long)]
         dashboard: bool,
-        /// Capture OwnerRaw payloads (requires the matching acknowledgement).
         #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-capture-owner-raw")]
-        dashboard_capture_owner_raw: bool,
-        /// Acknowledge that OwnerRaw capture exposes PII to the dashboard TCB.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-acknowledge-owner-raw-risk")]
-        dashboard_acknowledge_owner_raw_risk: bool,
-        /// Capture OwnerRestored payloads (requires the matching acknowledgement).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-capture-owner-restored")]
-        dashboard_capture_owner_restored: bool,
-        /// Acknowledge that OwnerRestored capture exposes re-identified text.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-acknowledge-owner-restored-risk")]
-        dashboard_acknowledge_owner_restored_risk: bool,
-        /// Literal loopback dashboard bind with port 0 (default: fresh CSPRNG 127/8 origin).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-bind")]
-        dashboard_bind: Option<std::net::SocketAddrV4>,
-        /// Dashboard retention TTL such as `5m` (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-ttl")]
-        dashboard_ttl: Option<String>,
-        /// Dashboard retained logical-event cap (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-max-events")]
-        dashboard_max_events: Option<usize>,
-        /// Dashboard retained byte cap (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-max-bytes")]
-        dashboard_max_bytes: Option<usize>,
-        /// Inherited FIFO descriptor for noninteractive pairing-token delivery.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-pairing-fd")]
-        dashboard_pairing_fd: Option<i32>,
+        #[command(flatten)]
+        dashboard_opts: proxy_dashboard::DashboardArgs,
     },
     /// Start proxy as a detached daemon.
     Start {
@@ -495,42 +296,9 @@ enum ProxyCmd {
         #[cfg(feature = "dashboard")]
         #[arg(long)]
         dashboard: bool,
-        /// Capture OwnerRaw payloads (requires the matching acknowledgement).
         #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-capture-owner-raw")]
-        dashboard_capture_owner_raw: bool,
-        /// Acknowledge that OwnerRaw capture exposes PII to the dashboard TCB.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-acknowledge-owner-raw-risk")]
-        dashboard_acknowledge_owner_raw_risk: bool,
-        /// Capture OwnerRestored payloads (requires the matching acknowledgement).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-capture-owner-restored")]
-        dashboard_capture_owner_restored: bool,
-        /// Acknowledge that OwnerRestored capture exposes re-identified text.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-acknowledge-owner-restored-risk")]
-        dashboard_acknowledge_owner_restored_risk: bool,
-        /// Literal loopback dashboard bind with port 0 (default: fresh CSPRNG 127/8 origin).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-bind")]
-        dashboard_bind: Option<std::net::SocketAddrV4>,
-        /// Dashboard retention TTL such as `5m` (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-ttl")]
-        dashboard_ttl: Option<String>,
-        /// Dashboard retained logical-event cap (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-max-events")]
-        dashboard_max_events: Option<usize>,
-        /// Dashboard retained byte cap (crate-ceiling capped).
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-max-bytes")]
-        dashboard_max_bytes: Option<usize>,
-        /// Inherited FIFO descriptor for noninteractive pairing-token delivery.
-        #[cfg(feature = "dashboard")]
-        #[arg(long = "dashboard-pairing-fd")]
-        dashboard_pairing_fd: Option<i32>,
+        #[command(flatten)]
+        dashboard_opts: proxy_dashboard::DashboardArgs,
     },
     /// Stop the detached proxy daemon.
     Stop {
@@ -812,75 +580,7 @@ pub(crate) enum SafetyNetFallback {
 
 pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
     match cli.cmd {
-        Cmd::Clean {
-            policy,
-            format,
-            session_ttl,
-            session_scope,
-            locale,
-            ner_threshold,
-            ner_model_dir,
-            ner_locale,
-            rulepack_bundled,
-            rulepack_paths,
-            max_bytes,
-            context_json,
-            audit_db,
-            safety_net,
-            safety_net_backend,
-            safety_net_registry,
-            safety_net_add,
-            openai_filter_command,
-            openai_filter_checkpoint,
-            openai_filter_operating_point,
-            openai_filter_device,
-            kiji_backend,
-            kiji_distilbert_precision,
-            opf_locales,
-            opf_command,
-            opf_checkpoint,
-            kiji_distilbert_command,
-            kiji_distilbert_model_dir,
-            kiji_distilbert_locales,
-            safety_net_timeout_ms,
-            safety_net_input_limit_bytes,
-            safety_net_mode,
-            safety_net_fallback,
-        } => clean::run(clean::Args {
-            policy,
-            format,
-            session_ttl,
-            session_scope,
-            locale,
-            ner_threshold,
-            ner_model_dir,
-            ner_locale,
-            rulepack_bundled,
-            rulepack_paths,
-            max_bytes,
-            context_json,
-            audit_db,
-            safety_net,
-            safety_net_backend,
-            safety_net_registry,
-            safety_net_add,
-            openai_filter_command,
-            openai_filter_checkpoint,
-            openai_filter_operating_point,
-            openai_filter_device,
-            kiji_backend,
-            kiji_distilbert_precision,
-            opf_locales,
-            opf_command,
-            opf_checkpoint,
-            kiji_distilbert_command,
-            kiji_distilbert_model_dir,
-            kiji_distilbert_locales,
-            safety_net_timeout_ms,
-            safety_net_input_limit_bytes,
-            safety_net_mode,
-            safety_net_fallback,
-        }),
+        Cmd::Clean { args } => clean::run(args),
         Cmd::Restore {
             format,
             restore_mode,
@@ -895,55 +595,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
             audit_db,
             max_bytes,
         }),
-        Cmd::Daemon {
-            policy,
-            safety_net,
-            safety_net_backend,
-            idle_timeout,
-            session_idle_timeout,
-            session_cap,
-            audit_db,
-            locale,
-            ner_threshold,
-            ner_model_dir,
-            ner_locale,
-            openai_filter_command,
-            openai_filter_checkpoint,
-            openai_filter_operating_point,
-            openai_filter_device,
-            kiji_backend,
-            kiji_distilbert_command,
-            kiji_distilbert_model_dir,
-            kiji_distilbert_locales,
-            safety_net_timeout_ms,
-            safety_net_input_limit_bytes,
-            safety_net_mode,
-            safety_net_fallback,
-        } => daemon::run(daemon::Args {
-            policy,
-            safety_net,
-            safety_net_backend,
-            idle_timeout_secs: idle_timeout,
-            session_idle_timeout_secs: session_idle_timeout,
-            session_cap,
-            audit_db,
-            locale,
-            ner_threshold,
-            ner_model_dir,
-            ner_locale,
-            openai_filter_command,
-            openai_filter_checkpoint,
-            openai_filter_operating_point,
-            openai_filter_device,
-            kiji_backend,
-            kiji_distilbert_command,
-            kiji_distilbert_model_dir,
-            kiji_distilbert_locales,
-            safety_net_timeout_ms,
-            safety_net_input_limit_bytes,
-            safety_net_mode,
-            safety_net_fallback,
-        }),
+        Cmd::Daemon { args } => daemon::run(args),
         Cmd::Audit { command } => match command {
             AuditCmd::Query {
                 audit_db,
@@ -1151,23 +803,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 #[cfg(feature = "dashboard")]
                 dashboard,
                 #[cfg(feature = "dashboard")]
-                dashboard_capture_owner_raw,
-                #[cfg(feature = "dashboard")]
-                dashboard_acknowledge_owner_raw_risk,
-                #[cfg(feature = "dashboard")]
-                dashboard_capture_owner_restored,
-                #[cfg(feature = "dashboard")]
-                dashboard_acknowledge_owner_restored_risk,
-                #[cfg(feature = "dashboard")]
-                dashboard_bind,
-                #[cfg(feature = "dashboard")]
-                dashboard_ttl,
-                #[cfg(feature = "dashboard")]
-                dashboard_max_events,
-                #[cfg(feature = "dashboard")]
-                dashboard_max_bytes,
-                #[cfg(feature = "dashboard")]
-                dashboard_pairing_fd,
+                dashboard_opts,
             } => proxy::serve(proxy::ServeArgs {
                 bind,
                 upstream_openai,
@@ -1180,15 +816,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 #[cfg(feature = "dashboard")]
                 dashboard: proxy_dashboard::DashboardArgs {
                     dashboard,
-                    capture_owner_raw: dashboard_capture_owner_raw,
-                    acknowledge_owner_raw_risk: dashboard_acknowledge_owner_raw_risk,
-                    capture_owner_restored: dashboard_capture_owner_restored,
-                    acknowledge_owner_restored_risk: dashboard_acknowledge_owner_restored_risk,
-                    bind: dashboard_bind,
-                    ttl: dashboard_ttl,
-                    max_events: dashboard_max_events,
-                    max_bytes: dashboard_max_bytes,
-                    pairing_fd: dashboard_pairing_fd,
+                    ..dashboard_opts
                 },
             }),
             ProxyCmd::Start {
@@ -1202,23 +830,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 #[cfg(feature = "dashboard")]
                 dashboard,
                 #[cfg(feature = "dashboard")]
-                dashboard_capture_owner_raw,
-                #[cfg(feature = "dashboard")]
-                dashboard_acknowledge_owner_raw_risk,
-                #[cfg(feature = "dashboard")]
-                dashboard_capture_owner_restored,
-                #[cfg(feature = "dashboard")]
-                dashboard_acknowledge_owner_restored_risk,
-                #[cfg(feature = "dashboard")]
-                dashboard_bind,
-                #[cfg(feature = "dashboard")]
-                dashboard_ttl,
-                #[cfg(feature = "dashboard")]
-                dashboard_max_events,
-                #[cfg(feature = "dashboard")]
-                dashboard_max_bytes,
-                #[cfg(feature = "dashboard")]
-                dashboard_pairing_fd,
+                dashboard_opts,
             } => proxy::start(proxy::StartArgs {
                 bind,
                 upstream_openai,
@@ -1230,15 +842,7 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
                 #[cfg(feature = "dashboard")]
                 dashboard: proxy_dashboard::DashboardArgs {
                     dashboard,
-                    capture_owner_raw: dashboard_capture_owner_raw,
-                    acknowledge_owner_raw_risk: dashboard_acknowledge_owner_raw_risk,
-                    capture_owner_restored: dashboard_capture_owner_restored,
-                    acknowledge_owner_restored_risk: dashboard_acknowledge_owner_restored_risk,
-                    bind: dashboard_bind,
-                    ttl: dashboard_ttl,
-                    max_events: dashboard_max_events,
-                    max_bytes: dashboard_max_bytes,
-                    pairing_fd: dashboard_pairing_fd,
+                    ..dashboard_opts
                 },
             }),
             ProxyCmd::Stop { force, timeout } => proxy::stop(proxy::StopArgs { force, timeout }),
@@ -1269,20 +873,167 @@ pub(crate) fn dispatch(cli: Cli) -> std::result::Result<(), CliError> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use clap::{Args as ClapArgsTrait, Command, CommandFactory};
+
+    use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
     use super::*;
+
+    /// Long flag names a subcommand accepts, hidden ones included.
+    fn long_flags(path: &[&str]) -> BTreeSet<String> {
+        let mut cmd = Cli::command();
+        for name in path {
+            let sub = cmd
+                .get_subcommands()
+                .find(|sub| sub.get_name() == *name)
+                .cloned()
+                .unwrap_or_else(|| panic!("no `{name}` subcommand under {path:?}"));
+            cmd = sub;
+        }
+        cmd.get_arguments()
+            .filter_map(|arg| arg.get_long().map(str::to_string))
+            .collect()
+    }
+
+    /// Long flag names contributed by one shared `#[derive(Args)]` struct.
+    ///
+    /// Read off the struct itself rather than restated as a list, so the
+    /// expectation cannot drift away from the declaration it is checking.
+    fn long_flags_of<T: ClapArgsTrait>() -> BTreeSet<String> {
+        T::augment_args(Command::new("probe"))
+            .get_arguments()
+            .filter_map(|arg| arg.get_long().map(str::to_string))
+            .filter(|long| long != "help")
+            .collect()
+    }
+
+    fn walk(cmd: &Command, path: String, out: &mut Vec<(String, Vec<String>)>) {
+        out.push((
+            path.clone(),
+            cmd.get_arguments()
+                .map(|arg| arg.get_id().to_string())
+                .collect(),
+        ));
+        for sub in cmd.get_subcommands() {
+            walk(sub, format!("{path} {}", sub.get_name()), out);
+        }
+    }
 
     #[test]
     fn openai_filter_device_defaults_to_auto() {
         let cli = Cli::parse_from(["gaze", "clean"]);
 
-        let Cmd::Clean {
-            openai_filter_device,
-            ..
-        } = cli.cmd
-        else {
+        let Cmd::Clean { args } = cli.cmd else {
             unreachable!("expected clean command");
         };
 
-        assert_eq!(openai_filter_device, OpenAiFilterDevice::Auto);
+        assert_eq!(args.openai_filter_device, OpenAiFilterDevice::Auto);
+    }
+
+    /// Clap keys an argument on its Rust field name, not on its `--long` name,
+    /// so two flattened structs that both name a field `bind` silently merge
+    /// into one argument and the loser's default disappears. Nothing in the
+    /// type system catches that, so assert it here across every command.
+    #[test]
+    fn no_command_has_two_arguments_sharing_an_id() {
+        let root = Cli::command();
+        let mut commands = Vec::new();
+        walk(&root, "gaze".to_string(), &mut commands);
+        assert!(
+            commands.len() > 1,
+            "walked no subcommands; the traversal is broken"
+        );
+
+        let mut collisions = Vec::new();
+        for (path, ids) in &commands {
+            let mut seen = BTreeMap::new();
+            for id in ids {
+                *seen.entry(id.clone()).or_insert(0usize) += 1;
+            }
+            for (id, count) in seen {
+                if count > 1 {
+                    collisions.push(format!("`{path}` declares `{id}` {count} times"));
+                }
+            }
+        }
+        assert!(
+            collisions.is_empty(),
+            "clap argument id collisions: {}",
+            collisions.join("; ")
+        );
+    }
+
+    /// The shared safety-net groups must reach both verbs. If a future edit
+    /// drops a `#[command(flatten)]`, or re-declares the block inline on one
+    /// side only, this fails instead of shipping a verb with a weaker Pass-3
+    /// safety net than its sibling under the same policy.
+    #[test]
+    fn shared_safety_net_groups_reach_both_clean_and_daemon() {
+        let clean = long_flags(&["clean"]);
+        let daemon = long_flags(&["daemon"]);
+
+        for group in [
+            long_flags_of::<OpenAiFilterSubprocessArgs>(),
+            long_flags_of::<SafetyNetLimitArgs>(),
+        ] {
+            assert!(!group.is_empty(), "a shared group contributed no flags");
+            for flag in &group {
+                assert!(clean.contains(flag), "`gaze clean` is missing --{flag}");
+                assert!(daemon.contains(flag), "`gaze daemon` is missing --{flag}");
+            }
+        }
+    }
+
+    /// `clean` and `daemon` do not accept the same flags, and the difference is
+    /// a product decision rather than an accident. Pin it in both directions so
+    /// that a new flag landing on only one verb fails here, and so that closing
+    /// one of these gaps has to update this list deliberately.
+    ///
+    /// `daemon` cannot opt into the locale-aware safety-net registry, cannot
+    /// select int8 Kiji precision, and takes no rulepack overrides: passing any
+    /// of these to `gaze daemon` is rejected, not ignored (see solo todo for
+    /// the capability gap).
+    #[test]
+    fn clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set() {
+        let clean = long_flags(&["clean"]);
+        let daemon = long_flags(&["daemon"]);
+
+        let clean_only: BTreeSet<String> = clean.difference(&daemon).cloned().collect();
+        let daemon_only: BTreeSet<String> = daemon.difference(&clean).cloned().collect();
+
+        let expected_clean_only: BTreeSet<String> = [
+            "context-json",
+            "format",
+            "kiji-distilbert-precision",
+            "max-bytes",
+            "opf-checkpoint",
+            "opf-command",
+            "opf-locales",
+            "rulepack-bundled",
+            "rulepack-path",
+            "safety-net-add",
+            "safety-net-registry",
+            "session-scope",
+            "session-ttl",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+        let expected_daemon_only: BTreeSet<String> =
+            ["idle-timeout", "session-cap", "session-idle-timeout"]
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect();
+
+        assert_eq!(
+            clean_only, expected_clean_only,
+            "flags on `gaze clean` but not `gaze daemon` changed"
+        );
+        assert_eq!(
+            daemon_only, expected_daemon_only,
+            "flags on `gaze daemon` but not `gaze clean` changed"
+        );
     }
 }

--- a/crates/gaze-cli/src/commands/proxy_dashboard.rs
+++ b/crates/gaze-cli/src/commands/proxy_dashboard.rs
@@ -32,17 +32,80 @@ const DEFAULT_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Section 2 dashboard flags carried by `gaze proxy serve` and relayed
 /// verbatim by `gaze proxy start`.
-#[derive(Clone, Debug, Default)]
+///
+/// Both verbs flatten this struct, so the capture/acknowledgement pairs and
+/// the retention caps are declared once. `dashboard` itself is `#[arg(skip)]`
+/// because the two verbs word its help differently (`start` notes the relay),
+/// so each declares `--dashboard` inline and fills this field in.
+#[derive(Clone, Debug, Default, clap::Args)]
 pub(crate) struct DashboardArgs {
+    #[arg(skip)]
     pub(crate) dashboard: bool,
+    // Every arg below pins `id` explicitly. Clap identifies an argument by its
+    // Rust field name, so the short field names here (`bind`, `ttl`, ...) would
+    // collide with the host verb's own args once flattened -- `proxy serve` has
+    // its own `bind`. A collision is silent: clap merges the two and the loser's
+    // default vanishes. An explicit id is also used verbatim as the help
+    // placeholder, so value-carrying args restate `value_name` to keep the
+    // published `<DASHBOARD_BIND>` spelling.
+    /// Capture OwnerRaw payloads (requires the matching acknowledgement).
+    #[arg(
+        id = "dashboard_capture_owner_raw",
+        long = "dashboard-capture-owner-raw"
+    )]
     pub(crate) capture_owner_raw: bool,
+    /// Acknowledge that OwnerRaw capture exposes PII to the dashboard TCB.
+    #[arg(
+        id = "dashboard_acknowledge_owner_raw_risk",
+        long = "dashboard-acknowledge-owner-raw-risk"
+    )]
     pub(crate) acknowledge_owner_raw_risk: bool,
+    /// Capture OwnerRestored payloads (requires the matching acknowledgement).
+    #[arg(
+        id = "dashboard_capture_owner_restored",
+        long = "dashboard-capture-owner-restored"
+    )]
     pub(crate) capture_owner_restored: bool,
+    /// Acknowledge that OwnerRestored capture exposes re-identified text.
+    #[arg(
+        id = "dashboard_acknowledge_owner_restored_risk",
+        long = "dashboard-acknowledge-owner-restored-risk"
+    )]
     pub(crate) acknowledge_owner_restored_risk: bool,
+    /// Literal loopback dashboard bind with port 0 (default: fresh CSPRNG 127/8 origin).
+    #[arg(
+        id = "dashboard_bind",
+        long = "dashboard-bind",
+        value_name = "DASHBOARD_BIND"
+    )]
     pub(crate) bind: Option<SocketAddrV4>,
+    /// Dashboard retention TTL such as `5m` (crate-ceiling capped).
+    #[arg(
+        id = "dashboard_ttl",
+        long = "dashboard-ttl",
+        value_name = "DASHBOARD_TTL"
+    )]
     pub(crate) ttl: Option<String>,
+    /// Dashboard retained logical-event cap (crate-ceiling capped).
+    #[arg(
+        id = "dashboard_max_events",
+        long = "dashboard-max-events",
+        value_name = "DASHBOARD_MAX_EVENTS"
+    )]
     pub(crate) max_events: Option<usize>,
+    /// Dashboard retained byte cap (crate-ceiling capped).
+    #[arg(
+        id = "dashboard_max_bytes",
+        long = "dashboard-max-bytes",
+        value_name = "DASHBOARD_MAX_BYTES"
+    )]
     pub(crate) max_bytes: Option<usize>,
+    /// Inherited FIFO descriptor for noninteractive pairing-token delivery.
+    #[arg(
+        id = "dashboard_pairing_fd",
+        long = "dashboard-pairing-fd",
+        value_name = "DASHBOARD_PAIRING_FD"
+    )]
     pub(crate) pairing_fd: Option<i32>,
 }
 

--- a/crates/gaze-cli/src/commands/shared_args.rs
+++ b/crates/gaze-cli/src/commands/shared_args.rs
@@ -1,0 +1,56 @@
+//! Argument groups shared by more than one `gaze` subcommand.
+//!
+//! Each struct here is the single owner of its flags. Subcommands pull them in
+//! with `#[command(flatten)]`, so a flag cannot exist on one verb and quietly
+//! go missing on a sibling: adding a field here adds it everywhere, and
+//! removing a `flatten` is caught by the parity tests in [`super`].
+//!
+//! Only flags whose declaration is *identical* across every consumer belong
+//! here. Where two verbs describe the same flag differently, the divergence is
+//! recorded by `clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set`
+//! rather than papered over by unifying help text, which would change the
+//! published CLI surface.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+use super::{OpenAiFilterOperatingPoint, SafetyNetFallback, SafetyNetMode};
+
+/// OpenAI Privacy Filter subprocess location and operating point.
+///
+/// Shared by `gaze clean` and `gaze daemon`.
+#[derive(Args, Debug)]
+pub(crate) struct OpenAiFilterSubprocessArgs {
+    /// Path to the local OpenAI Privacy Filter `opf` command.
+    #[arg(long)]
+    pub(crate) openai_filter_command: Option<PathBuf>,
+    /// Path to the local OpenAI Privacy Filter checkpoint or model directory.
+    #[arg(long)]
+    pub(crate) openai_filter_checkpoint: Option<PathBuf>,
+    /// OpenAI Privacy Filter operating point, when supported by the command.
+    #[arg(long, value_enum)]
+    pub(crate) openai_filter_operating_point: Option<OpenAiFilterOperatingPoint>,
+}
+
+/// Pass-3 safety-net budget and failure handling.
+///
+/// Shared by `gaze clean` and `gaze daemon`. These four decide what happens to
+/// a suspected residual leak, so a verb that silently lacked one would run a
+/// weaker safety net than its sibling under the same policy — the reason this
+/// group is owned in one place.
+#[derive(Args, Debug)]
+pub(crate) struct SafetyNetLimitArgs {
+    /// Safety-net subprocess timeout in milliseconds.
+    #[arg(long, default_value_t = super::DEFAULT_SAFETY_NET_TIMEOUT_MS)]
+    pub(crate) safety_net_timeout_ms: u64,
+    /// Maximum clean-text bytes submitted to the safety net.
+    #[arg(long, default_value_t = super::DEFAULT_SAFETY_NET_INPUT_LIMIT_BYTES)]
+    pub(crate) safety_net_input_limit_bytes: usize,
+    /// Safety-net handling mode for suspected leaks.
+    #[arg(long, value_enum, default_value_t = SafetyNetMode::Resolve)]
+    pub(crate) safety_net_mode: SafetyNetMode,
+    /// Fallback when safety-net resolve or redact cannot complete.
+    #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
+    pub(crate) safety_net_fallback: SafetyNetFallback,
+}

--- a/crates/gaze-cli/tests/cli_help_surface.rs
+++ b/crates/gaze-cli/tests/cli_help_surface.rs
@@ -1,0 +1,149 @@
+//! Drift check for the committed `gaze --help` capture.
+//!
+//! The authoritative proof that a refactor left the CLI surface alone is
+//! `scripts/verify/cli-help-surface.sh`, which builds two revisions in one run
+//! and diffs them against each other. This test is the cheap companion: it
+//! compares the running binary against the capture committed under
+//! `tests/fixtures/cli-help/`, so a reviewer can see the surface without a
+//! two-revision build and an accidental change gets a name.
+//!
+//! It is a golden comparison, so it is `#[ignore]`d — refreshing the fixture
+//! makes it pass again, and that is exactly what a before/after harness must
+//! never allow. Run it with:
+//!
+//!     cargo test -p gaze-cli --all-features --test cli_help_surface -- --ignored
+//!
+//! Refresh the fixture with `scripts/verify/cli-help-surface.sh --write-fixtures`,
+//! which only writes when the before/after diff is empty.
+//!
+//! The fixture records the `--all-features` surface, so the whole file compiles
+//! away unless every subcommand-bearing feature is on.
+#![cfg(all(
+    feature = "setup",
+    feature = "document",
+    feature = "index",
+    feature = "mcp",
+    feature = "proxy",
+    feature = "dashboard",
+    feature = "runtime-tract",
+    feature = "runtime-candle"
+))]
+
+use std::path::Path;
+
+use assert_cmd::Command;
+
+/// Hidden command paths, which never appear under `Commands:` in help output.
+/// Kept in step with `HIDDEN_PATHS` in `scripts/verify/cli-help-surface.sh`.
+const HIDDEN_PATHS: &[&[&str]] = &[&["proxy", "_dashboard-child"]];
+
+fn help_for(path: &[&str]) -> String {
+    let mut cmd = Command::cargo_bin("gaze").expect("gaze binary");
+    cmd.args(path).arg("--help");
+    let out = cmd.output().expect("run gaze --help");
+    assert!(
+        out.status.success(),
+        "`gaze {} --help` exited {:?}",
+        path.join(" "),
+        out.status.code()
+    );
+    String::from_utf8(out.stdout).expect("utf-8 help")
+}
+
+/// Subcommand names listed in a help text's `Commands:` block.
+fn child_names(help: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut in_block = false;
+    for line in help.lines() {
+        if line.starts_with("Commands:") {
+            in_block = true;
+            continue;
+        }
+        if in_block {
+            if line.ends_with(':') && !line.starts_with(' ') {
+                break;
+            }
+            let trimmed = line.trim_start();
+            let indent = line.len() - trimmed.len();
+            if indent == 2 {
+                if let Some(name) = trimmed.split_whitespace().next() {
+                    if name != "help" && name.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                        names.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    names
+}
+
+fn slug(path: &[&str]) -> String {
+    if path.is_empty() {
+        "root".to_string()
+    } else {
+        path.join("-")
+    }
+}
+
+fn collect(path: &[&str], out: &mut Vec<(String, String)>) {
+    let help = help_for(path);
+    for child in child_names(&help) {
+        let mut next: Vec<&str> = path.to_vec();
+        next.push(&child);
+        collect(&next, out);
+    }
+    out.push((slug(path), help));
+}
+
+#[test]
+#[ignore = "golden comparison against a committed capture; the two-revision script is the real gate"]
+fn help_output_matches_the_committed_capture() {
+    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cli-help");
+
+    let mut captured = Vec::new();
+    collect(&[], &mut captured);
+    for path in HIDDEN_PATHS {
+        captured.push((slug(path), help_for(path)));
+    }
+    assert!(
+        captured.len() > 10,
+        "walked only {} commands; the traversal is broken",
+        captured.len()
+    );
+
+    let mut mismatches = Vec::new();
+    for (name, help) in &captured {
+        let path = fixture_dir.join(format!("{name}.txt"));
+        match std::fs::read_to_string(&path) {
+            Ok(expected) => {
+                if expected.trim_end() != help.trim_end() {
+                    mismatches.push(format!("{name}: help differs from the committed capture"));
+                }
+            }
+            Err(_) => mismatches.push(format!(
+                "{name}: no committed capture at {}",
+                path.display()
+            )),
+        }
+    }
+
+    let captured_names: Vec<&str> = captured.iter().map(|(name, _)| name.as_str()).collect();
+    for entry in std::fs::read_dir(&fixture_dir).expect("fixture dir") {
+        let entry = entry.expect("fixture entry");
+        let file = entry.file_name();
+        let name = file.to_string_lossy();
+        let Some(stem) = name.strip_suffix(".txt") else {
+            continue;
+        };
+        if !captured_names.contains(&stem) {
+            mismatches.push(format!("{stem}: committed capture has no matching command"));
+        }
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "CLI help surface drifted from tests/fixtures/cli-help:\n  {}\n\
+         Re-run scripts/verify/cli-help-surface.sh to see the before/after diff.",
+        mismatches.join("\n  ")
+    );
+}

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit-export.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit-export.txt
@@ -1,0 +1,37 @@
+Export filtered audit metadata rows
+
+Usage: gaze audit export [OPTIONS] --audit-db <AUDIT_DB>
+
+Options:
+      --audit-db <AUDIT_DB>
+          SQLite redaction-log database path
+      --format <FORMAT>
+          Export format [default: jsonl] [possible values: jsonl]
+      --output <OUTPUT>
+          Optional output file. Defaults to stdout
+      --class <PII_CLASS>
+          Filter by PII class, such as `email`, `name`, or `custom:term`
+      --source <SOURCE>
+          Filter by source recognizer name
+      --action <ACTION>
+          Filter by action, such as `tokenize`, `redact`, or `preserve`
+      --document-kind <DOCUMENT_KIND>
+          Filter by document kind, such as `text` or `structured`
+      --from <FROM_ISO8601>
+          Include rows created at or after this ISO 8601 timestamp
+      --to <TO_ISO8601>
+          Include rows created at or before this ISO 8601 timestamp
+      --session <SESSION_ID>
+          Filter by opaque audit session id
+      --has-ambiguity
+          Include only rows with an ambiguity side-channel record
+      --ambiguity-reason <AMBIGUITY_REASON>
+          Filter by ambiguity reason, such as `no-anchor`
+      --collision-family <COLLISION_FAMILY>
+          Filter by collision family identifier
+      --collision-variant <COLLISION_VARIANT>
+          Filter by collision variant identifier
+      --restore-events
+          Include only restore telemetry rows
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit-purge.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit-purge.txt
@@ -1,0 +1,9 @@
+Purge audit metadata rows older than an ISO 8601 UTC timestamp
+
+Usage: gaze audit purge [OPTIONS] --audit-db <AUDIT_DB> --before <BEFORE>
+
+Options:
+      --audit-db <AUDIT_DB>  SQLite redaction-log database path
+      --before <BEFORE>      Purge rows where created_at is before this ISO 8601 UTC timestamp
+      --dry-run              Count matching rows without deleting them
+  -h, --help                 Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit-query.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit-query.txt
@@ -1,0 +1,33 @@
+Print filtered audit metadata rows as tab-separated values
+
+Usage: gaze audit query [OPTIONS] --audit-db <AUDIT_DB>
+
+Options:
+      --audit-db <AUDIT_DB>
+          SQLite redaction-log database path
+      --class <PII_CLASS>
+          Filter by PII class, such as `email`, `name`, or `custom:term`
+      --source <SOURCE>
+          Filter by source recognizer name
+      --action <ACTION>
+          Filter by action, such as `tokenize`, `redact`, or `preserve`
+      --document-kind <DOCUMENT_KIND>
+          Filter by document kind, such as `text` or `structured`
+      --from <FROM_ISO8601>
+          Include rows created at or after this ISO 8601 timestamp
+      --to <TO_ISO8601>
+          Include rows created at or before this ISO 8601 timestamp
+      --session <SESSION_ID>
+          Filter by opaque audit session id
+      --has-ambiguity
+          Include only rows with an ambiguity side-channel record
+      --ambiguity-reason <AMBIGUITY_REASON>
+          Filter by ambiguity reason, such as `no-anchor`
+      --collision-family <COLLISION_FAMILY>
+          Filter by collision family identifier
+      --collision-variant <COLLISION_VARIANT>
+          Filter by collision variant identifier
+      --restore-events
+          Include only restore telemetry rows
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit-safety-net-query.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit-safety-net-query.txt
@@ -1,0 +1,13 @@
+Print filtered safety-net metadata rows as tab-separated values
+
+Usage: gaze audit safety-net query [OPTIONS] --audit-db <AUDIT_DB>
+
+Options:
+      --audit-db <AUDIT_DB>          SQLite redaction-log database path
+      --leak-kind <LEAK_KIND>        Filter by safety-net leak kind
+      --raw-label <RAW_LABEL>        Filter by raw backend label
+      --mapped-class <MAPPED_CLASS>  Filter by mapped Gaze class
+      --field-path <FIELD_PATH>      Filter by structured field path
+      --from <FROM_ISO8601>          Include rows created at or after this ISO 8601 timestamp
+      --to <TO_ISO8601>              Include rows created at or before this ISO 8601 timestamp
+  -h, --help                         Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit-safety-net.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit-safety-net.txt
@@ -1,0 +1,10 @@
+Query safety-net leak metadata without changing redaction-log output
+
+Usage: gaze audit safety-net <COMMAND>
+
+Commands:
+  query  Print filtered safety-net metadata rows as tab-separated values
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/audit.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/audit.txt
@@ -1,0 +1,13 @@
+Query, export, or maintain redaction-log metadata without reading raw PII payloads
+
+Usage: gaze audit <COMMAND>
+
+Commands:
+  query       Print filtered audit metadata rows as tab-separated values
+  export      Export filtered audit metadata rows
+  purge       Purge audit metadata rows older than an ISO 8601 UTC timestamp
+  safety-net  Query safety-net leak metadata without changing redaction-log output
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/clean.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/clean.txt
@@ -1,0 +1,73 @@
+Read raw text from stdin; emit `{clean_text, session_blob, stats}` JSON to stdout
+
+Usage: gaze clean [OPTIONS]
+
+Options:
+      --policy <POLICY>
+          Path to policy.toml. Required once the policy loader lands (issue #3)
+      --format <FORMAT>
+          Output format. Only `json` is supported today [default: json]
+      --session-ttl <SESSION_TTL>
+          Override the persistent session TTL in seconds
+      --session-scope <SESSION_SCOPE>
+          Override policy \[session].scope
+      --locale <LOCALE>
+          Active locale fallback chain, comma separated and priority ordered
+      --ner-threshold <NER_THRESHOLD>
+          Override policy \[ner] threshold. Must be between 0.0 and 1.0 inclusive
+      --ner-model-dir <NER_MODEL_DIR>
+          Override policy \[ner].model_dir
+      --ner-locale <NER_LOCALE>
+          Override policy \[ner].locale
+      --rulepack-bundled <RULEPACK_BUNDLED>
+          Override policy.rulepacks.bundled. Comma-separated and repeatable
+      --rulepack-path <RULEPACK_PATHS>
+          Override policy.rulepacks.paths. Repeatable
+      --max-bytes <MAX_BYTES>
+          Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge [default: 10485760]
+      --context-json <CONTEXT_JSON>
+          Path to a typed Context JSON envelope. stdin remains raw text
+      --audit-db <AUDIT_DB>
+          Optional SQLite redaction-log database path
+      --safety-net <SAFETY_NET>
+          Optional observer-only privacy safety net [possible values: openai-filter, kiji-distilbert]
+      --safety-net-backend <SAFETY_NET_BACKEND>
+          v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins. Lets adopters swap the Pass-3 backend without re-typing the legacy `--safety-net` value [possible values: openai-filter, kiji-distilbert]
+      --safety-net-registry
+          Enable locale-aware Pass-3 safety-net registry dispatch
+      --safety-net-add <SAFETY_NET_ADD>
+          Add one backend to the locale-aware safety-net registry. Repeatable [possible values: openai-filter, kiji-distilbert]
+      --openai-filter-command <OPENAI_FILTER_COMMAND>
+          Path to the local OpenAI Privacy Filter `opf` command
+      --openai-filter-checkpoint <OPENAI_FILTER_CHECKPOINT>
+          Path to the local OpenAI Privacy Filter checkpoint or model directory
+      --openai-filter-operating-point <OPENAI_FILTER_OPERATING_POINT>
+          OpenAI Privacy Filter operating point, when supported by the command [possible values: high-recall, balanced, high-precision]
+      --openai-filter-device <OPENAI_FILTER_DEVICE>
+          Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide) [default: auto] [possible values: auto, cpu, cuda, mps]
+      --kiji-backend <KIJI_BACKEND>
+          Kiji DistilBERT runtime backend. Default: subprocess for compatibility [default: subprocess] [possible values: subprocess, ort, tract, candle]
+      --kiji-distilbert-precision <KIJI_DISTILBERT_PRECISION>
+          Kiji DistilBERT ONNX precision. Default: fp32 [default: fp32] [possible values: fp32, int8]
+      --opf-locales <OPF_LOCALES>
+          Locale list for the OpenAI Privacy Filter registry entry
+      --opf-command <OPF_COMMAND>
+          Alias for --openai-filter-command in registry examples
+      --opf-checkpoint <OPF_CHECKPOINT>
+          Alias for --openai-filter-checkpoint in registry examples
+      --kiji-distilbert-command <KIJI_DISTILBERT_COMMAND>
+          Path to the local Kiji DistilBERT subprocess command
+      --kiji-distilbert-model-dir <KIJI_DISTILBERT_MODEL_DIR>
+          Path to the pinned Kiji DistilBERT model directory (must contain SHA256SUMS, labels.json, model.onnx, tokenizer.json)
+      --kiji-distilbert-locales <KIJI_DISTILBERT_LOCALES>
+          Locale list for the Kiji DistilBERT registry entry
+      --safety-net-timeout-ms <SAFETY_NET_TIMEOUT_MS>
+          Safety-net subprocess timeout in milliseconds [default: 5000]
+      --safety-net-input-limit-bytes <SAFETY_NET_INPUT_LIMIT_BYTES>
+          Maximum clean-text bytes submitted to the safety net [default: 1048576]
+      --safety-net-mode <SAFETY_NET_MODE>
+          Safety-net handling mode for suspected leaks [default: resolve] [possible values: strict, tolerant, redact, resolve]
+      --safety-net-fallback <SAFETY_NET_FALLBACK>
+          Fallback when safety-net resolve or redact cannot complete [default: redact] [possible values: strict, tolerant, redact]
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/daemon.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/daemon.txt
@@ -1,0 +1,53 @@
+Run a long-lived JSON-lines stdio cleaning daemon
+
+Usage: gaze daemon [OPTIONS] --policy <POLICY>
+
+Options:
+      --policy <POLICY>
+          Path to policy.toml
+      --safety-net <SAFETY_NET>
+          Optional observer-only privacy safety net [possible values: openai-filter, kiji-distilbert]
+      --safety-net-backend <SAFETY_NET_BACKEND>
+          v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins [possible values: openai-filter, kiji-distilbert]
+      --idle-timeout <IDLE_TIMEOUT>
+          Exit when stdin is idle for this many seconds [default: 1800]
+      --session-idle-timeout <SESSION_IDLE_TIMEOUT>
+          Evict sessions idle for this many seconds [default: 3600]
+      --session-cap <SESSION_CAP>
+          Maximum live sessions before LRU eviction [default: 1000]
+      --audit-db <AUDIT_DB>
+          Optional SQLite redaction-log database path
+      --locale <LOCALE>
+          Active locale fallback chain, comma separated and priority ordered
+      --ner-threshold <NER_THRESHOLD>
+          Override policy \[ner\] threshold. Must be between 0.0 and 1.0 inclusive
+      --ner-model-dir <NER_MODEL_DIR>
+          Override policy \[ner\].model_dir
+      --ner-locale <NER_LOCALE>
+          Override policy \[ner\].locale
+      --openai-filter-command <OPENAI_FILTER_COMMAND>
+          Path to the local OpenAI Privacy Filter `opf` command
+      --openai-filter-checkpoint <OPENAI_FILTER_CHECKPOINT>
+          Path to the local OpenAI Privacy Filter checkpoint or model directory
+      --openai-filter-operating-point <OPENAI_FILTER_OPERATING_POINT>
+          OpenAI Privacy Filter operating point, when supported by the command [possible values: high-recall, balanced, high-precision]
+      --openai-filter-device <OPENAI_FILTER_DEVICE>
+          Device selection for the OpenAI safety-net subprocess [default: auto] [possible values: auto, cpu, cuda, mps]
+      --kiji-backend <KIJI_BACKEND>
+          Kiji DistilBERT runtime backend [default: subprocess] [possible values: subprocess, ort, tract, candle]
+      --kiji-distilbert-command <KIJI_DISTILBERT_COMMAND>
+          Path to the local Kiji DistilBERT subprocess command
+      --kiji-distilbert-model-dir <KIJI_DISTILBERT_MODEL_DIR>
+          Path to the pinned Kiji DistilBERT model directory
+      --kiji-distilbert-locales <KIJI_DISTILBERT_LOCALES>
+          Locale list for the Kiji DistilBERT backend
+      --safety-net-timeout-ms <SAFETY_NET_TIMEOUT_MS>
+          Safety-net subprocess timeout in milliseconds [default: 5000]
+      --safety-net-input-limit-bytes <SAFETY_NET_INPUT_LIMIT_BYTES>
+          Maximum clean-text bytes submitted to the safety net [default: 1048576]
+      --safety-net-mode <SAFETY_NET_MODE>
+          Safety-net handling mode for suspected leaks [default: resolve] [possible values: strict, tolerant, redact, resolve]
+      --safety-net-fallback <SAFETY_NET_FALLBACK>
+          Fallback when safety-net resolve or redact cannot complete [default: redact] [possible values: strict, tolerant, redact]
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/document-clean.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/document-clean.txt
@@ -1,0 +1,12 @@
+Run OCR + Gaze redact on `<input>` and split agent-safe files from owner restore material
+
+Usage: gaze document clean [OPTIONS] <--out <OUT>|--agent-out <AGENT_OUT>> <INPUT>
+
+Arguments:
+  <INPUT>  Source file. Must be `.png`, `.jpg`, `.jpeg`, or `.pdf` (single-page)
+
+Options:
+      --out <OUT>              Convenience output root. Creates `<PATH>/agent` and `<PATH>/owner`
+      --agent-out <AGENT_OUT>  Agent-visible output directory for `clean.md` and `report.json`
+      --owner-out <OWNER_OUT>  Owner-only output directory for `manifest.json`
+  -h, --help                   Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/document.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/document.txt
@@ -1,0 +1,13 @@
+Ingest a document (PNG/JPG/PDF) into a split SafeBundle.
+
+Requires the binary to be built with `--features document`.
+
+Usage: gaze document <COMMAND>
+
+Commands:
+  clean  Run OCR + Gaze redact on `<input>` and split agent-safe files from owner restore material
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/gaze-cli/tests/fixtures/cli-help/index-ingest.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/index-ingest.txt
@@ -1,0 +1,12 @@
+Ingest `.txt` and `.md` files into a local owner-side index
+
+Usage: gaze index ingest [OPTIONS] <DIR>
+
+Arguments:
+  <DIR>  Directory containing text/Markdown files
+
+Options:
+      --domain <DOMAIN>            Local index domain id [default: local_owner/docs/v1]
+      --index-path <INDEX_PATH>    Owner-side index directory. Defaults to `GAZE_INDEX_PATH` or `./.gaze-index/`
+      --on-residual <ON_RESIDUAL>  Safety-net fallback for residual suspects after resolver pass [default: redact] [possible values: redact, strict]
+  -h, --help                       Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/index-search.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/index-search.txt
@@ -1,0 +1,12 @@
+Search the local owner-side index by one entity
+
+Usage: gaze index search [OPTIONS] <ENTITY>
+
+Arguments:
+  <ENTITY>  Entity value to search for. It is tokenized before authorization/search
+
+Options:
+      --domain <DOMAIN>          Local index domain id [default: local_owner/docs/v1]
+      --class <CLASS>            Entity class: name, email, org, organization, or `custom:<name>`
+      --index-path <INDEX_PATH>  Owner-side index directory. Defaults to `GAZE_INDEX_PATH` or `./.gaze-index/`
+  -h, --help                     Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/index.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/index.txt
@@ -1,0 +1,19 @@
+Owner-side local text/Markdown index ingest and search.
+
+Requires the binary to be built with `--features index`.
+
+Usage: gaze index [OPTIONS] <COMMAND>
+
+Commands:
+  ingest  Ingest `.txt` and `.md` files into a local owner-side index
+  search  Search the local owner-side index by one entity
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --safety-net-timeout-ms <SAFETY_NET_TIMEOUT_MS>
+          Safety-net subprocess timeout in milliseconds
+          
+          [default: 5000]
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/gaze-cli/tests/fixtures/cli-help/mcp-bridge.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/mcp-bridge.txt
@@ -1,0 +1,10 @@
+Run the policy-gated MCP bridge over stdio
+
+Usage: gaze mcp bridge [OPTIONS] --config <CONFIG>
+
+Options:
+      --config <CONFIG>            Bridge TOML configuration
+      --session-dir <SESSION_DIR>  Override [session].dir from the config
+      --dry-run                    Load config and discover downstream surface without serving
+      --print-tools                Print namespaced downstream tools and denied resource/prompt counts
+  -h, --help                       Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/mcp-doctor.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/mcp-doctor.txt
@@ -1,0 +1,9 @@
+Diagnose MCP server dependencies and client configuration
+
+Usage: gaze mcp doctor [OPTIONS]
+
+Options:
+      --agents-md <AGENTS_MD>  Agent guidance file to check
+      --strict                 Exit non-zero when any warning is present
+      --json                   Emit machine-readable JSON
+  -h, --help                   Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/mcp-install.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/mcp-install.txt
@@ -1,0 +1,10 @@
+Install Gaze as an MCP stdio server in a supported client config
+
+Usage: gaze mcp install [OPTIONS] --client <CLIENT>
+
+Options:
+      --client <CLIENT>        Client config to update [possible values: claude-code, claude-desktop, cursor, all]
+      --agents-md <AGENTS_MD>  Agent guidance file to create/update
+      --dry-run                Print planned changes without writing files
+      --skip-agents-md         Skip the marker-fenced AGENTS.md skill section
+  -h, --help                   Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/mcp-serve.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/mcp-serve.txt
@@ -1,0 +1,8 @@
+Run the Gaze MCP stdio server
+
+Usage: gaze mcp serve [OPTIONS]
+
+Options:
+      --manifest-dir <MANIFEST_DIR>    Directory where MCP manifest call records are written
+      --max-file-size <MAX_FILE_SIZE>  Maximum file size accepted by `gaze_read_file`
+  -h, --help                           Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/mcp.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/mcp.txt
@@ -1,0 +1,16 @@
+Install, diagnose, or run the Gaze MCP stdio server.
+
+Requires the binary to be built with `--features mcp`.
+
+Usage: gaze mcp <COMMAND>
+
+Commands:
+  install  Install Gaze as an MCP stdio server in a supported client config
+  doctor   Diagnose MCP server dependencies and client configuration
+  serve    Run the Gaze MCP stdio server
+  bridge   Run the policy-gated MCP bridge over stdio
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-_dashboard-child.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-_dashboard-child.txt
@@ -1,0 +1,10 @@
+Internal dashboard child runtime
+
+Usage: gaze proxy _dashboard-child --bind-addr <BIND_ADDR> --ttl-secs <TTL_SECS> --max-events <MAX_EVENTS> --max-bytes <MAX_BYTES>
+
+Options:
+      --bind-addr <BIND_ADDR>    
+      --ttl-secs <TTL_SECS>      
+      --max-events <MAX_EVENTS>  
+      --max-bytes <MAX_BYTES>    
+  -h, --help                     Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-install-launchd.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-install-launchd.txt
@@ -1,0 +1,6 @@
+Install macOS launchd auto-start integration
+
+Usage: gaze proxy install-launchd
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-install-systemd-user.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-install-systemd-user.txt
@@ -1,0 +1,6 @@
+Install Linux systemd user auto-start integration
+
+Usage: gaze proxy install-systemd-user
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-logs.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-logs.txt
@@ -1,0 +1,7 @@
+Print proxy daemon logs
+
+Usage: gaze proxy logs [OPTIONS]
+
+Options:
+      --follow  
+  -h, --help    Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-restart.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-restart.txt
@@ -1,0 +1,8 @@
+Restart proxy daemon using persisted config
+
+Usage: gaze proxy restart [OPTIONS]
+
+Options:
+      --force              
+      --timeout <TIMEOUT>  [default: 10s]
+  -h, --help               Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-serve.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-serve.txt
@@ -1,0 +1,41 @@
+Run proxy in the foreground
+
+Usage: gaze proxy serve [OPTIONS]
+
+Options:
+      --bind <BIND>
+          [default: 127.0.0.1:8787]
+      --upstream-openai <UPSTREAM_OPENAI>
+          [default: https://api.openai.com]
+      --upstream-anthropic <UPSTREAM_ANTHROPIC>
+          [default: https://api.anthropic.com]
+      --upstream-gemini <UPSTREAM_GEMINI>
+          [default: https://generativelanguage.googleapis.com]
+      --policy <POLICY>
+          
+      --rulepack <RULEPACK>
+          [default: core]
+      --session-ttl <SESSION_TTL>
+          [default: 30m]
+      --dashboard
+          Launch the isolated memory-only inspection dashboard child
+      --dashboard-capture-owner-raw
+          Capture OwnerRaw payloads (requires the matching acknowledgement)
+      --dashboard-acknowledge-owner-raw-risk
+          Acknowledge that OwnerRaw capture exposes PII to the dashboard TCB
+      --dashboard-capture-owner-restored
+          Capture OwnerRestored payloads (requires the matching acknowledgement)
+      --dashboard-acknowledge-owner-restored-risk
+          Acknowledge that OwnerRestored capture exposes re-identified text
+      --dashboard-bind <DASHBOARD_BIND>
+          Literal loopback dashboard bind with port 0 (default: fresh CSPRNG 127/8 origin)
+      --dashboard-ttl <DASHBOARD_TTL>
+          Dashboard retention TTL such as `5m` (crate-ceiling capped)
+      --dashboard-max-events <DASHBOARD_MAX_EVENTS>
+          Dashboard retained logical-event cap (crate-ceiling capped)
+      --dashboard-max-bytes <DASHBOARD_MAX_BYTES>
+          Dashboard retained byte cap (crate-ceiling capped)
+      --dashboard-pairing-fd <DASHBOARD_PAIRING_FD>
+          Inherited FIFO descriptor for noninteractive pairing-token delivery
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-start.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-start.txt
@@ -1,0 +1,41 @@
+Start proxy as a detached daemon
+
+Usage: gaze proxy start [OPTIONS]
+
+Options:
+      --bind <BIND>
+          
+      --upstream-openai <UPSTREAM_OPENAI>
+          
+      --upstream-anthropic <UPSTREAM_ANTHROPIC>
+          
+      --upstream-gemini <UPSTREAM_GEMINI>
+          
+      --policy <POLICY>
+          
+      --rulepack <RULEPACK>
+          
+      --session-ttl <SESSION_TTL>
+          
+      --dashboard
+          Launch the isolated memory-only inspection dashboard child (relayed to the daemon)
+      --dashboard-capture-owner-raw
+          Capture OwnerRaw payloads (requires the matching acknowledgement)
+      --dashboard-acknowledge-owner-raw-risk
+          Acknowledge that OwnerRaw capture exposes PII to the dashboard TCB
+      --dashboard-capture-owner-restored
+          Capture OwnerRestored payloads (requires the matching acknowledgement)
+      --dashboard-acknowledge-owner-restored-risk
+          Acknowledge that OwnerRestored capture exposes re-identified text
+      --dashboard-bind <DASHBOARD_BIND>
+          Literal loopback dashboard bind with port 0 (default: fresh CSPRNG 127/8 origin)
+      --dashboard-ttl <DASHBOARD_TTL>
+          Dashboard retention TTL such as `5m` (crate-ceiling capped)
+      --dashboard-max-events <DASHBOARD_MAX_EVENTS>
+          Dashboard retained logical-event cap (crate-ceiling capped)
+      --dashboard-max-bytes <DASHBOARD_MAX_BYTES>
+          Dashboard retained byte cap (crate-ceiling capped)
+      --dashboard-pairing-fd <DASHBOARD_PAIRING_FD>
+          Inherited FIFO descriptor for noninteractive pairing-token delivery
+  -h, --help
+          Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-status.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-status.txt
@@ -1,0 +1,6 @@
+Show proxy daemon status
+
+Usage: gaze proxy status
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-stop.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-stop.txt
@@ -1,0 +1,8 @@
+Stop the detached proxy daemon
+
+Usage: gaze proxy stop [OPTIONS]
+
+Options:
+      --force              
+      --timeout <TIMEOUT>  [default: 10s]
+  -h, --help               Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-uninstall-launchd.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-uninstall-launchd.txt
@@ -1,0 +1,6 @@
+Uninstall macOS launchd auto-start integration
+
+Usage: gaze proxy uninstall-launchd
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy-uninstall-systemd-user.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy-uninstall-systemd-user.txt
@@ -1,0 +1,6 @@
+Uninstall Linux systemd user auto-start integration
+
+Usage: gaze proxy uninstall-systemd-user
+
+Options:
+  -h, --help  Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/proxy.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/proxy.txt
@@ -1,0 +1,22 @@
+Run or manage the Gaze LLM proxy.
+
+Requires the binary to be built with `--features proxy`.
+
+Usage: gaze proxy <COMMAND>
+
+Commands:
+  serve                   Run proxy in the foreground
+  start                   Start proxy as a detached daemon
+  stop                    Stop the detached proxy daemon
+  status                  Show proxy daemon status
+  logs                    Print proxy daemon logs
+  restart                 Restart proxy daemon using persisted config
+  install-launchd         Install macOS launchd auto-start integration
+  uninstall-launchd       Uninstall macOS launchd auto-start integration
+  install-systemd-user    Install Linux systemd user auto-start integration
+  uninstall-systemd-user  Uninstall Linux systemd user auto-start integration
+  help                    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/gaze-cli/tests/fixtures/cli-help/restore.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/restore.txt
@@ -1,0 +1,12 @@
+Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout
+
+Usage: gaze restore [OPTIONS]
+
+Options:
+      --format <FORMAT>              Output format. Only `json` is supported today [default: json]
+      --restore-mode <RESTORE_MODE>  Unknown-token handling during restore [default: strict] [possible values: strict, tolerant]
+      --policy <RESTORE_POLICY>      Alias for `--restore-mode` used by restore-boundary telemetry [possible values: strict, tolerant]
+      --telemetry                    Emit restore telemetry in the JSON response
+      --audit-db <AUDIT_DB>          Optional SQLite redaction-log database path for restore telemetry rows
+      --max-bytes <MAX_BYTES>        Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge [default: 10485760]
+  -h, --help                         Print help

--- a/crates/gaze-cli/tests/fixtures/cli-help/root.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/root.txt
@@ -1,0 +1,19 @@
+Channel-agnostic PII redaction for LLM pipes
+
+Usage: gaze <COMMAND>
+
+Commands:
+  clean     Read raw text from stdin; emit `{clean_text, session_blob, stats}` JSON to stdout
+  daemon    Run a long-lived JSON-lines stdio cleaning daemon
+  restore   Read `{session_blob, text}` JSON from stdin; emit `{text}` JSON to stdout
+  audit     Query, export, or maintain redaction-log metadata without reading raw PII payloads
+  setup     Install the pinned local model, write a working policy, and run a doctor check
+  document  Ingest a document (PNG/JPG/PDF) into a split SafeBundle
+  index     Owner-side local text/Markdown index ingest and search
+  mcp       Install, diagnose, or run the Gaze MCP stdio server
+  proxy     Run or manage the Gaze LLM proxy
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version

--- a/crates/gaze-cli/tests/fixtures/cli-help/setup.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/setup.txt
@@ -1,0 +1,26 @@
+Install the pinned local model, write a working policy, and run a doctor check.
+
+Requires the binary to be built with `--features setup`.
+
+Usage: gaze setup [OPTIONS]
+
+Options:
+      --safety-net <SAFETY_NET>
+          Safety-net setup path. Defaults to NER; OPF verifies an existing `opf download` checkpoint when available
+          
+          [possible values: ner, opf]
+
+      --policy-out <POLICY_OUT>
+          Policy TOML output path. Defaults to ./gaze.toml
+
+      --model-dir <MODEL_DIR>
+          Model install directory. Defaults to $XDG_DATA_HOME/gaze/models/kiji-distilbert
+
+      --non-interactive
+          Use defaults without prompts
+
+      --force
+          Overwrite an existing policy file
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,3 +26,9 @@ repository root.
 | `scripts/bench/onnx-token-classification-runner.py` | Generic ONNX Runtime token-classification subprocess wrapper. | NER leaderboard and warm-latency scripts. |
 | `scripts/bench/transformers-runner.py` | Generic Hugging Face transformers NER subprocess wrapper. | NER leaderboard scorer. |
 | `scripts/bench/quantize-kiji-int8.py` | Quantizes an already-fetched Kiji ONNX bundle to int8 and writes checksums. | Operators and Kiji benchmark setup. |
+
+## Verify
+
+| Script | What it does | Who calls it |
+|---|---|---|
+| `scripts/verify/cli-help-surface.sh` | Builds `gaze` at a base revision and at the working tree in one run and diffs `--help` for the root command and every subcommand, so a CLI refactor can be shown not to have moved the published surface. Refreshes `crates/gaze-cli/tests/fixtures/cli-help/` with `--write-fixtures`. | Anyone refactoring `gaze-cli` argument parsing, and reviewers checking that claim. |

--- a/scripts/verify/cli-help-surface.sh
+++ b/scripts/verify/cli-help-surface.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Prove that a `gaze` CLI refactor left the user-facing surface unchanged.
+#
+# Builds the `gaze` binary at a BASE revision and at the current working tree,
+# captures `--help` for the root command and every reachable subcommand from
+# BOTH binaries in the same run, and diffs them. The comparison is always
+# before-vs-after; it is never against a checked-in constant, so the harness
+# cannot go stale and cannot pass because someone refreshed a golden file.
+#
+#   scripts/verify/cli-help-surface.sh                 # base = merge-base with origin/main
+#   scripts/verify/cli-help-surface.sh --base <rev>    # explicit base revision
+#   scripts/verify/cli-help-surface.sh --write-fixtures # refresh the committed capture
+#
+# Exit 0 = surfaces identical. Exit 1 = a diff (printed). Exit 2 = harness error.
+#
+# Known blind spot: `--help` does not render hidden commands or hidden args.
+# HIDDEN_PATHS below names the hidden command paths explicitly; hidden *args*
+# (for example `proxy serve --_foreground-daemon`) are covered instead by the
+# clap-model parity tests in crates/gaze-cli/src/commands/mod.rs.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE_DIR="${REPO_ROOT}/crates/gaze-cli/tests/fixtures/cli-help"
+FEATURES="--all-features"
+
+# Hidden command paths, captured explicitly because they never appear under
+# `Commands:` in help output. Space-separated argv, one path per line.
+HIDDEN_PATHS=(
+  "proxy _dashboard-child"
+)
+
+die() { printf 'cli-help-surface: %s\n' "$*" >&2; exit 2; }
+
+BASE_REV=""
+WRITE_FIXTURES=0
+OUT_DIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE_REV="${2:-}"; shift 2 || die "--base needs a revision" ;;
+    --out) OUT_DIR="${2:-}"; shift 2 || die "--out needs a directory" ;;
+    --write-fixtures) WRITE_FIXTURES=1; shift ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v cargo >/dev/null 2>&1 || die "cargo not on PATH"
+cd "$REPO_ROOT" || die "cannot cd to repo root"
+
+if [ -z "$BASE_REV" ]; then
+  BASE_REV="$(git merge-base HEAD origin/main 2>/dev/null)" \
+    || die "cannot resolve a base revision; pass --base <rev>"
+fi
+BASE_SHA="$(git rev-parse --verify "${BASE_REV}^{commit}" 2>/dev/null)" \
+  || die "not a commit: ${BASE_REV}"
+
+WORK_DIR="${OUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/gaze-cli-help.XXXXXX")}"
+mkdir -p "${WORK_DIR}/before" "${WORK_DIR}/after" || die "cannot create ${WORK_DIR}"
+BASE_TREE="${WORK_DIR}/base-tree"
+
+cleanup() {
+  if [ -d "$BASE_TREE" ]; then
+    git -C "$REPO_ROOT" worktree remove --force "$BASE_TREE" >/dev/null 2>&1
+  fi
+}
+trap cleanup EXIT
+
+# Capture root + every reachable subcommand's help into $2, using binary $1.
+# Subcommands are discovered from the help text itself, so a newly added verb
+# is picked up without editing this script.
+capture_all() {
+  local bin="$1" dest="$2"
+  local -a queue=("")
+  local path slug out
+
+  while [ ${#queue[@]} -gt 0 ]; do
+    path="${queue[0]}"
+    queue=("${queue[@]:1}")
+
+    if [ -z "$path" ]; then slug="root"; else slug="$(printf '%s' "$path" | tr ' ' '-')"; fi
+    # shellcheck disable=SC2086
+    out="$("$bin" $path --help 2>&1)" || die "'gaze $path --help' failed"
+    printf '%s\n' "$out" > "${dest}/${slug}.txt"
+
+    # Children are the first token of each indented line in the Commands: block.
+    while IFS= read -r child; do
+      [ -n "$child" ] || continue
+      case "$child" in help) continue ;; esac
+      if [ -z "$path" ]; then queue+=("$child"); else queue+=("$path $child"); fi
+    done < <(printf '%s\n' "$out" | awk '
+      /^Commands:/ { inblock = 1; next }
+      inblock && /^[A-Za-z]+:/ { inblock = 0 }
+      inblock && /^  [a-zA-Z_]/ { print $1 }
+    ')
+  done
+
+  for path in "${HIDDEN_PATHS[@]}"; do
+    slug="$(printf '%s' "$path" | tr ' ' '-')"
+    # shellcheck disable=SC2086
+    out="$("$bin" $path --help 2>&1)" || die "'gaze $path --help' (hidden) failed"
+    printf '%s\n' "$out" > "${dest}/${slug}.txt"
+  done
+}
+
+build_and_capture() {
+  local tree="$1" dest="$2" label="$3" target_dir="$4" log bin
+  log="${WORK_DIR}/build-${label}.log"
+  printf 'cli-help-surface: building %s (%s)\n' "$label" "$tree" >&2
+  # NOTE: exit status is captured on the very next line; never pipe cargo into
+  # tail here, because the pipeline status would be tail's, not cargo's.
+  ( cd "$tree" && CARGO_TARGET_DIR="$target_dir" cargo build -p gaze-cli ${FEATURES} --bin gaze ) >"$log" 2>&1
+  local status=$?
+  if [ "$status" -ne 0 ]; then
+    tail -30 "$log" >&2
+    die "build failed for ${label} (see ${log})"
+  fi
+  bin="${target_dir}/debug/gaze"
+  [ -x "$bin" ] || die "no binary at ${bin}"
+  capture_all "$bin" "$dest"
+}
+
+git worktree add --detach "$BASE_TREE" "$BASE_SHA" >/dev/null 2>&1 \
+  || die "cannot create a worktree at ${BASE_SHA}"
+
+build_and_capture "$BASE_TREE" "${WORK_DIR}/before" "before-${BASE_SHA:0:12}" "${WORK_DIR}/target-before"
+build_and_capture "$REPO_ROOT" "${WORK_DIR}/after" "after-working-tree" "${WORK_DIR}/target-after"
+
+printf '\ncli-help-surface: base %s\n' "$BASE_SHA"
+printf 'cli-help-surface: captures in %s\n' "$WORK_DIR"
+
+if diff -ru "${WORK_DIR}/before" "${WORK_DIR}/after" > "${WORK_DIR}/help.diff" 2>&1; then
+  printf 'cli-help-surface: PASS — %s help captures byte-identical before and after\n' \
+    "$(find "${WORK_DIR}/after" -name '*.txt' | wc -l | tr -d ' ')"
+  result=0
+else
+  printf 'cli-help-surface: FAIL — the CLI help surface changed:\n\n'
+  cat "${WORK_DIR}/help.diff"
+  result=1
+fi
+
+if [ "$WRITE_FIXTURES" -eq 1 ] && [ "$result" -eq 0 ]; then
+  mkdir -p "$FIXTURE_DIR"
+  rm -f "${FIXTURE_DIR}"/*.txt
+  cp "${WORK_DIR}"/after/*.txt "$FIXTURE_DIR"/
+  printf 'cli-help-surface: refreshed fixtures in %s\n' "$FIXTURE_DIR"
+elif [ "$WRITE_FIXTURES" -eq 1 ]; then
+  printf 'cli-help-surface: fixtures NOT refreshed; the surface diff above must be resolved first\n'
+fi
+
+exit "$result"


### PR DESCRIPTION
Audit 7201 finding **S11-F1**: `gaze-cli` declared the same flag lists in several places at once, so a flag could be added on one subcommand and go missing on a sibling with nothing to catch it.

Resolves solo todo #3003
Resolves solo todo #2368

## What changed

Each shared flag group is now declared once and pulled in with `#[command(flatten)]`.

| Mirror | Before | After |
|---|---|---|
| `clean` flags | inline in `Cmd::Clean` + 33-field destructure + 33-field restructure + `clean::Args` | `clean::Args` derives `clap::Args`; `dispatch` is `Cmd::Clean { args } => clean::run(args)` |
| `daemon` flags | inline in `Cmd::Daemon` + 23-field destructure + 23-field restructure + `daemon::Args` | `daemon::Args` derives `clap::Args`; same one-line dispatch |
| OpenAI-filter subprocess flags (3) | declared in both verbs | `shared_args::OpenAiFilterSubprocessArgs`, flattened into both |
| Safety-net budget flags (4) | declared in both verbs | `shared_args::SafetyNetLimitArgs`, flattened into both |
| Dashboard flags (9) | two byte-identical 31-line blocks in `proxy serve` / `proxy start` + two 10-field hand mappings | `proxy_dashboard::DashboardArgs` derives `clap::Args`, flattened into both |

Non-test source in `crates/gaze-cli/src/commands/` goes from 2,459 to 2,279 lines (−180); `dispatch` alone loses 118.

The shared safety-net group is the one that matters for axis 1: `--safety-net-timeout-ms`, `--safety-net-input-limit-bytes`, `--safety-net-mode`, `--safety-net-fallback` decide what happens to a suspected residual leak, so a verb that quietly lost one would run a weaker Pass-3 safety net than its sibling under the same policy. That parity is now structural.

## Evidence: the CLI surface did not move

`scripts/verify/cli-help-surface.sh` builds `gaze` at a base revision **and** at the working tree **in one run**, captures `--help` for the root command and every reachable subcommand from both binaries, and diffs them against each other. It never compares against a checked-in constant, so it cannot pass because someone refreshed a golden file.

```
$ scripts/verify/cli-help-surface.sh --base 3878c5f
cli-help-surface: base 3878c5f9e58604a20b4cbadedc8114a17b155238
cli-help-surface: PASS — 33 help captures byte-identical before and after
```

The 33 captures are committed under `crates/gaze-cli/tests/fixtures/cli-help/` so a reviewer can read the surface without a two-revision build, and `crates/gaze-cli/tests/cli_help_surface.rs` (`#[ignore]`d) checks the running binary against them.

**The harness is calibrated in both directions, in this branch's history of runs:**

| Run | Result |
|---|---|
| Injected a throwaway `--calibration-probe-flag` on `daemon` | FAIL, diff named exactly that flag |
| Real regression: explicit clap `id` changed `<DASHBOARD_BIND>` to `<dashboard_bind>` | FAIL, diff named all five placeholders |
| Final state | PASS, 33/33 byte-identical |

`--write-fixtures` only writes when the diff is empty, so a rejected surface change cannot be blessed into the fixture.

## A real bug this refactor surfaced (and fixed before landing)

**Clap identifies an argument by its Rust field name, not its `--long` name.** `DashboardArgs` has `bind: Option<SocketAddrV4>` (`--dashboard-bind`); `ProxyCmd::Serve` has `bind: SocketAddr` (`--bind`). Flattening put two args with id `bind` into one command. Clap merged them silently: `--bind` lost its `127.0.0.1:8787` default and `--help` stopped working on both proxy verbs. Nothing in the type system catches this.

Fixed by pinning `id` explicitly on all nine dashboard args (and `value_name`, because an explicit id is used verbatim as the help placeholder). Guarded by `no_command_has_two_arguments_sharing_an_id`, which walks every command and asserts no duplicate ids.

## Per-subcommand flag inventory

No subcommand gained or lost a flag. Full `--help` captures are in `crates/gaze-cli/tests/fixtures/cli-help/`.

The pre-existing divergence between `clean` and `daemon` is unchanged and now pinned in both directions by `clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set`:

- **On `clean`, not on `daemon` (13):** `--context-json`, `--format`, `--kiji-distilbert-precision`, `--max-bytes`, `--opf-checkpoint`, `--opf-command`, `--opf-locales`, `--rulepack-bundled`, `--rulepack-path`, `--safety-net-add`, `--safety-net-registry`, `--session-scope`, `--session-ttl`
- **On `daemon`, not on `clean` (3):** `--idle-timeout`, `--session-cap`, `--session-idle-timeout`

### The gap `clean`-only leaves on `daemon` — reported, not changed here

`gaze daemon` cannot enable the locale-aware multi-backend safety-net registry, cannot select int8 Kiji precision, and takes no rulepack overrides; `daemon.rs::clean_options` hardcodes `safety_net_registry: false`, `safety_net_add: &[]`, `rulepack_*: empty`, and `kiji_distilbert_precision: Fp32`. Under the same policy the daemon chokepoint runs a strictly weaker Pass-3 configuration than `clean`, with no flag to ask for the stronger one. Same family as S11-F2's proxy gap. Filed as solo todo #3004; whether the daemon should gain any of these is a product decision, not a refactor.

**It is not a silent-ignore leak.** Clap rejects the unknown flag and the daemon fails closed. Verified with a calibrated probe (known-accept, known-reject, case under test):

| Command | Result |
|---|---|
| `clean --policy p.toml --safety-net-registry` | accepted, then a policy error **with** `detail` |
| `clean --policy p.toml --totally-bogus` | `{"error":"PolicyConfig","exit":2}`, **no** `detail` |
| `daemon --policy p.toml --safety-net-registry` | `{"error":"PolicyConfig","exit":2}`, **no** `detail` |
| `daemon --policy p.toml` | policy error **with** `detail` |

The secondary finding is diagnosability: `main.rs` routes every clap parse error to `CliError::PolicyConfig` with no flag name (deliberate — clap's default handler echoes raw argv, and argv can carry PII), so "this verb has no such flag" is indistinguishable from "your policy is broken" except by the missing `detail`. Also covered by #3004.

## Vacuity checks

Every new test was mutated to RED, then reverted, **rebuilt**, and re-run green.

| Test | Mutation | Under mutation |
|---|---|---|
| `no_command_has_two_arguments_sharing_an_id` | dropped `id = "dashboard_bind"` | RED: ``` `gaze proxy serve` declares `bind` 2 times; `gaze proxy start` declares `bind` 2 times ``` |
| `shared_safety_net_groups_reach_both_clean_and_daemon` | `daemon`'s `#[command(flatten)] openai_filter` to `#[arg(skip)]` | RED: `` `gaze daemon` is missing --openai-filter-checkpoint `` |
| `clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set` | added `--mutation-probe` to `daemon` | RED: `left: {"idle-timeout", "mutation-probe", ...}` |
| `help_output_matches_the_committed_capture` | edited `--policy` help prose on `daemon` | RED: `daemon: help differs from the committed capture` |
| `scripts/verify/cli-help-surface.sh` | added `--calibration-probe-flag` to `daemon` | FAIL with the exact diff |

After each revert the file was byte-compared against a pre-mutation copy before the green re-run, so no mutation residue survives.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean (repo-canonical line, verbatim)
- `cargo test --workspace --all-features` — see checks
- `cargo test -p gaze-cli --all-features --test cli_pipe` — the suite that pins CLI behaviour
- `scripts/verify/cli-help-surface.sh --base 3878c5f` — PASS, 33/33

## Deliberately not done

- **No flag added to any subcommand.** Closing the daemon gap is #3004.
- **Divergent help prose left alone.** Eight flags shared by `clean` and `daemon` describe themselves differently (`--kiji-backend`, `--openai-filter-device`, `--kiji-distilbert-model-dir`, `--kiji-distilbert-locales`, `--safety-net-backend`, and the three `--ner-*` flags, which differ only in `\[ner]` vs `\[ner\]` escaping). Converging them would let those flags join the shared structs, but it changes published help text, so it is out of a surface-preserving refactor.
- **`audit query` / `audit export` mirror 12 filter flags** the same way. Not part of S11-F1; filed as #3005 with the clap-id trap written down.

## Reviewer follow-up: solo todo #3006 (harness blind spot, recorded not papered over)

Independent review of this PR found a blind spot in the new harness that the harness's own header comment does not describe accurately. `scripts/verify/cli-help-surface.sh` says hidden *args* "are covered instead by the clap-model parity tests in `crates/gaze-cli/src/commands/mod.rs`". Those parity tests compare only the `clean`/`daemon` **pair**, so a hidden arg added to `proxy serve` — or added to `clean` and `daemon` at the same time — is pinned by nothing.

Demonstrated at this head: adding a real `#[arg(long = "kk-hidden-probe", hide = true)]` flag to `ProxyCmd::Serve` leaves `scripts/verify/cli-help-surface.sh` reporting `PASS — 33 help captures byte-identical` **and** the whole `gaze-cli` suite green, while `proxy serve` goes from rejecting that flag (`PolicyConfig`/exit 2) to accepting it (`PolicyOpen`/exit 4).

This does not weaken the claim this PR actually makes. The published `--help` surface is unchanged — independently re-verified at 33/33 byte-identical, with the committed fixtures byte-identical to freshly built captures — and the hidden surface is byte-identical on `3878c5f` and `a6a6457` (one hidden arg `--_foreground-daemon`, one hidden command `_dashboard-child` on both), so nothing in this PR walks through the gap. A new instrument with a known blind spot, honestly scoped, beats no instrument, provided the blind spot is recorded.

Filed as **solo todo #3006**: reword the comment so it stops claiming coverage it lacks, and add a both-directions hidden-surface pin vacuity-checked with the mutation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk6GN9NsN377qtNZFCyteY

