### PR TITLE
fix(daemon): let the daemon chokepoint run the safety-net registry `clean` can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gaze daemon` gained the eight safety-net and detection-surface flags only
+  `gaze clean` accepted** (#446): `--safety-net-registry`, `--safety-net-add`,
+  `--opf-locales`, `--opf-command`, `--opf-checkpoint`,
+  `--kiji-distilbert-precision`, `--rulepack-bundled`, and `--rulepack-path`.
+  None of these has a policy.toml equivalent — `gaze::Policy` carries no
+  safety-net section — so under an identical policy the daemon chokepoint could
+  previously only ever run a *single* Pass-3 backend, never the locale-aware
+  multi-backend registry, with no configuration able to reach the stronger
+  setup. The daemon now refuses a document whose locale no registered backend
+  covers, where a single backend would scan it with a model that does not cover
+  it and report nothing. This was a capability gap, not a leak: the flags were
+  rejected by clap and the daemon failed closed, so nothing was silently
+  ignored. The five flags `clean` still has that `daemon` does not
+  (`--format`, `--max-bytes`, `--context-json`, `--session-scope`,
+  `--session-ttl`) are deliberate and each is justified where its value is set.
+
 - **`gaze_proxy::ProxyConfig::with_dictionaries` installs one immutable
   dictionary source for every proxy detection pass.** Omitting the builder keeps
   the existing empty-bundle default. `ProxyConfig` was already

--- a/crates/gaze-cli/src/commands/clean.rs
+++ b/crates/gaze-cli/src/commands/clean.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 
 use clap::Args as ClapArgs;
 
-use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
-use super::{
-    KijiBackend, KijiDistilbertPrecision, OpenAiFilterDevice, SafetyNetBackend, SafetyNetKind,
+use super::shared_args::{
+    KijiPrecisionArgs, OpenAiFilterSubprocessArgs, OpfRegistryArgs, RulepackOverrideArgs,
+    SafetyNetLimitArgs, SafetyNetRegistryArgs,
 };
+use super::{KijiBackend, OpenAiFilterDevice, SafetyNetBackend, SafetyNetKind};
 use crate::error::CliError;
 use crate::io::DEFAULT_MAX_BYTES;
 use crate::pipeline::{run_clean, CleanOptions};
@@ -41,12 +42,8 @@ pub(crate) struct Args {
     /// Override policy \[ner].locale.
     #[arg(long)]
     pub(crate) ner_locale: Option<String>,
-    /// Override policy.rulepacks.bundled. Comma-separated and repeatable.
-    #[arg(long, value_delimiter = ',')]
-    pub(crate) rulepack_bundled: Vec<String>,
-    /// Override policy.rulepacks.paths. Repeatable.
-    #[arg(long = "rulepack-path")]
-    pub(crate) rulepack_paths: Vec<PathBuf>,
+    #[command(flatten)]
+    pub(crate) rulepacks: RulepackOverrideArgs,
     /// Max stdin size in bytes. stdin longer than this exits 1 InputTooLarge.
     #[arg(long, default_value_t = DEFAULT_MAX_BYTES)]
     pub(crate) max_bytes: u64,
@@ -64,12 +61,8 @@ pub(crate) struct Args {
     /// Pass-3 backend without re-typing the legacy `--safety-net` value.
     #[arg(long, value_enum)]
     pub(crate) safety_net_backend: Option<SafetyNetBackend>,
-    /// Enable locale-aware Pass-3 safety-net registry dispatch.
-    #[arg(long)]
-    pub(crate) safety_net_registry: bool,
-    /// Add one backend to the locale-aware safety-net registry. Repeatable.
-    #[arg(long, value_enum)]
-    pub(crate) safety_net_add: Vec<SafetyNetBackend>,
+    #[command(flatten)]
+    pub(crate) safety_net_registry: SafetyNetRegistryArgs,
     #[command(flatten)]
     pub(crate) openai_filter: OpenAiFilterSubprocessArgs,
     /// Device selection for the OpenAI safety-net subprocess (auto|cpu|cuda|mps). Default: auto (let opf decide).
@@ -78,18 +71,10 @@ pub(crate) struct Args {
     /// Kiji DistilBERT runtime backend. Default: subprocess for compatibility.
     #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
     pub(crate) kiji_backend: KijiBackend,
-    /// Kiji DistilBERT ONNX precision. Default: fp32.
-    #[arg(long, value_enum, default_value_t = KijiDistilbertPrecision::Fp32)]
-    pub(crate) kiji_distilbert_precision: KijiDistilbertPrecision,
-    /// Locale list for the OpenAI Privacy Filter registry entry.
-    #[arg(long, value_delimiter = ',')]
-    pub(crate) opf_locales: Vec<String>,
-    /// Alias for --openai-filter-command in registry examples.
-    #[arg(long)]
-    pub(crate) opf_command: Option<PathBuf>,
-    /// Alias for --openai-filter-checkpoint in registry examples.
-    #[arg(long)]
-    pub(crate) opf_checkpoint: Option<PathBuf>,
+    #[command(flatten)]
+    pub(crate) kiji_precision: KijiPrecisionArgs,
+    #[command(flatten)]
+    pub(crate) opf_registry: OpfRegistryArgs,
     /// Path to the local Kiji DistilBERT subprocess command.
     #[arg(long)]
     pub(crate) kiji_distilbert_command: Option<PathBuf>,
@@ -114,24 +99,24 @@ pub(crate) fn run(args: Args) -> std::result::Result<(), CliError> {
         ner_threshold: args.ner_threshold,
         ner_model_dir: args.ner_model_dir,
         ner_locale: args.ner_locale.as_deref(),
-        rulepack_bundled: &args.rulepack_bundled,
-        rulepack_paths: args.rulepack_paths,
+        rulepack_bundled: &args.rulepacks.rulepack_bundled,
+        rulepack_paths: args.rulepacks.rulepack_paths,
         max_bytes: args.max_bytes,
         context_json: args.context_json.as_deref(),
         audit_db: args.audit_db.as_deref(),
         safety_net: args.safety_net,
         safety_net_backend: args.safety_net_backend,
-        safety_net_registry: args.safety_net_registry,
-        safety_net_add: &args.safety_net_add,
+        safety_net_registry: args.safety_net_registry.safety_net_registry,
+        safety_net_add: &args.safety_net_registry.safety_net_add,
         openai_filter_command: args.openai_filter.openai_filter_command.as_deref(),
         openai_filter_checkpoint: args.openai_filter.openai_filter_checkpoint.as_deref(),
         openai_filter_operating_point: args.openai_filter.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
-        kiji_distilbert_precision: args.kiji_distilbert_precision,
-        opf_locales: &args.opf_locales,
-        opf_command: args.opf_command.as_deref(),
-        opf_checkpoint: args.opf_checkpoint.as_deref(),
+        kiji_distilbert_precision: args.kiji_precision.kiji_distilbert_precision,
+        opf_locales: &args.opf_registry.opf_locales,
+        opf_command: args.opf_registry.opf_command.as_deref(),
+        opf_checkpoint: args.opf_registry.opf_checkpoint.as_deref(),
         kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
         kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
         kiji_distilbert_locales: &args.kiji_distilbert_locales,

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -377,9 +377,16 @@ fn clean_options(args: &Args) -> CleanOptions<'_> {
     CleanOptions {
         policy: Some(args.policy.as_path()),
         format: DAEMON_CLEAN_FORMAT,
-        // `[session].ttl_secs` and `[session].scope` in policy.toml, which is mandatory
-        // on `gaze daemon`. `None` here means "no CLI override", so the daemon operator
-        // still reaches both through the policy file. Deliberately not exposed as flags:
+        // Both are `[session]` keys in policy.toml, which is mandatory on `gaze daemon`,
+        // so `None` ("no CLI override") still leaves the operator able to set them.
+        //
+        // `session_ttl` additionally has no live consumer on this path: only `run_clean`
+        // passes it to `Session::from_policy_with_ttl_override`, while `ensure_session`
+        // builds every session with `Session::from_policy`, which supplies `None`. Adding
+        // a `--session-ttl` flag and wiring it only here would therefore be accepted and
+        // then silently ignored -- strictly worse than not offering it. Closing that gap
+        // means threading the override into `ensure_session`, not adding a flag.
+        //
         // `--session-ttl` would also read as governing the daemon's own session registry,
         // which `--session-idle-timeout` and `--session-cap` own instead.
         session_ttl: None,

--- a/crates/gaze-cli/src/commands/daemon.rs
+++ b/crates/gaze-cli/src/commands/daemon.rs
@@ -9,12 +9,16 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
+use super::shared_args::{
+    KijiPrecisionArgs, OpenAiFilterSubprocessArgs, OpfRegistryArgs, RulepackOverrideArgs,
+    SafetyNetLimitArgs, SafetyNetRegistryArgs,
+};
 use super::{
     KijiBackend, OpenAiFilterDevice, SafetyNetBackend, SafetyNetFallback, SafetyNetKind,
     SafetyNetMode,
 };
 use crate::error::CliError;
+use crate::io::DEFAULT_MAX_BYTES;
 use crate::pipeline::build::{map_policy_error, resolve_pipeline, validate_ner_threshold};
 use crate::pipeline::run::{
     clean_overrides_from_options, enforce_safety_net_mode, entry_class_to_string,
@@ -48,6 +52,8 @@ pub(crate) struct Args {
     /// v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins.
     #[arg(long, value_enum)]
     pub(crate) safety_net_backend: Option<SafetyNetBackend>,
+    #[command(flatten)]
+    pub(crate) safety_net_registry: SafetyNetRegistryArgs,
     /// Exit when stdin is idle for this many seconds.
     #[arg(long, default_value_t = default_process_idle_timeout_secs())]
     pub(crate) idle_timeout: u64,
@@ -73,6 +79,8 @@ pub(crate) struct Args {
     #[arg(long)]
     pub(crate) ner_locale: Option<String>,
     #[command(flatten)]
+    pub(crate) rulepacks: RulepackOverrideArgs,
+    #[command(flatten)]
     pub(crate) openai_filter: OpenAiFilterSubprocessArgs,
     /// Device selection for the OpenAI safety-net subprocess.
     #[arg(long, value_enum, default_value_t = OpenAiFilterDevice::Auto)]
@@ -80,6 +88,10 @@ pub(crate) struct Args {
     /// Kiji DistilBERT runtime backend.
     #[arg(long, value_enum, default_value_t = KijiBackend::Subprocess)]
     pub(crate) kiji_backend: KijiBackend,
+    #[command(flatten)]
+    pub(crate) kiji_precision: KijiPrecisionArgs,
+    #[command(flatten)]
+    pub(crate) opf_registry: OpfRegistryArgs,
     /// Path to the local Kiji DistilBERT subprocess command.
     #[arg(long)]
     pub(crate) kiji_distilbert_command: Option<PathBuf>,
@@ -206,7 +218,11 @@ impl Daemon {
             policy: loaded_policy,
             locale_chain: locale_chain.as_slice().to_vec(),
             dictionaries,
-            safety_net_active: args.safety_net.is_some(),
+            // Mirrors `run_clean`: the registry activates the Pass-3 safety net exactly
+            // as `--safety-net` does, so a registry-only daemon must map safety-net
+            // failures to their typed variant instead of a generic pipeline error.
+            safety_net_active: args.safety_net.is_some()
+                || args.safety_net_registry.safety_net_registry,
             safety_net_mode: args.safety_net_limits.safety_net_mode,
             safety_net_fallback: args.safety_net_limits.safety_net_fallback,
             logger,
@@ -342,34 +358,58 @@ impl Daemon {
     }
 }
 
+/// `CleanOptions::format` is read only by `require_json_format` inside `run_clean`.
+/// The daemon never calls `run_clean`: its wire format is the JSONL protocol written
+/// by `write_json_line` and is not selectable, which is why there is no `--format` on
+/// `gaze daemon`. The field is inert here, and set to the encoding the daemon does in
+/// fact emit rather than to an arbitrary string.
+const DAEMON_CLEAN_FORMAT: &str = "json";
+
+/// `CleanOptions::max_bytes` bounds `read_stdin_text`, which only `run_clean` calls.
+/// The daemon reads its own newline-delimited frames from stdin and never goes through
+/// that path, so the field is inert; bounding one daemon request is a protocol concern
+/// needing a typed over-limit response, which is not smuggled in here. It carries
+/// `clean`'s default rather than `u64::MAX` so that if a later change ever does route
+/// the daemon through this field it inherits a bound instead of an unbounded read.
+const DAEMON_CLEAN_MAX_BYTES: u64 = DEFAULT_MAX_BYTES;
+
 fn clean_options(args: &Args) -> CleanOptions<'_> {
     CleanOptions {
         policy: Some(args.policy.as_path()),
-        format: "json",
+        format: DAEMON_CLEAN_FORMAT,
+        // `[session].ttl_secs` and `[session].scope` in policy.toml, which is mandatory
+        // on `gaze daemon`. `None` here means "no CLI override", so the daemon operator
+        // still reaches both through the policy file. Deliberately not exposed as flags:
+        // `--session-ttl` would also read as governing the daemon's own session registry,
+        // which `--session-idle-timeout` and `--session-cap` own instead.
         session_ttl: None,
         session_scope: None,
         locale: &args.locale,
         ner_threshold: args.ner_threshold,
         ner_model_dir: args.ner_model_dir.clone(),
         ner_locale: args.ner_locale.as_deref(),
-        rulepack_bundled: &[],
-        rulepack_paths: Vec::new(),
-        max_bytes: u64::MAX,
+        rulepack_bundled: &args.rulepacks.rulepack_bundled,
+        rulepack_paths: args.rulepacks.rulepack_paths.clone(),
+        max_bytes: DAEMON_CLEAN_MAX_BYTES,
+        // A typed context envelope describes one document. The daemon serves many
+        // documents across many sessions from one process, so a process-wide
+        // `--context-json` would apply one document's context to every session's every
+        // request. That belongs in the per-request protocol frame, not in a flag.
         context_json: None,
         audit_db: args.audit_db.as_deref(),
         safety_net: args.safety_net,
         safety_net_backend: args.safety_net_backend,
-        safety_net_registry: false,
-        safety_net_add: &[],
+        safety_net_registry: args.safety_net_registry.safety_net_registry,
+        safety_net_add: &args.safety_net_registry.safety_net_add,
         openai_filter_command: args.openai_filter.openai_filter_command.as_deref(),
         openai_filter_checkpoint: args.openai_filter.openai_filter_checkpoint.as_deref(),
         openai_filter_operating_point: args.openai_filter.openai_filter_operating_point,
         openai_filter_device: args.openai_filter_device,
         kiji_backend: args.kiji_backend,
-        kiji_distilbert_precision: super::KijiDistilbertPrecision::Fp32,
-        opf_locales: &[],
-        opf_command: None,
-        opf_checkpoint: None,
+        kiji_distilbert_precision: args.kiji_precision.kiji_distilbert_precision,
+        opf_locales: &args.opf_registry.opf_locales,
+        opf_command: args.opf_registry.opf_command.as_deref(),
+        opf_checkpoint: args.opf_registry.opf_checkpoint.as_deref(),
         kiji_distilbert_command: args.kiji_distilbert_command.as_deref(),
         kiji_distilbert_model_dir: args.kiji_distilbert_model_dir.as_deref(),
         kiji_distilbert_locales: &args.kiji_distilbert_locales,

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -877,7 +877,10 @@ mod tests {
 
     use clap::{Args as ClapArgsTrait, Command, CommandFactory};
 
-    use super::shared_args::{OpenAiFilterSubprocessArgs, SafetyNetLimitArgs};
+    use super::shared_args::{
+        KijiPrecisionArgs, OpenAiFilterSubprocessArgs, OpfRegistryArgs, RulepackOverrideArgs,
+        SafetyNetLimitArgs, SafetyNetRegistryArgs,
+    };
     use super::*;
 
     /// Long flag names a subcommand accepts, hidden ones included.
@@ -976,6 +979,10 @@ mod tests {
         for group in [
             long_flags_of::<OpenAiFilterSubprocessArgs>(),
             long_flags_of::<SafetyNetLimitArgs>(),
+            long_flags_of::<SafetyNetRegistryArgs>(),
+            long_flags_of::<OpfRegistryArgs>(),
+            long_flags_of::<KijiPrecisionArgs>(),
+            long_flags_of::<RulepackOverrideArgs>(),
         ] {
             assert!(!group.is_empty(), "a shared group contributed no flags");
             for flag in &group {
@@ -990,10 +997,17 @@ mod tests {
     /// that a new flag landing on only one verb fails here, and so that closing
     /// one of these gaps has to update this list deliberately.
     ///
-    /// `daemon` cannot opt into the locale-aware safety-net registry, cannot
-    /// select int8 Kiji precision, and takes no rulepack overrides: passing any
-    /// of these to `gaze daemon` is rejected, not ignored (see solo todo for
-    /// the capability gap).
+    /// The safety-net half of this list was closed by solo todo #3004: `daemon`
+    /// now opts into the locale-aware registry, selects Kiji precision, and takes
+    /// rulepack overrides, because none of those have a policy.toml equivalent
+    /// and `daemon` could otherwise only ever run a single safety-net backend.
+    ///
+    /// What is left is deliberate, and each exclusion is justified where its
+    /// value is set in `daemon::clean_options`: `--format` and `--max-bytes`
+    /// configure `run_clean`'s stdio, which the daemon never uses;
+    /// `--context-json` is per-document and the daemon serves many documents per
+    /// process; `--session-scope` and `--session-ttl` are reachable through the
+    /// policy file, which is mandatory on `daemon`.
     #[test]
     fn clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set() {
         let clean = long_flags(&["clean"]);
@@ -1005,15 +1019,7 @@ mod tests {
         let expected_clean_only: BTreeSet<String> = [
             "context-json",
             "format",
-            "kiji-distilbert-precision",
             "max-bytes",
-            "opf-checkpoint",
-            "opf-command",
-            "opf-locales",
-            "rulepack-bundled",
-            "rulepack-path",
-            "safety-net-add",
-            "safety-net-registry",
             "session-scope",
             "session-ttl",
         ]

--- a/crates/gaze-cli/src/commands/shared_args.rs
+++ b/crates/gaze-cli/src/commands/shared_args.rs
@@ -15,7 +15,10 @@ use std::path::PathBuf;
 
 use clap::Args;
 
-use super::{OpenAiFilterOperatingPoint, SafetyNetFallback, SafetyNetMode};
+use super::{
+    KijiDistilbertPrecision, OpenAiFilterOperatingPoint, SafetyNetBackend, SafetyNetFallback,
+    SafetyNetMode,
+};
 
 /// OpenAI Privacy Filter subprocess location and operating point.
 ///
@@ -53,4 +56,71 @@ pub(crate) struct SafetyNetLimitArgs {
     /// Fallback when safety-net resolve or redact cannot complete.
     #[arg(long, value_enum, default_value_t = SafetyNetFallback::Redact)]
     pub(crate) safety_net_fallback: SafetyNetFallback,
+}
+
+/// Locale-aware Pass-3 safety-net registry activation.
+///
+/// Shared by `gaze clean` and `gaze daemon`. Safety-net backend selection has
+/// no policy.toml equivalent — [`gaze::Policy`] carries no safety-net section —
+/// so a verb without these flags cannot run the multi-backend registry under
+/// *any* configuration, only the single-backend path. That made the daemon
+/// chokepoint structurally weaker than `clean` under an identical policy
+/// (solo todo #3004), which is why this group is owned in one place.
+#[derive(Args, Debug)]
+pub(crate) struct SafetyNetRegistryArgs {
+    /// Enable locale-aware Pass-3 safety-net registry dispatch.
+    #[arg(long)]
+    pub(crate) safety_net_registry: bool,
+    /// Add one backend to the locale-aware safety-net registry. Repeatable.
+    #[arg(long, value_enum)]
+    pub(crate) safety_net_add: Vec<SafetyNetBackend>,
+}
+
+/// OpenAI Privacy Filter registry-entry configuration.
+///
+/// Shared by `gaze clean` and `gaze daemon`. `--opf-locales` is the only way to
+/// scope the OPF entry to a locale, so without it a registry is registered but
+/// cannot be made locale-aware — the whole point of registry dispatch. The two
+/// aliases keep a working `clean` registry command line valid when it is moved
+/// to `daemon`.
+#[derive(Args, Debug)]
+pub(crate) struct OpfRegistryArgs {
+    /// Locale list for the OpenAI Privacy Filter registry entry.
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) opf_locales: Vec<String>,
+    /// Alias for --openai-filter-command in registry examples.
+    #[arg(long)]
+    pub(crate) opf_command: Option<PathBuf>,
+    /// Alias for --openai-filter-checkpoint in registry examples.
+    #[arg(long)]
+    pub(crate) opf_checkpoint: Option<PathBuf>,
+}
+
+/// Kiji DistilBERT ONNX precision selection.
+///
+/// Shared by `gaze clean` and `gaze daemon`. Precision has no policy.toml
+/// equivalent either, so hardcoding it pinned the daemon to fp32 with no way to
+/// ask for the int8 build. One field, but owned here for the same reason as the
+/// groups above: a re-declaration on one verb only is how the two drift apart.
+#[derive(Args, Debug)]
+pub(crate) struct KijiPrecisionArgs {
+    /// Kiji DistilBERT ONNX precision. Default: fp32.
+    #[arg(long, value_enum, default_value_t = KijiDistilbertPrecision::Fp32)]
+    pub(crate) kiji_distilbert_precision: KijiDistilbertPrecision,
+}
+
+/// policy.toml rulepack overrides.
+///
+/// Shared by `gaze clean` and `gaze daemon`. Rulepacks decide which recognizers
+/// run, so this is a detection-surface control (axis 1). The override plumbing
+/// already reached the daemon through `clean_overrides_from_options`; only the
+/// flags were missing, leaving the wiring hardcoded to "no override".
+#[derive(Args, Debug)]
+pub(crate) struct RulepackOverrideArgs {
+    /// Override policy.rulepacks.bundled. Comma-separated and repeatable.
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) rulepack_bundled: Vec<String>,
+    /// Override policy.rulepacks.paths. Repeatable.
+    #[arg(long = "rulepack-path")]
+    pub(crate) rulepack_paths: Vec<PathBuf>,
 }

--- a/crates/gaze-cli/tests/daemon_smoke.rs
+++ b/crates/gaze-cli/tests/daemon_smoke.rs
@@ -902,3 +902,356 @@ fn daemonized_proxy_start_fails_closed_when_the_policy_cannot_be_loaded() {
         "a failed start must not leave the pidfile that bricks the next one"
     );
 }
+
+// ---------------------------------------------------------------------------
+// solo todo #3004: `gaze daemon` can run the locale-aware safety-net registry.
+//
+// Before #3004 `daemon.rs::clean_options` hardcoded `safety_net_registry: false`
+// and `safety_net_add: &[]`, and clap rejected the flags outright, so under an
+// identical policy the daemon chokepoint could only ever run a *single*
+// safety-net backend. `gaze::Policy` has no safety-net section, so there was no
+// second route to the stronger configuration either.
+//
+// These tests assert behaviour, not parsing: a flag that were accepted and then
+// ignored would be strictly worse than the honest rejection it replaces.
+// ---------------------------------------------------------------------------
+
+/// The Pass-3 safety-net subprocess budget, mirroring `safety_net_cli.rs`.
+fn safety_net_timeout_ms() -> String {
+    let seconds = std::env::var("GAZE_TEST_SUBPROCESS_TIMEOUT_SECS")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .expect("test subprocess timeout must be an integer")
+        })
+        .unwrap_or(60);
+    assert!(seconds > 0, "test subprocess timeout must be positive");
+    seconds.saturating_mul(1_000).to_string()
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+}
+
+/// A policy that tokenizes nothing in the fixtures below, so the daemon's
+/// `clean_text` is byte-identical to the request text and any difference is
+/// attributable to the Pass-3 safety net rather than to Pass-1 detection.
+fn write_preserve_default_policy() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("policy.toml");
+    fs::write(
+        &path,
+        r#"
+[session]
+scope = "persistent"
+ttl_secs = 86400
+
+[[rule]]
+kind = "default"
+action = "preserve"
+"#,
+    )
+    .unwrap();
+    (dir, path)
+}
+
+/// Drives one JSONL request through a `gaze daemon` started with `extra_args`
+/// and returns the single parsed response line.
+fn daemon_request(policy: &Path, extra_args: &[String], text: &str) -> (Value, Output) {
+    let mut child = Command::new(assert_cmd::cargo::cargo_bin("gaze"))
+        .args(["daemon", "--policy", policy.to_str().unwrap()])
+        .args(extra_args)
+        .args(["--idle-timeout", "30"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        let request = json!({ "session_id": "session-3004", "text": text });
+        writeln!(stdin, "{request}").unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout
+        .lines()
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "daemon produced no response line; stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+        .to_string();
+    let value: Value = serde_json::from_str(&line)
+        .unwrap_or_else(|err| panic!("daemon response is not JSON ({err}): {line}"));
+    (value, output)
+}
+
+/// An `opf` stand-in that reports nothing: a backend with no coverage for the
+/// text it is handed.
+fn write_blind_opf(dir: &Path) -> PathBuf {
+    let path = dir.join("blind-opf");
+    write_executable(&path, "#!/bin/sh\ncat >/dev/null\nprintf '[]\\n'\n");
+    path
+}
+
+fn opf_checkpoint(dir: &Path) -> PathBuf {
+    let path = dir.join("opf-checkpoint");
+    fs::create_dir(&path).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    path
+}
+
+/// Both registry entries are live inside one daemon process, and the daemon
+/// dispatches between them by locale.
+///
+/// The en-US request reaches the OPF entry (which answers, so the request
+/// succeeds); the de-DE request reaches the Kiji entry (whose model is a
+/// placeholder, so it fails closed). One backend could not produce both
+/// outcomes, which is what makes this a multi-backend proof rather than a
+/// parsing one.
+#[cfg(all(feature = "safety-net-openai", feature = "safety-net-kiji"))]
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemon_safety_net_registry_dispatches_between_two_backends_by_locale() {
+    let dir = tempdir().unwrap();
+    let opf = write_blind_opf(dir.path());
+    let checkpoint = opf_checkpoint(dir.path());
+    let kiji = dir.path().join("kiji");
+    write_executable(&kiji, "#!/bin/sh\nexit 91\n");
+    let model_dir = dir.path().join("kiji-distilbert");
+    fs::create_dir(&model_dir).unwrap();
+    for artifact in ["SHA256SUMS", "labels.json", "model.onnx", "tokenizer.json"] {
+        fs::write(model_dir.join(artifact), b"placeholder").unwrap();
+    }
+    let (_policy_dir, policy) = write_preserve_default_policy();
+
+    let registry_args = |locale: &str| -> Vec<String> {
+        vec![
+            format!("--locale={locale}"),
+            "--safety-net-registry".to_string(),
+            "--safety-net-add=openai-filter".to_string(),
+            "--safety-net-add=kiji-distilbert".to_string(),
+            format!("--safety-net-timeout-ms={}", safety_net_timeout_ms()),
+            format!("--opf-command={}", opf.display()),
+            format!("--opf-checkpoint={}", checkpoint.display()),
+            "--opf-locales=en-US,en-GB".to_string(),
+            format!("--kiji-distilbert-command={}", kiji.display()),
+            format!("--kiji-distilbert-model-dir={}", model_dir.display()),
+            "--kiji-distilbert-locales=de-DE,de-AT".to_string(),
+        ]
+    };
+
+    let (english, output) = daemon_request(&policy, &registry_args("en-US"), "hello there");
+    assert_eq!(
+        english["clean_text"],
+        "hello there",
+        "en-US must route to the OPF entry and answer: response={english}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        english.get("error").is_none(),
+        "en-US must not fail closed: {english}"
+    );
+
+    let (german, _output) = daemon_request(&policy, &registry_args("de-DE"), "hallo zusammen");
+    assert_eq!(
+        german["error"], "ModelUnavailable",
+        "de-DE must route to the Kiji entry and fail closed on its placeholder model: {german}"
+    );
+    assert!(
+        german.get("clean_text").is_none(),
+        "a failed-closed request must not answer with text: {german}"
+    );
+}
+
+/// The axis-1 contrast: same daemon, same policy, same document, same `opf`
+/// binary — the only difference is the capability #3004 adds.
+///
+/// A single backend has no locale gate: it scans every locale with one model,
+/// reports nothing for the locale it does not cover, and the document ships.
+/// The registry resolves by locale and refuses to hand on a document no
+/// registered backend covers.
+#[cfg(feature = "safety-net-openai")]
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemon_single_backend_ships_what_the_registry_refuses() {
+    let dir = tempdir().unwrap();
+    let opf = write_blind_opf(dir.path());
+    let checkpoint = opf_checkpoint(dir.path());
+    let (_policy_dir, policy) = write_preserve_default_policy();
+    let german = "Rueckfragen an Hanna Weber";
+
+    // What `gaze daemon` could do before #3004: one backend, no locale gate.
+    // `--safety-net-backend` only selects; `--safety-net` is what activates.
+    let single_backend = vec![
+        "--locale=de-DE".to_string(),
+        "--safety-net=openai-filter".to_string(),
+        "--safety-net-backend=openai-filter".to_string(),
+        format!("--safety-net-timeout-ms={}", safety_net_timeout_ms()),
+        format!("--openai-filter-command={}", opf.display()),
+        format!("--openai-filter-checkpoint={}", checkpoint.display()),
+    ];
+    let (shipped, output) = daemon_request(&policy, &single_backend, german);
+    assert_eq!(
+        shipped["clean_text"], german,
+        "the single-backend daemon ships the de-DE document unflagged: response={shipped}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // What #3004 makes reachable: locale-keyed dispatch that fails closed.
+    let registry = vec![
+        "--locale=de-DE".to_string(),
+        "--safety-net-registry".to_string(),
+        "--safety-net-add=openai-filter".to_string(),
+        format!("--safety-net-timeout-ms={}", safety_net_timeout_ms()),
+        format!("--opf-command={}", opf.display()),
+        format!("--opf-checkpoint={}", checkpoint.display()),
+        "--opf-locales=en-US".to_string(),
+    ];
+    let (refused, _output) = daemon_request(&policy, &registry, german);
+    assert_eq!(
+        refused["error"], "Unavailable",
+        "the registry must refuse a locale no registered backend covers: {refused}"
+    );
+    assert!(
+        refused.get("clean_text").is_none(),
+        "a refused request must not answer with text: {refused}"
+    );
+}
+
+/// The registry's findings reach the daemon's enforcement path.
+///
+/// Under the default `resolve` mode a residual-PII suspect is substituted out
+/// of the answer. Without the registry flags the identical daemon returns the
+/// same name verbatim, so this pins that the flags are acted on rather than
+/// accepted and dropped.
+#[cfg(feature = "safety-net-openai")]
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemon_safety_net_registry_finding_is_enforced_not_merely_parsed() {
+    let dir = tempdir().unwrap();
+    let checkpoint = opf_checkpoint(dir.path());
+    let text = "Freundliche Gruesse Hanna Weber";
+    let name = "Hanna Weber";
+    let start = text.find(name).expect("fixture contains the name");
+    let end = start + name.len();
+    let opf = dir.path().join("reporting-opf");
+    write_executable(
+        &opf,
+        &format!(
+            "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' \
+             '[{{\"label\":\"private_person\",\"start\":{start},\"end\":{end},\"score\":0.99}}]'\n"
+        ),
+    );
+    let (_policy_dir, policy) = write_preserve_default_policy();
+
+    let registry = vec![
+        "--locale=de-DE".to_string(),
+        "--safety-net-registry".to_string(),
+        "--safety-net-add=openai-filter".to_string(),
+        format!("--safety-net-timeout-ms={}", safety_net_timeout_ms()),
+        format!("--opf-command={}", opf.display()),
+        format!("--opf-checkpoint={}", checkpoint.display()),
+        "--opf-locales=de-DE".to_string(),
+    ];
+    let (caught, output) = daemon_request(&policy, &registry, text);
+    let clean_text = caught["clean_text"].as_str().unwrap_or_else(|| {
+        panic!(
+            "registry run must answer; response={caught}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert!(
+        !clean_text.contains(name),
+        "the registry reported the residual name, so it must not survive into the answer: {clean_text}"
+    );
+
+    // Same daemon, same document, registry flags withheld.
+    let (missed, output) = daemon_request(&policy, &["--locale=de-DE".to_string()], text);
+    assert_eq!(
+        missed["clean_text"], text,
+        "without the registry the identical daemon ships the name verbatim: response={missed}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The rulepack overrides #3004 added actually reach the daemon's detection
+/// surface: the plumbing already ran through `clean_overrides_from_options`,
+/// only the flags were missing, so the hardcoded empty override silently pinned
+/// the daemon to whatever the policy declared.
+#[test]
+#[file_serial(gaze_subprocess)]
+fn daemon_rulepack_override_changes_the_detection_surface() {
+    let (_dir, policy) = write_policy_with_es_locale_gated_path_rulepack();
+    let text = "id ES-TEST-123456";
+
+    // Baseline: the policy's path rulepack tokenizes the ES id.
+    let (baseline, output) = daemon_request(&policy, &["--locale=es-ES".to_string()], text);
+    let baseline_text = baseline["clean_text"].as_str().unwrap_or_else(|| {
+        panic!(
+            "baseline run must answer; response={baseline}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert!(
+        baseline_text.contains("Custom:es_test_id_"),
+        "the policy's path rulepack must tokenize the ES id: {baseline_text}"
+    );
+
+    // `--rulepack-path` replaces `policy.rulepacks.paths` wholesale, so pointing
+    // it at a rulepack without the ES recognizer removes that class from the
+    // detection surface. Before #3004 the daemon had no way to express this.
+    let override_dir = tempdir().unwrap();
+    let unrelated = override_dir.path().join("unrelated.toml");
+    fs::write(
+        &unrelated,
+        concat!(
+            "schema_version = \"0.1.0\"\n",
+            "rulepack_id = \"unrelated\"\n",
+            "rulepack_version = \"0.1.0\"\n",
+            "default_locales = [\"global\"]\n",
+            "\n",
+            "[[recognizers]]\n",
+            "id = \"unrelated.marker\"\n",
+            "class = \"custom:unrelated_marker\"\n",
+            "enabled = true\n",
+            "locales = [\"global\"]\n",
+            "\n",
+            "[recognizers.match]\n",
+            "kind = \"regex\"\n",
+            "pattern = \"ZZ-UNRELATED-[0-9]{4}\"\n",
+        ),
+    )
+    .unwrap();
+
+    let (overridden, output) = daemon_request(
+        &policy,
+        &[
+            "--locale=es-ES".to_string(),
+            format!("--rulepack-path={}", unrelated.display()),
+        ],
+        text,
+    );
+    let overridden_text = overridden["clean_text"].as_str().unwrap_or_else(|| {
+        panic!(
+            "override run must answer; response={overridden}, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    assert_eq!(
+        overridden_text, text,
+        "--rulepack-path replaced the policy's rulepack, so the ES id is no longer tokenized: {overridden_text}"
+    );
+}

--- a/crates/gaze-cli/tests/fixtures/cli-help/daemon.txt
+++ b/crates/gaze-cli/tests/fixtures/cli-help/daemon.txt
@@ -9,6 +9,10 @@ Options:
           Optional observer-only privacy safety net [possible values: openai-filter, kiji-distilbert]
       --safety-net-backend <SAFETY_NET_BACKEND>
           v0.8 backend selector. When set with `--safety-net=<kind>`, this flag wins [possible values: openai-filter, kiji-distilbert]
+      --safety-net-registry
+          Enable locale-aware Pass-3 safety-net registry dispatch
+      --safety-net-add <SAFETY_NET_ADD>
+          Add one backend to the locale-aware safety-net registry. Repeatable [possible values: openai-filter, kiji-distilbert]
       --idle-timeout <IDLE_TIMEOUT>
           Exit when stdin is idle for this many seconds [default: 1800]
       --session-idle-timeout <SESSION_IDLE_TIMEOUT>
@@ -25,6 +29,10 @@ Options:
           Override policy \[ner\].model_dir
       --ner-locale <NER_LOCALE>
           Override policy \[ner\].locale
+      --rulepack-bundled <RULEPACK_BUNDLED>
+          Override policy.rulepacks.bundled. Comma-separated and repeatable
+      --rulepack-path <RULEPACK_PATHS>
+          Override policy.rulepacks.paths. Repeatable
       --openai-filter-command <OPENAI_FILTER_COMMAND>
           Path to the local OpenAI Privacy Filter `opf` command
       --openai-filter-checkpoint <OPENAI_FILTER_CHECKPOINT>
@@ -35,6 +43,14 @@ Options:
           Device selection for the OpenAI safety-net subprocess [default: auto] [possible values: auto, cpu, cuda, mps]
       --kiji-backend <KIJI_BACKEND>
           Kiji DistilBERT runtime backend [default: subprocess] [possible values: subprocess, ort, tract, candle]
+      --kiji-distilbert-precision <KIJI_DISTILBERT_PRECISION>
+          Kiji DistilBERT ONNX precision. Default: fp32 [default: fp32] [possible values: fp32, int8]
+      --opf-locales <OPF_LOCALES>
+          Locale list for the OpenAI Privacy Filter registry entry
+      --opf-command <OPF_COMMAND>
+          Alias for --openai-filter-command in registry examples
+      --opf-checkpoint <OPF_CHECKPOINT>
+          Alias for --openai-filter-checkpoint in registry examples
       --kiji-distilbert-command <KIJI_DISTILBERT_COMMAND>
           Path to the local Kiji DistilBERT subprocess command
       --kiji-distilbert-model-dir <KIJI_DISTILBERT_MODEL_DIR>


### PR DESCRIPTION
## What was wrong

`daemon.rs::clean_options` hardcoded `safety_net_registry: false` and `safety_net_add: &[]`, and clap rejected the flags outright. Under an identical policy `gaze daemon` could only ever run a **single** safety-net backend, and there was no flag with which to ask for the stronger locale-aware registry. `gaze::Policy` carries no safety-net section, so the policy file was not a second route either — the chokepoint adopters run in production was structurally weaker than the one they test with. Axis 1.

**This is a capability gap, not a leak.** The flags were rejected and the daemon failed closed; nothing was silently ignored and no PII was exposed. Framing it as an exposure would be as wrong as ignoring it.

## Which of the 13 flags `daemon` gained, and which it did not

The test applied: does the flag's absence leave the daemon unable to reach a configuration `clean` can reach, with no policy-file route? `--policy` is *mandatory* on `daemon`, so anything expressible in policy.toml is already reachable by the operator.

**Added (8)** — none has a policy.toml equivalent, or the override plumbing already reached the daemon and only the flag was missing:

| Flag | Why |
|---|---|
| `--safety-net-registry`, `--safety-net-add` | The registry itself. The axis-1 core of this todo. |
| `--opf-locales` | The only way to scope the OPF entry to a locale — without it a registry can be built but cannot be made *locale-aware*, which is the whole point. |
| `--opf-command`, `--opf-checkpoint` | The registry entry's binary and checkpoint. Aliases of the `--openai-filter-*` pair, so a working `clean` registry command line stays valid when moved to `daemon`. |
| `--kiji-distilbert-precision` | CLI-only, no policy route. Hardcoded `Fp32` pinned the daemon to fp32 with no way to ask for the int8 build. |
| `--rulepack-bundled`, `--rulepack-path` | Detection surface — which recognizers run. The override already ran through `clean_overrides_from_options` on the daemon path; the hardcoded empty value was a dangling half-wire, not a decision. |

**Deliberately not added (5)** — each hardcoded value is now justified in a comment where it is set:

| Flag | Why not |
|---|---|
| `--format` | Read only by `require_json_format` inside `run_clean`, which the daemon never calls. The daemon's wire format is the JSONL protocol written by `write_json_line` and is not selectable — there is no second format to pick. |
| `--max-bytes` | Bounds `read_stdin_text`, which only `run_clean` calls; the daemon reads its own newline-delimited frames. Bounding one daemon request is a protocol concern needing a typed over-limit response, deliberately not smuggled in here. |
| `--context-json` | A typed context describes **one document**. The daemon serves many documents across many sessions from one process, so a process-wide flag would apply one document's context to every session's every request. That belongs in the per-request protocol frame. |
| `--session-scope`, `--session-ttl` | `[session].scope` and `[session].ttl_secs` in policy.toml, which is mandatory on `daemon`, so the operator already reaches both. `--session-ttl` would also read as governing the daemon's own session registry, which `--session-idle-timeout` and `--session-cap` own instead. |

## The fabrications are gone

`format: "json"` and `max_bytes: u64::MAX` were invented values, not defaults derived from anywhere. Both are now named constants with a comment stating they are inert on the daemon path and why. `DAEMON_CLEAN_MAX_BYTES` carries `clean`'s `DEFAULT_MAX_BYTES` rather than `u64::MAX`, so if a later change ever does route the daemon through that field it inherits a bound instead of an unbounded read.

## A second defect this surfaced

`safety_net_active` read `args.safety_net.is_some()` while `run_clean` reads `safety_net.is_some() || safety_net_registry`. Left alone, a registry-only daemon would have surfaced safety-net failures as a generic `Pipeline` error instead of the typed variant — the flag accepted and half-ignored. Fixed, and pinned by mutation M5 below.

## Behavioural evidence, not parsing evidence

A flag accepted and then ignored would be strictly worse than the honest rejection it replaces, so every new test asserts daemon behaviour. In `crates/gaze-cli/tests/daemon_smoke.rs`:

1. **`daemon_safety_net_registry_dispatches_between_two_backends_by_locale`** — two registry entries live in one daemon process. `--locale=en-US` routes to the OPF entry and the request is answered; `--locale=de-DE` routes to the Kiji entry and fails closed on its placeholder model (`ModelUnavailable`). One backend cannot produce both outcomes, which is what makes this a multi-backend proof.
2. **`daemon_single_backend_ships_what_the_registry_refuses`** — same daemon, same policy, same document, same `opf` binary. A single backend has no locale gate: it scans every locale with one model, reports nothing for the locale it does not cover, and **the document ships**. The registry resolves by locale and **refuses** it (`Unavailable`). The only difference between the two runs is the capability this PR adds.
3. **`daemon_safety_net_registry_finding_is_enforced_not_merely_parsed`** — the registry reports a residual name; under the default `resolve` mode it does not survive into the answer. The identical daemon with the flags withheld returns it verbatim.
4. **`daemon_rulepack_override_changes_the_detection_surface`** — `--rulepack-path` replaces the policy's rulepack, so a class the policy tokenized is no longer tokenized.

## Vacuity — five mutations, all RED with a unique anchor

Calibrated green first; every revert was followed by a **rebuild** before the green re-run, and the tree was byte-compared against `HEAD` after each.

| # | Mutation | Under mutation | After revert + rebuild |
|---|---|---|---|
| M1 | Registry group silently missing from `daemon::Args` (`#[arg(skip)]`) | **RED** — ``` `gaze daemon` is missing --safety-net-add ``` and the divergence set gains `safety-net-add`, `safety-net-registry` | green (4 passed) |
| M2 | Flags parse but `clean_options` ignores them (`safety_net_registry: false`, `safety_net_add: &[]`) | **RED** — all three registry tests | green (10 passed) |
| M3 | `--opf-locales` accepted then dropped on the way to the registry | **RED** — the daemon *runs* but is silently weaker: it answers the de-DE document instead of refusing it. `left: Null, right: "Unavailable"` | green |
| M4 | Rulepack overrides accepted then dropped | **RED** — `left: "id <…:Custom:es_test_id_1>", right: "id ES-TEST-123456"` | green |
| M5 | `safety_net_active` back to `safety_net.is_some()` | **RED** — `left: "Pipeline", right: "Unavailable"` / `"ModelUnavailable"`; registry failures lose their typed variant | green (10 passed) |

