### PR TITLE
fix(mcp)!: enforce strict reversible tool protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP protection intentionally changes runtime compatibility:** custom tools
+  must declare trusted object-member and non-sensitive numeric carriers;
+  empty primary pipelines now fail closed. Configure the bundled pipeline
+  and locale chain with `gaze-assembly::CorePipelineConfig`. Stricter safety-net
+  coverage, residual, and token-provenance checks can reject previously accepted
+  calls. Transport tool errors now expose only their class, with details kept
+  owner-side. See `crates/gaze-mcp-core/README.md` for migration requirements.
+  `SearchDocumentsTool` supplies its bounded carrier declarations, and
+  `gaze_read_file` restores protected paths owner-side before file validation.
+  Publication requires coordinated crate versions and dependency minimums;
+  these unreleased changes do not bump published versions.
+
+
 - **`gaze-cli` declares each shared flag group once** (audit 7201 S11-F1, solo
   todo #2368). `gaze clean` and `gaze daemon` each declared their flags inline
   in `Cmd`, restated them in a 33- and 23-field destructure, and rebuilt them

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ version = "0.12.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
+ "gaze-assembly",
  "gaze-mcp-core",
  "gaze-mcp-rmcp",
  "gaze-pii",
@@ -1544,6 +1545,7 @@ version = "0.12.0"
 dependencies = [
  "async-trait",
  "axum",
+ "gaze-assembly",
  "gaze-mcp-core",
  "gaze-pii",
  "rmcp",

--- a/crates/gaze-cli/src/commands/mcp/serve.rs
+++ b/crates/gaze-cli/src/commands/mcp/serve.rs
@@ -49,7 +49,7 @@ struct McpHost {
     registry: ToolRegistry,
     auth: AllowAgentAuth,
     manifest: Arc<FileManifestStore>,
-    pipeline: gaze::Pipeline,
+    pipeline: gaze_assembly::CorePipeline,
     session: gaze::Session,
     session_id_policy: SessionIdPolicy,
 }
@@ -63,7 +63,7 @@ impl McpHost {
         }
         gaze_document::mcp::register_tools(&mut registry, opts)
             .map_err(|err| CliError::McpDetail(format!("mcp tool registration failed: {err}")))?;
-        let pipeline = gaze::Pipeline::builder()
+        let pipeline = gaze_assembly::CorePipelineConfig::new()
             .build()
             .map_err(|err| CliError::McpDetail(format!("mcp redaction pipeline failed: {err}")))?;
         let session = gaze::Session::new(gaze::Scope::Ephemeral)
@@ -92,9 +92,9 @@ impl DispatchHost for McpHost {
             &self.registry,
             &self.auth,
             self.manifest.as_ref(),
-            &self.pipeline,
+            self.pipeline.pipeline(),
             &self.session,
-            &[gaze::LocaleTag::Global],
+            self.pipeline.locale_chain().as_slice(),
             &self.session_id_policy,
         );
         envelope
@@ -255,4 +255,43 @@ fn unix_ms(time: std::time::SystemTime) -> u128 {
     time.duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod strict_host_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shipped_host_has_real_primary_detection_and_document_round_trip() {
+        let directory = std::env::temp_dir().join(format!(
+            "gaze-mcp-host-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let manifest = Arc::new(FileManifestStore::new(directory.clone()).expect("manifest"));
+        let host = McpHost::new(manifest, None).expect("host");
+        // fixture-cited(crates/gaze-cli/src/commands/mcp/serve.rs:commands::mcp::serve::strict_host_tests::shipped_host_has_real_primary_detection_and_document_round_trip)
+        let input = "alice@example.invalid";
+        let response = host
+            .dispatch(
+                &Principal::new("synthetic"),
+                "gaze_read_text",
+                serde_json::json!({"text":input}),
+                None,
+            )
+            .await
+            .expect("document text succeeds");
+        let clean = response.payload["clean_markdown"]
+            .as_str()
+            .expect("markdown");
+        assert!(!clean.contains(input));
+        assert!(host
+            .session
+            .restore_strict_text(clean)
+            .expect("restore")
+            .contains(input));
+        std::fs::remove_dir_all(directory).expect("remove synthetic manifest");
+    }
 }

--- a/crates/gaze-cli/src/commands/mod.rs
+++ b/crates/gaze-cli/src/commands/mod.rs
@@ -235,7 +235,7 @@ enum McpCmd {
         /// Bridge TOML configuration.
         #[arg(long)]
         config: PathBuf,
-        /// Override [session].dir from the config.
+        /// Override `[session].dir` from the config.
         #[arg(long)]
         session_dir: Option<PathBuf>,
         /// Load config and discover downstream surface without serving.

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -43,6 +43,7 @@ extract-docling = []
 render-image = []
 
 [dev-dependencies]
+gaze-assembly = { workspace = true }
 ab_glyph = "0.2"
 gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.12.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -163,7 +163,15 @@ impl Tool for GazeReadFile {
     }
 
     async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
-        let path = PathBuf::from(required_string(ctx.redacted_args(), "path")?);
+        // Restore only inside the trusted tool, after protected manifest args
+        // were recorded. Opening the token spelling can select a different file.
+        let protected_path = required_string(ctx.redacted_args(), "path")?;
+        let raw_path = ctx
+            .resources()
+            .session()
+            .restore_strict_text(protected_path)
+            .map_err(|_| ToolError::InvalidArgs("path restoration failed".into()))?;
+        let path = PathBuf::from(raw_path);
         validate_file(&path, self.max_file_size)?;
         read_file_response(&path, ctx).map(|response| ToolResponse::json(json!(response)))
     }
@@ -395,6 +403,7 @@ mod tests {
         begins: AtomicUsize,
         finishes: AtomicUsize,
         failures: AtomicUsize,
+        args: std::sync::Mutex<Vec<serde_json::Value>>,
     }
 
     impl RecordingManifest {
@@ -403,6 +412,7 @@ mod tests {
                 begins: AtomicUsize::new(0),
                 finishes: AtomicUsize::new(0),
                 failures: AtomicUsize::new(0),
+                args: Default::default(),
             }
         }
     }
@@ -411,6 +421,7 @@ mod tests {
     impl ManifestStore for RecordingManifest {
         async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
             self.begins.fetch_add(1, Ordering::SeqCst);
+            self.args.lock().unwrap().push(ctx.redacted_args.clone());
             Ok(CallHandle::new(ctx.call_id))
         }
 
@@ -565,6 +576,89 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn configured_dispatch_restores_owner_path_before_file_validation() {
+        let core = gaze_assembly::CorePipelineConfig::new().build().unwrap();
+        let session = gaze::Session::new(gaze::Scope::Ephemeral).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let raw_path = directory
+            .path()
+            .join("alice@example.invalid")
+            .join("input.png");
+        std::fs::create_dir_all(raw_path.parent().unwrap()).unwrap();
+        std::fs::write(&raw_path, b"oversized").unwrap();
+        let gaze::CleanDocument::Text(protected_path) = core
+            .pseudonymize_text(&session, raw_path.to_str().unwrap())
+            .unwrap()
+        else {
+            panic!("text expected")
+        };
+        assert_ne!(protected_path, raw_path.to_str().unwrap());
+        // A distinct literal-token file must never replace the owner's target.
+        let literal_path = PathBuf::from(&protected_path);
+        assert!(literal_path.starts_with(directory.path()));
+        std::fs::create_dir_all(literal_path.parent().unwrap()).unwrap();
+        std::fs::write(&literal_path, b"").unwrap();
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(GazeReadFile::with_max_file_size(1))
+            .unwrap();
+        let manifest = RecordingManifest::new();
+        let policy = SessionIdPolicy::default_strict();
+        let envelope = PiiEnvelope::new(
+            &registry,
+            &AllowAllAuth,
+            &manifest,
+            core.pipeline(),
+            &session,
+            core.locale_chain().as_slice(),
+            &policy,
+        );
+        for path in [raw_path.to_str().unwrap(), &protected_path] {
+            let err = envelope
+                .dispatch(
+                    &Principal::new("unit-test"),
+                    "gaze_read_file",
+                    json!({"path": path}),
+                    None,
+                )
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, DispatchError::ToolError(ToolError::LimitExceeded(_))),
+                "{err:?}"
+            );
+        }
+        for args in manifest.args.lock().unwrap().iter() {
+            let path = args["path"].as_str().unwrap();
+            assert!(!path.contains("alice@example.invalid"));
+            assert_eq!(
+                session.restore_strict_text(path).unwrap(),
+                raw_path.to_str().unwrap()
+            );
+        }
+        let unknown_path = directory
+            .path()
+            .join("<deadbeef:Email_999>")
+            .join("input.png");
+        std::fs::create_dir_all(unknown_path.parent().unwrap()).unwrap();
+        std::fs::write(&unknown_path, b"oversized").unwrap();
+        let err = envelope
+            .dispatch(
+                &Principal::new("unit-test"),
+                "gaze_read_file",
+                json!({"path": unknown_path}),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DispatchError::ToolError(ToolError::InvalidArgs(_))),
+            "{err:?}"
+        );
+        assert_eq!(manifest.finishes.load(Ordering::SeqCst), 0);
     }
 
     #[cfg(feature = "ocr-tesseract")]

--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -8,7 +8,6 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use gaze::{CleanDocument, RawDocument};
 use gaze_mcp_core::{
     Tool, ToolCtx, ToolDescriptor, ToolError, ToolRegistry, ToolRegistryError, ToolResponse,
 };
@@ -74,7 +73,8 @@ impl GazeReadText {
                 }),
             )
             .with_description("Pseudonymize already-extracted text before returning it to an MCP client.")
-            .with_output_schema(response_schema()),
+            .with_output_schema(response_schema())
+            .with_carriers(gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]), response_carriers()),
         }
     }
 }
@@ -140,7 +140,11 @@ impl GazeReadFile {
             .with_description(
                 "Read an image or PDF through OCR and Gaze pseudonymization before MCP return.",
             )
-            .with_output_schema(response_schema()),
+            .with_output_schema(response_schema())
+            .with_carriers(
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["path"]),
+                response_carriers(),
+            ),
             max_file_size,
         }
     }
@@ -186,21 +190,43 @@ fn required_string<'a>(args: &'a serde_json::Value, field: &str) -> Result<&'a s
         .ok_or_else(|| ToolError::InvalidArgs(format!("missing required string field `{field}`")))
 }
 
