### PR TITLE
test(dashboard): remove size_of tautologies and the source-text ordering test

### DIFF
--- a/crates/gaze-proxy-dashboard/tests/process_isolation.rs
+++ b/crates/gaze-proxy-dashboard/tests/process_isolation.rs
@@ -5,8 +5,3 @@ assert_not_impl_any!(gaze_proxy_dashboard::PendingDashboardActivation: Clone, st
 assert_not_impl_any!(gaze_proxy_dashboard::DashboardLaunch: Clone, std::fmt::Debug);
 assert_not_impl_any!(gaze_proxy_dashboard::SpawnedDashboardChild: Clone, std::fmt::Debug);
 assert_not_impl_any!(gaze_proxy_dashboard::ChildInheritedHandles: Clone, std::fmt::Debug);
-
-#[test]
-fn activation_and_child_ownership_are_one_shot_by_type() {
-    assert!(std::mem::size_of::<gaze_proxy_dashboard::PendingDashboardActivation>() > 0);
-}

--- a/crates/gaze-proxy-dashboard/tests/runtime_lifecycle.rs
+++ b/crates/gaze-proxy-dashboard/tests/runtime_lifecycle.rs
@@ -83,27 +83,6 @@ fn assert_process_reaped(pid: u32) {
 }
 
 #[test]
-fn binding_precedes_socket_writer_runtime_and_admission_activation_in_commit() {
-    let source = include_str!("../src/supervisor.rs");
-    let commit = source
-        .find("impl PendingDashboardActivation")
-        .expect("pending activation implementation");
-    let body = &source[commit..];
-    let binding = body.find(".bind(activated)").expect("binding step");
-    for (name, needle) in [
-        ("socket take", "child.take_inspection()"),
-        ("writer spawn", "WriterHandle::spawn"),
-        ("runtime start", "DashboardLaunch::start"),
-        ("admission activation", "admission.activate()"),
-    ] {
-        let side_effect = body
-            .find(needle)
-            .unwrap_or_else(|| panic!("missing {name}"));
-        assert!(binding < side_effect, "binding must precede {name}");
-    }
-}
-
-#[test]
 #[cfg(not(target_os = "macos"))]
 fn matched_activation_owns_serialized_purge_shutdown_and_child_reap() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/gaze-proxy-dashboard/tests/sink_isolation.rs
+++ b/crates/gaze-proxy-dashboard/tests/sink_isolation.rs
@@ -3,9 +3,3 @@ use static_assertions::assert_not_impl_any;
 assert_not_impl_any!(gaze_proxy_dashboard::DashboardInspectionSink: Clone, std::fmt::Debug);
 assert_not_impl_any!(gaze_proxy_dashboard::PendingDashboardActivation: Clone, std::fmt::Debug);
 assert_not_impl_any!(gaze_proxy_dashboard::SpawnedDashboardChild: Clone, std::fmt::Debug);
-
-#[test]
-fn activation_capability_and_child_custody_are_linear_types() {
-    assert!(std::mem::size_of::<gaze_proxy_dashboard::PendingDashboardActivation>() > 0);
-    assert!(std::mem::size_of::<gaze_proxy_dashboard::SpawnedDashboardChild>() > 0);
-}


### PR DESCRIPTION
Resolves solo todo #2998

Deletes the two tautology shapes called out in F6 of the §6 mini-audit (scratchpad 7359):

- `tests/sink_isolation.rs` — deleted test fn `activation_capability_and_child_custody_are_linear_types` (was lines 7-11): its only assertions were two `size_of::<T>() > 0` checks, true for any non-ZST. The file-level `assert_not_impl_any!` statics remain and carry the claim.
- `tests/process_isolation.rs` — deleted test fn `activation_and_child_ownership_are_one_shot_by_type` (was lines 9-12): single `size_of` tautology. The five file-level `assert_not_impl_any!` statics remain.
- `tests/runtime_lifecycle.rs` — deleted test fn `binding_precedes_socket_writer_runtime_and_admission_activation_in_commit` (was lines 85-104): it used `include_str!` on `src/supervisor.rs` and compared `find()` byte offsets, i.e. a source-text ordering check (the shape AGENTS.md forbids). It fails on a rename and passes on a real ordering violation introduced by control flow. The two behavioral tests in the file are untouched.

Nothing else changed. `dashboard_child_helper` and everything it calls are untouched (its log line `test result: FAILED` is the parent test deliberately spawning and killing it).

Verification (all exit 0, logs not piped):
- `cargo fmt --all -- --check` → 0
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` → 0
- `cargo test -p gaze-proxy-dashboard --all-features` → 0
- `cargo run -p xtask -- dashboard-isolation` → 0 (`dashboard_isolation: passed`)

No merge; awaiting review.