### PR TITLE
[agent] prepare Gaze v0.13.0 coordinated release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,26 @@ jobs:
 
           cargo run -p xtask -- scrub-public-text "${files[@]}"
 
+  model-setup-ownership-preflight:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Verify real model ownership across working directories
+        run: scripts/gate/model-setup-ownership.sh "$RUNNER_TEMP/model-setup-ownership"
+      - name: Upload ownership preflight receipts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: model-setup-ownership-${{ github.sha }}
+          path: ${{ runner.temp }}/model-setup-ownership/
+          if-no-files-found: error
+          retention-days: 30
+
   build:
     if: github.event_name == 'push'
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-09-09
+
 ### Added
 
+- **Opt-in local proxy inspection dashboard** (#397). The default-off
+  `gaze-cli` `dashboard` feature adds an isolated, killable child runtime with
+  bounded, memory-only inspection. Pairing, authentication, registration-bound
+  activation, purge, and disable are fail-closed boundaries. Inspection may
+  expose owner-side content to the authenticated local operator; it is not an
+  agent-facing surface. See the [local dashboard guide](docs/how-to/dashboard/run-local-dashboard.md)
+  and [trust boundary](docs/explanation/dashboard/trust-boundary.md).
+- **Strict Anthropic Messages direct profile** (#397, #399). The proxy validates
+  supported request and response carriers, stages reversible substitutions,
+  and rejects unsupported opaque or numeric schema carriers before forwarding.
+  Limits, tool-schema handling, buffering, and unsupported features are explicit
+  in the [Anthropic contract](docs/explanation/proxy/anthropic-messages-contract.md).
+  These guarantees are profile-specific, not a blanket promise for every
+  provider or every SDK extension.
+- **Reusable pinned model setup library** (#366–#368). `gaze-model-setup` and
+  the public Kiji bundle verifier provide the installation path used by
+  `gaze setup`, with verified artifacts and typed installation outcomes.
+
 - **`passport.cue_anchored` recognizer and an extended `national_id.cue_anchored`
-  close the passport / national-ID / ID-card detection gap on the shipped
+  expand passport / national-ID / ID-card detection on the shipped
   default** (solo todo #3025, slice A). A new `custom:passport` recognizer
   (government-ID collision family, precedence 15 — a passport cue beats a
   tax-number or national-ID cue but yields to an SSN cue) covers passport /
@@ -19,10 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hyphenated `national-id` forms) and shapes (Swiss AHV `756.dddd.dddd.dd`,
   longer alphanumerics). Both carry the byte-identical shared connector, so
   passport is the sixth member of the drift-guarded connector family. Measured
-  on the pinned EN/DE corpus (shipped default): PASSPORTID −1,791, NATIONALID
-  −1,017, IDCARDNUM −577 fewer leaked bytes, with zero A4 negative movement and
-  the national-ID extension a strict superset of the prior rule (no
-  previously-covered span lost). The passport check digit and the Swiss AHV
+  on the pinned EN/DE corpus at candidate `cfb3aed` against `def702a`, the
+  full-stack Kiji resolve cell removes 3,480 leaked labelled bytes: PASSPORTID
+  −1,810, NATIONALID −1,027, IDCARDNUM −586, plus incidental BUILDINGNUM −26.
+  These are slice-specific measurements, not a v0.12.0-to-v0.13.0 comparison.
+  The deterministic cells add 12 false-positive bytes from one unlabelled
+  national-ID span; the rule floor adds one false-positive document. A4 negative
+  results are unchanged. Kiji also loses coverage on LICENSEPLATENUM, ZIP, and
+  PASSWORD, and the scorecard's strict regression comparison does not pass.
+  See the [measured scorecard, hardware, and limits](docs/reference/benchmarks/v0.12-3025a-cfb3aed-scorecard.md)
+  and [benchmark runner](scripts/bench/run_no_opf_benchmark.py). The passport check digit and the Swiss AHV
   EAN-13 check digit are real validators, but the synthetic corpus carries no
   valid check digits, so no validator is attached. The passport shape is a single
   capture and the prefixed Swiss AHV form (`CH-756.dddd.dddd.dd`) is a dedicated
@@ -61,20 +87,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every adopter of the default bundle, not only for configurations that
   auto-activate locale-gated recognizers.
 
-  Measured against the EN/DE benchmark holdout: those two anchors carry 232 of
-  276 gold URL spans and 6,385 of 7,209 leaked URL bytes (88.6%), while matching
-  nothing at all across the 1,024 documents of the committed A4 negative corpus.
-  Before this recognizer the deterministic rule floor was completely blind to
-  URLs — 0 of 276 spans covered and 0 overlapped.
-
-  **Bare-host URLs are deliberately out of scope.** Shapes with no scheme and no
-  `www.` prefix (`example.invalid/orders`) are the remaining 47 spans / 887 bytes
-  / 12.3% of the bucket, and 97 of the 1,024 committed negative documents contain
-  bare-host shapes, so no bare-host rule can clear the negative gate.
+  The [consolidated scorecard](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md)
+  records the measured EN/DE coverage and A4 negative results. Bare-host URLs
+  without a scheme or `www.` prefix remain outside this rule's scope because
+  they also occur in the negative corpus.
 
   **Documentation, repository, and example URLs are tokenized.** This is
-  intentional: 16 of the 232 gold spans the rule covers are themselves
-  reference-host shaped, so the corpus treats a reference URL inside a
+  intentional: the benchmark includes reference-host shaped gold spans, so it treats a reference URL inside a
   data-owner document as PII to protect. Tokens stay restorable through the
   manifest, so an over-tokenized public URL is a recoverable ergonomics cost
   (axis 5) while an under-tokenized private one is a leak (axis 1).
@@ -86,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to explicit English or German credential cues, emitting the reversible
   `custom:security_token` class.
 
-  A fresh full EN/DE comparison removed 3,065 leaked SECURITYTOKEN bytes at the
+  The [consolidated EN/DE comparison](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md) removed 3,065 leaked SECURITYTOKEN bytes at the
   rule floor and 2,985 with pass2 NER. Each deterministic cell added 17
   false-positive bytes, ratios of about 180:1 and 176:1, while the rule matched
   0 of all 1,024 committed A4 negative documents. Cue anchoring is supported by
@@ -158,8 +177,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   owner-side. See `crates/gaze-mcp-core/README.md` for migration requirements.
   `SearchDocumentsTool` supplies its bounded carrier declarations, and
   `gaze_read_file` restores protected paths owner-side before file validation.
-  Publication requires coordinated crate versions and dependency minimums;
-  these unreleased changes do not bump published versions.
+  All publishable workspace crates and their internal dependency minimums
+  move together to 0.13.0 in this release (#452).
 
 
 - **`gaze-cli` declares each shared flag group once** (audit 7201 S11-F1, solo
@@ -175,18 +194,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `commands::shared_args` and shared by `clean` and `daemon`, so a verb cannot
   quietly lose one and run a weaker Pass-3 safety net than its sibling.
 
-  **The published CLI surface is unchanged.** `scripts/verify/cli-help-surface.sh`
+  **The shared-argument refactor preserved the CLI surface at that commit.** `scripts/verify/cli-help-surface.sh`
   builds the base revision and the working tree in one run and diffs `--help`
   for the root command and all 32 subcommands; all 33 captures are byte-identical
   across the change, and the captures are committed under
   `crates/gaze-cli/tests/fixtures/cli-help/`.
 
-  `gaze daemon` still accepts fewer flags than `gaze clean`: no
-  `--safety-net-registry`, `--safety-net-add`, `--kiji-distilbert-precision`,
-  `--opf-locales`, `--opf-command`, `--opf-checkpoint`, `--rulepack-bundled`,
-  or `--rulepack-path`. That gap is unchanged by this release and is now pinned
-  by a test rather than left implicit; passing one of those to `gaze daemon` is
-  rejected, not ignored.
+  The refactor preceded #446, which adds the eight daemon flags listed above.
+  Its help-surface comparison describes the refactor alone, not the cumulative
+  v0.13.0 release.
 
 - **One documented safety-net default across the library and the CLI** (audit
   7201 S01-F1, solo todo #2949). `Pipeline::clean_with_safety_net` and
@@ -373,7 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`url.anchored`, `security_token.anchored`, …) won on `ClassPriority`,
   `remove_overlaps` dropped the whole container, and the clean text carried a
   mid-word token with the head and tail of the identifier raw — for example
-  `https://www.finanzamt.at` split around `nzamt`, or an `AKIA…` credential
+  a URL split around an embedded NER name, or an `AKIA…` credential
   split around `AKIAIOSF`. Measured on the shipped default: 1,522 URL bytes and
   44 credential bytes leaked this way on the pinned EN/DE corpus; the rule
   floor was unaffected because it has no NER pass. `resolve_candidates` now
@@ -389,14 +405,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-word phrasing between the cue and the value is covered** (solo todo #3025, slice G).
   `ssn.us`, `ssn.de_cue`, `tax_number.cue_anchored`, `driver_license.cue_anchored` and
   `national_id.cue_anchored` previously allowed a single optional keyword plus one punctuation
-  mark between the cue and the value, so real phrasing such as `license number, D1234567`,
-  `Sozialversicherungsnummer, die lautet 756.1234.5678.90` and `tax number as 123-456-789`
+  mark between the cue and the value, so real phrasing such as a licence cue followed by a comma,
+  a German social-insurance cue followed by a relative clause, and a tax cue followed by `as`
   leaked. All five now carry one byte-identical connector fragment (up to four closed-vocabulary
   tokens with Unicode-aware, unbounded whitespace — matching `ssn.us`'s prior `\s*` tolerance, so
   aligned columns, long padding and non-breaking spaces stay covered — and one optional separator).
   This is a grammar-only change: cue
   vocabulary and value shapes are unchanged, so the set of eligible value shapes did not move.
-  Measured on the pinned EN/DE corpus, on the shipped default (`full-stack-kiji-resolve`),
+  Measured in the [connector scorecard](docs/reference/benchmarks/v0.12-3025g-edfb167-scorecard.md), on the shipped default (`full-stack-kiji-resolve`),
   against the slice-U merge (`56e1a3d`): 1,802 fewer leaked labelled bytes — SSN −526,
   DRIVERLICENSENUM −582, IDCARDNUM −384, NATIONALID −205, TAXNUM −95. On the deterministic rule
   floor, 190 more entities fully covered for zero false-positive movement (rule and pass2
@@ -618,6 +634,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of silently mapping to `O` or returning no spans. The bundle ships no
   `id2label` artifact, so the registry cannot be re-checked at bundle load; the
   SHA-256 bundle pin plus the parity tests are the guard.
+
+### Evidence and known limits
+
+The release includes all changes since v0.12.0, not only MCP #452. Detection
+remains dependent on the configured recognizers, dictionaries, locales, and
+safety nets. MCP protects supported tool-call carriers; it does not protect
+chat UI uploads or pasted user messages outside that path. Operator restore
+surfaces remain privileged and may intentionally return raw owner data.
+
+Benchmark numbers above describe the named historical candidate/base pairs.
+They are not a fresh measurement of this release head and must not be added
+together as an end-to-end release gain. The
+[benchmark runner](scripts/bench/run_no_opf_benchmark.py),
+[consolidated scorecard and machine specification](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md),
+[post-wave scorecard](docs/reference/benchmarks/v0.12-post-wave-a8f7182-scorecard.md),
+and linked slice scorecards retain corpus pins, hardware, failed-closed
+accounting, false positives, and known class regressions. No universal
+PII-detection or exact-restore rate is claimed. Safety-net `Redact` fallback
+still deletes residual bytes; strict MCP rejects results that cannot satisfy
+its reversible protection contract.
 
 ## [0.12.0] - 2026-07-06
 
@@ -1985,7 +2021,8 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/EmpireTwo/gaze/compare/v0.6.4...HEAD
+[Unreleased]: https://github.com/CertaMesh/gaze/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/CertaMesh/gaze/compare/v0.12.0...v0.13.0
 [0.6.4]: https://github.com/EmpireTwo/gaze/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/EmpireTwo/gaze/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/EmpireTwo/gaze/compare/v0.6.1...v0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,18 +105,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to explicit English or German credential cues, emitting the reversible
   `custom:security_token` class.
 
-  The [consolidated EN/DE comparison](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md) removed 3,065 leaked SECURITYTOKEN bytes at the
-  rule floor and 2,985 with pass2 NER. Each deterministic cell added 17
-  false-positive bytes, ratios of about 180:1 and 176:1, while the rule matched
-  0 of all 1,024 committed A4 negative documents. Cue anchoring is supported by
-  the corpus asymmetry: 88.1% of SECURITYTOKEN spans have `token` or `secret`
-  in the preceding 64 characters, versus only 1.8% cue context for URL.
+  The [consolidated EN/DE comparison](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md)
+  measures this rule together with URL detection and discloses both increased
+  false positives and class-level Kiji regressions. Its subtractive baseline
+  is specific to that recognizer wave, not the previous release.
 
   Arm 2 requires at least one unambiguous delimiter between cue and value.
   Whitespace and `:`, `=`, or `#` qualify; `_` and a directly abutting `-` do
-  not. The holdout has 0 of 193 cue-context spans with no delimiter and 0 using
-  direct hyphen alone, so the requirement costs no measured gold coverage.
-  This prevents the safe default from splitting cue-prefixed snake_case
+  not. This prevents the safe default from splitting cue-prefixed snake_case
   identifiers such as tokenization helper names. A4 does not contain this
   identifier class; post-fix dogfooding across project documentation and Rust
   source produced zero SECURITYTOKEN detections.
@@ -390,9 +386,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `remove_overlaps` dropped the whole container, and the clean text carried a
   mid-word token with the head and tail of the identifier raw — for example
   a URL split around an embedded NER name, or an `AKIA…` credential
-  split around `AKIAIOSF`. Measured on the shipped default: 1,522 URL bytes and
-  44 credential bytes leaked this way on the pinned EN/DE corpus; the rule
-  floor was unaffected because it has no NER pass. `resolve_candidates` now
+  split around its prefix. The
+  [structured-containment scorecard](docs/reference/benchmarks/v0.12-3025u-bfcf264-scorecard.md)
+  measures 1,490 fewer leaked URL bytes and 44 fewer credential bytes in the
+  full-stack Kiji resolve cell, with 2 more leaked PASSWORD bytes and 2 fewer
+  ZIP bytes from downstream re-segmentation. The rule floor is unchanged. `resolve_candidates` now
   carries a structured-containment rung (`ConflictTier::StructuredContainment`,
   audit string `structured_containment`): when a custom-class span strictly
   encloses a builtin-class span, the enclosing span keeps the slot and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`gaze setup` now verifies strict ownership and private file modes even
+  when an existing Kiji bundle lets it skip downloading** (#366–#368).
+  Only a complete tree owned by the current effective user may have loose
+  modes repaired, followed by mandatory verification. Foreign-owned or
+  otherwise invalid non-empty installs fail closed. Reinstall into a private
+  directory owned by the account that runs Gaze, or have the owner correct
+  ownership and permissions before retrying; changing the working directory
+  cannot change the trusted owner. The coordinated publish plan places
+  `gaze-recognizers` 0.13.0 before `gaze-model-setup` 0.13.0.
+
 - **MCP protection intentionally changes runtime compatibility:** custom tools
   must declare trusted object-member and non-sensitive numeric carriers;
   empty primary pipelines now fail closed. Configure the bundled pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `unsupported owner-side index schema 1; supported 2` error (the version is
   checked before the payload shape, so there is no partial or reinterpreted
   load), and a v2 payload carrying duplicate document keys is rejected the
-  same way. Rebuild local indexes by re-running `gaze index ingest <dir>`.
+  same way. Preserve the old encrypted index and its key for recovery, then
+  rebuild into a fresh private directory with
+  `gaze index ingest <dir> --index-path <new-private-directory>`. Reusing the
+  old path fails during load before ingest can clear it. Verify the new index
+  before pointing search and other consumers at its path.
   The `entities: N` metric printed by `gaze index ingest` keeps its meaning
   (indexed document/fingerprint pairs). `FileCorpusIndexStore::hit_count_for_domain`
   was removed (it had no callers). The AEAD/key layer and the sealed-file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-inspection"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "gaze-types",
  "serde",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-bridge"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-model-setup"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "gaze-recognizers",
  "libc",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy-dashboard"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64 0.22.1",
  "gaze-inspection",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "chacha20poly1305",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ homepage = "https://github.com/CertaMesh/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.12.0" }
-gaze-inspection = { path = "crates/gaze-inspection", version = "0.12.0" }
-gaze = { path = "crates/gaze", version = "0.12.0", package = "gaze-pii" }
-gaze-assembly = { path = "crates/gaze-assembly", version = "0.12.0" }
-gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.12.0" }
-gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.12.0" }
-gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.12.0" }
-gaze-model-setup = { path = "crates/gaze-model-setup", version = "0.12.0" }
-gaze-recognizers = { path = "crates/gaze-recognizers", version = "0.12.1" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.12.0" }
-gaze-proxy-dashboard = { path = "crates/gaze-proxy-dashboard", version = "0.12.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.12.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.13.0" }
+gaze-inspection = { path = "crates/gaze-inspection", version = "0.13.0" }
+gaze = { path = "crates/gaze", version = "0.13.0", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.13.0" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.13.0" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.13.0" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.13.0" }
+gaze-model-setup = { path = "crates/gaze-model-setup", version = "0.13.0" }
+gaze-recognizers = { path = "crates/gaze-recognizers", version = "0.13.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.13.0" }
+gaze-proxy-dashboard = { path = "crates/gaze-proxy-dashboard", version = "0.13.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.13.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your agent never sees a real email, phone number, or order ID. Your server keeps
 Three commands from zero to redacting real PII:
 
 ```sh
-cargo install gaze-cli --version 0.12.0                     # `gaze setup` ships in the default build
+cargo install gaze-cli --version 0.13.0                     # `gaze setup` ships in the default build
 gaze setup                                                   # installs + SHA-verifies the NER model, writes ./gaze.toml, runs a doctor check
 echo "Contact Markus Gottschaue at markus@acme.com" | gaze clean --policy gaze.toml
 ```
@@ -139,7 +139,7 @@ Architecture overview with eight Key Design Decisions: [`ARCHITECTURE.md`](ARCHI
 Install the CLI from crates.io:
 
 ```sh
-cargo install gaze-cli --version 0.12.0
+cargo install gaze-cli --version 0.13.0
 ```
 
 Or build from source (latest `main`, or to enable extra features):

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.12.0"
-gaze-assembly = "0.12.0"
-gaze-recognizers = "0.12.0"
+gaze-pii = "0.13.0"
+gaze-assembly = "0.13.0"
+gaze-recognizers = "0.13.0"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.12.0"
-gaze-audit = "0.12.0"
+gaze-pii = "0.13.0"
+gaze-audit = "0.13.0"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -48,18 +48,18 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.12.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.13.0", optional = true }
 gaze-mcp-bridge = { workspace = true, optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.12.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.13.0", optional = true }
 gaze-model-setup = { workspace = true, optional = true }
 gaze-proxy = { workspace = true, optional = true }
 gaze-proxy-dashboard = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
-gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.12.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.13.0", optional = true }
 gaze-types = { workspace = true }
 getrandom = { version = "0.3", optional = true }
 pdfium-render = { version = "0.9", optional = true }
@@ -76,7 +76,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 serial_test = { version = "3", features = ["file_locks"] }

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.12.0
+$ cargo install gaze-cli --version 0.13.0
 ```
 
 Build from the workspace root:
@@ -111,7 +111,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.12.0 --features mcp
+$ cargo install gaze-cli --version 0.13.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -45,7 +45,7 @@ render-image = []
 [dev-dependencies]
 gaze-assembly = { workspace = true }
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.12.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.13.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.12.0"
+gaze-document = "0.13.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.12.0 --features document
+cargo install gaze-cli --version 0.13.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-inspection/Cargo.toml
+++ b/crates/gaze-inspection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-inspection"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-bridge"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,6 +1,6 @@
 # gaze-mcp-bridge
 
-`gaze-mcp-bridge = "0.12.0"` is the optional policy-gated MCP bridge for Gaze.
+`gaze-mcp-bridge = "0.13.0"` is the optional policy-gated MCP bridge for Gaze.
 
 The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
 downstream MCP tools receive restored PII only for explicitly allowed argument

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -35,6 +35,6 @@ core-tools = []
 operator-tier = []
 
 [dev-dependencies]
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii", features = ["test-support"] }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii", features = ["test-support"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1"

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/CertaMesh/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.12.0) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.13.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -23,7 +23,7 @@ axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
 gaze-assembly = { workspace = true }
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.12.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.13.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.12.0"
-gaze-mcp-rmcp = "0.12.0"
+gaze-mcp-core = "0.13.0"
+gaze-mcp-rmcp = "0.13.0"
 ```
 
 ```rust

--- a/crates/gaze-model-setup/Cargo.toml
+++ b/crates/gaze-model-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-model-setup"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-model-setup/src/lib.rs
+++ b/crates/gaze-model-setup/src/lib.rs
@@ -688,31 +688,67 @@ mod tests {
         .unwrap();
     }
 
+    #[cfg(unix)]
     #[test]
     #[ignore = "requires a real pinned bundle that is safe to chmod"]
     fn loose_mode_current_user_dir_is_repaired_then_accepted() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
         let model_dir = PathBuf::from(
             std::env::var_os("GAZE_KIJI_LOOSE_MODEL_DIR")
                 .expect("set GAZE_KIJI_LOOSE_MODEL_DIR to a loose current-euid-owned bundle"),
         );
 
         let outcome = install_kiji_bundle(&InstallOptions {
-            model_dir: Some(model_dir),
+            model_dir: Some(model_dir.clone()),
             precision: KijiDistilbertPrecision::Fp32,
         })
         .unwrap();
 
         assert!(matches!(outcome, InstallOutcome::AlreadyPresent { .. }));
+        verify_kiji_bundle(&model_dir, KijiDistilbertPrecision::Fp32).unwrap();
+        let uid = unsafe { libc::geteuid() };
+        let mut pending = vec![model_dir];
+        while let Some(path) = pending.pop() {
+            let metadata = fs::symlink_metadata(&path).unwrap();
+            assert_eq!(metadata.uid(), uid, "repaired path must retain its owner");
+            assert!(!metadata.file_type().is_symlink());
+            let mode = metadata.permissions().mode() & 0o777;
+            if metadata.is_dir() {
+                assert_eq!(mode, 0o700, "repaired directories must be private");
+                pending.extend(
+                    fs::read_dir(&path)
+                        .unwrap()
+                        .map(|entry| entry.unwrap().path()),
+                );
+            } else {
+                assert!(metadata.is_file());
+                assert_eq!(mode, 0o600, "repaired files must be private");
+            }
+        }
     }
 
+    #[cfg(unix)]
     #[test]
-    #[ignore = "requires a real pinned bundle owned by another uid"]
+    #[ignore = "requires a real pinned bundle in a readable directory owned by another uid"]
     fn foreign_owned_dir_fails_closed() {
+        use std::os::unix::fs::MetadataExt;
+
         let model_dir = PathBuf::from(
             std::env::var_os("GAZE_KIJI_FOREIGN_MODEL_DIR")
-                .expect("set GAZE_KIJI_FOREIGN_MODEL_DIR to a foreign-owned bundle"),
+                .expect("set GAZE_KIJI_FOREIGN_MODEL_DIR to a readable foreign-owned bundle"),
         );
-
+        assert_ne!(fs::symlink_metadata(&model_dir).unwrap().uid(), unsafe {
+            libc::geteuid()
+        });
+        let verification_error =
+            verify_kiji_bundle(&model_dir, KijiDistilbertPrecision::Fp32).unwrap_err();
+        assert!(matches!(
+            &verification_error,
+            SafetyNetError::ModelUnavailable { reason }
+                if reason == "kiji sensitive path owner mismatch"
+        ));
+        let expected_reason = verification_error.to_string();
         let err = install_kiji_bundle(&InstallOptions {
             model_dir: Some(model_dir),
             precision: KijiDistilbertPrecision::Fp32,
@@ -721,7 +757,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            SetupError::NonEmptyInvalidDir { .. } | SetupError::Verify(_)
+            SetupError::NonEmptyInvalidDir { reason, .. } if reason == expected_reason
         ));
     }
 }

--- a/crates/gaze-proxy-dashboard/Cargo.toml
+++ b/crates/gaze-proxy-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy-dashboard"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -10,8 +10,8 @@ repository = "https://github.com/CertaMesh/gaze"
 [dependencies]
 base64 = "0.22.1"
 getrandom = "0.3.4"
-gaze-inspection = { path = "../gaze-inspection", version = "0.12.0" }
-gaze-types = { path = "../gaze-types", version = "0.12.0" }
+gaze-inspection = { path = "../gaze-inspection", version = "0.13.0" }
+gaze-types = { path = "../gaze-types", version = "0.13.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,8 +27,8 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.12.0" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
 gaze-inspection = { workspace = true }
 gaze-types = { workspace = true }
 getrandom = "0.3"
@@ -51,7 +51,7 @@ uuid = { version = "1", features = ["v4"] }
 zeroize = "1"
 
 [dev-dependencies]
-gaze = { path = "../gaze", version = "0.12.0", package = "gaze-pii", features = ["test-support"] }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0" }
+gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.12.0"
+gaze-proxy = "0.13.0"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.12.0
+cargo install gaze-cli --version 0.13.0
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.12.0"
-gaze-recognizers = "0.12.1"
+gaze-pii = "0.13.0"
+gaze-recognizers = "0.13.0"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.12.1", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.13.0", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,7 +16,7 @@ categories = ["text-processing"]
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii", version = "0.12.0" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.13.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chacha20poly1305 = { version = "0.10", features = ["std"] }
@@ -27,7 +27,7 @@ rand = "0.8"
 zeroize = "1"
 # Track C chokepoint integration — optional, OFF by default. Pulled in only by
 # the `chokepoint` feature below; the default build/test graph is byte-identical.
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.12.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,11 +1,11 @@
 # gaze-token-bridge
 
-> **Status:** experimental and published as `gaze-token-bridge = "0.12.0"`.
+> **Status:** experimental and published as `gaze-token-bridge = "0.13.0"`.
 > API is pre-1.0 and may change.
 
 ```toml
 [dependencies]
-gaze-token-bridge = "0.12.0"
+gaze-token-bridge = "0.13.0"
 ```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.12.0"
+gaze-types = "0.13.0"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.89"
 build = "build.rs"
@@ -31,7 +31,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.12.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.12.0"
-gaze-assembly = "0.12.0"
-gaze-recognizers = "0.12.0"
+gaze-pii = "0.13.0"
+gaze-assembly = "0.13.0"
+gaze-recognizers = "0.13.0"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -35,6 +35,32 @@ After the seed publish, add the crate's Trusted Publisher on crates.io for `Cert
 
 Cutting a release: tag the merge commit on `main` with `vX.Y.Z` and push the tag. Both workflows fire from the same tag push; no manual crates.io step is needed for crates already in the OIDC publish loop.
 
+## Pre-tag model-setup ownership gate
+
+Before the first `gaze-model-setup` publication, run `release.yml` with
+`workflow_dispatch` on the reviewed preparation branch. This path scrubs the
+release text and runs `scripts/gate/model-setup-ownership.sh` on hosted Linux;
+it does not build release assets, create a release, or publish crates.
+
+The ownership gate uses the shipped installer to fetch and strictly verify
+the source-pinned real Kiji FP32 bundle. It checks identical artifact hashes
+before testing a copy owned by a distinct user, uses a foreign-owned working
+directory, and explicitly runs the ignored cross-directory effective-user test.
+It also verifies loose-mode repair for the current owner and rejection of a
+foreign-owned installation. Exact test names must report a passing test;
+a zero-test cargo result cannot pass the gate.
+
+After review, dispatch with `gh workflow run release.yml --ref <preparation-branch>
+-f version=0.13.0 -f pr_number=<release-pr>`. Require a successful
+`model-setup-ownership-preflight` job for that exact preparation head before
+tagging. Its `model-setup-ownership-<commit>` artifact
+records the commit, commands, toolchain, model hashes, owner/mode inventory,
+and test results. It contains receipts only; model files are temporary and
+are removed when the gate exits. The script requires an unprivileged Linux
+user with passwordless sudo so real foreign ownership can be constructed.
+The publish plan orders `gaze-recognizers` before `gaze-model-setup` at the
+coordinated release version.
+
 ## Homebrew Tap Location
 
 Decision for v0.4.6 S6 (#184), reaffirmed post repo-public flip: keep Homebrew repo-local until the organization creates an explicit public tap and release publication target.

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -21,7 +21,7 @@ Source: [`.github/workflows/publish-crates.yml`](../../../.github/workflows/publ
 - Triggered on `v*` tag pushes (with `workflow_dispatch` dry-run available).
 - Authenticates to crates.io via OIDC trusted-publisher (`rust-lang/crates-io-auth-action`); no long-lived `CARGO_REGISTRY_TOKEN` secret.
 - Derives the publish set and topological order from `cargo metadata` with `cargo run -p xtask -- publish-plan`. Every workspace member with `publish != false` is included automatically, including new crates. The core crate is published as `gaze-pii` while its library target remains `gaze`.
-- Runs a manifest pre-flight before any real publish: `cargo package --no-verify -p <crate>` for each crate in the derived plan. This catches unpublishable workspace dependency manifests before OIDC auth or partial publishing.
+- Runs a manifest pre-flight before any real publish: `cargo package --no-verify --workspace --exclude xtask` for the workspace. Workspace packaging resolves coordinated, not-yet-published dependency versions together. Per-crate packaging would resolve those versions against crates.io before they exist. This catches unpublishable manifests before OIDC auth or partial publishing.
 - Checks crates.io for every planned crate before publishing. If any crate is absent, the workflow fails up front because OIDC trusted publishing cannot first-publish a new crate.
 - Skips crates already at the published version (idempotent re-runs) and retries on index-propagation lag.
 - New crates require a one-time manual seed publish with a crates.io token, followed by trusted-publisher linking, before a tag publish can proceed:

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -46,8 +46,11 @@ The ownership gate uses the shipped installer to fetch and strictly verify
 the source-pinned real Kiji FP32 bundle. It checks identical artifact hashes
 before testing a copy owned by a distinct user, uses a foreign-owned working
 directory, and explicitly runs the ignored cross-directory effective-user test.
-It also verifies loose-mode repair for the current owner and rejection of a
-foreign-owned installation. Exact test names must report a passing test;
+It also verifies loose-mode repair with an independent bundle check and
+exact effective-user ownership, 0700 directory modes, and 0600 file modes.
+A separately hashed, readable foreign-owned copy proves setup rejects the
+owner mismatch specifically; the verifier keeps its separate private copy.
+Post-repair hashes and owner/mode inventory are retained in the receipts. Exact test names must report a passing test;
 a zero-test cargo result cannot pass the gate.
 
 After review, dispatch with `gh workflow run release.yml --ref <preparation-branch>

--- a/scripts/gate/model-setup-ownership.sh
+++ b/scripts/gate/model-setup-ownership.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Release gate: real pinned Kiji artifacts must be trusted by process owner, not cwd owner.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+receipt_dir="${1:?usage: model-setup-ownership.sh <receipt-directory>}"
+mkdir -p "$receipt_dir"
+receipt_dir="$(cd "$receipt_dir" && pwd)"
+exec > >(tee "$receipt_dir/gate.log") 2>&1
+
+[[ "$(uname -s)" == Linux ]] || { echo 'Requires Linux with passwordless sudo'; exit 1; }
+[[ "$(id -u)" != 0 ]] || { echo 'Run as an unprivileged user, not root'; exit 1; }
+sudo -n true
+fixture_root="$(mktemp -d)"
+cleanup() {
+  local result=$?
+  trap - EXIT
+  sudo -n rm -rf -- "$fixture_root"
+  echo "OWNERSHIP_GATE_EXIT=$result"
+  exit "$result"
+}
+trap cleanup EXIT
+
+set -x
+git rev-parse HEAD
+rustc --version --verbose
+cargo --version
+id
+export GAZE_KIJI_DISTILBERT_MODEL_DIR="$fixture_root/owned"
+export GAZE_KIJI_FOREIGN_MODEL_DIR="$fixture_root/foreign"
+export GAZE_KIJI_FOREIGN_CWD="$fixture_root/foreign-cwd"
+export GAZE_KIJI_LOOSE_MODEL_DIR="$fixture_root/loose"
+
+# The shipped installer downloads the source-pinned bundle and performs its real verification.
+cargo run --locked -p gaze-cli --features setup -- setup --non-interactive \
+  --safety-net ner --model-dir "$GAZE_KIJI_DISTILBERT_MODEL_DIR" \
+  --policy-out "$fixture_root/policy.toml"
+(
+  cd "$GAZE_KIJI_DISTILBERT_MODEL_DIR"
+  sha256sum -c SHA256SUMS
+  sha256sum SHA256SUMS labels.json model.onnx tokenizer.json
+) | tee "$receipt_dir/artifact-hashes.txt"
+
+cp -R "$GAZE_KIJI_DISTILBERT_MODEL_DIR" "$GAZE_KIJI_FOREIGN_MODEL_DIR"
+cp -R "$GAZE_KIJI_DISTILBERT_MODEL_DIR" "$GAZE_KIJI_LOOSE_MODEL_DIR"
+mkdir "$GAZE_KIJI_FOREIGN_CWD"
+chmod 0755 "$GAZE_KIJI_FOREIGN_CWD" "$GAZE_KIJI_LOOSE_MODEL_DIR"
+chmod 0666 "$GAZE_KIJI_LOOSE_MODEL_DIR"/*
+sudo -n chown -R 0:0 "$GAZE_KIJI_FOREIGN_MODEL_DIR" "$GAZE_KIJI_FOREIGN_CWD"
+[[ "$(stat -c %u "$GAZE_KIJI_DISTILBERT_MODEL_DIR")" == "$(id -u)" ]]
+[[ "$(stat -c %u "$GAZE_KIJI_FOREIGN_MODEL_DIR")" != "$(id -u)" ]]
+[[ "$(stat -c %u "$GAZE_KIJI_FOREIGN_CWD")" != "$(id -u)" ]]
+# Prove rejection uses a valid foreign-owned copy, not a missing or corrupt model.
+sudo -n sh -c 'cd "$1"; sha256sum -c SHA256SUMS; sha256sum SHA256SUMS labels.json model.onnx tokenizer.json' \
+  sh "$GAZE_KIJI_FOREIGN_MODEL_DIR" | tee "$receipt_dir/foreign-artifact-hashes.txt"
+cmp "$receipt_dir/artifact-hashes.txt" "$receipt_dir/foreign-artifact-hashes.txt"
+sudo -n find "$fixture_root" -printf '%U %m %p\n' | tee "$receipt_dir/ownership.txt"
+
+cross_directory_test=safety_net::kiji_distilbert::backend::artifacts::tests::verify_kiji_bundle_is_cwd_independent
+cargo test --locked -p gaze-recognizers --features safety-net-kiji --lib \
+  "$cross_directory_test" -- --ignored --exact --nocapture \
+  | tee "$receipt_dir/cross-directory.log"
+grep -F "test $cross_directory_test ... ok" "$receipt_dir/cross-directory.log"
+
+for setup_test in loose_mode_current_user_dir_is_repaired_then_accepted foreign_owned_dir_fails_closed; do
+  cargo test --locked -p gaze-model-setup --lib "tests::$setup_test" -- --ignored --exact --nocapture \
+    | tee "$receipt_dir/$setup_test.log"
+  grep -F "test tests::$setup_test ... ok" "$receipt_dir/$setup_test.log"
+done
+set +x
+echo 'PASS: live cross-directory euid and strict setup ownership/mode gates'

--- a/scripts/gate/model-setup-ownership.sh
+++ b/scripts/gate/model-setup-ownership.sh
@@ -44,10 +44,16 @@ cargo run --locked -p gaze-cli --features setup -- setup --non-interactive \
 
 cp -R "$GAZE_KIJI_DISTILBERT_MODEL_DIR" "$GAZE_KIJI_FOREIGN_MODEL_DIR"
 cp -R "$GAZE_KIJI_DISTILBERT_MODEL_DIR" "$GAZE_KIJI_LOOSE_MODEL_DIR"
+# Setup must enumerate a non-empty foreign directory to return its ownership error.
+# Keep the verifier's private foreign copy separate from this readable setup copy.
+foreign_setup_dir="$fixture_root/foreign-setup"
+cp -R "$GAZE_KIJI_DISTILBERT_MODEL_DIR" "$foreign_setup_dir"
+chmod 0755 "$foreign_setup_dir"
+chmod 0644 "$foreign_setup_dir"/*
 mkdir "$GAZE_KIJI_FOREIGN_CWD"
 chmod 0755 "$GAZE_KIJI_FOREIGN_CWD" "$GAZE_KIJI_LOOSE_MODEL_DIR"
 chmod 0666 "$GAZE_KIJI_LOOSE_MODEL_DIR"/*
-sudo -n chown -R 0:0 "$GAZE_KIJI_FOREIGN_MODEL_DIR" "$GAZE_KIJI_FOREIGN_CWD"
+sudo -n chown -R 0:0 "$GAZE_KIJI_FOREIGN_MODEL_DIR" "$GAZE_KIJI_FOREIGN_CWD" "$foreign_setup_dir"
 [[ "$(stat -c %u "$GAZE_KIJI_DISTILBERT_MODEL_DIR")" == "$(id -u)" ]]
 [[ "$(stat -c %u "$GAZE_KIJI_FOREIGN_MODEL_DIR")" != "$(id -u)" ]]
 [[ "$(stat -c %u "$GAZE_KIJI_FOREIGN_CWD")" != "$(id -u)" ]]
@@ -55,6 +61,13 @@ sudo -n chown -R 0:0 "$GAZE_KIJI_FOREIGN_MODEL_DIR" "$GAZE_KIJI_FOREIGN_CWD"
 sudo -n sh -c 'cd "$1"; sha256sum -c SHA256SUMS; sha256sum SHA256SUMS labels.json model.onnx tokenizer.json' \
   sh "$GAZE_KIJI_FOREIGN_MODEL_DIR" | tee "$receipt_dir/foreign-artifact-hashes.txt"
 cmp "$receipt_dir/artifact-hashes.txt" "$receipt_dir/foreign-artifact-hashes.txt"
+[[ "$(stat -c %u "$foreign_setup_dir")" != "$(id -u)" ]]
+(
+  cd "$foreign_setup_dir"
+  sha256sum -c SHA256SUMS
+  sha256sum SHA256SUMS labels.json model.onnx tokenizer.json
+) | tee "$receipt_dir/foreign-setup-artifact-hashes.txt"
+cmp "$receipt_dir/artifact-hashes.txt" "$receipt_dir/foreign-setup-artifact-hashes.txt"
 sudo -n find "$fixture_root" -printf '%U %m %p\n' | tee "$receipt_dir/ownership.txt"
 
 cross_directory_test=safety_net::kiji_distilbert::backend::artifacts::tests::verify_kiji_bundle_is_cwd_independent
@@ -64,9 +77,16 @@ cargo test --locked -p gaze-recognizers --features safety-net-kiji --lib \
 grep -F "test $cross_directory_test ... ok" "$receipt_dir/cross-directory.log"
 
 for setup_test in loose_mode_current_user_dir_is_repaired_then_accepted foreign_owned_dir_fails_closed; do
-  cargo test --locked -p gaze-model-setup --lib "tests::$setup_test" -- --ignored --exact --nocapture \
+  GAZE_KIJI_FOREIGN_MODEL_DIR="$foreign_setup_dir" cargo test --locked -p gaze-model-setup --lib "tests::$setup_test" -- --ignored --exact --nocapture \
     | tee "$receipt_dir/$setup_test.log"
   grep -F "test tests::$setup_test ... ok" "$receipt_dir/$setup_test.log"
 done
+(
+  cd "$GAZE_KIJI_LOOSE_MODEL_DIR"
+  sha256sum -c SHA256SUMS
+  sha256sum SHA256SUMS labels.json model.onnx tokenizer.json
+) | tee "$receipt_dir/repaired-artifact-hashes.txt"
+cmp "$receipt_dir/artifact-hashes.txt" "$receipt_dir/repaired-artifact-hashes.txt"
+find "$GAZE_KIJI_LOOSE_MODEL_DIR" -printf '%U %m %p\n' | tee "$receipt_dir/repaired-ownership.txt"
 set +x
 echo 'PASS: live cross-directory euid and strict setup ownership/mode gates'


### PR DESCRIPTION
Prepare the coordinated Gaze v0.13.0 release from merged main `9d39aa2130ead884fbce55981593ad746dc4bb8d` (#452). All 15 publishable workspace packages and versioned internal dependency requirements move to 0.13.0; Cargo.lock and current README installation examples agree. Runtime source is unchanged from reviewed tree `8f8943762f3d6d44c28fa3e7ced46241261bdb7a`.

Resolves Solo todo #3499.

Tracks Solo todo #3498; the parent remains open until publication is complete.

### Release contents and compatibility

The changelog covers the full interval since v0.12.0, including the optional dashboard, strict Anthropic profile, model setup library, detector and safety-net fixes, proxy policy alignment, and strict MCP protection. It corrects the superseded daemon flag gap and replaces preliminary benchmark claims with committed measured evidence and disclosed regressions. Historical release sections and generated GitHub Release notes behavior are preserved; no dist/release-notes file is committed.

Adopters must review MCP carrier declarations and class-only transport errors, enforcing safety-net defaults and structured-document rejection, format-basis locale behavior, schema-v2 local index rebuilds at a fresh private `--index-path`, and strict setup ownership/mode checks when reusing existing downloads automatically. Preserve the old encrypted index and its key until the replacement is verified before switching consumers. Current-user loose model directories may be repaired and reverified; foreign-owned or invalid non-empty installations fail closed.

Axes 1–4 remain the priority. This preparation changes metadata, documentation, pre-tag validation, and ignored test assertions only; it introduces no runtime tradeoff. The included release deliberately trades axis-5 output/API compatibility for stronger protection. Detection is configuration- and carrier-dependent, operator restore remains privileged, and global safety-net Redact fallback can still delete residual bytes. This is not a universal detection or reversibility claim. Historical benchmark deltas are not a new release-head measurement or additive release gain. See the [benchmark runner](scripts/bench/run_no_opf_benchmark.py), [hardware and consolidated evidence](docs/reference/benchmarks/v0.12-consolidated-post-wave-scorecard.md), and [passport measurement with known regressions](docs/reference/benchmarks/v0.12-3025a-cfb3aed-scorecard.md).

### Pre-tag ownership validation

Adds a manual-only hosted Linux job to `release.yml` and a reusable `scripts/gate/model-setup-ownership.sh` gate. The shipped installer fetches the exact pinned real Kiji bundle; the gate hashes separate private and readable foreign-owned copies, explicitly runs the ignored cross-directory test plus both setup owner/mode tests, and uploads receipts on success or failure. Setup must fail with the exact owner-mismatch reason. The repaired current-user copy must independently verify, retain the effective user as owner, and have 0700 directories and 0600 files; post-repair hashes and ownership inventory are retained. It does not alter `publish-crates.yml` or add credential/bootstrap infrastructure.

### Validation

- PASS: `cargo build --workspace --all-features`.
- PASS: `cargo package --no-verify --workspace --exclude xtask --locked`, all 15 packages.
- PASS: `cargo package --workspace --exclude xtask --locked`, all 15 package verification builds.
- PASS: `cargo run -p xtask -- readme-version-check`, all 15 packages.
- PASS: release-section `scrub-public-text`, metadata version/minimum audit, clean tracked user-path scan, and signed DCO commits.
- PASS: external adopter built from extracted package archives, synthetic-email protection and exact restore, and new MCP carrier declarations.
- PASS: full `ci-feature-matrix` with the complete Rust 1.96 toolchain on `19e688c3`, exit 0. Earlier toolchain-mismatch failures are preserved separately.
- PASS: final-head model-setup unit tests and Clippy, corrected ignored real-bundle loose-mode test with independent verification and owner/mode assertions, formatting, shell syntax, ShellCheck, and actionlint.
- PASS: final release-section and PR prose scrub, plus the root release narrative at SHA256 `c467b3e6fdb27851cd0d37802c871aed8eefe5321b9cb673dce05d8568193faa`.
- PASS: [hosted ownership and public-text gates](https://github.com/CertaMesh/gaze/actions/runs/34327956792) on corrected head `9c26cdb0581a998ff52b0d5d26a57aa5f084141a`: all three named real-bundle tests passed, strict repair ownership/modes and unchanged hashes verified, exit 0. The post-matrix source delta is limited to ignored tests, the fixture script, and documentation; production code and dependency graphs are unchanged.
- RED evidence: hosted run 34325510850 on `19e688c3` passed text scrub and the cross-directory test, but the setup foreign-owned fixture failed as predicted. Its old loose-mode test lacked the new independent assertions. This run is not full ownership-gate success.

The package verifier warns about already-locked yanked transitive versions (`spin` and `chacha20`); package compilation succeeds. No unrelated dependency update is included.

Independent source review is CLEAN for the exact final head. Root applied the delivered patch to an isolated index and reproduced tree `1270760d591f32809fdff5cd08b854f0d036dd04`, verified all five commit signatures and all 17 delivered receipt hashes. All 12 final PR checks passed on `9c26cdb0581a998ff52b0d5d26a57aa5f084141a`; preparation is ready to merge. Registry and GitHub release publication remain tracked separately.

### Publication gates

Do not tag until the orchestrator resolves first-publication setup for `gaze-inspection`, `gaze-model-setup`, and `gaze-proxy-dashboard`, which returned crates.io 404. The workflow's first-publish guard remains enabled; the orchestrator owns the reviewed staged bootstrap and trusted-publisher setup. Todo #2123 also requires the real pinned-bundle cross-directory effective-user test before model-setup publication; the new manual pre-tag ownership job constructs real distinct-owner fixtures on hosted Linux and uploads receipts; the orchestrator must run and verify it before publication. The derived publish plan places recognizers before model-setup at 0.13.0. This PR does not merge, tag, publish, or trigger release workflows.

### Documentation evidence

Before/after local Markdown previews captured with the project's Playwright installation from the exact base and preparation head. Version-only changes preserve layout; the changelog also has a mobile pair. These are documentation renders, not new dashboard runtime screenshots.

<details>
<summary>CHANGELOG.md</summary>

![CHANGELOG.md before](https://github.com/user-attachments/assets/def6e99e-258c-4ae9-8a21-bf9747d0979f)

![CHANGELOG.md after](https://github.com/user-attachments/assets/e3760b65-936f-4dc8-98af-aba7ed3ae4dd)

</details>

<details>
<summary>README.md</summary>

![README.md before](https://github.com/user-attachments/assets/6bc0d1ea-af68-42c9-bc10-e83116d372b3)

![README.md after](https://github.com/user-attachments/assets/f454fd29-e2f8-455b-a028-56687e276202)

</details>

<details>
<summary>crates/gaze-assembly/README.md</summary>

![crates/gaze-assembly/README.md before](https://github.com/user-attachments/assets/9e07dd84-7877-40e9-b3a4-854fefa1a91a)

![crates/gaze-assembly/README.md after](https://github.com/user-attachments/assets/938f19d4-b87e-4151-ae85-cbaa258afc68)

</details>

<details>
<summary>crates/gaze-audit/README.md</summary>

![crates/gaze-audit/README.md before](https://github.com/user-attachments/assets/a1c85d5d-181a-4025-8c9c-1be46ff1533d)

![crates/gaze-audit/README.md after](https://github.com/user-attachments/assets/6267a1bc-ba6c-433c-8174-dec69786f1b2)

</details>

<details>
<summary>crates/gaze-cli/README.md</summary>

![crates/gaze-cli/README.md before](https://github.com/user-attachments/assets/f71e096e-77b0-46f6-b430-3f9fa19d6e35)

![crates/gaze-cli/README.md after](https://github.com/user-attachments/assets/0a33573e-12b8-4964-9a77-76c87d80249f)

</details>

<details>
<summary>crates/gaze-document/README.md</summary>

![crates/gaze-document/README.md before](https://github.com/user-attachments/assets/79c948b7-231e-4ab7-9d07-5b4ee89b92b4)

![crates/gaze-document/README.md after](https://github.com/user-attachments/assets/9d922032-a6c0-4852-98c9-3548752f53ef)

</details>

<details>
<summary>crates/gaze-mcp-bridge/README.md</summary>

![crates/gaze-mcp-bridge/README.md before](https://github.com/user-attachments/assets/38e870d4-9d3d-449b-afd8-9b408a9c317c)

![crates/gaze-mcp-bridge/README.md after](https://github.com/user-attachments/assets/c10fcd96-73fe-4104-aaa0-0727db359090)

</details>

<details>
<summary>crates/gaze-mcp-core/README.md</summary>

![crates/gaze-mcp-core/README.md before](https://github.com/user-attachments/assets/e7963fa3-5605-412f-b317-940ad013f821)

![crates/gaze-mcp-core/README.md after](https://github.com/user-attachments/assets/fad56acc-696b-4863-904f-786f32a6becf)

</details>

<details>
<summary>crates/gaze-mcp-rmcp/README.md</summary>

![crates/gaze-mcp-rmcp/README.md before](https://github.com/user-attachments/assets/89981f72-2428-4eb9-ad81-651018ef3b34)

![crates/gaze-mcp-rmcp/README.md after](https://github.com/user-attachments/assets/abb7e42c-e8d2-4489-8769-3f1a6e05dab6)

</details>

<details>
<summary>crates/gaze-proxy/README.md</summary>

![crates/gaze-proxy/README.md before](https://github.com/user-attachments/assets/d3be65fd-ce3d-40bc-b4f0-d04b3fef9e99)

![crates/gaze-proxy/README.md after](https://github.com/user-attachments/assets/7b5dc512-8fd2-4e9b-90db-b9d36d852dee)

</details>

<details>
<summary>crates/gaze-recognizers/README.md</summary>

![crates/gaze-recognizers/README.md before](https://github.com/user-attachments/assets/3b35e350-9f0d-43f3-afbc-b361e28e432b)

![crates/gaze-recognizers/README.md after](https://github.com/user-attachments/assets/c59dd2b5-4c48-4022-9070-6183f7114a94)

</details>

<details>
<summary>crates/gaze-token-bridge/README.md</summary>

![crates/gaze-token-bridge/README.md before](https://github.com/user-attachments/assets/6922c218-747a-41a5-abc2-6dbf2af0a9a8)

![crates/gaze-token-bridge/README.md after](https://github.com/user-attachments/assets/2b2f8ab1-c81f-4aac-87f5-f2033349fdf7)

</details>

<details>
<summary>crates/gaze-types/README.md</summary>

![crates/gaze-types/README.md before](https://github.com/user-attachments/assets/b03b50cd-c4ad-4e16-9dd5-15e4a39a4919)

![crates/gaze-types/README.md after](https://github.com/user-attachments/assets/71a3f135-034f-4ea4-a5cc-21cfbb4674db)

</details>

<details>
<summary>crates/gaze/README.md</summary>

![crates/gaze/README.md before](https://github.com/user-attachments/assets/3306c3ab-ced0-4988-b220-99f9161f55cf)

![crates/gaze/README.md after](https://github.com/user-attachments/assets/a0836a17-a420-4db4-96da-25a72c231003)

</details>

<details>
<summary>docs/how-to/maintainers/release-process.md</summary>

![docs/how-to/maintainers/release-process.md before](https://github.com/user-attachments/assets/ca159308-6773-464e-b50f-55df7c26da94)

![docs/how-to/maintainers/release-process.md after](https://github.com/user-attachments/assets/3348cac5-0b0e-4852-a156-0d4716881ce0)

</details>

<details>
<summary>Changelog mobile</summary>

![Changelog mobile before](https://github.com/user-attachments/assets/ba59258b-ee9d-4ed4-8501-bd4eaa65b1e0)

![Changelog mobile after](https://github.com/user-attachments/assets/ec550086-8a4a-4879-9d99-49a1df95c743)

</details>