+fn response_carriers() -> gaze_mcp_core::CarrierDeclaration {
+    use gaze_mcp_core::CarrierSegment::Member;
+    let path = |names: &[&str]| {
+        names
+            .iter()
+            .map(|name| Member((*name).into()))
+            .collect::<Vec<_>>()
+    };
+    let mut members = ["clean_markdown", "manifest_id", "file_metadata"]
+        .iter()
+        .map(|name| path(&[name]))
+        .collect::<Vec<_>>();
+    for name in [
+        "source_kind",
+        "ocr_mean_confidence",
+        "bundle_version",
+        "page_count",
+    ] {
+        members.push(path(&["file_metadata", name]));
+    }
+    let numbers = ["ocr_mean_confidence", "bundle_version", "page_count"]
+        .iter()
+        .map(|name| path(&["file_metadata", name]))
+        .collect();
+    gaze_mcp_core::CarrierDeclaration::new(members, numbers)
+}
+
 fn redact_document_text(text: &str, ctx: &ToolCtx<'_>) -> Result<String, ToolError> {
     let pipeline = crate::bundle::build_document_pipeline().map_err(map_document_error)?;
+    // The envelope may have already protected arguments. Preserve the session's
+    // exact owned tokens while applying the document-specific primary graph.
+    let mut transaction = ctx.resources().session().begin_transaction();
     let clean = pipeline
-        .pseudonymize_with_context(
-            ctx.resources().session(),
-            RawDocument::Text(text.to_string()),
-            ctx.resources().locale_chain(),
-        )
-        .map_err(|err| ToolError::BackendFailure(format!("document pipeline failed: {err}")))?;
-    match clean {
-        CleanDocument::Text(text) => Ok(text),
-        _ => Err(ToolError::BackendFailure(
-            "document pipeline returned non-text output".to_string(),
-        )),
-    }
+        .protect_text_transaction(&mut transaction, text, ctx.resources().protection_context())
+        .map_err(ToolError::internal)?;
+    transaction.commit().map_err(ToolError::internal)?;
+    Ok(clean)
 }
 
 fn validate_file(path: &Path, max_file_size: u64) -> Result<(), ToolError> {

--- a/crates/gaze-document/tests/mcp_stdio.rs
+++ b/crates/gaze-document/tests/mcp_stdio.rs
@@ -85,7 +85,7 @@ struct EnvelopeHost {
     registry: gaze_mcp_core::ToolRegistry,
     auth: AllowAllAuth,
     manifest: Arc<RecordingManifest>,
-    pipeline: gaze::Pipeline,
+    pipeline: gaze_assembly::CorePipeline,
     session: gaze::Session,
     session_id_policy: SessionIdPolicy,
 }
@@ -102,7 +102,9 @@ impl EnvelopeHost {
             registry,
             auth: AllowAllAuth,
             manifest: Arc::new(RecordingManifest::new()),
-            pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
+            pipeline: gaze_assembly::CorePipelineConfig::new()
+                .build()
+                .expect("pipeline"),
             session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
             session_id_policy: SessionIdPolicy::default_strict(),
         }
@@ -122,9 +124,9 @@ impl DispatchHost for EnvelopeHost {
             &self.registry,
             &self.auth,
             self.manifest.as_ref(),
-            &self.pipeline,
+            self.pipeline.pipeline(),
             &self.session,
-            &[gaze::LocaleTag::Global],
+            self.pipeline.locale_chain().as_slice(),
             &self.session_id_policy,
         );
         envelope
@@ -199,6 +201,38 @@ async fn stdio_document_tools_return_clean_payloads() {
         .expect("text tool call succeeds");
     let text_payload = parse_success_payload(text_result);
     assert_clean_response(&text_payload, "text");
+    let restored = host
+        .session
+        .restore_strict_text(text_payload["clean_markdown"].as_str().unwrap())
+        .expect("actual document restore");
+    assert!(restored.contains("jane.doe@example.invalid"));
+    assert!(restored.contains("Jane Doe"));
+
+    let custom = host
+        .session
+        .tokenize(
+            &gaze::PiiClass::Custom("class_alpha".into()),
+            "synthetic alpha",
+        )
+        .unwrap();
+    let fake = host
+        .session
+        .format_preserving_fake(&gaze::PiiClass::Email, "alice@example.invalid")
+        .unwrap();
+    let echo_input = format!("{custom}{custom} {fake}");
+    let echo_result = client
+        .call_tool(
+            CallToolRequestParams::new("gaze_read_text")
+                .with_arguments(json!({"text":echo_input}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+    let echo_payload = parse_success_payload(echo_result);
+    let echo_clean = echo_payload["clean_markdown"].as_str().unwrap();
+    assert!(echo_clean.contains(&custom));
+    assert!(echo_clean.contains(&fake));
+    let echo_restored = host.session.restore_strict_text(echo_clean).unwrap();
+    assert!(echo_restored.contains("synthetic alphasynthetic alpha alice@example.invalid"));
 
     let file_args = json!({ "path": synthetic_image_path() })
         .as_object()
@@ -221,8 +255,8 @@ async fn stdio_document_tools_return_clean_payloads() {
     let file_payload = parse_success_payload(file_result);
     assert_clean_response(&file_payload, "image");
 
-    assert_eq!(host.manifest.begins.load(Ordering::SeqCst), 2);
-    assert_eq!(host.manifest.finishes.load(Ordering::SeqCst), 2);
+    assert_eq!(host.manifest.begins.load(Ordering::SeqCst), 3);
+    assert_eq!(host.manifest.finishes.load(Ordering::SeqCst), 3);
     assert_eq!(host.manifest.fails.load(Ordering::SeqCst), 0);
 
     client.cancel().await.expect("client cancels");

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -35,5 +35,6 @@ core-tools = []
 operator-tier = []
 
 [dev-dependencies]
+gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii", features = ["test-support"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1"

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -105,6 +105,10 @@ payloads offline under the v0.7.x threat model.
 
 ## Adopter quickstart
 
+Add `gaze-assembly` as a direct dependency alongside `gaze-mcp-core` and
+`gaze` (package `gaze-pii`). It builds the bundled primary recognizers and
+matching locale chain used below.
+
 ```rust
 use std::sync::Arc;
 
@@ -165,7 +169,7 @@ impl AuthHook for MyAuth {
 }
 
 // 3. Build the gaze pipeline + session per conversation.
-let pipeline = gaze::Pipeline::builder().build().expect("pipeline");
+let core = gaze_assembly::CorePipelineConfig::new().build().expect("core pipeline");
 let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");
 
 // 4. Register tools.
@@ -177,7 +181,10 @@ registry.register(gaze_mcp_core::core_tools::CleanTool::new()).unwrap();
 let manifest = MyManifest {};
 let auth = MyAuth;
 let policy = SessionIdPolicy::default_strict();
-let _envelope = PiiEnvelope::new(&registry, &auth, &manifest, &pipeline, &session, &[], &policy);
+let _envelope = PiiEnvelope::new(
+    &registry, &auth, &manifest, core.pipeline(), &session,
+    core.locale_chain().as_slice(), &policy,
+);
 ```
 
 The transport sink (e.g. `gaze-mcp-rmcp::RmcpFrontend`) wraps the envelope

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -233,3 +233,94 @@ The `ToolCtx` audit-correlation surface (`call_id`, `tool_name`,
 (`begin_call` / `finish_call` / `fail_call`), the closed `FailureReason`
 set, and the `AuthHook` decision audit are cataloged in
 [`docs/reference/metrics.md`](../../docs/reference/metrics.md#7-mcp-chokepoint-observability-gaze-mcp-core).
+
+## Strict protection boundary and migration
+
+`PiiEnvelope` now protects both arguments and agent responses through
+`Pipeline::protect_text_transaction`. Supply a configured primary pipeline,
+for example `gaze_assembly::CorePipelineConfig::new().build()`, and pass its
+locale chain to the envelope. An empty primary registry is rejected even for
+calls containing no strings. The CLI MCP host uses this assembly path.
+
+The compatible `PiiEnvelope::new` constructor uses an empty dictionary bundle.
+Use `.with_dictionaries(&bundle)` to supply tenant terms. Primary recognizers,
+mandatory safety nets, and `ToolResources::protection_context()` receive the
+same locale and bundle. Observer tools use the new
+`scan_safety_nets_with_dictionaries` and structured counterpart; the old
+observer signatures retain an empty bundle. Model interfaces that do not
+consume dictionaries are unchanged.
+
+Every installed custom safety net must support the supplied locale chain.
+A configured model registry must resolve coverage. All selected safety-net
+backends run on every complete final string leaf, even when primary detection
+emits nothing or the input consists entirely of existing tokens. Observer
+skip optimizations cannot disable this boundary check. Invalid spans, backend
+failures, and residual suspects outside verified token coverage reject the
+operation. Zero installed safety nets is a **primary-only floor**, not a
+claim that all PII was detected. Global residual policies are unchanged.
+
+Custom producers must declare their JSON carriers at trusted registration:
+
+```rust
+use gaze_mcp_core::{CarrierDeclaration, ToolDescriptor};
+use serde_json::json;
+
+let descriptor = ToolDescriptor::agent("lookup", json!({"type":"object"}))
+    .with_carriers(
+        CarrierDeclaration::text_fields(&["query"]),
+        CarrierDeclaration::text_fields(&["result"]),
+    );
+```
+
+Use `CarrierDeclaration::new` for nested objects or explicitly non-sensitive
+numbers. Each path is a vector of `CarrierSegment::Member(exact_name)` and
+`CarrierSegment::AnyIndex` (one array edge only). Declare every encountered
+object edge and every numeric leaf separately. Full paths must match exactly;
+parent declarations do not authorize descendants. Numbers retain their
+original `serde_json::Number` representation. Numeric declarations mean the
+producer asserts those fields are non-sensitive; detectors do not certify
+their contents. Booleans and null remain non-text values.
+
+Schemas are catalog metadata and grant no authority. Declarations are omitted
+from serialization; deserializing a descriptor cannot recreate trusted
+permissions. Unconfigured descriptors accept root strings or arrays of strings
+but reject object members and numbers. Built-in text, tokenize, and document
+tools carry explicit declarations. For structured `SafetyNetCheckTool` input,
+use `with_argument_carriers` with the complete supported document shape.
+Arbitrary dynamic keys and cross-field concatenation are unsupported.
+
+Known tokens are matched with the session's actual restoration semantics,
+including non-angle format-preserving tokens. Only owned input ranges and
+verified newly emitted ranges are protected coverage. Literal collisions,
+including across JSON leaves, reject rather than silently reinterpret input.
+Primary detection still runs independently on gaps between owned tokens;
+this does not extend its cross-token detection domain. Full-leaf safety nets
+see the entire final text. One-way replacements fail reversibility checks.
+
+Arguments stage as one operation: preflight, protect, begin manifest, commit,
+then invoke. A fresh response transaction starts after invocation. Response
+preflight, protection, and snapshot construction precede its commit; successful
+`finish_call` then permits egress. A later leaf failure discards that operation's
+staging. Argument mappings and legitimate tool-side live-session mutations
+are outside response rollback. Concurrent generation conflicts publish none
+of the losing transaction's state.
+
+A terminal manifest attempt consumes the handle even when persistence fails.
+Never call `fail_call` after attempting `finish_call`. Response mappings are
+already committed when finish is attempted; a failed finish retains those
+mappings but returns no payload. This is not whole-call rollback.
+
+Authorized operator response bypass remains a separate exception: its raw
+keys, strings, and numbers are intentional, require operator authorization,
+and return only after successful manifest finish. Operator arguments still
+use the strict declared-carrier boundary. Agent bypass registration rejects.
+All transport errors remain class-only; detailed backend errors and manifest
+records belong exclusively to trusted-side diagnostics.
+
+Direct users of the core leaf API must discard their transaction after any
+error: staged mappings may remain, and previously returned strings are not
+immutable operation proofs. The envelope performs this discard automatically.
+Safety-net reconstructed `raw_span` offsets address expanded input, with owned
+tokens replaced by their stored raw values; they cannot index the literal
+input containing those tokens. Observer `nets_run` remains a configured count
+(a nonempty registry counts as one), not an executed-model count.

--- a/crates/gaze-mcp-core/src/carrier.rs
+++ b/crates/gaze-mcp-core/src/carrier.rs
@@ -1,0 +1,97 @@
+//! Producer-owned carrier declarations. JSON schemas confer no authority.
+use serde_json::Value;
+
+/// One unambiguous edge in a JSON path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CarrierSegment {
+    /// Exact object member, including punctuation or numeric-looking names.
+    Member(String),
+    /// Exactly one array edge; never matches an object member.
+    AnyIndex,
+}
+
+/// Full path from the operation root.
+pub type CarrierPath = Vec<CarrierSegment>;
+
+/// Trusted static object edges and explicitly non-sensitive numeric leaves.
+/// Empty declarations allow strings, arrays, booleans and null, but no object
+/// members or numbers. Parent paths never authorize descendants.
+#[derive(Debug, Clone, Default)]
+pub struct CarrierDeclaration {
+    members: Vec<CarrierPath>,
+    numbers: Vec<CarrierPath>,
+}
+
+/// Class-only failure; rejected keys, paths and values are never included.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum CarrierError {
+    /// Declaration has duplicate or invalid paths.
+    #[error("invalid carrier declaration")]
+    InvalidDeclaration,
+    /// An object edge lacks a full static-key declaration.
+    #[error("undeclared object member")]
+    UndeclaredMember,
+    /// A number lacks a non-sensitive numeric declaration.
+    #[error("undeclared numeric carrier")]
+    UndeclaredNumber,
+}
+
+impl CarrierDeclaration {
+    /// Explicit declarations are validated when the producer registers.
+    pub fn new(members: Vec<CarrierPath>, numbers: Vec<CarrierPath>) -> Self {
+        Self { members, numbers }
+    }
+    /// Convenience for a flat object with text/boolean/null fields only.
+    pub fn text_fields(fields: &[&str]) -> Self {
+        Self::new(
+            fields
+                .iter()
+                .map(|field| vec![CarrierSegment::Member((*field).into())])
+                .collect(),
+            vec![],
+        )
+    }
+    pub(crate) fn validate(&self) -> Result<(), CarrierError> {
+        use std::collections::HashSet;
+        if self
+            .members
+            .iter()
+            .any(|path| !matches!(path.last(), Some(CarrierSegment::Member(_))))
+            || self.members.iter().collect::<HashSet<_>>().len() != self.members.len()
+            || self.numbers.iter().collect::<HashSet<_>>().len() != self.numbers.len()
+        {
+            return Err(CarrierError::InvalidDeclaration);
+        }
+        Ok(())
+    }
+    pub(crate) fn preflight(&self, value: &Value) -> Result<(), CarrierError> {
+        self.validate()?;
+        self.walk(value, &mut vec![])
+    }
+    fn walk(&self, value: &Value, path: &mut CarrierPath) -> Result<(), CarrierError> {
+        match value {
+            Value::Object(map) => {
+                for (key, value) in map {
+                    path.push(CarrierSegment::Member(key.clone()));
+                    if !self.members.contains(path) {
+                        return Err(CarrierError::UndeclaredMember);
+                    }
+                    self.walk(value, path)?;
+                    path.pop();
+                }
+            }
+            Value::Array(values) => {
+                path.push(CarrierSegment::AnyIndex);
+                for value in values {
+                    self.walk(value, path)?;
+                }
+                path.pop();
+            }
+            Value::Number(_) if !self.numbers.contains(path) => {
+                return Err(CarrierError::UndeclaredNumber)
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/crates/gaze-mcp-core/src/ctx.rs
+++ b/crates/gaze-mcp-core/src/ctx.rs
@@ -70,23 +70,51 @@ pub struct ToolResources<'a> {
     session: &'a gaze::Session,
     manifest: &'a dyn ManifestStore,
     locale_chain: &'a [gaze::LocaleTag],
+    dictionaries: &'a gaze::DictionaryBundle,
     _life: PhantomData<&'a ()>,
 }
 
 impl<'a> ToolResources<'a> {
+    #[allow(dead_code)]
     pub(crate) fn new(
         pipeline: &'a gaze::Pipeline,
         session: &'a gaze::Session,
         manifest: &'a dyn ManifestStore,
         locale_chain: &'a [gaze::LocaleTag],
     ) -> Self {
+        Self::new_with_dictionaries(
+            pipeline,
+            session,
+            manifest,
+            locale_chain,
+            crate::dispatch::default_dictionaries(),
+        )
+    }
+
+    pub(crate) fn new_with_dictionaries(
+        pipeline: &'a gaze::Pipeline,
+        session: &'a gaze::Session,
+        manifest: &'a dyn ManifestStore,
+        locale_chain: &'a [gaze::LocaleTag],
+        dictionaries: &'a gaze::DictionaryBundle,
+    ) -> Self {
         Self {
+            dictionaries,
             pipeline,
             session,
             manifest,
             locale_chain,
             _life: PhantomData,
         }
+    }
+
+    /// Caller-supplied dictionaries shared by primary and observer operations.
+    pub fn dictionaries(&self) -> &'a gaze::DictionaryBundle {
+        self.dictionaries
+    }
+    /// Strict boundary context with the same caller-supplied inputs.
+    pub fn protection_context(&self) -> gaze::ProtectionContext<'a> {
+        gaze::ProtectionContext::strict(self.locale_chain, self.dictionaries)
     }
 
     /// Gaze pipeline backing this dispatch.

--- a/crates/gaze-mcp-core/src/dispatch.rs
+++ b/crates/gaze-mcp-core/src/dispatch.rs
@@ -30,14 +30,21 @@ use crate::registry::ToolRegistry;
 use crate::session_id::{SessionIdError, SessionIdPolicy};
 use crate::tool::{ResponseRedaction, ToolError, ToolResponse, ToolTier};
 
-/// Errors returned by [`PiiEnvelope::dispatch`]. Each variant maps onto a
-/// distinct manifest [`FailureReason`] (or, on the success path, no failure
-/// reason at all). The dispatcher always finalizes the manifest entry before
-/// returning a `Dispatch_Error` — there is no path that records a failure
-/// without persisting the row.
+/// Typed dispatch failures. Errors before begin have no manifest handle.
+/// Open handles receive one terminal attempt; persistence failure prevents
+/// response egress and must not trigger another terminal call.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum DispatchError {
+    /// Strict boundary failure, containing class-only diagnostics.
+    #[error("protection failed: {0}")]
+    Protection(#[from] gaze::ProtectionError),
+    /// Producer carrier contract violation, containing no input paths or values.
+    #[error("carrier rejected: {0}")]
+    Carrier(#[from] crate::CarrierError),
+    /// Concurrent live mutation invalidated operation staging.
+    #[error("session transaction conflict")]
+    Transaction(#[from] gaze::SessionTransactionError),
     /// Transport supplied an invalid session id (format or entropy).
     #[error("session id rejected: {0}")]
     SessionId(#[from] SessionIdError),
@@ -87,6 +94,8 @@ pub struct PiiEnvelope<'a> {
     pub session: &'a gaze::Session,
     /// Locale chain available to tool bodies that need observer-only checks.
     pub locale_chain: &'a [gaze::LocaleTag],
+    /// Default-empty unless explicitly supplied by the host.
+    pub dictionaries: &'a gaze::DictionaryBundle,
     /// Transport-supplied session id validation policy.
     pub session_id_policy: &'a SessionIdPolicy,
 }
@@ -105,6 +114,7 @@ impl<'a> PiiEnvelope<'a> {
         session_id_policy: &'a SessionIdPolicy,
     ) -> Self {
         Self {
+            dictionaries: default_dictionaries(),
             registry,
             auth,
             manifest,
@@ -115,15 +125,16 @@ impl<'a> PiiEnvelope<'a> {
         }
     }
 
-    /// Dispatch a tool call. The contract is:
-    ///
-    /// - Either a redacted [`ToolResponse`] is returned AND a manifest
-    ///   `finish_call` row was persisted, OR
-    /// - A [`DispatchError`] is returned AND a manifest `fail_call` row was
-    ///   persisted (when a manifest entry was opened — variants returned
-    ///   before `begin_call` cannot persist a row).
-    ///
-    /// There is no third path. Verified by `tests/chokepoint_ordering.rs`.
+    /// Supply dictionaries without changing the compatible empty-bundle constructor.
+    pub fn with_dictionaries(mut self, dictionaries: &'a gaze::DictionaryBundle) -> Self {
+        self.dictionaries = dictionaries;
+        self
+    }
+
+    /// Protect one declared JSON argument operation, invoke with live resources,
+    /// then protect a fresh response operation. Egress requires response commit
+    /// and successful manifest finish. A failed terminal attempt is never retried;
+    /// failed finish retains committed mappings but returns no response.
     pub async fn dispatch(
         &self,
         principal: &Principal,
@@ -155,8 +166,10 @@ impl<'a> PiiEnvelope<'a> {
         };
 
         // 4. Redact raw args. Errors before begin_call also stay pre-manifest.
-        let redacted_args = redact_json(self.pipeline, self.session, &raw_args)
-            .map_err(|e| DispatchError::Redaction(e.to_string()))?;
+        descriptor.argument_carriers().preflight(&raw_args)?;
+        let context = gaze::ProtectionContext::strict(self.locale_chain, self.dictionaries);
+        let mut args_transaction = self.session.begin_transaction();
+        let redacted_args = protect_json(self.pipeline, &mut args_transaction, context, &raw_args)?;
 
         // Generate the call id once and reuse it as the manifest handle.
         let call_id = Ulid::new();
@@ -173,6 +186,17 @@ impl<'a> PiiEnvelope<'a> {
             started_at,
         };
         let handle = self.manifest.begin_call(begin_ctx).await?;
+        if let Err(error) = args_transaction.commit() {
+            self.manifest
+                .fail_call(
+                    handle,
+                    FailureReason::RedactionFailed {
+                        message: "session transaction conflict".into(),
+                    },
+                )
+                .await?;
+            return Err(error.into());
+        }
 
         // 6. Build the sealed ToolCtx — pub(crate) constructor; this is the
         //    only call site in the entire crate.
@@ -183,11 +207,12 @@ impl<'a> PiiEnvelope<'a> {
             None => call_id.to_string(),
         };
         let session_handle = SessionHandle::new(&audit_session_id_owned);
-        let resources = ToolResources::new(
+        let resources = ToolResources::new_with_dictionaries(
             self.pipeline,
             self.session,
             self.manifest,
             self.locale_chain,
+            self.dictionaries,
         );
         let ctx = ToolCtx::new_with_resources(
             session_handle,
@@ -214,31 +239,49 @@ impl<'a> PiiEnvelope<'a> {
             }
         };
 
-        // 8. Redact the response payload unless an operator-tier descriptor
-        //    explicitly opted out for restore/export semantics.
-        let response_payload = match (tier, descriptor.response_redaction()) {
-            (ToolTier::Agent, ResponseRedaction::BypassByOperator) => {
-                let reason = FailureReason::Other {
-                    message: "agent tool with BypassByOperator reached dispatch".to_string(),
-                };
-                self.manifest.fail_call(handle, reason).await?;
-                return Err(DispatchError::Redaction(
-                    "agent tool cannot bypass response redaction".to_string(),
-                ));
-            }
-            (_, ResponseRedaction::Apply) => {
-                match redact_json(self.pipeline, self.session, &raw_response.payload) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        let reason = FailureReason::RedactionFailed {
-                            message: e.to_string(),
-                        };
-                        self.manifest.fail_call(handle, reason).await?;
-                        return Err(DispatchError::Redaction(e.to_string()));
+        // Response staging starts after invoke, preserving legitimate live tool changes.
+        let mut response_transaction = None;
+        let response_result: Result<_, DispatchError> =
+            match (tier, descriptor.response_redaction()) {
+                (ToolTier::Agent, ResponseRedaction::BypassByOperator) => {
+                    Err(DispatchError::Redaction("agent bypass rejected".into()))
+                }
+                (_, ResponseRedaction::Apply) => {
+                    match descriptor
+                        .response_carriers()
+                        .preflight(&raw_response.payload)
+                    {
+                        Err(error) => Err(error.into()),
+                        Ok(()) => {
+                            let mut transaction = self.session.begin_transaction();
+                            let result = protect_json(
+                                self.pipeline,
+                                &mut transaction,
+                                context,
+                                &raw_response.payload,
+                            );
+                            response_transaction = Some(transaction);
+                            result.map_err(Into::into)
+                        }
                     }
                 }
+                (ToolTier::Operator, ResponseRedaction::BypassByOperator) => {
+                    Ok(raw_response.payload)
+                }
+            };
+        let response_payload = match response_result {
+            Ok(payload) => payload,
+            Err(error) => {
+                self.manifest
+                    .fail_call(
+                        handle,
+                        FailureReason::RedactionFailed {
+                            message: error.to_string(),
+                        },
+                    )
+                    .await?;
+                return Err(error);
             }
-            (ToolTier::Operator, ResponseRedaction::BypassByOperator) => raw_response.payload,
         };
 
         // 9. Compute SnapshotRef on the redacted bytes (out-of-row metadata
@@ -262,82 +305,95 @@ impl<'a> PiiEnvelope<'a> {
         // 10. Finalize the manifest entry. If finish_call fails, the redacted
         //     response is NOT returned — the chokepoint contract demands the
         //     response only escape after the manifest row is durable.
+        if let Some(transaction) = response_transaction {
+            if let Err(error) = transaction.commit() {
+                self.manifest
+                    .fail_call(
+                        handle,
+                        FailureReason::RedactionFailed {
+                            message: "session transaction conflict".into(),
+                        },
+                    )
+                    .await?;
+                return Err(error.into());
+            }
+        }
+        // A terminal attempt consumes the handle even when persistence fails.
+        // A failed finish retains committed response mappings but returns no payload.
         self.manifest.finish_call(handle, snapshot).await?;
 
         Ok(ToolResponse::json(response_payload))
     }
 }
 
-/// Walk a JSON value and run the gaze pipeline on every string leaf. Numbers,
-/// booleans, and nulls pass through unchanged. Object keys are preserved
-/// verbatim (keys aren't redacted — the chokepoint contract redacts values,
-/// not field names).
-fn redact_json(
+pub(crate) fn default_dictionaries() -> &'static gaze::DictionaryBundle {
+    static DEFAULT: std::sync::LazyLock<gaze::DictionaryBundle> =
+        std::sync::LazyLock::new(gaze::DictionaryBundle::default);
+    &DEFAULT
+}
+
+fn protect_json(
     pipeline: &gaze::Pipeline,
-    session: &gaze::Session,
+    transaction: &mut gaze::SessionTransaction<'_>,
+    context: gaze::ProtectionContext<'_>,
     value: &serde_json::Value,
-) -> Result<serde_json::Value, gaze::Error> {
+) -> Result<serde_json::Value, gaze::ProtectionError> {
+    pipeline.validate_protection_context(context)?;
+    // Freeze interpretation for the whole operation, not just the current leaf.
+    let original_tokens = transaction.tokens();
+    let output = protect_json_leaves(pipeline, transaction, context, value)?;
+    for token in transaction
+        .tokens()
+        .iter()
+        .filter(|token| !original_tokens.contains(token))
+    {
+        if json_contains_literal(value, token) {
+            return Err(gaze::ProtectionError::Provenance);
+        }
+    }
+    Ok(output)
+}
+
+fn json_contains_literal(value: &serde_json::Value, token: &str) -> bool {
+    match value {
+        serde_json::Value::String(text) => text.contains(token),
+        serde_json::Value::Array(values) => values.iter().any(|v| json_contains_literal(v, token)),
+        serde_json::Value::Object(values) => {
+            values.values().any(|v| json_contains_literal(v, token))
+        }
+        _ => false,
+    }
+}
+
+fn protect_json_leaves(
+    pipeline: &gaze::Pipeline,
+    transaction: &mut gaze::SessionTransaction<'_>,
+    context: gaze::ProtectionContext<'_>,
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, gaze::ProtectionError> {
     use serde_json::Value as JsonValue;
     match value {
-        JsonValue::String(s) => Ok(JsonValue::String(redact_json_string(pipeline, session, s)?)),
-        JsonValue::Array(arr) => {
-            let mut out = Vec::with_capacity(arr.len());
-            for item in arr {
-                out.push(redact_json(pipeline, session, item)?);
-            }
-            Ok(JsonValue::Array(out))
-        }
-        JsonValue::Object(map) => {
-            let mut out = serde_json::Map::with_capacity(map.len());
-            for (k, v) in map {
-                out.insert(k.clone(), redact_json(pipeline, session, v)?);
-            }
-            Ok(JsonValue::Object(out))
-        }
-        // Null / Bool / Number — no string content to redact.
+        JsonValue::String(text) => Ok(JsonValue::String(pipeline.protect_text_transaction(
+            transaction,
+            text,
+            context,
+        )?)),
+        JsonValue::Array(values) => values
+            .iter()
+            .map(|value| protect_json_leaves(pipeline, transaction, context, value))
+            .collect::<Result<Vec<_>, _>>()
+            .map(JsonValue::Array),
+        JsonValue::Object(values) => values
+            .iter()
+            .map(|(key, value)| {
+                Ok((
+                    key.clone(),
+                    protect_json_leaves(pipeline, transaction, context, value)?,
+                ))
+            })
+            .collect::<Result<serde_json::Map<_, _>, _>>()
+            .map(JsonValue::Object),
         other => Ok(other.clone()),
-    }
-}
-
-fn redact_json_string(
-    pipeline: &gaze::Pipeline,
-    session: &gaze::Session,
-    value: &str,
-) -> Result<String, gaze::Error> {
-    let mut out = String::with_capacity(value.len());
-    let mut cursor = 0usize;
-    for token in gaze::token_shape::pattern().find_iter(value) {
-        if !session.contains_token(token.as_str()) {
-            continue;
-        }
-        out.push_str(&redact_json_string_segment(
-            pipeline,
-            session,
-            &value[cursor..token.start()],
-        )?);
-        out.push_str(token.as_str());
-        cursor = token.end();
-    }
-    out.push_str(&redact_json_string_segment(
-        pipeline,
-        session,
-        &value[cursor..],
-    )?);
-    Ok(out)
-}
-
-fn redact_json_string_segment(
-    pipeline: &gaze::Pipeline,
-    session: &gaze::Session,
-    segment: &str,
-) -> Result<String, gaze::Error> {
-    if segment.is_empty() {
-        return Ok(String::new());
-    }
-    let clean = pipeline.redact(session, gaze::RawDocument::Text(segment.to_string()))?;
-    match clean {
-        gaze::CleanDocument::Text(text) => Ok(text),
-        _ => Err(gaze::Error::UnsupportedRawDocumentVariant),
     }
 }
 
@@ -453,7 +509,14 @@ mod tests {
         };
 
         let payload = json!(format!("{token}alice@example.invalid"));
-        let redacted = redact_json(&pipeline, &session, &payload).expect("redact json");
+        let mut transaction = session.begin_transaction();
+        let redacted = protect_json(
+            &pipeline,
+            &mut transaction,
+            gaze::ProtectionContext::strict(&[gaze::LocaleTag::Global], default_dictionaries()),
+            &payload,
+        )
+        .expect("protect json");
 
         assert_eq!(redacted, json!(format!("{token}{token}")));
     }

--- a/crates/gaze-mcp-core/src/lib.rs
+++ b/crates/gaze-mcp-core/src/lib.rs
@@ -74,3 +74,6 @@ pub use crate::manifest::{
 pub use crate::registry::{ToolRegistry, ToolRegistryError};
 pub use crate::session_id::{SessionIdError, SessionIdFormat, SessionIdPolicy};
 pub use crate::tool::{ResponseRedaction, Tool, ToolDescriptor, ToolError, ToolResponse, ToolTier};
+
+mod carrier;
+pub use carrier::{CarrierDeclaration, CarrierError, CarrierPath, CarrierSegment};

--- a/crates/gaze-mcp-core/src/manifest.rs
+++ b/crates/gaze-mcp-core/src/manifest.rs
@@ -189,9 +189,10 @@ pub trait ManifestStore: Send + Sync {
     /// this AFTER the tool returned and AFTER its response was redacted,
     /// passing an out-of-row [`SnapshotRef`] to the redacted response bytes.
     ///
-    /// The chokepoint contract requires this call to complete (or
-    /// [`fail_call`](Self::fail_call) to be called) before the dispatcher
-    /// returns the response to the transport.
+    /// Attempting this terminal operation consumes the handle's terminal
+    /// opportunity even on persistence failure. The caller must never then
+    /// attempt `fail_call`. Only successful finish permits response egress.
+    /// Response mappings commit before finish; failed finish retains them.
     async fn finish_call(
         &self,
         handle: CallHandle,
@@ -199,9 +200,10 @@ pub trait ManifestStore: Send + Sync {
     ) -> Result<(), ManifestError>;
 
     /// Finalize a manifest entry on the failure path. The dispatcher calls
-    /// this when auth, the tool body, or response redaction returned an error.
+    /// this when the tool body or response protection returned an error.
     /// The manifest entry is closed with a [`FailureReason`] so operators can
-    /// review the call later.
+    /// review the call later. Attempting this consumes the terminal opportunity
+    /// even on persistence failure; neither terminal method may be retried.
     async fn fail_call(
         &self,
         handle: CallHandle,

--- a/crates/gaze-mcp-core/src/manifest.rs
+++ b/crates/gaze-mcp-core/src/manifest.rs
@@ -68,6 +68,9 @@ pub struct BeginCallContext<'a> {
 /// Reason a manifest call did not complete successfully. The dispatcher always
 /// supplies one of these on the failure path so the manifest row carries
 /// enough context to drive operator review later.
+///
+/// These records are trusted-side diagnostics and may contain PII. Transports
+/// must never serialize manifest records into model-facing responses.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FailureReason {
@@ -75,7 +78,8 @@ pub enum FailureReason {
     ToolError {
         /// Stable error class string, e.g. `"invalid-args"`.
         class: String,
-        /// Human-readable error message; safe to persist (post-redaction).
+        /// Trusted-side diagnostic text; may contain unredacted PII from the tool
+        /// or backend. Never expose this field to a model-facing transport.
         message: String,
     },
     /// Authorization denied by the [`crate::auth::AuthHook`] before the tool

--- a/crates/gaze-mcp-core/src/registry.rs
+++ b/crates/gaze-mcp-core/src/registry.rs
@@ -77,6 +77,13 @@ impl ToolRegistry {
         T: Tool + 'static,
     {
         let descriptor = tool.descriptor();
+        descriptor
+            .argument_carriers()
+            .validate()
+            .and_then(|()| descriptor.response_carriers().validate())
+            .map_err(|_| {
+                ToolRegistryError::InvalidDescriptor("invalid carrier declaration".into())
+            })?;
         let name = descriptor.name().to_string();
         if name.is_empty() {
             return Err(ToolRegistryError::InvalidDescriptor(

--- a/crates/gaze-mcp-core/src/tool.rs
+++ b/crates/gaze-mcp-core/src/tool.rs
@@ -164,6 +164,11 @@ impl ToolResponse {
 /// Error returned by a [`Tool::invoke`] body. The dispatcher classifies these
 /// into a [`crate::manifest::FailureReason::ToolError`] manifest row and a
 /// transport-level error response.
+///
+/// Payloads and error sources are trusted-side diagnostics and may contain PII,
+/// including backend text that never passed through redaction. Transports must
+/// expose only [`Self::class`], never serialize these details or their Display
+/// / Debug representations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ToolError {
@@ -189,7 +194,7 @@ pub enum ToolError {
 
 impl ToolError {
     /// Classify the error into the wire-stable class string the manifest
-    /// records (`"invalid-args"`, `"not-found"`, `"internal"`).
+    /// records. This class is the only tool-error text safe for transport egress.
     pub fn class(&self) -> &'static str {
         match self {
             Self::InvalidArgs(_) => "invalid-args",

--- a/crates/gaze-mcp-core/src/tool.rs
+++ b/crates/gaze-mcp-core/src/tool.rs
@@ -43,6 +43,10 @@ pub enum ResponseRedaction {
 pub struct ToolDescriptor {
     /// Stable wire name (`"clean"`, `"query"`, …). Must be unique per registry.
     name: String,
+    #[serde(skip)]
+    argument_carriers: crate::CarrierDeclaration,
+    #[serde(skip)]
+    response_carriers: crate::CarrierDeclaration,
     /// Tier — drives both auth-hook routing and feature-flag visibility.
     tier: ToolTier,
     /// JSON-schema document describing the tool's input arguments. The
@@ -67,6 +71,8 @@ impl ToolDescriptor {
     pub fn agent(name: impl Into<String>, schema: serde_json::Value) -> Self {
         Self {
             name: name.into(),
+            argument_carriers: Default::default(),
+            response_carriers: Default::default(),
             tier: ToolTier::Agent,
             schema,
             description: None,
@@ -79,12 +85,33 @@ impl ToolDescriptor {
     pub fn operator(name: impl Into<String>, schema: serde_json::Value) -> Self {
         Self {
             name: name.into(),
+            argument_carriers: Default::default(),
+            response_carriers: Default::default(),
             tier: ToolTier::Operator,
             schema,
             description: None,
             output_schema: None,
             response_redaction: ResponseRedaction::Apply,
         }
+    }
+
+    /// Declare trusted producer carriers independently of wire schemas.
+    pub fn with_carriers(
+        mut self,
+        arguments: crate::CarrierDeclaration,
+        response: crate::CarrierDeclaration,
+    ) -> Self {
+        self.argument_carriers = arguments;
+        self.response_carriers = response;
+        self
+    }
+    /// Trusted argument carrier declaration.
+    pub fn argument_carriers(&self) -> &crate::CarrierDeclaration {
+        &self.argument_carriers
+    }
+    /// Trusted response carrier declaration.
+    pub fn response_carriers(&self) -> &crate::CarrierDeclaration {
+        &self.response_carriers
     }
 
     /// Builder-style description override.

--- a/crates/gaze-mcp-core/src/tools/clean.rs
+++ b/crates/gaze-mcp-core/src/tools/clean.rs
@@ -41,6 +41,10 @@ impl CleanTool {
                     "required": ["text"]
                 }),
             )
+            .with_carriers(
+                crate::CarrierDeclaration::text_fields(&["text"]),
+                crate::CarrierDeclaration::text_fields(&["text"]),
+            )
             .with_description("Redact PII in the supplied text via the gaze pipeline."),
         }
     }

--- a/crates/gaze-mcp-core/src/tools/export.rs
+++ b/crates/gaze-mcp-core/src/tools/export.rs
@@ -25,6 +25,10 @@ impl ExportSessionTokensTool {
                     "properties": {}
                 }),
             )
+            .with_carriers(
+                crate::CarrierDeclaration::text_fields(&[]),
+                crate::CarrierDeclaration::text_fields(&[]),
+            )
             .with_description("Export the token/raw inventory for the current Session.")
             .with_response_redaction(ResponseRedaction::BypassByOperator),
         }

--- a/crates/gaze-mcp-core/src/tools/restore.rs
+++ b/crates/gaze-mcp-core/src/tools/restore.rs
@@ -45,6 +45,10 @@ impl RestoreTool {
                     "required": ["token"]
                 }),
             )
+            .with_carriers(
+                crate::CarrierDeclaration::text_fields(&["token"]),
+                crate::CarrierDeclaration::text_fields(&[]),
+            )
             .with_description("Operator-only: restore PII from a manifest token.")
             .with_response_redaction(ResponseRedaction::BypassByOperator),
         }

--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -35,6 +35,7 @@ impl RestoreStrictTool {
                     "required": ["text"]
                 }),
             )
+            .with_carriers(crate::CarrierDeclaration::text_fields(&["text"]), crate::CarrierDeclaration::text_fields(&[]))
             .with_description(
                 "Operator-only: strict restore that fails if any token is missing.",
             )

--- a/crates/gaze-mcp-core/src/tools/safety_net.rs
+++ b/crates/gaze-mcp-core/src/tools/safety_net.rs
@@ -16,6 +16,14 @@ pub struct SafetyNetCheckTool {
 }
 
 impl SafetyNetCheckTool {
+    /// Declare the supported structured input shape explicitly, including the
+    /// root `document` member. Schemas and incoming keys never authorize it.
+    pub fn with_argument_carriers(mut self, declaration: crate::CarrierDeclaration) -> Self {
+        self.descriptor = self
+            .descriptor
+            .with_carriers(declaration, response_carriers());
+        self
+    }
     /// Construct a `SafetyNetCheckTool` with its canonical descriptor.
     pub fn new() -> Self {
         Self {
@@ -33,6 +41,7 @@ impl SafetyNetCheckTool {
                     }
                 }),
             )
+            .with_carriers(crate::CarrierDeclaration::text_fields(&["text", "document"]), response_carriers())
             .with_description("Run the gaze safety-net pass against text and report residual PII.")
             .with_output_schema(json!({
                 "type": "object",
@@ -78,17 +87,23 @@ impl Tool for SafetyNetCheckTool {
                     .ok_or_else(|| ToolError::InvalidArgs("`text` must be a string".into()))?;
                 resources
                     .pipeline()
-                    .scan_safety_nets(resources.session(), text, resources.locale_chain())
+                    .scan_safety_nets_with_dictionaries(
+                        resources.session(),
+                        text,
+                        resources.locale_chain(),
+                        resources.dictionaries(),
+                    )
                     .map_err(ToolError::internal)?
             }
             (None, Some(document)) => {
                 let document = decode_structured_document(document)?;
                 resources
                     .pipeline()
-                    .scan_safety_nets_structured(
+                    .scan_safety_nets_structured_with_dictionaries(
                         resources.session(),
                         &document,
                         resources.locale_chain(),
+                        resources.dictionaries(),
                     )
                     .map_err(ToolError::internal)?
             }
@@ -128,6 +143,44 @@ impl Tool for SafetyNetCheckTool {
             "stats": stats,
         })))
     }
+}
+
+fn response_carriers() -> crate::CarrierDeclaration {
+    use crate::CarrierSegment::{AnyIndex as I, Member as M};
+    let path = |names: &[&str]| {
+        names
+            .iter()
+            .map(|name| M((*name).into()))
+            .collect::<Vec<_>>()
+    };
+    let mut members = ["ok", "nets_run", "leak_count", "leaks", "stats"]
+        .iter()
+        .map(|name| path(&[name]))
+        .collect::<Vec<_>>();
+    let mut numbers = vec![path(&["nets_run"]), path(&["leak_count"])];
+    for name in [
+        "class",
+        "score",
+        "kind",
+        "safety_net_id",
+        "field_path",
+        "span",
+    ] {
+        members.push(vec![M("leaks".into()), I, M(name.into())]);
+    }
+    numbers.push(vec![M("leaks".into()), I, M("score".into())]);
+    numbers.push(vec![M("leaks".into()), I, M("span".into()), I]);
+    for name in [
+        "suspect_count",
+        "uncovered_count",
+        "partial_bleed_count",
+        "class_mismatch_count",
+        "locale_skipped_count",
+    ] {
+        members.push(path(&["stats", name]));
+        numbers.push(path(&["stats", name]));
+    }
+    crate::CarrierDeclaration::new(members, numbers)
 }
 
 fn decode_structured_document(

--- a/crates/gaze-mcp-core/src/tools/tokenize.rs
+++ b/crates/gaze-mcp-core/src/tools/tokenize.rs
@@ -28,6 +28,10 @@ impl TokenizeFieldTool {
                     "required": ["value"]
                 }),
             )
+            .with_carriers(
+                crate::CarrierDeclaration::text_fields(&["value"]),
+                crate::CarrierDeclaration::text_fields(&["token"]),
+            )
             .with_description("Tokenize a single field value via the gaze pipeline."),
         }
     }

--- a/crates/gaze-mcp-core/tests/chokepoint_ordering.rs
+++ b/crates/gaze-mcp-core/tests/chokepoint_ordering.rs
@@ -182,7 +182,7 @@ impl Detector for FixedDetector {
 }
 
 fn make_pipeline() -> gaze::Pipeline {
-    gaze::Pipeline::builder().build().expect("pipeline build")
+    tokenizing_pipeline()
 }
 
 fn tokenizing_pipeline() -> gaze::Pipeline {
@@ -210,7 +210,10 @@ async fn dispatch_orders_begin_invoke_finish() {
     let mut registry = ToolRegistry::new();
     registry
         .register(RecordingTool {
-            descriptor: ToolDescriptor::agent("clean", json!({"type": "object"})),
+            descriptor: ToolDescriptor::agent("clean", json!({"type": "object"})).with_carriers(
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+            ),
             events: events_handle.clone(),
             behavior: ToolBehavior::EchoArgs,
         })
@@ -267,7 +270,10 @@ async fn dispatch_redacts_agent_response_payload() {
     let mut registry = ToolRegistry::new();
     registry
         .register(RecordingTool {
-            descriptor: ToolDescriptor::agent("lookup", json!({"type": "object"})),
+            descriptor: ToolDescriptor::agent("lookup", json!({"type": "object"})).with_carriers(
+                Default::default(),
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["email"]),
+            ),
             events: events_handle,
             behavior: ToolBehavior::ReturnPayload(json!({"email": "alice@example.invalid"})),
         })
@@ -308,6 +314,10 @@ async fn dispatch_bypasses_response_redaction_for_operator_with_bypass() {
     registry
         .register(RecordingTool {
             descriptor: ToolDescriptor::operator("restore", json!({"type": "object"}))
+                .with_carriers(
+                    gaze_mcp_core::CarrierDeclaration::text_fields(&["token"]),
+                    Default::default(),
+                )
                 .with_response_redaction(ResponseRedaction::BypassByOperator),
             events: events_handle,
             behavior: ToolBehavior::ReturnPayload(json!({"email": "alice@example.invalid"})),
@@ -356,7 +366,10 @@ async fn dispatch_writes_fail_call_on_tool_error() {
     let mut registry = ToolRegistry::new();
     registry
         .register(RecordingTool {
-            descriptor: ToolDescriptor::agent("explode", json!({"type": "object"})),
+            descriptor: ToolDescriptor::agent("explode", json!({"type": "object"})).with_carriers(
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+                Default::default(),
+            ),
             events: events_handle,
             behavior: ToolBehavior::ReturnError,
         })
@@ -442,7 +455,10 @@ async fn deny_all_hook_blocks_agent_dispatch_pre_manifest() {
     let mut registry = ToolRegistry::new();
     registry
         .register(RecordingTool {
-            descriptor: ToolDescriptor::agent("clean", json!({"type": "object"})),
+            descriptor: ToolDescriptor::agent("clean", json!({"type": "object"})).with_carriers(
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+            ),
             events: events_handle,
             behavior: ToolBehavior::EchoArgs,
         })

--- a/crates/gaze-mcp-core/tests/strict_contract.rs
+++ b/crates/gaze-mcp-core/tests/strict_contract.rs
@@ -1,0 +1,841 @@
+//! Synthetic producer-to-envelope contract, not direct Tool::invoke tests.
+use async_trait::async_trait;
+use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, PiiClass, Scope, Session};
+use gaze_mcp_core::*;
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+const EMAIL: &str = "alice@example.invalid";
+const FRESH: &str = "bob@example.invalid";
+#[derive(Clone)]
+struct Primary;
+impl Detector for Primary {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        [EMAIL, FRESH]
+            .into_iter()
+            .flat_map(|raw| {
+                input.match_indices(raw).map(move |(start, _)| {
+                    Detection::new(start..start + raw.len(), PiiClass::Email, "synthetic")
+                })
+            })
+            .collect()
+    }
+}
+fn pipeline() -> gaze::Pipeline {
+    gaze::Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+struct Auth;
+#[async_trait]
+impl AuthHook for Auth {
+    async fn authorize_agent(&self, _: &Principal, _: &str) -> Result<(), AuthError> {
+        Ok(())
+    }
+    async fn authorize_operator(&self, principal: &Principal, _: &str) -> Result<(), AuthError> {
+        if principal.id == "operator" {
+            Ok(())
+        } else {
+            Err(AuthError::Denied("synthetic".into()))
+        }
+    }
+}
+#[derive(Default)]
+struct Store {
+    events: Arc<Mutex<Vec<&'static str>>>,
+    fail: Option<&'static str>,
+    mutate_begin: Option<Arc<Session>>,
+}
+#[async_trait]
+impl ManifestStore for Store {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        self.events.lock().unwrap().push("begin");
+        if let Some(session) = &self.mutate_begin {
+            session
+                .tokenize(&PiiClass::Name, "synthetic concurrent")
+                .unwrap();
+        }
+        if self.fail == Some("begin") {
+            return Err(ManifestError::Validation("synthetic".into()));
+        }
+        Ok(CallHandle::new(ctx.call_id))
+    }
+    async fn finish_call(&self, _: CallHandle, _: SnapshotRef) -> Result<(), ManifestError> {
+        self.events.lock().unwrap().push("finish");
+        if self.fail == Some("finish") {
+            return Err(ManifestError::Validation("synthetic".into()));
+        }
+        Ok(())
+    }
+    async fn fail_call(&self, _: CallHandle, _: FailureReason) -> Result<(), ManifestError> {
+        self.events.lock().unwrap().push("fail");
+        if self.fail == Some("fail") {
+            return Err(ManifestError::Validation("synthetic".into()));
+        }
+        Ok(())
+    }
+}
+struct Producer {
+    descriptor: ToolDescriptor,
+    events: Arc<Mutex<Vec<&'static str>>>,
+    output: Option<Value>,
+    error: bool,
+    mutate: bool,
+}
+#[async_trait]
+impl Tool for Producer {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.descriptor
+    }
+    async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        self.events.lock().unwrap().push("invoke");
+        if self.mutate {
+            ctx.resources()
+                .session()
+                .tokenize(
+                    &PiiClass::Custom("class_alpha".into()),
+                    "synthetic tool value",
+                )
+                .unwrap();
+        }
+        if self.error {
+            return Err(ToolError::BackendFailure(EMAIL.into()));
+        }
+        Ok(ToolResponse::json(
+            self.output
+                .clone()
+                .unwrap_or_else(|| ctx.redacted_args().clone()),
+        ))
+    }
+}
+fn registry(
+    store: &Store,
+    declaration: CarrierDeclaration,
+    output: Option<Value>,
+    error: bool,
+    mutate: bool,
+) -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(Producer {
+            descriptor: ToolDescriptor::agent("test", json!({}))
+                .with_carriers(declaration.clone(), declaration),
+            events: store.events.clone(),
+            output,
+            error,
+            mutate,
+        })
+        .unwrap();
+    registry
+}
+async fn dispatch(
+    registry: &ToolRegistry,
+    store: &Store,
+    pipeline: &gaze::Pipeline,
+    session: &Session,
+    args: Value,
+) -> Result<ToolResponse, DispatchError> {
+    PiiEnvelope::new(
+        registry,
+        &Auth,
+        store,
+        pipeline,
+        session,
+        &[gaze::LocaleTag::Global],
+        &SessionIdPolicy::default_strict(),
+    )
+    .dispatch(&Principal::new("agent"), "test", args, None)
+    .await
+}
+#[tokio::test]
+async fn whole_operation_collision_is_rejected_without_begin_or_cache_state() {
+    let store = Store::default();
+    let registry = registry(&store, Default::default(), None, false, false);
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut prediction = session.begin_transaction();
+    let token = prediction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    drop(prediction);
+    for args in [json!([EMAIL, token]), json!([token, EMAIL])] {
+        assert!(matches!(
+            dispatch(&registry, &store, &pipeline(), &session, args).await,
+            Err(DispatchError::Protection(gaze::ProtectionError::Provenance))
+        ));
+        assert!(store.events.lock().unwrap().is_empty());
+        assert!(session.tokens().is_empty());
+        assert_eq!(session.prefix_cache_entry_count(), 0);
+    }
+}
+#[tokio::test]
+async fn terminal_attempts_are_once_only_and_response_commit_precedes_failed_finish() {
+    for (failure, tool_error, expected) in [
+        ("begin", false, vec!["begin"]),
+        ("finish", false, vec!["begin", "invoke", "finish"]),
+        ("fail", true, vec!["begin", "invoke", "fail"]),
+    ] {
+        let store = Store {
+            fail: Some(failure),
+            ..Default::default()
+        };
+        let registry = registry(
+            &store,
+            Default::default(),
+            Some(json!(FRESH)),
+            tool_error,
+            false,
+        );
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        assert!(matches!(
+            dispatch(&registry, &store, &pipeline(), &session, json!(EMAIL)).await,
+            Err(DispatchError::Manifest(_))
+        ));
+        assert_eq!(*store.events.lock().unwrap(), expected);
+        let entries = session.snapshot_entries();
+        assert_eq!(
+            entries.iter().any(|entry| entry.raw == EMAIL),
+            failure != "begin"
+        );
+        assert_eq!(
+            entries.iter().any(|entry| entry.raw == FRESH),
+            failure == "finish"
+        );
+    }
+}
+#[tokio::test]
+async fn begin_commit_conflict_prevents_invoke_and_keeps_only_winning_state() {
+    let session = Arc::new(Session::new(Scope::Ephemeral).unwrap());
+    let store = Store {
+        mutate_begin: Some(session.clone()),
+        ..Default::default()
+    };
+    let registry = registry(&store, Default::default(), None, false, false);
+    assert!(matches!(
+        dispatch(&registry, &store, &pipeline(), &session, json!(EMAIL)).await,
+        Err(DispatchError::Transaction(_))
+    ));
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "fail"]);
+    assert!(session
+        .snapshot_entries()
+        .iter()
+        .all(|entry| entry.raw != EMAIL));
+}
+#[tokio::test]
+async fn response_later_leaf_failure_rolls_back_response_only() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut prediction = session.begin_transaction();
+    prediction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let token = prediction.tokenize(&PiiClass::Email, FRESH).unwrap();
+    drop(prediction);
+    let store = Store::default();
+    let registry = registry(
+        &store,
+        Default::default(),
+        Some(json!([FRESH, token])),
+        false,
+        true,
+    );
+    assert!(matches!(
+        dispatch(&registry, &store, &pipeline(), &session, json!(EMAIL)).await,
+        Err(DispatchError::Protection(gaze::ProtectionError::Provenance))
+    ));
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "invoke", "fail"]);
+    let entries = session.snapshot_entries();
+    assert!(entries.iter().any(|entry| entry.raw == EMAIL));
+    assert!(entries
+        .iter()
+        .any(|entry| entry.raw == "synthetic tool value"));
+    assert!(!entries.iter().any(|entry| entry.raw == FRESH));
+}
+#[tokio::test]
+async fn exact_typed_paths_and_numbers_preserve_json_without_schema_authority() {
+    use CarrierSegment::{AnyIndex as I, Member as M};
+    let keys = ["*", "/", "~", ".", "123"];
+    let mut members = vec![vec![M("items".into())]];
+    let mut numbers = vec![];
+    let mut object = serde_json::Map::new();
+    for (key, number) in keys.into_iter().zip([
+        json!(u64::MAX),
+        json!(i64::MIN),
+        json!(1.25),
+        json!(-0.0),
+        json!(0),
+    ]) {
+        let path = vec![M("items".into()), I, M(key.into())];
+        members.push(path.clone());
+        numbers.push(path);
+        object.insert(key.into(), number);
+    }
+    let store = Store::default();
+    let registry = registry(
+        &store,
+        CarrierDeclaration::new(members, numbers),
+        None,
+        false,
+        false,
+    );
+    let input = json!({"items":[Value::Object(object)]});
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let result = dispatch(&registry, &store, &pipeline(), &session, input.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::to_string(&result.payload).unwrap(),
+        serde_json::to_string(&input).unwrap()
+    );
+    for rejected in [
+        json!({"items":{"*":42}}),
+        json!({"items":[{"*":{"nested":EMAIL}}]}),
+        json!({"alice@example.invalid":EMAIL}),
+        json!(42),
+    ] {
+        assert!(matches!(
+            dispatch(&registry, &store, &pipeline(), &session, rejected).await,
+            Err(DispatchError::Carrier(_))
+        ));
+    }
+    let descriptor =
+        ToolDescriptor::agent("schema", json!({"properties":{"text":{"type":"string"}}}))
+            .with_carriers(
+                CarrierDeclaration::text_fields(&["text"]),
+                Default::default(),
+            );
+    let decoded: ToolDescriptor =
+        serde_json::from_value(serde_json::to_value(descriptor).unwrap()).unwrap();
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(Producer {
+            descriptor: decoded,
+            events: store.events.clone(),
+            output: None,
+            error: false,
+            mutate: false,
+        })
+        .unwrap();
+    let result = PiiEnvelope::new(
+        &registry,
+        &Auth,
+        &store,
+        &pipeline(),
+        &session,
+        &[gaze::LocaleTag::Global],
+        &SessionIdPolicy::default_strict(),
+    )
+    .dispatch(
+        &Principal::new("agent"),
+        "schema",
+        json!({"text":EMAIL}),
+        None,
+    )
+    .await;
+    assert!(matches!(result, Err(DispatchError::Carrier(_))));
+}
+#[test]
+fn invalid_declaration_paths_and_duplicates_fail_registration() {
+    for declaration in [
+        CarrierDeclaration::new(vec![vec![]], vec![]),
+        CarrierDeclaration::new(vec![vec![CarrierSegment::AnyIndex]], vec![]),
+        CarrierDeclaration::text_fields(&["text", "text"]),
+        CarrierDeclaration::new(vec![], vec![vec![], vec![]]),
+    ] {
+        let mut registry = ToolRegistry::new();
+        assert!(registry
+            .register(Producer {
+                descriptor: ToolDescriptor::agent("test", json!({}))
+                    .with_carriers(declaration, Default::default()),
+                events: Default::default(),
+                output: None,
+                error: false,
+                mutate: false
+            })
+            .is_err());
+    }
+}
+
+#[tokio::test]
+async fn empty_primary_graph_rejects_even_operations_without_string_leaves() {
+    let store = Store::default();
+    let registry = registry(&store, Default::default(), None, false, false);
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let empty = gaze::Pipeline::builder().build().unwrap();
+    for args in [json!({}), json!(true), json!([]), json!([null, false])] {
+        assert!(matches!(
+            dispatch(&registry, &store, &empty, &session, args).await,
+            Err(DispatchError::Protection(
+                gaze::ProtectionError::EmptyPrimary
+            ))
+        ));
+    }
+    assert!(store.events.lock().unwrap().is_empty());
+}
+
+#[cfg(feature = "core-tools")]
+#[tokio::test]
+async fn real_primary_builtins_succeed_and_operator_bypass_requires_authorization() {
+    let core = gaze_assembly::CorePipelineConfig::new().build().unwrap();
+    let store = Store::default();
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut registry = ToolRegistry::new();
+    registry.register(core_tools::CleanTool::new()).unwrap();
+    registry
+        .register(core_tools::TokenizeFieldTool::new())
+        .unwrap();
+    registry
+        .register(core_tools::SafetyNetCheckTool::new())
+        .unwrap();
+    let policy = SessionIdPolicy::default_strict();
+    let env = PiiEnvelope::new(
+        &registry,
+        &Auth,
+        &store,
+        core.pipeline(),
+        &session,
+        core.locale_chain().as_slice(),
+        &policy,
+    );
+    for (name, args, field) in [
+        ("clean", json!({"text":EMAIL}), "text"),
+        ("tokenize_field", json!({"value":FRESH}), "token"),
+    ] {
+        let result = env
+            .dispatch(&Principal::new("agent"), name, args, None)
+            .await
+            .unwrap();
+        let text = result.payload[field].as_str().unwrap();
+        assert!(!text.contains("@example.invalid"));
+        assert!(session.contains_token(text));
+    }
+    let observation = env
+        .dispatch(
+            &Principal::new("agent"),
+            "safety_net_check",
+            json!({"text":"benign"}),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(observation.payload["ok"], "unconfigured");
+    assert_eq!(observation.payload["nets_run"], 0);
+    assert_eq!(store.events.lock().unwrap().len(), 6);
+    let raw = json!({"alice@example.invalid":{"raw":EMAIL,"number":123456789}});
+    let descriptor = ToolDescriptor::operator("raw", json!({}))
+        .with_response_redaction(ResponseRedaction::BypassByOperator);
+    registry
+        .register(Producer {
+            descriptor,
+            events: store.events.clone(),
+            output: Some(raw.clone()),
+            error: false,
+            mutate: false,
+        })
+        .unwrap();
+    let env = PiiEnvelope::new(
+        &registry,
+        &Auth,
+        &store,
+        core.pipeline(),
+        &session,
+        core.locale_chain().as_slice(),
+        &policy,
+    );
+    let before = store.events.lock().unwrap().len();
+    assert!(matches!(
+        env.dispatch(&Principal::new("agent"), "raw", json!({}), None)
+            .await,
+        Err(DispatchError::Auth(_))
+    ));
+    assert_eq!(store.events.lock().unwrap().len(), before);
+    let result = env
+        .dispatch(&Principal::new("operator"), "raw", json!({}), None)
+        .await
+        .unwrap();
+    assert_eq!(result.payload, raw);
+    assert!(registry
+        .register(Producer {
+            descriptor: ToolDescriptor::agent("bad", json!({}))
+                .with_response_redaction(ResponseRedaction::BypassByOperator),
+            events: Default::default(),
+            output: None,
+            error: false,
+            mutate: false
+        })
+        .is_err());
+}
+
+#[tokio::test]
+async fn supplied_locale_and_dictionary_reach_both_boundaries_and_tool_observers() {
+    use gaze::{
+        DictionaryBundle, DictionaryEntry, DictionarySource, LeakSuspect, LocaleTag,
+        ProtectionContext, SafetyNet, SafetyNetContext, SafetyNetError,
+    };
+    use gaze_types::{Candidate, ConflictTier, DetectContext, DetectError, Recognizer};
+    struct DictPrimary;
+    impl Recognizer for DictPrimary {
+        fn token_family(&self) -> &str {
+            "name"
+        }
+        fn id(&self) -> &str {
+            "dict-spy"
+        }
+        fn supported_class(&self) -> &PiiClass {
+            &PiiClass::Name
+        }
+        fn detect(
+            &self,
+            input: &str,
+            ctx: &DetectContext<'_>,
+        ) -> Result<Vec<Candidate>, DetectError> {
+            if ctx.locale_chain.first() != Some(&LocaleTag::DeDe) {
+                return Ok(vec![]);
+            }
+            let Some(dictionary) = ctx.dictionaries.get("dict_alpha") else {
+                return Ok(vec![]);
+            };
+            Ok(dictionary
+                .terms()
+                .iter()
+                .flat_map(|term| {
+                    input.match_indices(term).map(move |(start, _)| {
+                        Candidate::new(
+                            start..start + term.len(),
+                            PiiClass::Name,
+                            "dict-spy",
+                            1.0,
+                            0,
+                            None,
+                            "name",
+                            "dict-spy",
+                            ConflictTier::None,
+                            vec![],
+                        )
+                    })
+                })
+                .collect())
+        }
+    }
+    struct DictNet(Arc<Mutex<Vec<Option<String>>>>);
+    impl SafetyNet for DictNet {
+        fn id(&self) -> &str {
+            "dict-net"
+        }
+        fn supported_locales(&self) -> &[LocaleTag] {
+            &[LocaleTag::DeDe]
+        }
+        fn check(
+            &self,
+            _: &str,
+            context: SafetyNetContext<'_>,
+        ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+            assert_eq!(context.locale_chain.first(), Some(&LocaleTag::DeDe));
+            assert_eq!(
+                context
+                    .dictionaries
+                    .unwrap()
+                    .get("dict_alpha")
+                    .unwrap()
+                    .terms(),
+                ["Synthetic Alpha", "Synthetic Beta"]
+            );
+            self.0
+                .lock()
+                .unwrap()
+                .push(context.field_path.map(str::to_string));
+            Ok(vec![])
+        }
+    }
+    struct Observer {
+        descriptor: ToolDescriptor,
+    }
+    #[async_trait]
+    impl Tool for Observer {
+        fn descriptor(&self) -> &ToolDescriptor {
+            &self.descriptor
+        }
+        async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+            assert!(!ctx
+                .redacted_args()
+                .as_str()
+                .unwrap()
+                .contains("Synthetic Alpha"));
+            let resources = ctx.resources();
+            let context: ProtectionContext<'_> = resources.protection_context();
+            resources
+                .pipeline()
+                .scan_safety_nets_with_dictionaries(
+                    resources.session(),
+                    "benign",
+                    context.locale_chain(),
+                    context.dictionaries(),
+                )
+                .unwrap();
+            resources
+                .pipeline()
+                .scan_safety_nets_structured_with_dictionaries(
+                    resources.session(),
+                    &std::collections::BTreeMap::from([(
+                        "field".into(),
+                        gaze::Value::String("benign".into()),
+                    )]),
+                    context.locale_chain(),
+                    context.dictionaries(),
+                )
+                .unwrap();
+            Ok(ToolResponse::text("Synthetic Beta"))
+        }
+    }
+    let seen = Arc::new(Mutex::new(vec![]));
+    let pipeline = gaze::Pipeline::builder()
+        .recognizer(DictPrimary)
+        .rule(ClassRule::new(PiiClass::Name, Action::Tokenize))
+        .register_safety_net(DictNet(seen.clone()))
+        .build()
+        .unwrap();
+    let dictionary = DictionaryBundle::from_entries([(
+        "dict_alpha".into(),
+        DictionaryEntry::new(
+            "dict_alpha",
+            vec!["Synthetic Alpha".into(), "Synthetic Beta".into()],
+            true,
+            DictionarySource::Cli,
+        )
+        .unwrap(),
+    )]);
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let store = Store::default();
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(Observer {
+            descriptor: ToolDescriptor::agent("observe", json!({})),
+        })
+        .unwrap();
+    let policy = SessionIdPolicy::default_strict();
+    let env = PiiEnvelope::new(
+        &registry,
+        &Auth,
+        &store,
+        &pipeline,
+        &session,
+        &[LocaleTag::DeDe],
+        &policy,
+    )
+    .with_dictionaries(&dictionary);
+    let response = env
+        .dispatch(
+            &Principal::new("agent"),
+            "observe",
+            json!("Synthetic Alpha"),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(!response
+        .payload
+        .as_str()
+        .unwrap()
+        .contains("Synthetic Beta"));
+    assert_eq!(
+        session
+            .restore(response.payload.as_str().unwrap())
+            .as_deref(),
+        Some("Synthetic Beta")
+    );
+    assert_eq!(session.tokens().len(), 2);
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "finish"]);
+    assert_eq!(
+        *seen.lock().unwrap(),
+        [None, None, Some("field".into()), None]
+    );
+}
+
+#[tokio::test]
+async fn response_commit_conflict_returns_no_payload_and_no_losing_mappings() {
+    struct ConflictingNet {
+        session: Arc<Session>,
+    }
+    impl gaze::SafetyNet for ConflictingNet {
+        fn id(&self) -> &str {
+            "conflict"
+        }
+        fn supported_locales(&self) -> &[gaze::LocaleTag] {
+            &[gaze::LocaleTag::Global]
+        }
+        fn check(
+            &self,
+            _: &str,
+            context: gaze::SafetyNetContext<'_>,
+        ) -> Result<Vec<gaze::LeakSuspect>, gaze::SafetyNetError> {
+            if !context.manifest.spans.is_empty() {
+                self.session
+                    .tokenize(&PiiClass::Name, "synthetic concurrent response")
+                    .unwrap();
+            }
+            Ok(vec![])
+        }
+    }
+    let session = Arc::new(Session::new(Scope::Ephemeral).unwrap());
+    let pipeline = gaze::Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .register_safety_net(ConflictingNet {
+            session: session.clone(),
+        })
+        .build()
+        .unwrap();
+    let store = Store::default();
+    let registry = registry(&store, Default::default(), Some(json!(FRESH)), false, false);
+    assert!(matches!(
+        dispatch(&registry, &store, &pipeline, &session, json!("benign")).await,
+        Err(DispatchError::Transaction(_))
+    ));
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "invoke", "fail"]);
+    assert!(session
+        .snapshot_entries()
+        .iter()
+        .all(|entry| entry.raw != FRESH));
+    assert_eq!(session.snapshot_entries().len(), 1);
+}
+
+#[tokio::test]
+async fn later_residual_leaf_rejects_all_staging_and_undeclared_response_preflights_before_detection(
+) {
+    struct ResidualNet;
+    impl gaze::SafetyNet for ResidualNet {
+        fn id(&self) -> &str {
+            "residual"
+        }
+        fn supported_locales(&self) -> &[gaze::LocaleTag] {
+            &[gaze::LocaleTag::Global]
+        }
+        fn check(
+            &self,
+            text: &str,
+            _: gaze::SafetyNetContext<'_>,
+        ) -> Result<Vec<gaze::LeakSuspect>, gaze::SafetyNetError> {
+            Ok(text
+                .find("residual")
+                .map(|start| {
+                    gaze::LeakSuspect::new(
+                        start..start + 8,
+                        PiiClass::Name,
+                        "residual",
+                        None,
+                        gaze::LeakKind::Uncovered,
+                        "synthetic",
+                        None,
+                    )
+                })
+                .into_iter()
+                .collect())
+        }
+    }
+    let pipeline = gaze::Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .register_safety_net(ResidualNet)
+        .build()
+        .unwrap();
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let pipeline = pipeline.with_pipeline_optimizations(
+        gaze::PipelineOptimizationConfig::new().with_prefix_cache(true),
+    );
+    pipeline
+        .redact(&session, gaze::RawDocument::Text("cache seed".into()))
+        .unwrap();
+    let cache_before = session.prefix_cache_entry_count();
+    assert!(cache_before > 0);
+    let store = Store::default();
+    let registry_a = registry(&store, Default::default(), None, false, false);
+    assert!(matches!(
+        dispatch(
+            &registry_a,
+            &store,
+            &pipeline,
+            &session,
+            json!([EMAIL, "residual"])
+        )
+        .await,
+        Err(DispatchError::Protection(gaze::ProtectionError::Residual))
+    ));
+    assert!(session.tokens().is_empty());
+    assert_eq!(session.prefix_cache_entry_count(), cache_before);
+    assert!(store.events.lock().unwrap().is_empty());
+    let registry_b = registry(
+        &store,
+        Default::default(),
+        Some(json!([FRESH, "residual"])),
+        false,
+        false,
+    );
+    assert!(matches!(
+        dispatch(&registry_b, &store, &pipeline, &session, json!("benign")).await,
+        Err(DispatchError::Protection(gaze::ProtectionError::Residual))
+    ));
+    assert!(session.tokens().is_empty());
+    assert_eq!(session.prefix_cache_entry_count(), cache_before);
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "invoke", "fail"]);
+    let registry_c = registry(
+        &store,
+        Default::default(),
+        Some(json!([FRESH,{"undeclared":false}])),
+        false,
+        false,
+    );
+    assert!(matches!(
+        dispatch(&registry_c, &store, &pipeline, &session, json!("benign")).await,
+        Err(DispatchError::Carrier(_))
+    ));
+    assert!(session.tokens().is_empty());
+    assert_eq!(session.prefix_cache_entry_count(), cache_before);
+}
+
+#[cfg(feature = "core-tools")]
+#[tokio::test]
+async fn structured_observer_requires_explicit_producer_document_shape() {
+    use CarrierSegment::Member as M;
+    let core = gaze_assembly::CorePipelineConfig::new().build().unwrap();
+    let declaration = CarrierDeclaration::new(
+        vec![
+            vec![M("document".into())],
+            vec![M("document".into()), M("text".into())],
+        ],
+        vec![],
+    );
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(core_tools::SafetyNetCheckTool::new().with_argument_carriers(declaration))
+        .unwrap();
+    let store = Store::default();
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let policy = SessionIdPolicy::default_strict();
+    let env = PiiEnvelope::new(
+        &registry,
+        &Auth,
+        &store,
+        core.pipeline(),
+        &session,
+        core.locale_chain().as_slice(),
+        &policy,
+    );
+    let result = env
+        .dispatch(
+            &Principal::new("agent"),
+            "safety_net_check",
+            json!({"document":{"text":EMAIL}}),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.payload["ok"], "unconfigured");
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "finish"]);
+    assert!(matches!(
+        env.dispatch(
+            &Principal::new("agent"),
+            "safety_net_check",
+            json!({"document":{"other":EMAIL}}),
+            None
+        )
+        .await,
+        Err(DispatchError::Carrier(_))
+    ));
+    assert_eq!(*store.events.lock().unwrap(), ["begin", "finish"]);
+}

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -22,6 +22,7 @@ rmcp = { version = "1.6.0", features = ["server", "macros", "transport-io"] }
 axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
+gaze-assembly = { workspace = true }
 gaze = { package = "gaze-pii", path = "../gaze", version = "0.12.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -47,6 +47,19 @@ frontend
 
 Most adopters build `host` by wrapping `gaze_mcp_core::PiiEnvelope`: configure the Gaze pipeline/session, register tools in `ToolRegistry`, implement `ManifestStore`, then pass that dispatch host to `RmcpFrontend::serve`.
 
+## Tool Errors
+
+Tool failures return `isError: true` with a single text frame containing only
+`ToolError::class()`: `invalid-args`, `not-found`, `limit-exceeded`,
+`backend-unavailable`, `backend-failure`, or `internal`. Error payloads and
+source messages are never included, including for future error variants.
+
+Detailed typed errors and manifest records remain on the trusted side for
+caller control flow and operator diagnostics. They may contain unredacted PII
+and must never be serialized into model-facing transport responses. Manifest
+persistence still completes before a tool result is returned; persistence
+failure takes precedence over the tool error.
+
 ## Principal Resolution
 
 `PrincipalResolver` maps rmcp request context to `gaze_mcp_core::Principal`. For local stdio servers, `FixedPrincipalResolver` is enough. HTTP adopters should usually supply their own resolver that reads authenticated request context and emits stable principal ids plus roles.

--- a/crates/gaze-mcp-rmcp/src/adapter.rs
+++ b/crates/gaze-mcp-rmcp/src/adapter.rs
@@ -132,25 +132,11 @@ pub fn response_to_rmcp_call_tool_result(
 /// Translate a `gaze_mcp_core::ToolError` into an rmcp
 /// `CallToolResult { is_error: true }`.
 ///
-/// The error message is rendered as a single text frame and prefixed with
-/// the stable error class (`invalid-args`, `not-found`, `internal`) so
-/// consumers can branch on class without parsing free text.
+/// Only the stable error class is exposed. Payloads and sources can contain
+/// unredacted PII from tool bodies or backends, so they stay on the trusted
+/// side. Using `class()` for every variant also keeps future variants safe.
 pub fn error_to_rmcp_call_tool_result(err: ToolError) -> CallToolResult {
-    let class = err.class();
-    let message = match err {
-        ToolError::InvalidArgs(msg) => msg,
-        ToolError::NotFound(msg) => msg,
-        ToolError::LimitExceeded(msg) => msg,
-        ToolError::BackendUnavailable(msg) => msg,
-        ToolError::BackendFailure(msg) => msg,
-        ToolError::Internal(source) => source.to_string(),
-        // `ToolError` is `#[non_exhaustive]`. Future variants fall back to
-        // their `class()` string — the chokepoint contract guarantees a
-        // stable class for every variant, so this preserves observability
-        // even before the adapter knows the variant by name.
-        _ => class.to_string(),
-    };
-    CallToolResult::error(vec![Content::text(format!("{class}: {message}"))])
+    CallToolResult::error(vec![Content::text(err.class())])
 }
 
 fn json_value_to_object(value: &Value) -> JsonObject {
@@ -307,22 +293,33 @@ mod tests {
     }
 
     #[test]
-    fn tool_error_translates_to_error_call_tool_result_with_class_prefix() {
-        let err = ToolError::InvalidArgs("missing field text".into());
-        let result = error_to_rmcp_call_tool_result(err);
-        assert_eq!(result.is_error, Some(true));
-        let text = &result.content[0].raw.as_text().unwrap().text;
-        assert!(text.starts_with("invalid-args:"), "got: {text}");
-        assert!(text.contains("missing field text"));
-    }
-
-    #[test]
-    fn tool_error_internal_renders_source_message() {
-        let inner: Box<dyn std::error::Error + Send + Sync> = "manifest persist failed".into();
-        let err = ToolError::Internal(inner);
-        let result = error_to_rmcp_call_tool_result(err);
-        let text = &result.content[0].raw.as_text().unwrap().text;
-        assert!(text.starts_with("internal:"), "got: {text}");
-        assert!(text.contains("manifest persist failed"));
+    fn every_tool_error_exposes_only_its_stable_class() {
+        let detail = "/synthetic/alice@example.invalid/private.txt: Dr. Schmidt backend failed";
+        let cases = [
+            (ToolError::InvalidArgs(detail.into()), "invalid-args"),
+            (ToolError::NotFound(detail.into()), "not-found"),
+            (ToolError::LimitExceeded(detail.into()), "limit-exceeded"),
+            (
+                ToolError::BackendUnavailable(detail.into()),
+                "backend-unavailable",
+            ),
+            (ToolError::BackendFailure(detail.into()), "backend-failure"),
+            (
+                ToolError::internal(std::io::Error::other(detail)),
+                "internal",
+            ),
+        ];
+        for (error, class) in cases {
+            let result = error_to_rmcp_call_tool_result(error);
+            let wire = serde_json::to_value(&result).expect("result serializes");
+            assert!(!wire.to_string().contains(detail), "leaked {class} detail");
+            assert_eq!(
+                wire,
+                json!({
+                    "content": [{ "type": "text", "text": class }],
+                    "isError": true
+                })
+            );
+        }
     }
 }

--- a/crates/gaze-mcp-rmcp/src/frontend.rs
+++ b/crates/gaze-mcp-rmcp/src/frontend.rs
@@ -340,7 +340,10 @@ fn dispatch_error_to_tool_result(err: DispatchError) -> CallToolResult {
         DispatchError::Manifest(_) => {
             CallToolResult::error(vec![Content::text("manifest-persistence-failed")])
         }
-        DispatchError::Redaction(_) => {
+        DispatchError::Protection(_)
+        | DispatchError::Carrier(_)
+        | DispatchError::Transaction(_)
+        | DispatchError::Redaction(_) => {
             CallToolResult::error(vec![Content::text("redaction-failed")])
         }
         DispatchError::ResponseSerialization(_) => {

--- a/crates/gaze-mcp-rmcp/tests/manifest_persisted.rs
+++ b/crates/gaze-mcp-rmcp/tests/manifest_persisted.rs
@@ -132,7 +132,10 @@ async fn finish_call_failure_returns_error_instead_of_tool_response() {
     let mut registry = ToolRegistry::new();
     registry
         .register(EchoTool {
-            descriptor: ToolDescriptor::agent("echo", json!({ "type": "object" })),
+            descriptor: ToolDescriptor::agent("echo", json!({ "type": "object" })).with_carriers(
+                gaze_mcp_core::CarrierDeclaration::text_fields(&["text"]),
+                Default::default(),
+            ),
         })
         .expect("register echo tool");
 
@@ -145,7 +148,10 @@ async fn finish_call_failure_returns_error_instead_of_tool_response() {
             fails: AtomicUsize::new(0),
             reject_failure: false,
         },
-        pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
+        pipeline: gaze_assembly::CorePipelineConfig::new()
+            .build()
+            .expect("pipeline")
+            .into_pipeline(),
         session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
         session_id_policy: SessionIdPolicy::default_strict(),
     });
@@ -236,7 +242,10 @@ async fn assert_tool_error_egress(reject_failure: bool) {
             fails: AtomicUsize::new(0),
             reject_failure,
         },
-        pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
+        pipeline: gaze_assembly::CorePipelineConfig::new()
+            .build()
+            .expect("pipeline")
+            .into_pipeline(),
         session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
         session_id_policy: SessionIdPolicy::default_strict(),
     });

--- a/crates/gaze-mcp-rmcp/tests/manifest_persisted.rs
+++ b/crates/gaze-mcp-rmcp/tests/manifest_persisted.rs
@@ -57,6 +57,7 @@ struct FailingFinishManifest {
     begins: AtomicUsize,
     finishes: AtomicUsize,
     fails: AtomicUsize,
+    reject_failure: bool,
 }
 
 #[async_trait]
@@ -83,6 +84,9 @@ impl ManifestStore for FailingFinishManifest {
         _reason: FailureReason,
     ) -> Result<(), ManifestError> {
         self.fails.fetch_add(1, Ordering::SeqCst);
+        if self.reject_failure {
+            return Err(ManifestError::backend(std::io::Error::other(ERROR_DETAIL)));
+        }
         Ok(())
     }
 }
@@ -139,6 +143,7 @@ async fn finish_call_failure_returns_error_instead_of_tool_response() {
             begins: AtomicUsize::new(0),
             finishes: AtomicUsize::new(0),
             fails: AtomicUsize::new(0),
+            reject_failure: false,
         },
         pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
         session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
@@ -175,4 +180,113 @@ async fn finish_call_failure_returns_error_instead_of_tool_response() {
 
     client.cancel().await.expect("client cancels");
     server_task.await.expect("server finishes");
+}
+
+const ERROR_DETAIL: &str =
+    "/synthetic/alice@example.invalid/private.txt: Dr. Schmidt backend failed";
+const ERROR_CLASSES: [&str; 6] = [
+    "invalid-args",
+    "not-found",
+    "limit-exceeded",
+    "backend-unavailable",
+    "backend-failure",
+    "internal",
+];
+
+struct ErrorTool {
+    descriptor: ToolDescriptor,
+    variant: usize,
+}
+
+#[async_trait]
+impl Tool for ErrorTool {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.descriptor
+    }
+
+    async fn invoke(&self, _ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        Err(match self.variant {
+            0 => ToolError::InvalidArgs(ERROR_DETAIL.into()),
+            1 => ToolError::NotFound(ERROR_DETAIL.into()),
+            2 => ToolError::LimitExceeded(ERROR_DETAIL.into()),
+            3 => ToolError::BackendUnavailable(ERROR_DETAIL.into()),
+            4 => ToolError::BackendFailure(ERROR_DETAIL.into()),
+            5 => ToolError::internal(std::io::Error::other(ERROR_DETAIL)),
+            _ => unreachable!("test variant"),
+        })
+    }
+}
+
+async fn assert_tool_error_egress(reject_failure: bool) {
+    let mut registry = ToolRegistry::new();
+    for (variant, class) in ERROR_CLASSES.iter().enumerate() {
+        registry
+            .register(ErrorTool {
+                descriptor: ToolDescriptor::agent(*class, json!({ "type": "object" })),
+                variant,
+            })
+            .expect("register error tool");
+    }
+    let host = Arc::new(EnvelopeHost {
+        registry,
+        auth: AllowAllAuthHook,
+        manifest: FailingFinishManifest {
+            begins: AtomicUsize::new(0),
+            finishes: AtomicUsize::new(0),
+            fails: AtomicUsize::new(0),
+            reject_failure,
+        },
+        pipeline: gaze::Pipeline::builder().build().expect("pipeline"),
+        session: gaze::Session::new(gaze::Scope::Ephemeral).expect("session"),
+        session_id_policy: SessionIdPolicy::default_strict(),
+    });
+    let frontend = RmcpFrontend::stdio(Arc::new(FixedPrincipalResolver::agent("stdio-test")));
+    let handler = frontend.into_server_handler(host.clone());
+    let (client_stream, server_stream) = duplex(16 * 1024);
+    let server_task = tokio::spawn(async move {
+        let running = rmcp::serve_server(handler, server_stream)
+            .await
+            .expect("server initializes");
+        running.waiting().await.expect("server task joins")
+    });
+    let client = ().serve(client_stream).await.expect("client initializes");
+    for (index, class) in ERROR_CLASSES.iter().enumerate() {
+        let result = client
+            .call_tool(CallToolRequestParams::new(*class))
+            .await
+            .expect("tool error is an MCP result, not a protocol error");
+        let wire = serde_json::to_value(&result).expect("result serializes");
+        assert!(
+            !wire.to_string().contains(ERROR_DETAIL),
+            "leaked {class} detail"
+        );
+        let expected = if reject_failure {
+            "manifest-persistence-failed"
+        } else {
+            class
+        };
+        assert_eq!(
+            wire,
+            json!({
+                "content": [{ "type": "text", "text": expected }],
+                "isError": true
+            })
+        );
+        // The failure must be persisted (or rejected) before the client sees any result.
+        assert_eq!(host.manifest.begins.load(Ordering::SeqCst), index + 1);
+        assert_eq!(host.manifest.fails.load(Ordering::SeqCst), index + 1);
+        assert_eq!(host.manifest.finishes.load(Ordering::SeqCst), 0);
+    }
+    client.cancel().await.expect("client cancels");
+    server_task.await.expect("server finishes");
+}
+
+#[tokio::test]
+async fn tool_error_egress_is_class_only_after_manifest_failure_recorded() {
+    assert_tool_error_egress(false).await;
+}
+
+#[tokio::test]
+async fn fail_call_failure_takes_precedence_over_tool_error() {
+    assert_tool_error_egress(true).await;
 }

--- a/crates/gaze-mcp-rmcp/tests/strict_egress.rs
+++ b/crates/gaze-mcp-rmcp/tests/strict_egress.rs
@@ -1,0 +1,152 @@
+use async_trait::async_trait;
+use gaze_mcp_core::*;
+use gaze_mcp_rmcp::{FixedPrincipalResolver, RmcpFrontend};
+use rmcp::{ServiceExt, model::CallToolRequestParams};
+use serde_json::{Value, json};
+use std::sync::{Arc, Mutex};
+#[derive(Default)]
+struct Store(Mutex<Vec<&'static str>>);
+#[async_trait]
+impl ManifestStore for Store {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        self.0.lock().unwrap().push("begin");
+        Ok(CallHandle::new(ctx.call_id))
+    }
+    async fn finish_call(&self, _: CallHandle, _: SnapshotRef) -> Result<(), ManifestError> {
+        self.0.lock().unwrap().push("finish");
+        Ok(())
+    }
+    async fn fail_call(&self, _: CallHandle, _: FailureReason) -> Result<(), ManifestError> {
+        self.0.lock().unwrap().push("fail");
+        Ok(())
+    }
+}
+struct Auth;
+#[async_trait]
+impl AuthHook for Auth {
+    async fn authorize_agent(&self, _: &Principal, _: &str) -> Result<(), AuthError> {
+        Ok(())
+    }
+    async fn authorize_operator(&self, _: &Principal, _: &str) -> Result<(), AuthError> {
+        Err(AuthError::Denied("synthetic".into()))
+    }
+}
+struct Producer(ToolDescriptor);
+#[async_trait]
+impl Tool for Producer {
+    fn descriptor(&self) -> &ToolDescriptor {
+        &self.0
+    }
+    async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+        assert!(
+            !ctx.redacted_args()["text"]
+                .as_str()
+                .unwrap()
+                .contains("alice@example.invalid")
+        );
+        if ctx.redacted_args()["text"] == "fail" {
+            return Ok(ToolResponse::json(json!({"alice@example.invalid":42})));
+        }
+        Ok(ToolResponse::json(json!({"result":"bob@example.invalid"})))
+    }
+}
+struct Host {
+    registry: ToolRegistry,
+    core: gaze_assembly::CorePipeline,
+    session: gaze::Session,
+    store: Store,
+}
+#[async_trait]
+impl DispatchHost for Host {
+    async fn dispatch(
+        &self,
+        principal: &Principal,
+        name: &str,
+        args: Value,
+        sid: Option<&str>,
+    ) -> Result<ToolResponse, DispatchError> {
+        PiiEnvelope::new(
+            &self.registry,
+            &Auth,
+            &self.store,
+            self.core.pipeline(),
+            &self.session,
+            self.core.locale_chain().as_slice(),
+            &SessionIdPolicy::default_strict(),
+        )
+        .dispatch(principal, name, args, sid)
+        .await
+    }
+    fn list_tools(&self) -> Vec<ToolDescriptor> {
+        self.registry.list().into_iter().cloned().collect()
+    }
+}
+#[tokio::test]
+async fn actual_transport_protects_fresh_response_and_hides_carrier_errors() {
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(Producer(
+            ToolDescriptor::agent("test", json!({"type":"object"})).with_carriers(
+                CarrierDeclaration::text_fields(&["text"]),
+                CarrierDeclaration::text_fields(&["result"]),
+            ),
+        ))
+        .unwrap();
+    let host = Arc::new(Host {
+        registry,
+        core: gaze_assembly::CorePipelineConfig::new().build().unwrap(),
+        session: gaze::Session::new(gaze::Scope::Ephemeral).unwrap(),
+        store: Store::default(),
+    });
+    let handler = RmcpFrontend::stdio(Arc::new(FixedPrincipalResolver::agent("synthetic")))
+        .into_server_handler(host.clone());
+    let (client_stream, server_stream) = tokio::io::duplex(16384);
+    let server = tokio::spawn(async move {
+        rmcp::serve_server(handler, server_stream)
+            .await
+            .unwrap()
+            .waiting()
+            .await
+            .unwrap();
+    });
+    let client = ().serve(client_stream).await.unwrap();
+    let success = client
+        .call_tool(
+            CallToolRequestParams::new("test").with_arguments(
+                json!({"text":"alice@example.invalid"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_ne!(success.is_error, Some(true));
+    let wire = serde_json::to_string(&success).unwrap();
+    assert!(!wire.contains("alice@example.invalid"));
+    assert!(!wire.contains("bob@example.invalid"));
+    assert!(
+        host.session
+            .snapshot_entries()
+            .iter()
+            .any(|entry| entry.raw == "bob@example.invalid")
+    );
+    let rejected = client
+        .call_tool(
+            CallToolRequestParams::new("test")
+                .with_arguments(json!({"text":"fail"}).as_object().unwrap().clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.is_error, Some(true));
+    assert_eq!(
+        rejected.content[0].raw.as_text().unwrap().text,
+        "redaction-failed"
+    );
+    assert_eq!(
+        *host.store.0.lock().unwrap(),
+        ["begin", "finish", "begin", "fail"]
+    );
+    client.cancel().await.unwrap();
+    server.await.unwrap();
+}

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -102,3 +102,13 @@ For bring-your-own-data redaction, use the core folder scan example:
 ```bash
 cargo run -p gaze-pii --example scan_folder -- --path ./my-data
 ```
+
+### MCP host configuration
+
+With `chokepoint`, register `SearchDocumentsTool` in a `ToolRegistry` and
+supply a nonempty primary pipeline to `PiiEnvelope`, for example through
+`gaze_assembly::CorePipelineConfig::new().build()` with `core.pipeline()` and
+`core.locale_chain().as_slice()` (add `gaze-assembly` as a direct dependency).
+The tool declares its supported argument and typed result carriers itself;
+reserved `filters` supports an empty array, not arbitrary filter objects or
+numbers. Owner-side bridge tokens remain in their separate namespace.

--- a/crates/gaze-token-bridge/src/bridge/chokepoint.rs
+++ b/crates/gaze-token-bridge/src/bridge/chokepoint.rs
@@ -30,7 +30,9 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use async_trait::async_trait;
 use gaze::PiiClass;
-use gaze_mcp_core::{Tool, ToolCtx, ToolDescriptor, ToolError, ToolResponse};
+use gaze_mcp_core::{
+    CarrierDeclaration, CarrierSegment, Tool, ToolCtx, ToolDescriptor, ToolError, ToolResponse,
+};
 use serde_json::{json, Value};
 
 use crate::bridge::TokenBridge;
@@ -72,10 +74,22 @@ impl SearchDocumentsTool {
             bridge: Mutex::new(bridge),
             principals,
             sessions: Mutex::new(HashMap::new()),
-            descriptor: ToolDescriptor::agent(TOOL_NAME, input_schema()).with_description(
-                "Search an owner-registered index domain by a session token minted earlier in \
+            descriptor: ToolDescriptor::agent(TOOL_NAME, input_schema())
+                .with_carriers(
+                    CarrierDeclaration::text_fields(&[
+                        "source_token",
+                        "target_domain",
+                        "agent_run_id",
+                        "conversation_session_id",
+                        "purpose",
+                        "filters",
+                    ]),
+                    response_carriers(),
+                )
+                .with_description(
+                    "Search an owner-registered index domain by a session token minted earlier in \
                  this conversation. Results carry only current-session tokens — never raw PII.",
-            ),
+                ),
         }
     }
 
@@ -218,6 +232,25 @@ fn input_schema() -> Value {
         },
         "required": ["source_token", "target_domain"]
     })
+}
+
+/// Matches BridgeSearchResponse/AgentSearchHit plus the uniform deny flag.
+/// There are no numeric fields in this typed contract. Reserved filters have
+/// no declared child members, so arbitrary filter objects remain rejected.
+fn response_carriers() -> CarrierDeclaration {
+    use CarrierSegment::{AnyIndex, Member};
+    let mut members = ["target_domain", "audit_id", "results", "authorized"]
+        .iter()
+        .map(|name| vec![Member((*name).into())])
+        .collect::<Vec<_>>();
+    for name in ["doc_id", "snippet"] {
+        members.push(vec![
+            Member("results".into()),
+            AnyIndex,
+            Member(name.into()),
+        ]);
+    }
+    CarrierDeclaration::new(members, vec![])
 }
 
 /// Uniform, no-oracle deny. Byte-identical across unknown-principal, malformed-args,

--- a/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
+++ b/crates/gaze-token-bridge/tests/track_c_chokepoint.rs
@@ -1,8 +1,6 @@
 //! `search_documents` chokepoint tool acceptance tests.
 //!
-//! Drives [`SearchDocumentsTool::run`] directly: the sealed `gaze_mcp_core::ToolCtx`
-//! cannot be constructed outside its crate, so the unit-testable sync core is the
-//! seam. Asserts the owner-side session model (token resolves owner-side), the
+//! Exercises both the synchronous core and actual sealed-envelope dispatch. Asserts the owner-side session model (token resolves owner-side), the
 //! never-leak invariant (no raw PII / alias / fingerprint in agent output), and the
 //! no-oracle deny (no `DenyReason` variant ever surfaces; denies are
 //! indistinguishable across causes).
@@ -311,4 +309,162 @@ fn deny_outputs_are_indistinguishable_across_causes() {
         policy_deny, token_deny,
         "deny shape must not reveal whether the token resolved"
     );
+}
+
+// No async runtime is required: this fixture's tool and manifest never yield.
+fn ready<F: std::future::Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+    match future.as_mut().poll(&mut context) {
+        std::task::Poll::Ready(output) => output,
+        std::task::Poll::Pending => panic!("synchronous fixture unexpectedly yielded"),
+    }
+}
+
+#[derive(Default)]
+struct DispatchManifest(std::sync::Mutex<Vec<Value>>);
+
+#[async_trait::async_trait]
+impl gaze_mcp_core::ManifestStore for DispatchManifest {
+    async fn begin_call(
+        &self,
+        ctx: gaze_mcp_core::BeginCallContext<'_>,
+    ) -> Result<gaze_mcp_core::CallHandle, gaze_mcp_core::ManifestError> {
+        self.0.lock().unwrap().push(ctx.redacted_args.clone());
+        Ok(gaze_mcp_core::CallHandle::new(ctx.call_id))
+    }
+    async fn finish_call(
+        &self,
+        _: gaze_mcp_core::CallHandle,
+        _: gaze_mcp_core::SnapshotRef,
+    ) -> Result<(), gaze_mcp_core::ManifestError> {
+        Ok(())
+    }
+    async fn fail_call(
+        &self,
+        _: gaze_mcp_core::CallHandle,
+        _: gaze_mcp_core::FailureReason,
+    ) -> Result<(), gaze_mcp_core::ManifestError> {
+        Ok(())
+    }
+}
+struct DispatchAuth;
+#[async_trait::async_trait]
+impl gaze_mcp_core::AuthHook for DispatchAuth {
+    async fn authorize_agent(
+        &self,
+        _: &gaze_mcp_core::Principal,
+        _: &str,
+    ) -> Result<(), gaze_mcp_core::AuthError> {
+        Ok(())
+    }
+    async fn authorize_operator(
+        &self,
+        _: &gaze_mcp_core::Principal,
+        _: &str,
+    ) -> Result<(), gaze_mcp_core::AuthError> {
+        Err(gaze_mcp_core::AuthError::MissingHook)
+    }
+}
+struct SyntheticEmail;
+impl gaze::Detector for SyntheticEmail {
+    fn detect(&self, text: &str) -> Vec<gaze::Detection> {
+        text.match_indices("alice@example.invalid")
+            .map(|(start, raw)| {
+                gaze::Detection::new(start..start + raw.len(), PiiClass::Email, "synthetic-email")
+            })
+            .collect()
+    }
+}
+
+#[test]
+fn envelope_dispatch_search_preserves_allow_deny_and_carrier_boundary() {
+    let bridge = demo_bridge();
+    let alias = bridge
+        .primary_alias(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .unwrap();
+    let fingerprint = bridge
+        .primary_fingerprint(CUSTOMER_DOMAIN, "cust-001", &PiiClass::Name)
+        .unwrap();
+    let principal = support_principal();
+    let tool = SearchDocumentsTool::new(bridge, HashMap::from([(principal.id.clone(), principal)]));
+    let token = tool
+        .tokenize_for(SUPPORT_ID, &PiiClass::Name, "Markus Gottschaue")
+        .unwrap();
+    let mut registry = gaze_mcp_core::ToolRegistry::new();
+    registry.register(tool).unwrap();
+    let pipeline = Pipeline::builder()
+        .detector(SyntheticEmail)
+        .rule(gaze::ClassRule::new(
+            PiiClass::Email,
+            gaze::Action::Tokenize,
+        ))
+        .rule(gaze::DefaultRule::new(gaze::Action::Preserve))
+        .build()
+        .unwrap();
+    let session = gaze::Session::new(gaze::Scope::Ephemeral).unwrap();
+    let manifest = DispatchManifest::default();
+    let policy = gaze_mcp_core::SessionIdPolicy::default_strict();
+    let envelope = gaze_mcp_core::PiiEnvelope::new(
+        &registry,
+        &DispatchAuth,
+        &manifest,
+        &pipeline,
+        &session,
+        &[LocaleTag::Global],
+        &policy,
+    );
+    let dispatch = |args| {
+        ready(envelope.dispatch(
+            &gaze_mcp_core::Principal::new(SUPPORT_ID),
+            "search_documents",
+            args,
+            None,
+        ))
+    };
+    let out = dispatch(json!({"source_token": token, "target_domain": CUSTOMER_DOMAIN,
+        "agent_run_id": "run", "conversation_session_id": "conversation", "purpose": "alice@example.invalid", "filters": []})).expect("valid search must dispatch").payload;
+    assert_eq!(out["authorized"], true);
+    assert!(!out["results"].as_array().unwrap().is_empty());
+    let encoded = out.to_string();
+    assert!(encoded.contains(&token));
+    assert_no_raw_leak(&encoded);
+    assert!(!encoded.contains(&alias));
+    assert!(!encoded.contains(&fingerprint));
+    let args = manifest.0.lock().unwrap()[0].clone();
+    let protected = args["purpose"].as_str().unwrap();
+    assert!(!protected.contains("alice@example.invalid"));
+    assert_eq!(
+        session.restore_strict_text(protected).unwrap(),
+        "alice@example.invalid"
+    );
+    let denied = dispatch(json!({"source_token": token, "target_domain": LEGAL_DOMAIN}))
+        .unwrap()
+        .payload;
+    let unknown =
+        dispatch(json!({"source_token": "<fffffff0:Name_99>", "target_domain": LEGAL_DOMAIN}))
+            .unwrap()
+            .payload;
+    assert_eq!(denied, unknown);
+    assert_eq!(denied["authorized"], false);
+    assert_eq!(denied["results"], json!([]));
+    assert_no_deny_oracle(&denied.to_string());
+    assert_eq!(dispatch(json!({})).unwrap().payload["authorized"], false);
+    let begins = manifest.0.lock().unwrap().len();
+    for extra in [
+        json!({"unknown": "value"}),
+        json!({"purpose": 42}),
+        json!({"purpose": {"nested": "value"}}),
+        json!({"filters": [{"field": "name"}]}),
+    ] {
+        let mut args = json!({"source_token": token, "target_domain": CUSTOMER_DOMAIN});
+        args.as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
+        assert!(matches!(
+            dispatch(args),
+            Err(gaze_mcp_core::DispatchError::Carrier(_))
+        ));
+    }
+    assert_eq!(manifest.0.lock().unwrap().len(), begins);
 }

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -1249,7 +1249,14 @@ pub trait SafetyNet: Send + Sync {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct SafetyNetContext<'a> {
-    /// Tokens emitted by the pseudonymization pipeline for this text segment.
+    /// Optional caller-supplied dictionaries. `new` leaves this unset; pipeline
+    /// wrappers supply the caller bundle or `Some(empty default)`. Locale-aware
+    /// model backends have their separate text/locale interface without dictionaries.
+    pub dictionaries: Option<&'a DictionaryBundle>,
+    /// Tokens emitted by the pipeline or verified as owned at a strict boundary.
+    /// At that boundary, raw spans use expanded-owner input coordinates, not
+    /// offsets into the literal token-bearing input. Do not index that literal
+    /// input with reconstructed raw spans.
     pub manifest: &'a Manifest,
     /// Active session-level locale chain. For `RawDocument::Structured`, locale
     /// gating uses this same session-level chain across all fields; structured
@@ -1264,6 +1271,12 @@ pub struct SafetyNetContext<'a> {
 }
 
 impl<'a> SafetyNetContext<'a> {
+    /// Supplies the same dictionary bundle used by primary detection.
+    pub fn with_dictionaries(mut self, dictionaries: &'a DictionaryBundle) -> Self {
+        self.dictionaries = Some(dictionaries);
+        self
+    }
+
     /// Builds safety-net context for one clean text segment.
     pub fn new(
         manifest: &'a Manifest,
@@ -1273,6 +1286,7 @@ impl<'a> SafetyNetContext<'a> {
         field_path: Option<&'a str>,
     ) -> Self {
         Self {
+            dictionaries: None,
             manifest,
             locale_chain,
             document_kind,

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -42,8 +42,8 @@ pub use gaze_types::{
 pub use locale::{LocaleChain, LocaleError, LocaleTag};
 pub use pipeline::{
     Error, GazeLocalProtectionTraceItem, Pipeline, PipelineBuilder, PipelineOptimizationConfig,
-    PrefixCacheWriteMode, Result, SafetyNetDecision, SafetyNetFallback, SafetyNetMode,
-    SafetyNetPolicy,
+    PrefixCacheWriteMode, ProtectionContext, ProtectionError, Result, SafetyNetDecision,
+    SafetyNetFallback, SafetyNetMode, SafetyNetPolicy,
 };
 pub use policy::{
     validate_ner_locale, DetectorKind, DetectorSpec, NerPolicy, Policy, PolicyError, RuleSpec,

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1,3 +1,6 @@
+mod protection;
+pub use protection::{ProtectionContext, ProtectionError};
+
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::sync::Arc;
@@ -31,6 +34,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
+    #[error("strict protection failed: {0}")]
+    Protection(#[from] ProtectionError),
     #[error("invalid regex: {0}")]
     InvalidRegex(#[source] regex::Error),
     #[error("unknown token: [REDACTED]")]
@@ -800,6 +805,22 @@ impl Pipeline {
         clean_text: &str,
         locale_chain: &[crate::LocaleTag],
     ) -> Result<SafetyNetResult> {
+        self.scan_safety_nets_with_dictionaries(
+            session,
+            clean_text,
+            locale_chain,
+            &DictionaryBundle::default(),
+        )
+    }
+
+    /// Observer scan consuming caller-supplied locale and dictionaries.
+    pub fn scan_safety_nets_with_dictionaries(
+        &self,
+        session: &Session,
+        clean_text: &str,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
+    ) -> Result<SafetyNetResult> {
         let nets_run = self.safety_nets_len();
         if nets_run == 0 {
             return Ok(SafetyNetResult {
@@ -809,7 +830,7 @@ impl Pipeline {
         }
 
         let mut target = ProtectionTarget::Live(session);
-        let report = self.run_safety_nets(
+        let report = self.run_safety_nets_in_context(
             &mut target,
             clean_text,
             &Manifest::default(),
@@ -817,6 +838,8 @@ impl Pipeline {
             locale_chain,
             None,
             SafetyNetDecision::Observe { strict: true },
+            dictionaries,
+            false,
         )?;
         Ok(SafetyNetResult { nets_run, report })
     }
@@ -826,6 +849,22 @@ impl Pipeline {
         session: &Session,
         document: &BTreeMap<String, Value>,
         locale_chain: &[crate::LocaleTag],
+    ) -> Result<SafetyNetResult> {
+        self.scan_safety_nets_structured_with_dictionaries(
+            session,
+            document,
+            locale_chain,
+            &DictionaryBundle::default(),
+        )
+    }
+
+    /// Observer scan consuming caller-supplied locale and dictionaries.
+    pub fn scan_safety_nets_structured_with_dictionaries(
+        &self,
+        session: &Session,
+        document: &BTreeMap<String, Value>,
+        locale_chain: &[crate::LocaleTag],
+        dictionaries: &DictionaryBundle,
     ) -> Result<SafetyNetResult> {
         let nets_run = self.safety_nets_len();
         if nets_run == 0 {
@@ -842,7 +881,7 @@ impl Pipeline {
             &mut target,
             document,
             locale_chain,
-            &DictionaryBundle::default(),
+            dictionaries,
             &mut report,
             LeafOp::ScanOnly,
         )?;
@@ -1085,10 +1124,38 @@ impl Pipeline {
         field_path: Option<&str>,
         decision: SafetyNetDecision,
     ) -> Result<LeakReport> {
+        self.run_safety_nets_in_context(
+            target,
+            clean_text,
+            manifest,
+            document_kind,
+            locale_chain,
+            field_path,
+            decision,
+            &DictionaryBundle::default(),
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_safety_nets_in_context(
+        &self,
+        target: &mut ProtectionTarget<'_, '_>,
+        clean_text: &str,
+        manifest: &Manifest,
+        document_kind: DocumentKind,
+        locale_chain: &[crate::LocaleTag],
+        field_path: Option<&str>,
+        decision: SafetyNetDecision,
+        dictionaries: &DictionaryBundle,
+        mandatory: bool,
+    ) -> Result<LeakReport> {
         if self.safety_nets_len() == 0 {
             return Ok(LeakReport::default());
         }
-        if self.should_skip_safety_nets(clean_text, manifest, locale_chain, decision)? {
+        if !mandatory
+            && self.should_skip_safety_nets(clean_text, manifest, locale_chain, decision)?
+        {
             return Ok(LeakReport::default());
         }
 
@@ -1097,6 +1164,9 @@ impl Pipeline {
         let active = gaze_types::LocaleChain::from(locale_chain);
         for net in &self.safety_nets {
             if !active.intersects(net.supported_locales()) {
+                if mandatory {
+                    return Err(ProtectionError::UnsupportedCoverage.into());
+                }
                 telemetry.push(LeakReportTelemetry::LocaleSkipped {
                     safety_net_id: net.id().to_string(),
                     document_kind,
@@ -1111,7 +1181,8 @@ impl Pipeline {
                 document_kind,
                 Some(target.audit_session_id()),
                 field_path,
-            );
+            )
+            .with_dictionaries(dictionaries);
             let mut reported = net.check(clean_text, context)?;
             if let Some(path) = field_path {
                 for suspect in &mut reported {
@@ -1130,8 +1201,23 @@ impl Pipeline {
                 .unwrap_or(crate::LocaleTag::Global);
             let selected = registry
                 .resolve(&locale, ModelStage::Pass3SafetyNet)
-                .map_err(model_error_to_safety_net_error)?;
-            if selected.len() > 1 {
+                .map_err(|error| {
+                    if mandatory
+                        && matches!(
+                            error,
+                            ModelError::NoLocaleModelCoverage { .. }
+                                | ModelError::LocaleNotSupported(_)
+                        )
+                    {
+                        Error::Protection(ProtectionError::UnsupportedCoverage)
+                    } else {
+                        Error::SafetyNet(model_error_to_safety_net_error(error))
+                    }
+                })?;
+            if mandatory && !registry.is_empty() && selected.is_empty() {
+                return Err(ProtectionError::UnsupportedCoverage.into());
+            }
+            if !mandatory && selected.len() > 1 {
                 let selected_backend = selected[0].name();
                 let dropped = selected
                     .iter()
@@ -1151,20 +1237,41 @@ impl Pipeline {
                     dropped,
                 )?;
             }
-            if let Some(model) = selected.first() {
+            for model in selected
+                .iter()
+                .take(if mandatory { selected.len() } else { 1 })
+            {
                 let spans = model
                     .infer(
                         ModelInput {
                             text: clean_text.to_string(),
-                            locale,
+                            locale: locale.clone(),
                         },
                         ModelHints {
                             stage: ModelStage::Pass3SafetyNet,
                             max_spans: None,
                         },
                     )
-                    .map_err(model_error_to_safety_net_error)?;
+                    .map_err(|error| {
+                        if mandatory
+                            && matches!(
+                                error,
+                                ModelError::NoLocaleModelCoverage { .. }
+                                    | ModelError::LocaleNotSupported(_)
+                            )
+                        {
+                            Error::Protection(ProtectionError::UnsupportedCoverage)
+                        } else {
+                            Error::SafetyNet(model_error_to_safety_net_error(error))
+                        }
+                    })?;
                 for span in spans {
+                    if mandatory
+                        && (span.byte_range.start >= span.byte_range.end
+                            || clean_text.get(span.byte_range.clone()).is_none())
+                    {
+                        return Err(ProtectionError::Residual.into());
+                    }
                     if let Some(suspect) =
                         model_span_to_suspect(span, model.name(), manifest, field_path)
                     {
@@ -2937,7 +3044,7 @@ fn walk_structured_value(
                 )?;
                 // For RawDocument::Structured, locale gating uses the session-level
                 // locale chain across all fields; fields have no locale annotations.
-                let field_report = pipeline.run_safety_nets(
+                let field_report = pipeline.run_safety_nets_in_context(
                     target,
                     &clean.text,
                     &Manifest::from_spans(clean.manifest),
@@ -2945,13 +3052,15 @@ fn walk_structured_value(
                     locale_chain,
                     Some(field_path),
                     decision,
+                    dictionaries,
+                    false,
                 )?;
                 report.extend(field_report);
                 Ok(Some(Value::String(clean.text)))
             }
             LeafOp::ScanOnly => {
                 if !text.is_empty() {
-                    let field_report = pipeline.run_safety_nets(
+                    let field_report = pipeline.run_safety_nets_in_context(
                         target,
                         text,
                         &Manifest::default(),
@@ -2959,6 +3068,8 @@ fn walk_structured_value(
                         locale_chain,
                         Some(field_path),
                         op.decision(),
+                        dictionaries,
+                        false,
                     )?;
                     report.extend(field_report);
                 }
@@ -3007,7 +3118,7 @@ fn walk_structured_value(
         Value::Null | Value::Bool(_) | Value::I64(_) => {
             if !matches!(op, LeafOp::Pseudonymize) {
                 if let Some(scalar) = value.scalar_to_safety_net_string() {
-                    let field_report = pipeline.run_safety_nets(
+                    let field_report = pipeline.run_safety_nets_in_context(
                         target,
                         &scalar,
                         &Manifest::default(),
@@ -3015,6 +3126,8 @@ fn walk_structured_value(
                         locale_chain,
                         Some(field_path),
                         op.decision(),
+                        dictionaries,
+                        false,
                     )?;
                     report.extend(field_report);
                 }

--- a/crates/gaze/src/pipeline/protection.rs
+++ b/crates/gaze/src/pipeline/protection.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+/// Strict boundary inputs. There is deliberately no tolerant or one-way mode.
+/// Zero installed safety nets means primary-only protection, not PII completeness.
+#[derive(Clone, Copy)]
+pub struct ProtectionContext<'a> {
+    locale_chain: &'a [crate::LocaleTag],
+    dictionaries: &'a DictionaryBundle,
+}
+
+impl<'a> ProtectionContext<'a> {
+    pub fn strict(
+        locale_chain: &'a [crate::LocaleTag],
+        dictionaries: &'a DictionaryBundle,
+    ) -> Self {
+        Self {
+            locale_chain,
+            dictionaries,
+        }
+    }
+    pub fn locale_chain(self) -> &'a [crate::LocaleTag] {
+        self.locale_chain
+    }
+    pub fn dictionaries(self) -> &'a DictionaryBundle {
+        self.dictionaries
+    }
+}
+
+/// Class-only failures safe to expose at an untrusted boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProtectionError {
+    #[error("empty primary configuration")]
+    EmptyPrimary,
+    #[error("unsupported safety-net locale coverage")]
+    UnsupportedCoverage,
+    #[error("primary protection failed")]
+    Primary,
+    #[error("safety-net execution failed")]
+    SafetyNet,
+    #[error("residual suspect rejected")]
+    Residual,
+    #[error("token provenance or reversibility rejected")]
+    Provenance,
+}
+
+impl Pipeline {
+    /// Validates the actual primary graph and installed safety-net locale coverage.
+    /// Call before staging a structured operation, including operations with no strings.
+    pub fn validate_protection_context(
+        &self,
+        context: ProtectionContext<'_>,
+    ) -> std::result::Result<(), ProtectionError> {
+        if self.registry.is_empty() {
+            return Err(ProtectionError::EmptyPrimary);
+        }
+        let active = gaze_types::LocaleChain::from(context.locale_chain);
+        if self
+            .safety_nets
+            .iter()
+            .any(|net| !active.intersects(net.supported_locales()))
+        {
+            return Err(ProtectionError::UnsupportedCoverage);
+        }
+        #[cfg(feature = "bundled-recognizers")]
+        if let Some(registry) = &self.safety_net_registry {
+            if !registry.is_empty() {
+                let locale = context
+                    .locale_chain
+                    .first()
+                    .cloned()
+                    .unwrap_or(crate::LocaleTag::Global);
+                let models = registry
+                    .resolve(&locale, ModelStage::Pass3SafetyNet)
+                    .map_err(|error| match error {
+                        ModelError::NoLocaleModelCoverage { .. }
+                        | ModelError::LocaleNotSupported(_) => ProtectionError::UnsupportedCoverage,
+                        _ => ProtectionError::SafetyNet,
+                    })?;
+                if models.is_empty() {
+                    return Err(ProtectionError::UnsupportedCoverage);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Protects a complete string leaf in caller-owned staging state; never commits.
+    ///
+    /// An error may leave mappings staged. Abandon the operation transaction on
+    /// error; do not commit it or use earlier returned strings as proof. A returned
+    /// string reflects this leaf's entry interpretation, not an immutable whole-
+    /// operation proof. Multi-leaf callers must also reject cross-leaf collisions.
+    /// Reconstructed safety-manifest raw coordinates refer to the expanded input
+    /// interpretation: existing owned tokens stand for their stored raw bytes.
+    /// Owned tokens retain their input interpretation. All installed applicable nets
+    /// scan the complete final leaf, independently of observer optimization flags.
+    pub fn protect_text_transaction(
+        &self,
+        transaction: &mut SessionTransaction<'_>,
+        input: &str,
+        context: ProtectionContext<'_>,
+    ) -> std::result::Result<String, ProtectionError> {
+        self.validate_protection_context(context)?;
+        let owned = transaction.snapshot_entries();
+        let regex = transaction
+            .restore_regex()
+            .map_err(|_| ProtectionError::Provenance)?;
+        let ranges = regex
+            .as_ref()
+            .map(|re| re.find_iter(input).map(|m| m.range()).collect::<Vec<_>>())
+            .unwrap_or_default();
+        let mut clean = String::with_capacity(input.len());
+        let mut expected = String::with_capacity(input.len());
+        let mut spans = Vec::new();
+        let mut cursor = 0;
+        for range in ranges {
+            self.protect_gap(
+                transaction,
+                &input[cursor..range.start],
+                context,
+                &mut clean,
+                &mut expected,
+                &mut spans,
+            )?;
+            let entry = owned
+                .iter()
+                .find(|entry| entry.token == input[range.clone()])
+                .ok_or(ProtectionError::Provenance)?;
+            let clean_start = clean.len();
+            let raw_start = expected.len();
+            clean.push_str(&entry.token);
+            expected.push_str(&entry.raw);
+            spans.push(EmittedTokenSpan::new(
+                clean_start..clean.len(),
+                raw_start..expected.len(),
+                entry.class.clone(),
+            ));
+            cursor = range.end;
+        }
+        self.protect_gap(
+            transaction,
+            &input[cursor..],
+            context,
+            &mut clean,
+            &mut expected,
+            &mut spans,
+        )?;
+        let manifest = Manifest::from_spans(spans);
+        let entries = transaction.snapshot_entries();
+        let mut restored = String::new();
+        let mut cursor = 0;
+        for span in &manifest.spans {
+            if span.clean_span.start < cursor {
+                return Err(ProtectionError::Provenance);
+            }
+            let token = clean
+                .get(span.clean_span.clone())
+                .ok_or(ProtectionError::Provenance)?;
+            let entry = entries
+                .iter()
+                .find(|entry| entry.token == token && entry.class == span.class)
+                .ok_or(ProtectionError::Provenance)?;
+            if expected.get(span.raw_span.clone()) != Some(entry.raw.as_str()) {
+                return Err(ProtectionError::Provenance);
+            }
+            restored.push_str(&clean[cursor..span.clean_span.start]);
+            restored.push_str(&entry.raw);
+            cursor = span.clean_span.end;
+        }
+        restored.push_str(&clean[cursor..]);
+        if restored != expected {
+            return Err(ProtectionError::Provenance);
+        }
+        // Actual session restore must agree with provenance. A freshly minted spelling
+        // in an originally literal gap must not acquire authority by coincidence.
+        let actual_ranges = transaction
+            .restore_regex()
+            .map_err(|_| ProtectionError::Provenance)?
+            .map(|re| {
+                re.find_iter(&clean)
+                    .map(|found| found.range())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if actual_ranges
+            != manifest
+                .spans
+                .iter()
+                .map(|span| span.clean_span.clone())
+                .collect::<Vec<_>>()
+        {
+            return Err(ProtectionError::Provenance);
+        }
+        let mut target = ProtectionTarget::Staged(transaction, PrefixCacheWriteMode::Suppress);
+        let report = self
+            .run_safety_nets_in_context(
+                &mut target,
+                &clean,
+                &manifest,
+                DocumentKind::Text,
+                context.locale_chain,
+                None,
+                SafetyNetDecision::Observe { strict: true },
+                context.dictionaries,
+                true,
+            )
+            .map_err(|error| match error {
+                Error::Protection(error) => error,
+                _ => ProtectionError::SafetyNet,
+            })?;
+        for suspect in report.suspects {
+            if suspect.span.start >= suspect.span.end || clean.get(suspect.span.clone()).is_none() {
+                return Err(ProtectionError::Residual);
+            }
+            // Coverage is geometric: even a backend class disagreement entirely inside
+            // verified token bytes cannot expose raw data. Any raw gap still rejects.
+            let mut cursor = suspect.span.start;
+            for span in &manifest.spans {
+                if span.clean_span.end <= cursor {
+                    continue;
+                }
+                if span.clean_span.start > cursor {
+                    break;
+                }
+                cursor = span.clean_span.end;
+                if cursor >= suspect.span.end {
+                    break;
+                }
+            }
+            if cursor < suspect.span.end {
+                return Err(ProtectionError::Residual);
+            }
+        }
+        Ok(clean)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn protect_gap(
+        &self,
+        transaction: &mut SessionTransaction<'_>,
+        input: &str,
+        context: ProtectionContext<'_>,
+        clean: &mut String,
+        expected: &mut String,
+        spans: &mut Vec<EmittedTokenSpan>,
+    ) -> std::result::Result<(), ProtectionError> {
+        let clean_offset = clean.len();
+        let raw_offset = expected.len();
+        expected.push_str(input);
+        if input.is_empty() {
+            return Ok(());
+        }
+        let mut target = ProtectionTarget::Staged(transaction, PrefixCacheWriteMode::Suppress);
+        let result = self
+            .redact_text_with_manifest_uncached(
+                &mut target,
+                input,
+                None,
+                DocumentKind::Text,
+                context.locale_chain,
+                context.dictionaries,
+                None,
+            )
+            .map_err(|_| ProtectionError::Primary)?;
+        clean.push_str(&result.text);
+        spans.extend(result.manifest.into_iter().map(|span| {
+            EmittedTokenSpan::new(
+                span.clean_span.start + clean_offset..span.clean_span.end + clean_offset,
+                span.raw_span.start + raw_offset..span.raw_span.end + raw_offset,
+                span.class,
+            )
+        }));
+        Ok(())
+    }
+}

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -433,6 +433,10 @@ mod tests {
 }
 
 impl RecognizerRegistry {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     pub fn builder() -> RecognizerRegistryBuilder {
         RecognizerRegistryBuilder::default()
     }

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -874,6 +874,10 @@ impl Session {
 }
 
 impl<'session> SessionTransaction<'session> {
+    pub(crate) fn restore_regex(&self) -> Result<Option<Arc<Regex>>> {
+        build_restore_regex(&self.staged)
+    }
+
     pub fn tokenize(&mut self, class: &PiiClass, raw: &str) -> Result<String> {
         self.tokenize_with_family(DEFAULT_COUNTER_FAMILY, class, raw)
     }

--- a/crates/gaze/tests/strict_protection.rs
+++ b/crates/gaze/tests/strict_protection.rs
@@ -1,0 +1,440 @@
+use gaze::*;
+use std::sync::{Arc, Mutex};
+const EMAIL: &str = "alice@example.invalid";
+#[derive(Clone)]
+struct Primary;
+impl Detector for Primary {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        input
+            .match_indices(EMAIL)
+            .map(|(start, _)| {
+                Detection::new(start..start + EMAIL.len(), PiiClass::Email, "synthetic")
+            })
+            .collect()
+    }
+}
+fn pipeline(action: Action) -> Pipeline {
+    Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, action))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+fn protect(
+    pipeline: &Pipeline,
+    transaction: &mut SessionTransaction<'_>,
+    input: &str,
+) -> std::result::Result<String, ProtectionError> {
+    pipeline.protect_text_transaction(
+        transaction,
+        input,
+        ProtectionContext::strict(&[LocaleTag::Global], &DictionaryBundle::default()),
+    )
+}
+#[test]
+fn primary_floor_and_round_trip_without_publication() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut transaction = session.begin_transaction();
+    assert_eq!(
+        protect(
+            &Pipeline::builder().build().unwrap(),
+            &mut transaction,
+            "benign"
+        ),
+        Err(ProtectionError::EmptyPrimary)
+    );
+    let pipeline = pipeline(Action::Tokenize);
+    let token = protect(&pipeline, &mut transaction, EMAIL).unwrap();
+    assert!(session.tokens().is_empty());
+    assert_eq!(transaction.restore(&token).as_deref(), Some(EMAIL));
+    assert_eq!(
+        protect(&pipeline, &mut transaction, &format!("{token}{token}")),
+        Ok(format!("{token}{token}"))
+    );
+    let custom = transaction
+        .tokenize(&PiiClass::Custom("class_alpha".into()), "synthetic alpha")
+        .unwrap();
+    assert_eq!(protect(&pipeline, &mut transaction, &custom), Ok(custom));
+    let fake = transaction
+        .format_preserving_fake(&PiiClass::Email, "bob@example.invalid")
+        .unwrap();
+    assert_eq!(protect(&pipeline, &mut transaction, &fake), Ok(fake));
+    transaction.commit().unwrap();
+    let mut transaction = session.begin_transaction();
+    assert_eq!(protect(&pipeline, &mut transaction, &token), Ok(token));
+}
+#[test]
+fn literal_collision_and_one_way_replacements_reject_without_publish() {
+    for action in [Action::Redact, Action::Generalize] {
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let mut transaction = session.begin_transaction();
+        assert_eq!(
+            protect(&pipeline(action), &mut transaction, EMAIL),
+            Err(ProtectionError::Provenance)
+        );
+        drop(transaction);
+        assert!(session.tokens().is_empty());
+    }
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut prediction = session.begin_transaction();
+    let predicted = prediction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    drop(prediction);
+    let mut transaction = session.begin_transaction();
+    assert_eq!(
+        protect(
+            &pipeline(Action::Tokenize),
+            &mut transaction,
+            &format!("{predicted} {EMAIL}")
+        ),
+        Err(ProtectionError::Provenance)
+    );
+    assert!(session.tokens().is_empty());
+    assert_eq!(
+        protect(
+            &pipeline(Action::Tokenize),
+            &mut session.begin_transaction(),
+            "literal <Unknown_1>"
+        ),
+        Ok("literal <Unknown_1>".into())
+    );
+}
+#[derive(Clone)]
+struct Net {
+    seen: Arc<Mutex<Vec<(String, usize)>>>,
+    whole: bool,
+    locale: LocaleTag,
+}
+impl SafetyNet for Net {
+    fn id(&self) -> &str {
+        "spy"
+    }
+    fn supported_locales(&self) -> &[LocaleTag] {
+        std::slice::from_ref(&self.locale)
+    }
+    fn check(
+        &self,
+        text: &str,
+        context: SafetyNetContext<'_>,
+    ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+        assert!(context.dictionaries.is_some());
+        self.seen
+            .lock()
+            .unwrap()
+            .push((text.into(), context.manifest.spans.len()));
+        let range = if self.whole {
+            Some(0..text.len())
+        } else {
+            text.find("residual").map(|start| start..start + 8)
+        };
+        Ok(range
+            .into_iter()
+            .map(|range| {
+                LeakSuspect::new(
+                    range,
+                    PiiClass::Name,
+                    "spy",
+                    None,
+                    LeakKind::Uncovered,
+                    "synthetic",
+                    None,
+                )
+            })
+            .collect())
+    }
+}
+#[test]
+fn mandatory_scans_ignore_both_skip_flags_and_cover_complete_owned_leaf() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let p = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .register_safety_net(Net {
+            seen: seen.clone(),
+            whole: false,
+            locale: LocaleTag::Global,
+        })
+        .build()
+        .unwrap()
+        .with_pipeline_optimizations(
+            PipelineOptimizationConfig::new()
+                .with_skip_class_gating(true)
+                .with_capitals_heuristic_gate(true),
+        );
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    assert_eq!(
+        protect(&p, &mut session.begin_transaction(), "residual"),
+        Err(ProtectionError::Residual)
+    );
+    let mut tx = session.begin_transaction();
+    let token = protect(&p, &mut tx, EMAIL).unwrap();
+    assert_eq!(protect(&p, &mut tx, &token), Ok(token.clone()));
+    let seen = seen.lock().unwrap();
+    assert_eq!(
+        *seen,
+        vec![("residual".into(), 0), (token.clone(), 1), (token, 1)]
+    );
+}
+#[test]
+fn coverage_must_not_cross_raw_gap_and_incompatible_custom_locale_fails() {
+    let p = Pipeline::builder()
+        .detector(Primary)
+        .register_safety_net(Net {
+            seen: Default::default(),
+            whole: true,
+            locale: LocaleTag::Global,
+        })
+        .build()
+        .unwrap();
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let token = session.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    assert_eq!(
+        protect(&p, &mut session.begin_transaction(), &token),
+        Ok(token.clone())
+    );
+    assert_eq!(
+        protect(
+            &p,
+            &mut session.begin_transaction(),
+            &format!("{token} gap {token}")
+        ),
+        Err(ProtectionError::Residual)
+    );
+    let p = Pipeline::builder()
+        .detector(Primary)
+        .register_safety_net(Net {
+            seen: Default::default(),
+            whole: false,
+            locale: LocaleTag::DeDe,
+        })
+        .build()
+        .unwrap();
+    assert_eq!(
+        p.protect_text_transaction(
+            &mut session.begin_transaction(),
+            "benign",
+            ProtectionContext::strict(&[LocaleTag::EnUs], &DictionaryBundle::default())
+        ),
+        Err(ProtectionError::UnsupportedCoverage)
+    );
+}
+
+#[cfg(feature = "bundled-recognizers")]
+#[test]
+fn mandatory_registry_runs_every_selected_backend_and_rejects_uncovered_locale() {
+    use gaze_recognizers::{
+        LocaleAwareModel, LocaleAwareModelRegistry, ModelError, ModelHints, ModelInput, ModelSpan,
+    };
+    struct Model {
+        id: &'static str,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+    impl LocaleAwareModel for Model {
+        fn name(&self) -> &str {
+            self.id
+        }
+        fn native_locales(&self) -> &[LocaleTag] {
+            &[LocaleTag::EnUs]
+        }
+        fn infer(
+            &self,
+            _: ModelInput,
+            _: ModelHints,
+        ) -> std::result::Result<Vec<ModelSpan>, ModelError> {
+            self.seen.lock().unwrap().push(self.id.into());
+            Ok(vec![])
+        }
+    }
+    let seen = Arc::new(Mutex::new(vec![]));
+    let registry = LocaleAwareModelRegistry::from_backends(vec![
+        Box::new(Model {
+            id: "a",
+            seen: seen.clone(),
+        }),
+        Box::new(Model {
+            id: "b",
+            seen: seen.clone(),
+        }),
+    ]);
+    let p = pipeline(Action::Tokenize).with_safety_net_registry(registry);
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let dictionaries = DictionaryBundle::default();
+    p.protect_text_transaction(
+        &mut session.begin_transaction(),
+        "benign",
+        ProtectionContext::strict(&[LocaleTag::EnUs], &dictionaries),
+    )
+    .unwrap();
+    let mut names = seen.lock().unwrap().clone();
+    names.sort();
+    assert_eq!(names, ["a", "b"]);
+    assert!(p
+        .protect_text_transaction(
+            &mut session.begin_transaction(),
+            "benign",
+            ProtectionContext::strict(&[LocaleTag::DeDe], &dictionaries)
+        )
+        .is_err());
+}
+
+#[test]
+fn format_preserving_emission_must_match_actual_restore_word_boundaries() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    // The detector replaces EMAIL only; the final fake has no left word boundary.
+    assert_eq!(
+        protect(
+            &pipeline(Action::FormatPreserve),
+            &mut session.begin_transaction(),
+            &format!("x{EMAIL}")
+        ),
+        Err(ProtectionError::Provenance)
+    );
+    assert!(session.tokens().is_empty());
+}
+
+#[cfg(feature = "bundled-recognizers")]
+#[test]
+fn malformed_model_spans_reject_before_manifest_filtering() {
+    use gaze_recognizers::{
+        LocaleAwareModel, LocaleAwareModelRegistry, ModelError, ModelHints, ModelInput, ModelSpan,
+    };
+    struct BadModel(std::ops::Range<usize>);
+    impl LocaleAwareModel for BadModel {
+        fn name(&self) -> &str {
+            "bad-span"
+        }
+        fn native_locales(&self) -> &[LocaleTag] {
+            &[LocaleTag::EnUs]
+        }
+        fn infer(
+            &self,
+            _: ModelInput,
+            _: ModelHints,
+        ) -> std::result::Result<Vec<ModelSpan>, ModelError> {
+            Ok(vec![ModelSpan {
+                text: "synthetic".into(),
+                byte_range: self.0.clone(),
+                class: PiiClass::Email,
+                confidence: None,
+                model_name: "bad-span".into(),
+            }])
+        }
+    }
+    for range in [0..0, std::ops::Range { start: 2, end: 1 }, 0..100, 1..2] {
+        let p = pipeline(Action::Tokenize).with_safety_net_registry(
+            LocaleAwareModelRegistry::from_backends(vec![Box::new(BadModel(range))]),
+        );
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        assert_eq!(
+            p.protect_text_transaction(
+                &mut session.begin_transaction(),
+                "é benign",
+                ProtectionContext::strict(&[LocaleTag::EnUs], &DictionaryBundle::default())
+            ),
+            Err(ProtectionError::Residual)
+        );
+    }
+}
+
+#[test]
+fn manifest_coordinates_use_expanded_owner_input_and_exact_final_ranges() {
+    struct Coordinates;
+    impl SafetyNet for Coordinates {
+        fn id(&self) -> &str {
+            "coordinates"
+        }
+        fn supported_locales(&self) -> &[LocaleTag] {
+            &[LocaleTag::Global]
+        }
+        fn check(
+            &self,
+            text: &str,
+            context: SafetyNetContext<'_>,
+        ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+            let token = text.split(' ').next().unwrap();
+            assert_eq!(
+                context.manifest.spans,
+                [
+                    EmittedTokenSpan::new(0..token.len(), 0..EMAIL.len(), PiiClass::Email),
+                    EmittedTokenSpan::new(
+                        token.len() + 1..text.len(),
+                        EMAIL.len() + 1..2 * EMAIL.len() + 1,
+                        PiiClass::Email
+                    ),
+                ]
+            );
+            Ok(vec![])
+        }
+    }
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let token = session.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .register_safety_net(Coordinates)
+        .build()
+        .unwrap();
+    let input = format!("{token} {EMAIL}");
+    assert_eq!(
+        protect(&pipeline, &mut session.begin_transaction(), &input).unwrap(),
+        format!("{token} {token}")
+    );
+}
+
+#[test]
+fn malformed_custom_spans_fail_and_errors_require_discarding_staging() {
+    struct BadNet(std::ops::Range<usize>);
+    impl SafetyNet for BadNet {
+        fn id(&self) -> &str {
+            "bad-custom"
+        }
+        fn supported_locales(&self) -> &[LocaleTag] {
+            &[LocaleTag::Global]
+        }
+        fn check(
+            &self,
+            _: &str,
+            _: SafetyNetContext<'_>,
+        ) -> std::result::Result<Vec<LeakSuspect>, SafetyNetError> {
+            Ok(vec![LeakSuspect::new(
+                self.0.clone(),
+                PiiClass::Name,
+                "bad-custom",
+                None,
+                LeakKind::Uncovered,
+                "synthetic",
+                None,
+            )])
+        }
+    }
+    for range in [0..0, std::ops::Range { start: 2, end: 1 }, 0..1000, 1..2] {
+        let p = Pipeline::builder()
+            .detector(Primary)
+            .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+            .register_safety_net(BadNet(range))
+            .build()
+            .unwrap();
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let mut transaction = session.begin_transaction();
+        assert_eq!(
+            protect(&p, &mut transaction, &format!("é {EMAIL}")),
+            Err(ProtectionError::Residual)
+        );
+        assert!(
+            !transaction.tokens().is_empty(),
+            "Err does not automatically roll back caller-owned staging"
+        );
+        drop(transaction);
+        assert!(session.tokens().is_empty());
+    }
+    assert_eq!(
+        Pipeline::builder()
+            .build()
+            .unwrap()
+            .validate_protection_context(ProtectionContext::strict(
+                &[LocaleTag::Global],
+                &DictionaryBundle::default()
+            )),
+        Err(ProtectionError::EmptyPrimary)
+    );
+}


### PR DESCRIPTION
## What & why

Calls through `PiiEnvelope` could use primary-only protection with empty/default context and omit structured carriers; the rmcp sink could also expose raw tool diagnostics. This change protects complete argument and response operations with the configured locale, dictionaries, and installed safety nets, verifies token ownership and exact restoration, and returns only error classes to the model.

### Added

- **Strict transactional protection:** mandatory final-leaf scans, verified known-token preservation, exact restore matching, and cross-leaf literal-collision rejection.
- **Producer-owned JSON declarations:** exact static member paths and explicitly non-sensitive number paths; schemas cannot grant carrier authority and numeric values are not coerced.

### Fixed

- **Tool errors no longer expose backend detail:** rmcp renders only the error class; detailed errors remain within the documented trusted diagnostics boundary.
- **Real consumers use the contract:** CLI and document tools use configured protection; the token-bridge search tool declares its supported carriers; file tools restore protected paths only on the trusted side before filesystem access.
- **Audit terminal ordering:** response mappings commit before the sole finish attempt. A failed finish returns no payload and cannot trigger a second terminal call.

### Changed

- **Adopter migration is required:** custom tools must declare object keys and numeric leaves and supply a nonempty primary pipeline. Installed safety nets must cover the configured locale. Undeclared carriers, residual suspects, invalid spans, ownership conflicts, and irreversible replacements fail closed.
- **Error text is now class-only.** Consumers must use the error class and trusted diagnostics instead of parsing backend text from model-facing errors.

## Flow and state boundaries

```text
Preflight + protect all args -> begin manifest -> commit args -> invoke
  -> fresh response transaction -> preflight + protect all response leaves
  -> snapshot outgoing bytes -> commit response -> finish manifest -> return
```

A failed operation discards its staging. Response rollback excludes previously committed arguments and tool-side live-session changes. Failed finish retains response mappings without returning a payload. Authorized operator raw response bypass remains a separate, auth-gated exception.

## Five-axis assessment and limits

Reliability, reversibility, agentic integration, and auditability improve through enforced context, complete-operation checks, owned-token preservation, and typed rejection. **Adopter ergonomics has an intentional compatibility cost:** previously accepted undeclared objects/numbers and empty-primary hosts now reject; the migration guide and built-in consumers are updated. Dynamic keys and cross-field concatenation remain unsupported. Numeric declarations are trusted producer assertions, not detector certification. Zero installed safety nets remains a primary-only floor.

No global residual-default change or corpus/model benchmark is included, and these tests do not establish universal PII-detection coverage. Before publication, coordinate crate versions and dependency minimums for this behaviorally incompatible change; this PR does not release packages.

## Verification

Verified on signed commit `b78c8d6bce4f02d06560ee1b7ba6d88a6c79e7fb` with Rust 1.96.0. All **24 local verification stages passed**, including workspace Clippy, all-feature workspace tests, the full feature matrix (including its all-feature and default-feature workspace runs), document/CLI MCP suites, actual OCR stdio success, warnings-denied rustdoc, dependency audit, all policy gates, and scorer unit tests (123 run, one intentionally skipped). Existing ignored model/budget tests remain ignored; no corpus benchmark was run.

The adopted fix is byte-for-byte tree-equal to the independently reviewed artifact. Regression receipts show executed assertion failures on the old search/path behavior and success with the corrections. The unchanged core protection implementation also has eight deliberate-defect regression receipts with restored passing checks. Source review found no remaining material blocker within its stated scope. A separate `cargo test -p gaze-token-bridge --features chokepoint --locked --offline` run passed all 78 tests. All final stage log hashes, source tree, DCO trailers, and commit signatures were independently checked.

All **12 GitHub checks passed** on the same commit: [workspace tests, MSRV, scorer tests, and policy gates](https://github.com/CertaMesh/gaze/actions/runs/34275538696), [documentation](https://github.com/CertaMesh/gaze/actions/runs/34275538720), [dependency audit](https://github.com/CertaMesh/gaze/actions/runs/34275538645), [DCO](https://github.com/CertaMesh/gaze/actions/runs/34275538594), and [CodeQL](https://github.com/CertaMesh/gaze/actions/runs/34275535476).

## Local gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features --locked --offline -- --test-threads=1`
- [x] `cargo deny --locked check`
- [x] All behavioral xtask gates from CONTRIBUTING and CI
- [x] Feature-enabled document/CLI suites, warnings-denied rustdoc, and benchmark scorer unit tests
- [x] Synthetic fixtures only; fixture-citation and trybuild hygiene gates
- [x] Signed-off, cryptographically signed `[agent]` commits; specific staging; no force-push or hook bypass

## Visual evidence

The screenshots below show GitHub-rendered documentation from base `d1023ee` and the final reviewed commit. Documentation content changed; no responsive layout changed.

<details>
<summary>Before and after: adopter quickstart, errors, migration notes, token bridge</summary>

**Core adopter quickstart**

![Core adopter quickstart before](https://github.com/user-attachments/assets/0692b6d9-1b9e-4fd6-aeb9-fa58d8ee6c58)
![Core adopter quickstart after](https://github.com/user-attachments/assets/793677ed-3a24-4af0-b9fd-eeaeb4bf3cc3)

**Transport error contract**

![Transport documentation before](https://github.com/user-attachments/assets/6c926133-978f-419e-9f7f-788b913109da)
![Transport documentation after](https://github.com/user-attachments/assets/30eed32f-dabe-4cf6-8cbf-ade8397174bd)

**Unreleased migration note**

![Changelog before](https://github.com/user-attachments/assets/adff2e01-8f94-4626-b35e-a919dfab43f7)
![Changelog after](https://github.com/user-attachments/assets/148c5f91-c541-4b7d-9692-4b9f1e29ac52)

**Token bridge host setup**

![Token bridge documentation before](https://github.com/user-attachments/assets/e14bba8d-cd65-404f-bbdc-4da185bc856f)
![Token bridge documentation after](https://github.com/user-attachments/assets/aeeba135-efc3-407d-a820-0e6022298b14)

</details>