M3 is the load-bearing one: it simulates a working-but-weaker daemon rather than a crashing one, which is the failure mode a parsing-only test cannot see.

## The divergence tests were updated deliberately

`clean_and_daemon_flag_divergence_is_exactly_the_reviewed_set` pins the difference in **both** directions, so closing part of the gap had to update it explicitly — it went RED on this change before I touched it. `expected_clean_only` drops from 13 entries to 5; `expected_daemon_only` is unchanged. Its doc comment now records why each of the 5 survivors is deliberate. `shared_safety_net_groups_reach_both_clean_and_daemon` was extended to cover the four new shared groups, so a future edit that drops one of the new `#[command(flatten)]`s fails there too.

## CLI surface

`scripts/verify/cli-help-surface.sh --base 4c1ee31` reports the expected change: of 33 captures, **`daemon.txt` is the only one that differs**, with **8 added flag lines and 0 removals**. `clean --help` is byte-identical to its committed capture — the four new groups are flattened at the same declaration positions, and clap renders help in declaration order.

Flags gained per verb: `gaze daemon` +8 (`--safety-net-registry`, `--safety-net-add`, `--rulepack-bundled`, `--rulepack-path`, `--kiji-distilbert-precision`, `--opf-locales`, `--opf-command`, `--opf-checkpoint`). No other verb changed.

Re the harness's known blind spot (todo #3006 — a hidden flag passes while the accepted surface changes): **none of the 8 is hidden.** All eight appear in `gaze daemon --help` and in the committed capture, checked by hand as well as by the harness.

## Gates

Toolchain pinned as CI does — `RUSTUP_TOOLCHAIN=1.96.0` plus `RUSTC`/`RUSTDOC` exported via `rustup which` with their dir prepended to `PATH`.

| Gate | Exit |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` (repo-canonical line, verbatim) | 0 |
| `cargo test --workspace --all-features` | see below |
| `crates/gaze-cli/tests/daemon_smoke.rs` | 0 — 10 passed, 1 ignored |
| `crates/gaze-cli/tests/cli_help_surface.rs -- --ignored` | 0 — 1 passed |
| `scripts/verify/cli-help-surface.sh --base 4c1ee31` | 1 — the intended, itemised surface change above |

## North star

Axis 1 (never leak): the production chokepoint can now run the same Pass-3 protection its sibling can, and refuses a locale no registered backend covers instead of scanning it with a model that does not. Axis 4 (auditable): registry failures now carry their typed variant. Axis 2 and 3 unchanged. No axis weakened.

## Scope against solo todo #3004 — this closes one half of it

Todo #3004 tracks **two** defects. This PR closes the first and does **not** touch the second; recording that here so the split is legible from the merged history rather than only from the todo tracker.

- **Closed here — defect 1, the capability gap (axis 1).** `gaze daemon` can now run the locale-aware safety-net registry, select Kiji precision, and take rulepack overrides, as described above.
- **Not closed — defect 2, argv diagnosability (axis 4/5), carried forward as solo todo #3007.** `main.rs` routes *every* clap parse error to `CliError::PolicyConfig` with no detail and no flag name, so "this verb has no such flag" is indistinguishable from "your policy.toml is broken" except by the absence of a `detail` field. That catch-all is deliberate — clap's default handler echoes raw argv to stderr and argv can carry PII — so the fix is a distinct `CliError::Argv` variant carrying the clap `ErrorKind` but never the argv text. This PR touches neither `main.rs` nor `error.rs`.

Follow-up also filed from review: **solo todo #3008** — `rulepack_bundled` and `kiji_distilbert_precision` are correctly wired here but have no behavioural regression pin (a reviewer sweep dropped each of the 8 newly-wired `clean_options` fields individually: 6 go red, those 2 stay green). `rulepack_bundled` is the one that matters, being an axis-1 detection-surface control; the M4 mutation above pins only the `--rulepack-path` half.

