### PR TITLE
Bound benchmark subprocess I/O and prevent diagnostic persistence

### DIFF
--- a/docs/reference/benchmarks/evidence-protocol-v1.md
+++ b/docs/reference/benchmarks/evidence-protocol-v1.md
@@ -74,16 +74,23 @@ Operational defaults are 16 MiB per request frame, 64 MiB per stdout frame,
 Deadlines are 120 seconds for handshake, 300 seconds per exchange including
 writing/encoding/decoding, 21,600 seconds per invocation and 30 seconds for
 normal finish. Failed cleanup escalates from direct-child termination after
-2 seconds to kill and bounded reaping within a further 3 seconds. Tests inject
-smaller limits. These are resource policies, not scientific acceptance limits.
+2 seconds to kill and bounded reaping within a further 3 seconds. Those two
+cleanup budgets are deliberately not folded into the invocation budget, so
+termination and reaping stay available after an invocation deadline expires.
+Tests inject smaller limits. These are resource policies, not scientific
+acceptance limits.
 Unsupported platforms refuse before spawning; Windows support is not claimed.
 
 A response must be complete, within limits and strictly decoded/validated.
 Duplicate keys, nonfinite numbers, invalid UTF-8, excessive nesting, extra
-frames and partial EOF refuse; a truncated prefix is never scored. Parent
-exceptions from both calls contain only closed codes/phases, without retained
-payload-bearing exception chains. Cancellation also exits through a closed
-error after cleanup. Malformed transport, timeout or unconfirmed
+frames and partial EOF refuse; a truncated prefix is never scored. Standard
+output that is readable before the request write is observed complete cannot be
+a reply to that request and is refused, whichever order a readiness batch
+reports the pipes in. Parent exceptions from both calls contain only closed
+codes/phases, without retained payload-bearing exception chains, including when
+the caller is already handling another exception; the reported phase is the
+transport phase that was live when the failure was caught. Cancellation also
+exits through a closed error after cleanup. Malformed transport, timeout or unconfirmed
 cleanup aborts the cell, never yielding a successful scorecard, failed-closed
 protection credit or substitute zero-leak metric. Valid typed pipeline refusals
 retain the existing scoring/accounting behavior. Cleanup targets only the owned
@@ -111,8 +118,13 @@ python3.13 scripts/bench/test_bench_subprocess.py --mutation-proof
 
 The second command mutates code only in isolated test-process memory. Its named
 assertions detect diagnostic file/stdout emission, removed stderr/request
-bounds, accepted frame truncation, bypassed deadlines/cleanup and retained
-exception context. Compilation failures, unrelated errors and watchdog kills
+bounds, accepted frame truncation, bypassed deadlines/cleanup, retained
+exception context under an active caller handler, output accepted before its
+request completed, a stranded write registration, a misreported failure phase,
+a cleanup budget coupled to the invocation budget, and a transport that always
+fails where a scenario requires success. Every mutation site is asserted to
+occur exactly once in the transport source, so a roster entry cannot silently
+drift onto another line. Compilation failures, unrelated errors and watchdog kills
 are not counted as killed mutants. The existing scoring/population/evidence
 regressions remain separate requirements; the compiled validator probe is not
 needed for this synthetic subprocess proof.

--- a/docs/reference/benchmarks/evidence-protocol-v1.md
+++ b/docs/reference/benchmarks/evidence-protocol-v1.md
@@ -122,8 +122,10 @@ bounds, accepted frame truncation, bypassed deadlines/cleanup, retained
 exception context under an active caller handler, output accepted before its
 request completed, a stranded write registration, a misreported failure phase,
 a cleanup budget coupled to the invocation budget, and a transport that always
-fails where a scenario requires success. Every mutation site is asserted to
-occur exactly once in the transport source, so a roster entry cannot silently
+fails where a scenario requires success. Caller-level failure tests check reaping
+and closed descriptors before the harness emergency reaper runs. A separate
+mutation checks that an error-phase accessor cannot escape the closed boundary.
+Every mutation site is asserted to occur exactly once in the transport source, so a roster entry cannot silently
 drift onto another line. Compilation failures, unrelated errors and watchdog kills
 are not counted as killed mutants. The existing scoring/population/evidence
 regressions remain separate requirements; the compiled validator probe is not

--- a/docs/reference/benchmarks/evidence-protocol-v1.md
+++ b/docs/reference/benchmarks/evidence-protocol-v1.md
@@ -47,9 +47,9 @@ Hazards that must never be serialized or printed:
 * Observer `RedactionEntry` timestamps (`created_at`), `session_id`, source IDs,
   artifact/tokenizer SHA fields; manifests and suspect spans stay private.
 * `scripts/bench/gaze_bench_score.py`: `identified_document_population` persists
-  IDs and is not reused. Its child stderr-to-file runner is not reused either.
-  A future subprocess adapter must drain bounded memory pipes before any private
-  run. Redacting a file afterwards is insufficient.
+  IDs and is not reused. Its legacy scorecard remains synthetic-only, even with
+  the bounded subprocess transport described below. Redacting a file afterwards
+  is insufficient.
 
 Both emitters and consumers recursively validate every path, container type
 (including empty containers), leaf type and vocabulary. Boolean is not integer.
@@ -57,6 +57,49 @@ Refusals contain a closed code only, never an offending key/path/value. Test
 assertions compare private values as booleans with static messages. Canary
 probes cover success, nested refusals, errors, assertions, exceptions, oversize,
 truncation and timeout; an injected private-output mutation must fail them.
+
+## Legacy producer transport boundary
+
+The two Python benchmark calls, `run_config` and
+`collect_validator_measurements`, share `bench_subprocess.py`. On POSIX Linux
+and macOS, it exchanges binary JSONL through nonblocking pipes, draining stderr
+concurrently into discarded bounded chunks. It never persists or prints child
+diagnostics. The compatibility argument `diagnostics_dir` creates no directory
+or file. Newly emitted process metadata omits `stderr_log` and `stderr_bytes`;
+historical scorecards remain readable. No zero byte count or placeholder path
+stands in for an unavailable observation.
+
+Operational defaults are 16 MiB per request frame, 64 MiB per stdout frame,
+64 MiB cumulative stderr per invocation, nesting 64 and 64 KiB I/O chunks.
+Deadlines are 120 seconds for handshake, 300 seconds per exchange including
+writing/encoding/decoding, 21,600 seconds per invocation and 30 seconds for
+normal finish. Failed cleanup escalates from direct-child termination after
+2 seconds to kill and bounded reaping within a further 3 seconds. Tests inject
+smaller limits. These are resource policies, not scientific acceptance limits.
+Unsupported platforms refuse before spawning; Windows support is not claimed.
+
+A response must be complete, within limits and strictly decoded/validated.
+Duplicate keys, nonfinite numbers, invalid UTF-8, excessive nesting, extra
+frames and partial EOF refuse; a truncated prefix is never scored. Parent
+exceptions from both calls contain only closed codes/phases, without retained
+payload-bearing exception chains. Malformed transport, timeout or unconfirmed
+cleanup aborts the cell, never yielding a successful scorecard, failed-closed
+protection credit or substitute zero-leak metric. Valid typed pipeline refusals
+retain the existing scoring/accounting behavior. Cleanup targets only the owned
+direct child and closes all parent descriptors; it never kills by name or group
+or waits indefinitely for an inherited pipe writer.
+
+This improves parent-owned diagnostic sinks and lifecycle bounds only. It is
+not a sandbox against arbitrary child filesystem/network writes, crash dumps,
+swap or independently spawned descendants. Producers must be trusted. Existing
+schema-v4 document IDs, population digests, excluded-document records and
+comparison diagnostics are deliberately preserved for the authorized synthetic
+workflow. **Private inputs remain prohibited through these legacy producers and
+exporters.** Labels, ID prefixes and boolean attestations do not authorize a
+private run. A separately reviewed custody, provenance and in-memory
+producer-to-evaluator bridge is still required; unavailable observations and
+producer membership proof remain unmeasured/blocked. This change establishes
+no corpus-fitness, statistical-power or generalization claim.
 
 ## Receipt schema and stamps
 

--- a/docs/reference/benchmarks/evidence-protocol-v1.md
+++ b/docs/reference/benchmarks/evidence-protocol-v1.md
@@ -82,7 +82,8 @@ A response must be complete, within limits and strictly decoded/validated.
 Duplicate keys, nonfinite numbers, invalid UTF-8, excessive nesting, extra
 frames and partial EOF refuse; a truncated prefix is never scored. Parent
 exceptions from both calls contain only closed codes/phases, without retained
-payload-bearing exception chains. Malformed transport, timeout or unconfirmed
+payload-bearing exception chains. Cancellation also exits through a closed
+error after cleanup. Malformed transport, timeout or unconfirmed
 cleanup aborts the cell, never yielding a successful scorecard, failed-closed
 protection credit or substitute zero-leak metric. Valid typed pipeline refusals
 retain the existing scoring/accounting behavior. Cleanup targets only the owned
@@ -100,6 +101,21 @@ private run. A separately reviewed custody, provenance and in-memory
 producer-to-evaluator bridge is still required; unavailable observations and
 producer membership proof remain unmeasured/blocked. This change establishes
 no corpus-fitness, statistical-power or generalization claim.
+
+Focused model-free transport proof uses Python 3.13:
+
+```sh
+python3.13 -m unittest discover -s scripts/bench -p test_bench_subprocess.py
+python3.13 scripts/bench/test_bench_subprocess.py --mutation-proof
+```
+
+The second command mutates code only in isolated test-process memory. Its named
+assertions detect diagnostic file/stdout emission, removed stderr/request
+bounds, accepted frame truncation, bypassed deadlines/cleanup and retained
+exception context. Compilation failures, unrelated errors and watchdog kills
+are not counted as killed mutants. The existing scoring/population/evidence
+regressions remain separate requirements; the compiled validator probe is not
+needed for this synthetic subprocess proof.
 
 ## Receipt schema and stamps
 

--- a/scripts/bench/bench_subprocess.py
+++ b/scripts/bench/bench_subprocess.py
@@ -32,6 +32,27 @@ class ProducerFailure(RuntimeError):
         super().__init__(f"{self.code}:{self.phase}")
 
 
+def _owner_phase(args, default):
+    """A bound transport method knows its live phase; a module-level call does not."""
+    phase = getattr(args[0], "phase", None) if args else None
+    return phase if phase in PHASES else default
+
+
+def _raise_closed(code, phase):
+    """Raise a closed failure with no chain, even inside a live caller handler.
+
+    Clearing __context__ before the raise does not survive: the raise statement
+    re-attaches the caller's active exception. Only a bare re-raise skips that.
+    """
+    try:
+        raise ProducerFailure(code, phase) from None
+    except ProducerFailure as closed:
+        closed.__cause__ = None
+        closed.__context__ = None
+        closed.__suppress_context__ = True
+        raise
+
+
 def producer_boundary(function):
     """Drop diagnostic exceptions, including their implicit chained context."""
     @functools.wraps(function)
@@ -42,11 +63,13 @@ def producer_boundary(function):
         except ProducerFailure as error:
             code, phase = error.code, error.phase
         except Exception:
-            pass
+            phase = _owner_phase(args, phase)
         except BaseException:
-            code = "cancelled"
+            # Cancellation stays a closed outcome by contract: the raw signal
+            # exception can carry payload, and every caller must still abort.
+            code, phase = "cancelled", _owner_phase(args, phase)
         # Raising inside except would retain the original private exception.
-        raise ProducerFailure(code, phase) from None
+        _raise_closed(code, phase)
     return wrapped
 
 
@@ -78,6 +101,8 @@ class TransportLimits:
             raise ProducerFailure("invalid_limits", "start")
         if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds) > self.invocation_seconds:
             raise ProducerFailure("invalid_limits", "start")
+        # terminate_seconds/reap_seconds stay outside that comparison on purpose:
+        # cleanup keeps its own finite budget once the invocation budget expires.
 
 
 class BenchSubprocess:
@@ -125,12 +150,16 @@ class BenchSubprocess:
             self._cleanup()
             raise
 
+    def _unregister(self, stream):
+        if self.selector is None or stream is None:
+            return
+        try:
+            self.selector.unregister(stream)
+        except (KeyError, ValueError):
+            pass
+
     def _close_stream(self, stream):
-        if self.selector is not None:
-            try:
-                self.selector.unregister(stream)
-            except (KeyError, ValueError):
-                pass
+        self._unregister(stream)
         if stream is not None:
             stream.close()
 
@@ -270,39 +299,48 @@ class BenchSubprocess:
         offset = 0
         if request is not None:
             self.selector.register(self.process.stdin, selectors.EVENT_WRITE, "stdin")
-        while True:
-            self._check(deadline)
-            events = self.selector.select(min(0.05, max(0, deadline - time.monotonic())))
-            complete = False
-            for key, _ in events:
+        try:
+            while True:
                 self._check(deadline)
-                if key.data == "stdin":
-                    try:
-                        written = os.write(key.fd, memoryview(request)[offset:offset + self.limits.chunk_bytes])
-                    except BlockingIOError:
+                events = self.selector.select(min(0.05, max(0, deadline - time.monotonic())))
+                # Snapshot before the batch: a response cannot predate its request,
+                # whichever order this batch happens to report stdin and stdout in.
+                pending = request is not None and offset != len(request)
+                complete = False
+                for key, _ in events:
+                    self._check(deadline)
+                    if key.data == "stdin":
+                        try:
+                            written = os.write(key.fd, memoryview(request)[offset:offset + self.limits.chunk_bytes])
+                        except BlockingIOError:
+                            continue
+                        offset += written
+                        if offset == len(request):
+                            self._unregister(self.process.stdin)
                         continue
-                    offset += written
-                    if offset == len(request):
-                        self.selector.unregister(self.process.stdin)
-                    continue
-                chunk = self._read(key)
-                if chunk is None:
-                    continue
-                if key.data == "stderr":
-                    self._stderr(chunk)
-                    continue
-                if not chunk:
-                    raise ProducerFailure("protocol", self.phase)
-                if len(frame) + len(chunk) > self.limits.stdout_bytes:
-                    raise ProducerFailure("output_limit", self.phase)
-                frame.extend(chunk)
-                newline = frame.find(b"\n")
-                if newline >= 0:
-                    if newline != len(frame) - 1 or (request is not None and offset != len(request)):
+                    chunk = self._read(key)
+                    if chunk is None:
+                        continue
+                    if key.data == "stderr":
+                        self._stderr(chunk)
+                        continue
+                    if not chunk or pending:
                         raise ProducerFailure("protocol", self.phase)
-                    complete = True
-            if complete:
-                return self._decode(frame, deadline)
+                    if len(frame) + len(chunk) > self.limits.stdout_bytes:
+                        raise ProducerFailure("output_limit", self.phase)
+                    # Scan only the new bytes; every earlier chunk was newline-free.
+                    newline = chunk.find(b"\n")
+                    frame.extend(chunk)
+                    if newline >= 0:
+                        if newline != len(chunk) - 1:
+                            raise ProducerFailure("protocol", self.phase)
+                        complete = True
+                if complete:
+                    return self._decode(frame, deadline)
+        finally:
+            if request is not None:
+                # Never strand a write registration, and never mask the first failure.
+                self._unregister(self.process.stdin)
 
     @producer_boundary
     def receive_handshake(self):
@@ -401,7 +439,7 @@ class BenchSubprocess:
         finally:
             clean = self._cleanup()
         if not clean:
-            raise ProducerFailure("cleanup", "cleanup")
+            _raise_closed("cleanup", "cleanup")
         if failure is not None:
-            raise ProducerFailure(*failure)
+            _raise_closed(*failure)
         return False

--- a/scripts/bench/bench_subprocess.py
+++ b/scripts/bench/bench_subprocess.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 CODES = frozenset({
     "unsupported_platform", "invalid_limits", "invalid_state", "input_limit",
     "output_limit", "stderr_limit", "deadline", "protocol", "producer_exit",
-    "io", "payload_processing", "cleanup",
+    "io", "payload_processing", "cleanup", "cancelled",
 })
 PHASES = frozenset({"start", "handshake", "exchange", "finish", "cleanup", "payload"})
 
@@ -43,6 +43,8 @@ def producer_boundary(function):
             code, phase = error.code, error.phase
         except Exception:
             pass
+        except BaseException:
+            code = "cancelled"
         # Raising inside except would retain the original private exception.
         raise ProducerFailure(code, phase) from None
     return wrapped

--- a/scripts/bench/bench_subprocess.py
+++ b/scripts/bench/bench_subprocess.py
@@ -34,8 +34,12 @@ class ProducerFailure(RuntimeError):
 
 def _owner_phase(args, default):
     """A bound transport method knows its live phase; a module-level call does not."""
-    phase = getattr(args[0], "phase", None) if args else None
-    return phase if phase in PHASES else default
+    try:
+        phase = getattr(args[0], "phase", None) if args else None
+        return phase if type(phase) is str and phase in PHASES else default
+    except BaseException:
+        # Error reporting must not expose a second diagnostic from an accessor.
+        return default
 
 
 def _raise_closed(code, phase):

--- a/scripts/bench/bench_subprocess.py
+++ b/scripts/bench/bench_subprocess.py
@@ -1,0 +1,405 @@
+"""Bounded POSIX JSONL exchange with trusted benchmark producers.
+
+Pipes are private memory, never diagnostic output. This is not a child sandbox.
+"""
+from __future__ import annotations
+
+import functools
+import json
+import math
+import os
+import selectors
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+
+CODES = frozenset({
+    "unsupported_platform", "invalid_limits", "invalid_state", "input_limit",
+    "output_limit", "stderr_limit", "deadline", "protocol", "producer_exit",
+    "io", "payload_processing", "cleanup",
+})
+PHASES = frozenset({"start", "handshake", "exchange", "finish", "cleanup", "payload"})
+
+
+class ProducerFailure(RuntimeError):
+    """Only closed codes may cross the producer boundary."""
+
+    def __init__(self, code: str, phase: str = "payload") -> None:
+        self.code = code if code in CODES else "payload_processing"
+        self.phase = phase if phase in PHASES else "payload"
+        super().__init__(f"{self.code}:{self.phase}")
+
+
+def producer_boundary(function):
+    """Drop diagnostic exceptions, including their implicit chained context."""
+    @functools.wraps(function)
+    def wrapped(*args, **kwargs):
+        code, phase = "payload_processing", "payload"
+        try:
+            return function(*args, **kwargs)
+        except ProducerFailure as error:
+            code, phase = error.code, error.phase
+        except Exception:
+            pass
+        # Raising inside except would retain the original private exception.
+        raise ProducerFailure(code, phase) from None
+    return wrapped
+
+
+@dataclass(frozen=True)
+class TransportLimits:
+    request_bytes: int = 16 * 1024 * 1024
+    stdout_bytes: int = 64 * 1024 * 1024
+    stderr_bytes: int = 64 * 1024 * 1024
+    nesting: int = 64
+    chunk_bytes: int = 64 * 1024
+    handshake_seconds: float = 120
+    exchange_seconds: float = 300
+    invocation_seconds: float = 21600
+    finish_seconds: float = 30
+    terminate_seconds: float = 2
+    reap_seconds: float = 3
+
+    def validate(self) -> None:
+        for name in ("request_bytes", "stdout_bytes", "stderr_bytes", "nesting", "chunk_bytes"):
+            value = getattr(self, name)
+            if type(value) is not int or value <= 0:
+                raise ProducerFailure("invalid_limits", "start")
+        for name in ("handshake_seconds", "exchange_seconds", "invocation_seconds",
+                     "finish_seconds", "terminate_seconds", "reap_seconds"):
+            value = getattr(self, name)
+            if type(value) not in (int, float) or not math.isfinite(value) or value <= 0:
+                raise ProducerFailure("invalid_limits", "start")
+        if self.nesting > 64 or self.chunk_bytes > min(self.request_bytes, self.stdout_bytes, self.stderr_bytes):
+            raise ProducerFailure("invalid_limits", "start")
+        if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds) > self.invocation_seconds:
+            raise ProducerFailure("invalid_limits", "start")
+
+
+class BenchSubprocess:
+    """One direct child, no inherited diagnostic sink or persistent I/O threads."""
+
+    def __init__(self, command, *, cwd=None, env=None, limits=None):
+        self.limits = limits if limits is not None else TransportLimits()
+        self.command, self.cwd, self.env = command, cwd, env
+        self.process = None
+        self.selector = None
+        self.invocation_deadline = 0.0
+        self.stderr_seen = 0
+        self.phase = "start"
+        self.finished = False
+        self.message_deadline = 0.0
+
+    def _check(self, deadline):
+        if time.monotonic() >= deadline:
+            raise ProducerFailure("deadline", self.phase)
+
+    def check_deadline(self):
+        self._check(self.invocation_deadline)
+
+    @producer_boundary
+    def __enter__(self):
+        if os.name != "posix" or sys.platform not in ("darwin", "linux"):
+            raise ProducerFailure("unsupported_platform", "start")
+        self.limits.validate()
+        if self.process is not None:
+            raise ProducerFailure("invalid_state", "start")
+        self.invocation_deadline = time.monotonic() + self.limits.invocation_seconds
+        try:
+            self.process = subprocess.Popen(
+                self.command, cwd=self.cwd, env=self.env, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0,
+            )
+            self.selector = selectors.DefaultSelector()
+            for stream in (self.process.stdin, self.process.stdout, self.process.stderr):
+                os.set_blocking(stream.fileno(), False)
+            self.selector.register(self.process.stdout, selectors.EVENT_READ, "stdout")
+            self.selector.register(self.process.stderr, selectors.EVENT_READ, "stderr")
+            self.check_deadline()
+            return self
+        except BaseException:
+            self._cleanup()
+            raise
+
+    def _close_stream(self, stream):
+        if self.selector is not None:
+            try:
+                self.selector.unregister(stream)
+            except (KeyError, ValueError):
+                pass
+        if stream is not None:
+            stream.close()
+
+    def _read(self, key):
+        try:
+            chunk = os.read(key.fd, self.limits.chunk_bytes)
+        except BlockingIOError:
+            return None
+        if not chunk:
+            self._close_stream(key.fileobj)
+        return chunk
+
+    def _stderr(self, chunk):
+        self.stderr_seen += len(chunk)
+        if self.stderr_seen > self.limits.stderr_bytes:
+            raise ProducerFailure("stderr_limit", self.phase)
+
+    def _idle_output(self):
+        # Bytes already waiting before a request cannot be its response.
+        for key, _ in self.selector.select(0):
+            chunk = self._read(key)
+            if chunk and key.data == "stdout":
+                raise ProducerFailure("protocol", self.phase)
+            if chunk and key.data == "stderr":
+                self._stderr(chunk)
+
+    def _encode(self, value, deadline):
+        output = bytearray()
+        active = set()
+
+        def put(data):
+            self._check(deadline)
+            if len(output) + len(data) > self.limits.request_bytes:
+                raise ProducerFailure("input_limit", self.phase)
+            output.extend(data)
+
+        def string(text):
+            put(b'"')
+            # JSONEncoder.iterencode emits a whole string at once. Slice first.
+            for offset in range(0, len(text), min(4096, self.limits.chunk_bytes)):
+                piece = text[offset:offset + min(4096, self.limits.chunk_bytes)]
+                put(json.dumps(piece, ensure_ascii=False)[1:-1].encode("utf-8"))
+            put(b'"')
+
+        def visit(node, depth):
+            self._check(deadline)
+            if depth > self.limits.nesting:
+                raise ProducerFailure("input_limit", self.phase)
+            kind = type(node)
+            if kind is str:
+                string(node)
+            elif node is None:
+                put(b"null")
+            elif kind is bool:
+                put(b"true" if node else b"false")
+            elif kind in (int, float):
+                if kind is int and node.bit_length() > self.limits.request_bytes * 4:
+                    raise ProducerFailure("input_limit", self.phase)
+                put(json.dumps(node, allow_nan=False).encode("ascii"))
+            elif kind in (dict, list, tuple):
+                if id(node) in active:
+                    raise ProducerFailure("input_limit", self.phase)
+                active.add(id(node))
+                mapping = kind is dict
+                put(b"{" if mapping else b"[")
+                for index, item in enumerate(node):
+                    if index:
+                        put(b",")
+                    if mapping:
+                        if type(item) is not str:
+                            raise ProducerFailure("protocol", self.phase)
+                        string(item)
+                        put(b":")
+                        visit(node[item], depth + 1)
+                    else:
+                        visit(item, depth + 1)
+                put(b"}" if mapping else b"]")
+                active.remove(id(node))
+            else:
+                raise ProducerFailure("protocol", self.phase)
+
+        if type(value) is not dict:
+            raise ProducerFailure("protocol", self.phase)
+        visit(value, 1)
+        put(b"\n")
+        return output
+
+    def _decode(self, frame, deadline):
+        depth, quoted, escaped = 0, False, False
+        for index, char in enumerate(frame):
+            if index % self.limits.chunk_bytes == 0:
+                self._check(deadline)
+            if quoted:
+                if escaped:
+                    escaped = False
+                elif char == 92:
+                    escaped = True
+                elif char == 34:
+                    quoted = False
+            elif char == 34:
+                quoted = True
+            elif char in (91, 123):
+                depth += 1
+                if depth > self.limits.nesting:
+                    raise ProducerFailure("output_limit", self.phase)
+            elif char in (93, 125):
+                depth -= 1
+
+        def pairs(items):
+            result = {}
+            for key, value in items:
+                if key in result:
+                    raise ProducerFailure("protocol", self.phase)
+                result[key] = value
+            return result
+
+        def constant(_value):
+            raise ProducerFailure("protocol", self.phase)
+
+        result = json.loads(frame.decode("utf-8"), object_pairs_hook=pairs, parse_constant=constant)
+        if type(result) is not dict:
+            raise ProducerFailure("protocol", self.phase)
+        # JSON exponent overflow is not covered by parse_constant.
+        def finite(node):
+            self._check(deadline)
+            if type(node) is float and not math.isfinite(node):
+                raise ProducerFailure("protocol", self.phase)
+            if type(node) in (dict, list):
+                for value in (node.values() if type(node) is dict else node):
+                    finite(value)
+        finite(result)
+        self._check(deadline)
+        return result
+
+    def _receive(self, deadline, request=None):
+        frame = bytearray()
+        offset = 0
+        if request is not None:
+            self.selector.register(self.process.stdin, selectors.EVENT_WRITE, "stdin")
+        while True:
+            self._check(deadline)
+            events = self.selector.select(min(0.05, max(0, deadline - time.monotonic())))
+            complete = False
+            for key, _ in events:
+                self._check(deadline)
+                if key.data == "stdin":
+                    try:
+                        written = os.write(key.fd, memoryview(request)[offset:offset + self.limits.chunk_bytes])
+                    except BlockingIOError:
+                        continue
+                    offset += written
+                    if offset == len(request):
+                        self.selector.unregister(self.process.stdin)
+                    continue
+                chunk = self._read(key)
+                if chunk is None:
+                    continue
+                if key.data == "stderr":
+                    self._stderr(chunk)
+                    continue
+                if not chunk:
+                    raise ProducerFailure("protocol", self.phase)
+                if len(frame) + len(chunk) > self.limits.stdout_bytes:
+                    raise ProducerFailure("output_limit", self.phase)
+                frame.extend(chunk)
+                newline = frame.find(b"\n")
+                if newline >= 0:
+                    if newline != len(frame) - 1 or (request is not None and offset != len(request)):
+                        raise ProducerFailure("protocol", self.phase)
+                    complete = True
+            if complete:
+                return self._decode(frame, deadline)
+
+    @producer_boundary
+    def receive_handshake(self):
+        self.phase = "handshake"
+        deadline = min(self.invocation_deadline, time.monotonic() + self.limits.handshake_seconds)
+        self.message_deadline = deadline
+        return self._receive(deadline)
+
+    @producer_boundary
+    def exchange(self, request):
+        if self.finished or self.process is None or self.process.stdin.closed:
+            raise ProducerFailure("invalid_state", "exchange")
+        self.phase = "exchange"
+        deadline = min(self.invocation_deadline, time.monotonic() + self.limits.exchange_seconds)
+        self.message_deadline = deadline
+        self._idle_output()
+        encoded = self._encode(request, deadline)
+        return self._receive(deadline, encoded)
+
+    def check_message_deadline(self):
+        self._check(self.message_deadline)
+
+    def _wait_exit(self, deadline, *, discard):
+        while True:
+            if time.monotonic() >= deadline:
+                return False
+            for key, _ in self.selector.select(min(0.05, max(0, deadline - time.monotonic()))):
+                chunk = self._read(key)
+                if chunk and not discard:
+                    if key.data == "stdout":
+                        raise ProducerFailure("protocol", self.phase)
+                    self._stderr(chunk)
+            if self.process.poll() is not None:
+                # Drain currently available data, never wait on inherited writers.
+                while True:
+                    if time.monotonic() >= deadline:
+                        return False
+                    ready = self.selector.select(0)
+                    if not ready:
+                        return True
+                    for key, _ in ready:
+                        chunk = self._read(key)
+                        if chunk and not discard:
+                            if key.data == "stdout":
+                                raise ProducerFailure("protocol", self.phase)
+                            self._stderr(chunk)
+
+    @producer_boundary
+    def finish(self):
+        self.phase = "finish"
+        self._close_stream(self.process.stdin)
+        deadline = min(self.invocation_deadline, time.monotonic() + self.limits.finish_seconds)
+        if not self._wait_exit(deadline, discard=False):
+            raise ProducerFailure("deadline", "finish")
+        if self.process.returncode != 0:
+            raise ProducerFailure("producer_exit", "finish")
+        self.finished = True
+
+    def _cleanup(self):
+        clean = True
+        if self.process is None:
+            return clean
+        try:
+            self._close_stream(self.process.stdin)
+            if self.process.poll() is None:
+                self.process.terminate()
+                if self.selector is None:
+                    self.selector = selectors.DefaultSelector()
+                self._wait_exit(time.monotonic() + self.limits.terminate_seconds, discard=True)
+        except Exception:
+            clean = False
+        finally:
+            # A drain/close failure must not skip the final kill/reap attempt.
+            try:
+                if self.process.poll() is None:
+                    self.process.kill()
+                    self.process.wait(timeout=self.limits.reap_seconds)
+            except Exception:
+                clean = False
+            for stream in (self.process.stdin, self.process.stdout, self.process.stderr):
+                try:
+                    self._close_stream(stream)
+                except Exception:
+                    clean = False
+            if self.selector is not None:
+                self.selector.close()
+        return clean
+
+    def __exit__(self, kind, error, traceback):
+        failure = None
+        try:
+            if kind is None and not self.finished:
+                self.finish()
+        except ProducerFailure as caught:
+            failure = (caught.code, caught.phase)
+        finally:
+            clean = self._cleanup()
+        if not clean:
+            raise ProducerFailure("cleanup", "cleanup")
+        if failure is not None:
+            raise ProducerFailure(*failure)
+        return False

--- a/scripts/bench/gaze_bench_score.py
+++ b/scripts/bench/gaze_bench_score.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
+from bench_subprocess import BenchSubprocess, producer_boundary
+
 
 SCORECARD_SCHEMA_VERSION = 4
 READABLE_SCORECARD_SCHEMA_VERSIONS = frozenset({3, SCORECARD_SCHEMA_VERSION})
@@ -1486,6 +1488,7 @@ def _validate_validator_probe_response(
     }
 
 
+@producer_boundary
 def collect_validator_measurements(
     probe_binary: Path,
     documents: Sequence[Document],
@@ -1495,32 +1498,11 @@ def collect_validator_measurements(
     document_ids = {document.uid for document in documents}
     unknown_ids = measured_ids - document_ids
     if unknown_ids:
-        raise ValueError(
-            "validator measurement IDs are outside the document population: "
-            + ", ".join(sorted(unknown_ids))
-        )
-    process = subprocess.Popen(
-        [str(probe_binary)],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        encoding="utf-8",
-        bufsize=1,
-    )
-    assert process.stdin is not None
-    assert process.stdout is not None
-    assert process.stderr is not None
-    handshake_line = process.stdout.readline()
-    if not handshake_line:
-        stderr = process.stderr.read()
-        raise RuntimeError(
-            "validator recall probe exited before its handshake"
-            + (f": {stderr.strip()}" if stderr.strip() else "")
-        )
-    handshake = _validate_validator_probe_handshake(json.loads(handshake_line))
+        raise ValueError("validator measurement population mismatch")
     responses: dict[str, dict[str, object]] = {}
-    try:
+    with BenchSubprocess([str(probe_binary)]) as process:
+        handshake = _validate_validator_probe_handshake(process.receive_handshake())
+        process.check_message_deadline()
         for document in documents:
             request = {
                 "fixture_id": document.uid,
@@ -1539,31 +1521,12 @@ def collect_validator_measurements(
                 ],
                 "measure_predictions": document.uid in measured_ids,
             }
-            process.stdin.write(json.dumps(request, ensure_ascii=False) + "\n")
-            process.stdin.flush()
-            response_line = process.stdout.readline()
-            if not response_line:
-                stderr = process.stderr.read()
-                raise RuntimeError(
-                    f"validator recall probe exited before {document.uid}"
-                    + (f": {stderr.strip()}" if stderr.strip() else "")
-                )
             responses[document.uid] = _validate_validator_probe_response(
                 document,
-                json.loads(response_line),
+                process.exchange(request),
                 predictions_expected=document.uid in measured_ids,
             )
-    finally:
-        process.stdin.close()
-        return_code = process.wait(timeout=30)
-        stderr = process.stderr.read()
-        process.stdout.close()
-        process.stderr.close()
-        if return_code != 0:
-            raise RuntimeError(
-                f"validator recall probe failed with status {return_code}"
-                + (f": {stderr.strip()}" if stderr.strip() else "")
-            )
+            process.check_message_deadline()
     return {**handshake, "documents": responses}
 
 
@@ -1720,6 +1683,7 @@ def validator_recall_by_label(
     return result
 
 
+@producer_boundary
 def run_config(
     repo_root: Path,
     binary: Path,
@@ -1756,23 +1720,7 @@ def run_config(
     if opf_daemon_socket is not None:
         environment["GAZE_OPF_DAEMON_SOCKET"] = str(opf_daemon_socket)
     command = [str(binary), "--config", config]
-    diagnostics_dir.mkdir(parents=True, exist_ok=True)
-    stderr_path = diagnostics_dir / f"{config}.stderr.log"
-    stderr_handle = stderr_path.open("w", encoding="utf-8")
     started = time.perf_counter()
-    process = subprocess.Popen(
-        command,
-        cwd=repo_root,
-        env=environment,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=stderr_handle,
-        text=True,
-        encoding="utf-8",
-        bufsize=1,
-    )
-    assert process.stdin is not None
-    assert process.stdout is not None
 
     overall = MetricAccumulator()
     per_language: defaultdict[str, MetricAccumulator] = defaultdict(MetricAccumulator)
@@ -1791,27 +1739,22 @@ def run_config(
 
     def exchange(document: Document) -> tuple[dict[str, object], float]:
         nonlocal first_response_ms
+        if process.message_deadline:
+            process.check_message_deadline()
         request = {
             "fixture_id": document.uid,
             "locale_chain": document.locale_chain,
             "text": document.text,
         }
         request_started = time.perf_counter()
-        process.stdin.write(json.dumps(request, ensure_ascii=False) + "\n")
-        process.stdin.flush()
-        response_line = process.stdout.readline()
-        if not response_line:
-            return_code = process.poll()
-            raise RuntimeError(
-                f"benchmark runner exited before {document.uid}; status={return_code}"
-            )
-        response = validate_response(document, json.loads(response_line))
+        response = validate_response(document, process.exchange(request))
+        process.check_message_deadline()
         validated_at = time.perf_counter()
         if first_response_ms is None:
             first_response_ms = (validated_at - started) * 1000.0
         return response, (validated_at - request_started) * 1000.0
 
-    try:
+    with BenchSubprocess(command, cwd=repo_root, env=environment) as process:
         for warmup_index in range(warmup_count):
             warmup_document = documents[warmup_index % len(documents)]
             response, round_trip_ms = exchange(warmup_document)
@@ -1907,12 +1850,7 @@ def run_config(
                     f"{config}: scored {index + 1}/{len(documents)} documents",
                     file=sys.stderr,
                 )
-    finally:
-        process.stdin.close()
-        return_code = process.wait(timeout=30)
-        stderr_handle.close()
-        if return_code != 0:
-            raise RuntimeError(f"benchmark runner failed with status {return_code}")
+        process.check_message_deadline()
 
     wall_seconds = time.perf_counter() - started
     clean_ms = success_timing.get("clean_ms", [])
@@ -1936,7 +1874,7 @@ def run_config(
         "stage_counts": dict(sorted(pipeline_error_stages.items())),
     }
     failed_closed_count = len(failed_closed_documents)
-    return {
+    result = {
         "config": config,
         "scored_population": scored_population,
         "failed_closed_population": failed_closed_population,
@@ -1989,10 +1927,11 @@ def run_config(
             "cold_start_to_first_validated_response_ms": first_response_ms,
             "warmup_count": warmup_count,
             "discarded_warmup_samples": discarded_warmup_samples,
-            "stderr_log": str(stderr_path.relative_to(repo_root)),
-            "stderr_bytes": stderr_path.stat().st_size,
         },
     }
+
+    process.check_deadline()
+    return result
 
 
 def git_metadata(repo_root: Path) -> dict[str, object]:

--- a/scripts/bench/test_bench_subprocess.py
+++ b/scripts/bench/test_bench_subprocess.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
-import io
 import json
 import os
 from pathlib import Path
@@ -54,6 +53,8 @@ def child(mode):
                                          "validator_kind": "synthetic"}]})
     if mode in ("ignore", "finish-hang"):
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    if mode in ("blocked-write", "trickle", "silent", "no-newline"):
+        emit({"ready": True})
     if mode == "blocked-write":
         for _ in range(1024):
             os.write(2, b"x" * 1024)
@@ -101,6 +102,7 @@ def child(mode):
             from test_openpii_gaze_bench import ResponseValidationTests
             response = ResponseValidationTests().success_response()
             response["fixture_id"] = request["fixture_id"]
+            response["clean_text"] = request["text"]
             if mode == "score-bad":
                 response[CANARY] = CANARY
             elif mode == "score-reason":
@@ -111,12 +113,17 @@ def child(mode):
                 response = {"fixture_id": request["fixture_id"],
                             "pipeline_error_code": "safety_net_fallback_residual_suspect",
                             "pipeline_error_stage": "clean", "timing": {"total_ms": 1.0}}
-            os.write(2, CANARY.encode())
+            os.write(2, request["text"].encode())
             emit(response)
         else:
             emit(request)
         if mode == "nonzero":
             return 9
+    if mode == "exit-flood":
+        for _ in range(16):
+            os.write(2, CANARY.encode() * 512)
+    if mode == "exit-extra":
+        os.write(1, b"{}\n")
     return 0
 
 
@@ -127,7 +134,7 @@ def invoke(mode, root, *, late=False, post=False):
         created.append(owner)
         return owner
     from test_openpii_gaze_bench import ResponseValidationTests
-    document = ResponseValidationTests().document()
+    document = dataclasses.replace(ResponseValidationTests().document(), text=CANARY)
     with mock.patch.object(score, "BenchSubprocess", side_effect=factory):
         if mode.startswith("probe") or mode in ("bad-handshake", "early"):
             result = score.collect_validator_measurements(Path("synthetic"), [document], [document.uid])
@@ -155,6 +162,7 @@ def invoke(mode, root, *, late=False, post=False):
 
 
 def boundary_scenario(mode, root):
+    os.chdir(root)
     late = mode == "late"
     post = mode == "post"
     actual_mode = "score" if late or post else mode
@@ -182,7 +190,17 @@ def boundary_scenario(mode, root):
 class TransportTests(unittest.TestCase):
     def owner(self, mode="echo", **changes):
         owner = transport.BenchSubprocess(command(mode), limits=limits(**changes))
-        self.addCleanup(owner._cleanup)
+        def fixture_cleanup():
+            # Mutation probes must not disable the test harness's own reaper.
+            if owner.process is not None:
+                if owner.process.poll() is None:
+                    owner.process.kill()
+                owner.process.wait(timeout=1)
+                for stream in (owner.process.stdin, owner.process.stdout, owner.process.stderr):
+                    stream.close()
+            if owner.selector is not None:
+                owner.selector.close()
+        self.addCleanup(fixture_cleanup)
         return owner
 
     def reaped(self, owner):
@@ -284,6 +302,8 @@ class TransportTests(unittest.TestCase):
             started = time.monotonic()
             with self.assertRaises(transport.ProducerFailure, msg="absolute-deadline") as failure:
                 with owner:
+                    self.assertTrue(owner.receive_handshake() == {"ready": True}, "child-ready")
+                    started = time.monotonic()
                     owner.exchange({"text": "x" * 400_000})
             self.assertEqual(failure.exception.code, "deadline", "absolute-deadline")
             self.assertTrue(time.monotonic() - started < 1.1, "absolute-deadline")
@@ -331,6 +351,78 @@ class TransportTests(unittest.TestCase):
                 raise ValueError("synthetic processing failure")
         self.reaped(owner)
 
+    def test_shutdown_output_and_stderr_budget(self):
+        for mode, expected in (("exit-flood", "stderr_limit"), ("exit-extra", "protocol")):
+            owner = self.owner(mode, stderr_bytes=4096)
+            with self.assertRaises(transport.ProducerFailure) as failure:
+                with owner:
+                    owner.exchange({"x": 1})
+            self.assertEqual(failure.exception.code, expected, "shutdown-drain")
+            self.reaped(owner)
+
+    def test_invocation_and_parse_deadline(self):
+        owner = self.owner(invocation_seconds=0.6)
+        with self.assertRaises(transport.ProducerFailure) as failure:
+            with owner:
+                owner.exchange({"x": 1})
+                time.sleep(0.65)
+                owner.exchange({"x": 2})
+        self.assertEqual(failure.exception.code, "deadline", "invocation-deadline")
+        self.reaped(owner)
+        owner = self.owner()
+        with owner:
+            owner.exchange({"x": 1})
+            original = transport.json.loads
+            def slow(*args, **kwargs):
+                time.sleep(0.65)
+                return original(*args, **kwargs)
+            with mock.patch.object(transport.json, "loads", side_effect=slow):
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    owner.exchange({"x": 2})
+            self.assertEqual(failure.exception.code, "deadline", "decode-deadline")
+        self.reaped(owner)
+
+    def test_cleanup_drain_failure_still_reaps(self):
+        owner = self.owner("ignore")
+        with self.assertRaises(transport.ProducerFailure) as failure:
+            with owner:
+                owner.exchange({"x": 1})
+                with mock.patch.object(owner, "_wait_exit", side_effect=OSError(CANARY)):
+                    self.assertFalse(owner._cleanup(), "cleanup-report")
+                    raise transport.ProducerFailure("cleanup", "cleanup")
+        self.assertEqual(failure.exception.code, "cleanup")
+        self.reaped(owner)
+
+    def test_boundary_no_exception_context_in_process(self):
+        with tempfile.TemporaryDirectory() as root:
+            for mode in ("score-bad", "score-reason", "probe-bad", "bad-handshake"):
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    invoke(mode, Path(root))
+                error = failure.exception
+                self.assertTrue(error.__context__ is None and error.__cause__ is None, "exception-context")
+                self.assertTrue(CANARY not in repr(error), "exception-boundary")
+
+    def test_cancelled_payload_and_unknown_population_are_closed(self):
+        owners = []
+        def factory(*args, **kwargs):
+            owner = transport.BenchSubprocess(command("probe"), limits=limits())
+            owners.append(owner)
+            return owner
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch.object(score, "BenchSubprocess") as spawn:
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    score.collect_validator_measurements(Path(root), [], [CANARY])
+                spawn.assert_not_called()
+                self.assertTrue(failure.exception.__context__ is None, "exception-context")
+            with mock.patch.object(score, "BenchSubprocess", side_effect=factory), mock.patch.object(
+                score, "_validate_validator_probe_handshake", side_effect=KeyboardInterrupt(CANARY)
+            ):
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    score.collect_validator_measurements(Path(root), [], [])
+            self.assertEqual(failure.exception.code, "cancelled", "cancelled-boundary")
+            self.assertTrue(failure.exception.__context__ is None and failure.exception.__cause__ is None, "exception-context")
+            self.reaped(owners[0])
+
     def test_boundary_success_and_failure_sinks(self):
         for mode in ("score", "score-refusal", "probe", "early", "bad-handshake",
                      "probe-bad", "score-bad", "score-reason", "late", "post", "uncaught"):
@@ -345,10 +437,76 @@ class TransportTests(unittest.TestCase):
                     self.assertTrue(result.returncode == 0 and not result.stdout and not result.stderr, "boundary-result")
 
 
+MUTATIONS = {
+    "stderr-file": ("        self.stderr_seen += len(chunk)",
+                    "        open('synthetic-output', 'ab').write(chunk)\n        self.stderr_seen += len(chunk)",
+                    "test_boundary_success_and_failure_sinks", "file-boundary"),
+    "stderr-stdout": ("        self.stderr_seen += len(chunk)",
+                      "        print(chunk.decode('utf-8', errors='replace'))\n        self.stderr_seen += len(chunk)",
+                      "test_boundary_success_and_failure_sinks", "output-canary"),
+    "stderr-budget": ("if self.stderr_seen > self.limits.stderr_bytes:", "if False:",
+                      "test_stderr_budget", "stderr-budget"),
+    "request-cap": ("if len(output) + len(data) > self.limits.request_bytes:", "if False:",
+                    "test_request_cap_and_preallocation", "request-preallocation"),
+    "frame-truncation": ("if newline != len(frame) - 1 or (request is not None and offset != len(request)):\n                        raise ProducerFailure(\"protocol\", self.phase)",
+                         "if request is not None and offset != len(request):\n                        raise ProducerFailure(\"protocol\", self.phase)\n                    frame = frame[:newline + 1]",
+                         "test_malformed_extra_partial_frames", "frame-refusal"),
+    "deadline": ("if time.monotonic() >= deadline:", "if False:",
+                 "test_write_blocking_and_absolute_deadlines", "absolute-deadline"),
+    "cleanup": ("        if self.process is None:\n            return clean",
+                "        return clean\n        if self.process is None:\n            return clean",
+                "test_cleanup_on_processing_exception", "child-reaping"),
+    "context": ("        except Exception:\n            pass",
+                "        except Exception:\n            raise ProducerFailure('payload_processing') from None",
+                "test_boundary_no_exception_context_in_process", "exception-context"),
+}
+
+
+def apply_mutation(name):
+    old, new, _, _ = MUTATIONS[name]
+    source = Path(transport.__file__).read_text()
+    assert old in source, "mutation-site"
+    exec(compile(source.replace(old, new, 1), transport.__file__, "exec"), transport.__dict__)
+    score.run_config = transport.producer_boundary(score.run_config.__wrapped__)
+    score.collect_validator_measurements = transport.producer_boundary(score.collect_validator_measurements.__wrapped__)
+
+
+def mutation_worker(name):
+    apply_mutation(name)
+    target = MUTATIONS[name][2]
+    result = unittest.TestResult()
+    unittest.TestSuite([TransportTests(target)]).run(result)
+    # Only the named assertion is a kill. Errors/watchdog/compile failure aren't.
+    killed = any(MUTATIONS[name][3] in detail for _, detail in result.failures)
+    if not killed:
+        print("survived-or-wrong-failure:" + name)
+        return 1
+    print("killed:" + name + ":" + target)
+    return 0
+
+
+def mutation_proof():
+    for name in MUTATIONS:
+        environment = {**os.environ, "GAZE_BENCH_TEST_MUTANT": name}
+        result = subprocess.run([sys.executable, str(HERE), "--mutant", name],
+                                env=environment, capture_output=True, timeout=20)
+        if result.returncode != 0 or CANARY.encode() in result.stdout + result.stderr:
+            print("mutation-proof-failed:" + name)
+            return 1
+        print(result.stdout.decode().strip())
+    return 0
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "--child":
         raise SystemExit(child(sys.argv[2]))
+    if len(sys.argv) > 1 and sys.argv[1] == "--mutation-proof":
+        raise SystemExit(mutation_proof())
+    if len(sys.argv) > 1 and sys.argv[1] == "--mutant":
+        raise SystemExit(mutation_worker(sys.argv[2]))
     if len(sys.argv) > 1 and sys.argv[1] == "--boundary":
+        if os.environ.get("GAZE_BENCH_TEST_MUTANT"):
+            apply_mutation(os.environ["GAZE_BENCH_TEST_MUTANT"])
         boundary_scenario(sys.argv[2], Path(sys.argv[3]))
     else:
         unittest.main()

--- a/scripts/bench/test_bench_subprocess.py
+++ b/scripts/bench/test_bench_subprocess.py
@@ -142,8 +142,8 @@ def child(mode):
     return 0
 
 
-def invoke(mode, root, *, late=False, post=False):
-    created = []
+def invoke(mode, root, *, late=False, post=False, owners=None):
+    created = owners if owners is not None else []
     def factory(*args, **kwargs):
         owner = transport.BenchSubprocess(command(mode), cwd=root, limits=limits())
         created.append(owner)
@@ -202,6 +202,23 @@ def assert_success_counts(mode, result):
 
 
 def boundary_scenario(mode, root):
+    owners = []
+    try:
+        _boundary_scenario(mode, root, owners)
+    finally:
+        # Assert first; this independent emergency reaper must not hide a mutant.
+        for owner in owners:
+            if owner.process is not None:
+                if owner.process.poll() is None:
+                    owner.process.kill()
+                owner.process.wait(timeout=1)
+                for stream in (owner.process.stdin, owner.process.stdout, owner.process.stderr):
+                    stream.close()
+            if owner.selector is not None:
+                owner.selector.close()
+
+
+def _boundary_scenario(mode, root, owners):
     os.chdir(root)
     late = mode == "late"
     post = mode == "post"
@@ -209,17 +226,27 @@ def boundary_scenario(mode, root):
     error = None
     result = None
     try:
-        result, owners = invoke(actual_mode, root, late=late, post=post)
+        result, _ = invoke(actual_mode, root, late=late, post=post, owners=owners)
         process_meta = result.get("process", {})
         assert "stderr_log" not in process_meta and "stderr_bytes" not in process_meta, "metadata-boundary"
         assert CANARY not in repr(result), "result-boundary"
-        assert all(owner.process.returncode is not None for owner in owners), "caller-reaping"
     except transport.ProducerFailure as caught:
         assert caught.__context__ is None and caught.__cause__ is None, "exception-context"
         assert CANARY not in str(caught) and CANARY not in repr(caught), "exception-boundary"
         rendered = "".join(traceback.format_exception(caught))
         assert CANARY not in rendered, "traceback-boundary"
         error = (caught.code, caught.phase)
+    assert owners, "caller-reaping"
+    for owner in owners:
+        assert owner.process.returncode is not None, "caller-reaping"
+        assert all(stream.closed for stream in
+                   (owner.process.stdin, owner.process.stdout, owner.process.stderr)), "caller-fd-close"
+        try:
+            os.waitpid(owner.process.pid, os.WNOHANG)
+        except ChildProcessError:
+            pass
+        else:
+            raise AssertionError("caller-reaping")
     assert not list(root.iterdir()), "file-boundary"
     if mode in SUCCESS_MODES:
         assert error is None, "success-required"
@@ -227,7 +254,7 @@ def boundary_scenario(mode, root):
     else:
         assert error is not None, "failure-required"
     if mode == "uncaught":
-        invoke("score-bad", root)
+        invoke("score-bad", root, owners=owners)
 
 
 @unittest.skipUnless(os.name == "posix" and sys.platform in ("darwin", "linux"), "POSIX transport")
@@ -486,6 +513,34 @@ class TransportTests(unittest.TestCase):
 
     # ---- review round r1 regressions ------------------------------------------
 
+    def test_phase_accessor_cannot_escape_boundary(self):
+        class BadPhase:
+            @property
+            def phase(self):
+                raise RuntimeError(CANARY)
+
+        @transport.producer_boundary
+        def fail(owner):
+            raise ValueError(CANARY)
+
+        try:
+            error = self.ambient(lambda: fail(BadPhase()))
+        except RuntimeError:
+            self.fail("phase-boundary")
+        self.assertEqual(error.phase, "payload", "phase-boundary")
+
+    def test_caller_failures_reap_and_close(self):
+        previous = Path.cwd()
+        try:
+            for mode in ("bad-handshake", "probe-bad", "score-bad", "late", "post"):
+                with self.subTest(mode=mode), tempfile.TemporaryDirectory() as root:
+                    try:
+                        boundary_scenario(mode, Path(root))
+                    finally:
+                        os.chdir(previous)
+        finally:
+            os.chdir(previous)
+
     def ambient(self, call):
         """Enter the boundary from inside live, payload-bearing caller handlers."""
         try:
@@ -672,7 +727,7 @@ MUTATIONS = {
     "ambient-context": ("        closed.__cause__ = None\n        closed.__context__ = None",
                         "        closed.__cause__ = None",
                         "test_ambient_caller_context_never_crosses_high_level_calls", "exception-context"),
-    "owner-phase": ("    phase = getattr(args[0], \"phase\", None) if args else None", "    phase = None",
+    "owner-phase": ("        phase = getattr(args[0], \"phase\", None) if args else None", "        phase = None",
                     "test_transport_failures_carry_the_owner_phase", "phase-accuracy"),
     "early-prefix": ("                pending = request is not None and offset != len(request)",
                      "                pending = False",
@@ -686,6 +741,12 @@ MUTATIONS = {
     "cleanup-budget": ("        if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds) > self.invocation_seconds:",
                        "        if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds,\n               self.terminate_seconds, self.reap_seconds) > self.invocation_seconds:",
                        "test_cleanup_budget_outlives_the_invocation_budget", "cleanup-budget"),
+    "caller-cleanup": ("    def _cleanup(self):\n        clean = True",
+                       "    def _cleanup(self):\n        return True\n        clean = True",
+                       "test_caller_failures_reap_and_close", "caller-reaping"),
+    "phase-accessor": ("    except BaseException:\n        # Error reporting must not expose a second diagnostic from an accessor.\n        return default",
+                       "    except BaseException:\n        # Error reporting must not expose a second diagnostic from an accessor.\n        raise",
+                       "test_phase_accessor_cannot_escape_boundary", "phase-boundary"),
 }
 
 

--- a/scripts/bench/test_bench_subprocess.py
+++ b/scripts/bench/test_bench_subprocess.py
@@ -1,0 +1,354 @@
+"""Synthetic process falsifiers; run --mutation-proof for the targeted kill set."""
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import io
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+import tracemalloc
+import unittest
+from unittest import mock
+
+import bench_subprocess as transport
+import gaze_bench_score as score
+
+CANARY = "synthetic-private-canary"
+HERE = Path(__file__).resolve()
+
+
+def limits(**changes):
+    return dataclasses.replace(transport.TransportLimits(
+        request_bytes=512 * 1024, stdout_bytes=512 * 1024, stderr_bytes=512 * 1024,
+        chunk_bytes=1024, handshake_seconds=0.6, exchange_seconds=0.6,
+        invocation_seconds=4, finish_seconds=0.25, terminate_seconds=0.1,
+        reap_seconds=0.3,
+    ), **changes)
+
+
+def command(mode):
+    return [sys.executable, str(HERE), "--child", mode]
+
+
+def child(mode):
+    def emit(value):
+        os.write(1, json.dumps(value, ensure_ascii=False).encode() + b"\n")
+
+    if mode == "early":
+        os.write(2, CANARY.encode())
+        return 7
+    if mode == "bad-handshake":
+        emit({CANARY: CANARY})
+        return 0
+    if mode.startswith("probe"):
+        emit({"schema_version": score.VALIDATOR_PROBE_PROTOCOL_SCHEMA_VERSION,
+              "validator_kinds_by_class": {"email": ["synthetic"]},
+              "validator_recognizers": [{"id": "synthetic", "class": "email",
+                                         "validator_kind": "synthetic"}]})
+    if mode in ("ignore", "finish-hang"):
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    if mode == "blocked-write":
+        for _ in range(1024):
+            os.write(2, b"x" * 1024)
+        time.sleep(2)
+        return 0
+    for line in sys.stdin.buffer:
+        request = json.loads(line)
+        if mode in ("flood", "flood-excess"):
+            for _ in range(128):
+                os.write(2, (CANARY * 100).encode())
+        if mode == "early-response":
+            os.write(2, request.get("text", CANARY).encode())
+            return 8
+        if mode == "silent":
+            time.sleep(1.2)
+            emit(request)
+        elif mode == "trickle":
+            for byte in b'{"x":1}\n':
+                time.sleep(0.12)
+                os.write(1, bytes([byte]))
+        elif mode in ("ignore", "finish-hang"):
+            emit(request)
+            time.sleep(1.5)
+            return 0
+        elif mode == "inherit":
+            if os.fork() == 0:
+                time.sleep(0.7)
+                os._exit(0)
+            emit(request)
+            return 0
+        elif mode == "split":
+            for byte in json.dumps(request, ensure_ascii=False).encode() + b"\n":
+                os.write(1, bytes([byte]))
+        elif mode == "raw":
+            os.write(1, bytes.fromhex(request["wire"]))
+            return 0
+        elif mode == "no-newline":
+            os.write(1, b'{"x":1}')
+            time.sleep(1.2)
+        elif mode.startswith("probe"):
+            emit({"fixture_id": request["fixture_id"] if mode == "probe" else CANARY,
+                  "gold_validation": [],
+                  "predictions": {"validator_backed": [], "shape_only": []}})
+        elif mode.startswith("score"):
+            from test_openpii_gaze_bench import ResponseValidationTests
+            response = ResponseValidationTests().success_response()
+            response["fixture_id"] = request["fixture_id"]
+            if mode == "score-bad":
+                response[CANARY] = CANARY
+            elif mode == "score-reason":
+                response = {"fixture_id": request["fixture_id"],
+                            "pipeline_error_code": CANARY, "pipeline_error_stage": "clean",
+                            "timing": {"total_ms": 1.0}}
+            elif mode == "score-refusal":
+                response = {"fixture_id": request["fixture_id"],
+                            "pipeline_error_code": "safety_net_fallback_residual_suspect",
+                            "pipeline_error_stage": "clean", "timing": {"total_ms": 1.0}}
+            os.write(2, CANARY.encode())
+            emit(response)
+        else:
+            emit(request)
+        if mode == "nonzero":
+            return 9
+    return 0
+
+
+def invoke(mode, root, *, late=False, post=False):
+    created = []
+    def factory(*args, **kwargs):
+        owner = transport.BenchSubprocess(command(mode), cwd=root, limits=limits())
+        created.append(owner)
+        return owner
+    from test_openpii_gaze_bench import ResponseValidationTests
+    document = ResponseValidationTests().document()
+    with mock.patch.object(score, "BenchSubprocess", side_effect=factory):
+        if mode.startswith("probe") or mode in ("bad-handshake", "early"):
+            result = score.collect_validator_measurements(Path("synthetic"), [document], [document.uid])
+        else:
+            calls = 0
+            original_add = score.MetricAccumulator.add
+            def bad_add(accumulator, *args, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    return original_add(accumulator, *args, **kwargs)
+                raise ValueError(CANARY)
+            def bad(*args, **kwargs):
+                raise ValueError(CANARY)
+            with contextlib.ExitStack() as stack:
+                if late:
+                    stack.enter_context(mock.patch.object(score.MetricAccumulator, "add", new=bad_add))
+                if post:
+                    stack.enter_context(mock.patch.object(score, "identified_document_population", side_effect=bad))
+                result = score.run_config(
+                    root, Path("synthetic"), "rule-floor-extended", [document], root, root,
+                    None, None, None, 0.3, root / "diagnostics", warmup_count=1,
+                )
+    return result, created
+
+
+def boundary_scenario(mode, root):
+    late = mode == "late"
+    post = mode == "post"
+    actual_mode = "score" if late or post else mode
+    error = None
+    try:
+        result, owners = invoke(actual_mode, root, late=late, post=post)
+        process_meta = result.get("process", {})
+        assert "stderr_log" not in process_meta and "stderr_bytes" not in process_meta, "metadata-boundary"
+        assert CANARY not in repr(result), "result-boundary"
+        assert all(owner.process.returncode is not None for owner in owners), "caller-reaping"
+    except transport.ProducerFailure as caught:
+        assert caught.__context__ is None and caught.__cause__ is None, "exception-context"
+        assert CANARY not in str(caught) and CANARY not in repr(caught), "exception-boundary"
+        rendered = "".join(traceback.format_exception(caught))
+        assert CANARY not in rendered, "traceback-boundary"
+        error = (caught.code, caught.phase)
+    assert not list(root.iterdir()), "file-boundary"
+    if mode not in ("score", "score-refusal", "probe"):
+        assert error is not None, "failure-required"
+    if mode == "uncaught":
+        invoke("score-bad", root)
+
+
+@unittest.skipUnless(os.name == "posix" and sys.platform in ("darwin", "linux"), "POSIX transport")
+class TransportTests(unittest.TestCase):
+    def owner(self, mode="echo", **changes):
+        owner = transport.BenchSubprocess(command(mode), limits=limits(**changes))
+        self.addCleanup(owner._cleanup)
+        return owner
+
+    def reaped(self, owner):
+        self.assertTrue(owner.process.returncode is not None, "child-reaping")
+        self.assertTrue(all(stream.closed for stream in
+                            (owner.process.stdin, owner.process.stdout, owner.process.stderr)), "fd-close")
+        with self.assertRaises(ChildProcessError, msg="child-reaping"):
+            os.waitpid(owner.process.pid, os.WNOHANG)
+
+    def test_normal_multiple_split_unicode(self):
+        owner = self.owner("split")
+        with owner:
+            for index in range(3):
+                value = {"text": CANARY + "ä", "nested": [index, True, None, {"q": "\\\""}]}
+                self.assertTrue(owner.exchange(value) == value, "normal-exchange")
+        self.reaped(owner)
+
+    def test_limits_and_platform_reject_before_spawn(self):
+        cases = ({"request_bytes": 0}, {"exchange_seconds": float("nan")},
+                 {"finish_seconds": float("inf")}, {"nesting": 65},
+                 {"chunk_bytes": 600000}, {"handshake_seconds": 5}, {"chunk_bytes": True})
+        for changes in cases:
+            with self.subTest(changes=tuple(changes)), mock.patch.object(transport.subprocess, "Popen") as spawn:
+                with self.assertRaises(transport.ProducerFailure):
+                    with self.owner(**changes):
+                        pass
+                spawn.assert_not_called()
+        with mock.patch.object(transport.sys, "platform", "unsupported"), mock.patch.object(transport.subprocess, "Popen") as spawn:
+            with self.assertRaises(transport.ProducerFailure):
+                with self.owner():
+                    pass
+            spawn.assert_not_called()
+
+    def test_request_cap_and_preallocation(self):
+        owner = self.owner(request_bytes=1024)
+        with owner:
+            self.assertTrue(owner.exchange({"x": "a" * 1015}) == {"x": "a" * 1015}, "request-cap")
+            tracemalloc.start()
+            try:
+                huge = "x" * 2_000_000
+                before = tracemalloc.get_traced_memory()[0]
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    owner.exchange({"x": huge})
+                peak = tracemalloc.get_traced_memory()[1] - before
+                self.assertTrue(peak < 200_000, "request-preallocation")
+                self.assertEqual(failure.exception.code, "input_limit")
+            finally:
+                tracemalloc.stop()
+        self.reaped(owner)
+
+    def test_frame_cap_and_truncated_prefix(self):
+        wire = b'{"x":"' + b'a' * 1015 + b'"}\n'
+        for payload, cap, succeeds in ((wire, len(wire), True), (wire, len(wire)-1, False),
+                                       (b'{"x":1}\n' + b'a' * 1024, 1024, False)):
+            owner = self.owner("raw", stdout_bytes=cap, chunk_bytes=128)
+            if succeeds:
+                with owner:
+                    self.assertTrue(owner.exchange({"wire": payload.hex()}) == {"x": "a" * 1015}, "frame-cap")
+            else:
+                with self.assertRaises(transport.ProducerFailure, msg="no-truncated-prefix"):
+                    with owner:
+                        owner.exchange({"wire": payload.hex()})
+            self.reaped(owner)
+
+    def test_malformed_extra_partial_frames(self):
+        frames = [b'{"x":1}', b'{bad}\n', b'{"x":"\xff"}\n', b'{"x":1,"x":2}\n',
+                  b'{"x":NaN}\n', b'{"x":1e999}\n', b'[]\n', b'{}\n{}\n',
+                  b'{"x":' + b'[' * 65 + b'0' + b']' * 65 + b'}\n']
+        for index, wire in enumerate(frames):
+            with self.subTest(case=index):
+                owner = self.owner("raw")
+                with self.assertRaises(transport.ProducerFailure, msg="frame-refusal"):
+                    with owner:
+                        owner.exchange({"wire": wire.hex()})
+                self.reaped(owner)
+
+    def test_stderr_flood_success_bounded_memory(self):
+        owner = self.owner("flood")
+        tracemalloc.start()
+        try:
+            with owner:
+                self.assertTrue(owner.exchange({"x": 1}) == {"x": 1}, "flood-exchange")
+            self.assertTrue(tracemalloc.get_traced_memory()[1] < 2_000_000, "stderr-memory")
+        finally:
+            tracemalloc.stop()
+        self.reaped(owner)
+
+    def test_stderr_budget(self):
+        owner = self.owner("flood-excess", stderr_bytes=4096)
+        with self.assertRaises(transport.ProducerFailure, msg="stderr-budget") as failure:
+            with owner:
+                owner.exchange({"x": 1})
+        self.assertEqual(failure.exception.code, "stderr_limit", "stderr-budget")
+        self.reaped(owner)
+
+    def test_write_blocking_and_absolute_deadlines(self):
+        for mode in ("blocked-write", "trickle", "silent", "no-newline"):
+            owner = self.owner(mode, exchange_seconds=0.25, stderr_bytes=2 * 1024 * 1024)
+            started = time.monotonic()
+            with self.assertRaises(transport.ProducerFailure, msg="absolute-deadline") as failure:
+                with owner:
+                    owner.exchange({"text": "x" * 400_000})
+            self.assertEqual(failure.exception.code, "deadline", "absolute-deadline")
+            self.assertTrue(time.monotonic() - started < 1.1, "absolute-deadline")
+            self.reaped(owner)
+
+    def test_handshake_early_failure(self):
+        owner = self.owner("early")
+        with self.assertRaises(transport.ProducerFailure):
+            with owner:
+                owner.receive_handshake()
+        self.reaped(owner)
+
+    def test_finish_nonzero_and_ignored_termination(self):
+        for mode in ("nonzero", "ignore"):
+            owner = self.owner(mode)
+            start = time.monotonic()
+            with self.assertRaises(transport.ProducerFailure, msg="finish-failure"):
+                with owner:
+                    owner.exchange({"x": 1})
+            self.assertTrue(time.monotonic() - start < 1, "cleanup-deadline")
+            self.reaped(owner)
+            if mode == "ignore":
+                self.assertEqual(owner.process.returncode, -signal.SIGKILL, "kill-escalation")
+
+    def test_inherited_writer_and_unrelated_sentinel(self):
+        sentinel = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(3)"],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        try:
+            owner = self.owner("inherit")
+            started = time.monotonic()
+            with owner:
+                owner.exchange({"x": 1})
+            self.assertTrue(time.monotonic() - started < 0.6, "inherited-writer-deadline")
+            self.reaped(owner)
+            self.assertTrue(sentinel.poll() is None, "unrelated-process")
+        finally:
+            sentinel.terminate()
+            sentinel.wait(timeout=1)
+
+    def test_cleanup_on_processing_exception(self):
+        owner = self.owner("ignore")
+        with self.assertRaises(ValueError):
+            with owner:
+                owner.exchange({"x": 1})
+                raise ValueError("synthetic processing failure")
+        self.reaped(owner)
+
+    def test_boundary_success_and_failure_sinks(self):
+        for mode in ("score", "score-refusal", "probe", "early", "bad-handshake",
+                     "probe-bad", "score-bad", "score-reason", "late", "post", "uncaught"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as root:
+                result = subprocess.run([sys.executable, str(HERE), "--boundary", mode, root],
+                                        capture_output=True, timeout=5)
+                self.assertTrue(CANARY.encode() not in result.stdout + result.stderr, "output-canary")
+                self.assertTrue(not list(Path(root).iterdir()), "file-boundary")
+                if mode == "uncaught":
+                    self.assertTrue(result.returncode != 0 and b"ProducerFailure" in result.stderr, "uncaught-error")
+                else:
+                    self.assertTrue(result.returncode == 0 and not result.stdout and not result.stderr, "boundary-result")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--child":
+        raise SystemExit(child(sys.argv[2]))
+    if len(sys.argv) > 1 and sys.argv[1] == "--boundary":
+        boundary_scenario(sys.argv[2], Path(sys.argv[3]))
+    else:
+        unittest.main()

--- a/scripts/bench/test_bench_subprocess.py
+++ b/scripts/bench/test_bench_subprocess.py
@@ -60,6 +60,21 @@ def child(mode):
             os.write(2, b"x" * 1024)
         time.sleep(2)
         return 0
+    if mode == "bad-json-handshake":
+        os.write(1, b"{bad}\n")
+        return 0
+    if mode == "prefix-idle":
+        os.write(1, b'{"x":')
+        time.sleep(1.5)
+        return 0
+    if mode == "prefix":
+        # Unsolicited stdout only after the request write has started, never finished.
+        os.read(0, 4096)
+        os.write(1, b'{"x":')
+        while not os.read(0, 65536).endswith(b"\n"):
+            pass
+        os.write(1, b"1}\n")
+        return 0
     for line in sys.stdin.buffer:
         request = json.loads(line)
         if mode in ("flood", "flood-excess"):
@@ -161,12 +176,38 @@ def invoke(mode, root, *, late=False, post=False):
     return result, created
 
 
+SUCCESS_MODES = ("score", "score-refusal", "probe")
+
+
+def assert_success_counts(mode, result):
+    """A tolerated failure is not a pass: pin what each success actually produced."""
+    from test_openpii_gaze_bench import ResponseValidationTests
+    uid = ResponseValidationTests().document().uid
+    if mode == "probe":
+        assert result["schema_version"] == score.VALIDATOR_PROBE_PROTOCOL_SCHEMA_VERSION, "success-required"
+        assert list(result["documents"]) == [uid], "success-required"
+        return
+    process_meta, availability = result["process"], result["pipeline_availability"]
+    refused = mode == "score-refusal"
+    assert process_meta["warmup_count"] == 1, "success-required"
+    assert len(process_meta["discarded_warmup_samples"]) == 1, "success-required"
+    assert availability["attempted_documents"] == 1, "success-required"
+    assert availability["completed_documents"] == (0 if refused else 1), "success-required"
+    assert availability["failed_closed_documents"] == (1 if refused else 0), "success-required"
+    assert result["scored_population"]["documents"] == (0 if refused else 1), "success-required"
+    assert result["failed_closed_population"]["documents"] == (1 if refused else 0), "success-required"
+    assert availability["errors"] == (
+        {"safety_net_fallback_residual_suspect": 1} if refused else {}
+    ), "success-required"
+
+
 def boundary_scenario(mode, root):
     os.chdir(root)
     late = mode == "late"
     post = mode == "post"
     actual_mode = "score" if late or post else mode
     error = None
+    result = None
     try:
         result, owners = invoke(actual_mode, root, late=late, post=post)
         process_meta = result.get("process", {})
@@ -180,7 +221,10 @@ def boundary_scenario(mode, root):
         assert CANARY not in rendered, "traceback-boundary"
         error = (caught.code, caught.phase)
     assert not list(root.iterdir()), "file-boundary"
-    if mode not in ("score", "score-refusal", "probe"):
+    if mode in SUCCESS_MODES:
+        assert error is None, "success-required"
+        assert_success_counts(mode, result)
+    else:
         assert error is not None, "failure-required"
     if mode == "uncaught":
         invoke("score-bad", root)
@@ -221,7 +265,8 @@ class TransportTests(unittest.TestCase):
     def test_limits_and_platform_reject_before_spawn(self):
         cases = ({"request_bytes": 0}, {"exchange_seconds": float("nan")},
                  {"finish_seconds": float("inf")}, {"nesting": 65},
-                 {"chunk_bytes": 600000}, {"handshake_seconds": 5}, {"chunk_bytes": True})
+                 {"chunk_bytes": 600000}, {"handshake_seconds": 5}, {"chunk_bytes": True},
+                 {"terminate_seconds": 0}, {"reap_seconds": float("nan")})
         for changes in cases:
             with self.subTest(changes=tuple(changes)), mock.patch.object(transport.subprocess, "Popen") as spawn:
                 with self.assertRaises(transport.ProducerFailure):
@@ -433,8 +478,172 @@ class TransportTests(unittest.TestCase):
                 self.assertTrue(not list(Path(root).iterdir()), "file-boundary")
                 if mode == "uncaught":
                     self.assertTrue(result.returncode != 0 and b"ProducerFailure" in result.stderr, "uncaught-error")
+                elif mode in SUCCESS_MODES:
+                    # An always-failing transport must die here, not merely elsewhere.
+                    self.assertTrue(result.returncode == 0 and not result.stdout and not result.stderr, "success-required")
                 else:
                     self.assertTrue(result.returncode == 0 and not result.stdout and not result.stderr, "boundary-result")
+
+    # ---- review round r1 regressions ------------------------------------------
+
+    def ambient(self, call):
+        """Enter the boundary from inside live, payload-bearing caller handlers."""
+        try:
+            raise ValueError(CANARY)
+        except ValueError:
+            try:
+                raise KeyError(CANARY)
+            except KeyError:
+                with self.assertRaises(transport.ProducerFailure) as failure:
+                    call()
+        error = failure.exception
+        self.assertIsNone(error.__context__, "exception-context")
+        self.assertIsNone(error.__cause__, "exception-context")
+        self.assertNotIn(CANARY, "".join(traceback.format_exception(error)), "exception-context")
+        self.assertNotIn(CANARY, repr(error), "exception-context")
+        return error
+
+    def test_ambient_caller_context_never_crosses_high_level_calls(self):
+        # `raise ... from None` only hides the caller's live exception; it stays attached.
+        with tempfile.TemporaryDirectory() as root:
+            for mode in ("early", "bad-handshake", "score-bad", "score-reason", "probe-bad"):
+                with self.subTest(mode=mode):
+                    self.ambient(lambda mode=mode: invoke(mode, Path(root)))
+
+    def test_ambient_context_cleared_for_validation_and_cancellation(self):
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch.object(score, "BenchSubprocess") as spawn:
+                error = self.ambient(
+                    lambda: score.collect_validator_measurements(Path(root), [], [CANARY]))
+                spawn.assert_not_called()
+            self.assertEqual(error.code, "payload_processing", "exception-context")
+            owners = []
+            def factory(*args, **kwargs):
+                owner = transport.BenchSubprocess(command("probe"), limits=limits())
+                owners.append(owner)
+                return owner
+            with mock.patch.object(score, "BenchSubprocess", side_effect=factory), mock.patch.object(
+                score, "_validate_validator_probe_handshake", side_effect=KeyboardInterrupt(CANARY)
+            ):
+                error = self.ambient(
+                    lambda: score.collect_validator_measurements(Path(root), [], []))
+            self.assertEqual(error.code, "cancelled", "cancelled-boundary")
+            self.reaped(owners[0])
+
+    def test_ambient_context_cleared_on_context_manager_exit(self):
+        # __exit__ raises outside the decorated boundary and needs the same scrub.
+        owner = self.owner("nonzero")
+        def call():
+            with owner:
+                owner.exchange({"x": 1})
+        error = self.ambient(call)
+        self.assertEqual((error.code, error.phase), ("producer_exit", "finish"), "exception-context")
+        self.reaped(owner)
+
+    def test_ambient_context_cleared_on_cleanup_failure(self):
+        owner = self.owner("ignore")
+        def call():
+            with owner:
+                owner.exchange({"x": 1})
+                owner._wait_exit = mock.Mock(side_effect=OSError(CANARY))
+        error = self.ambient(call)
+        self.assertEqual(error.code, "cleanup", "exception-context")
+        self.reaped(owner)
+
+    def test_early_stdout_prefix_rejected_before_request_completes(self):
+        # A response cannot predate its request, in either selector report order.
+        for reverse in (False, True):
+            with self.subTest(reverse=reverse):
+                owner = self.owner("prefix", chunk_bytes=8192, exchange_seconds=2)
+                with self.assertRaises(transport.ProducerFailure, msg="early-prefix") as failure:
+                    with owner:
+                        real_select = owner.selector.select
+                        def ordered(timeout, _real=real_select, _reverse=reverse):
+                            events = _real(timeout)
+                            return list(reversed(events)) if _reverse else events
+                        with mock.patch.object(owner.selector, "select", side_effect=ordered):
+                            owner.exchange({"text": "x" * 200_000})
+                self.assertEqual(failure.exception.code, "protocol", "early-prefix")
+                self.reaped(owner)
+
+    def test_idle_stdout_before_request_rejected(self):
+        owner = self.owner("prefix-idle")
+        with self.assertRaises(transport.ProducerFailure, msg="idle-prefix") as failure:
+            with owner:
+                time.sleep(0.25)
+                owner.exchange({"x": 1})
+        self.assertEqual(failure.exception.code, "protocol", "idle-prefix")
+        self.reaped(owner)
+
+    def test_transport_failures_carry_the_owner_phase(self):
+        missing = HERE.parent / "definitely-absent-producer-binary"
+        owner = transport.BenchSubprocess([str(missing)], limits=limits())
+        self.addCleanup(lambda: owner.selector.close() if owner.selector is not None else None)
+        with self.assertRaises(transport.ProducerFailure, msg="phase-accuracy") as failure:
+            with owner:
+                pass
+        self.assertEqual(failure.exception.phase, "start", "phase-accuracy")
+        self.assertNotIn(str(missing), str(failure.exception), "phase-accuracy")
+        owner = self.owner("bad-json-handshake")
+        with self.assertRaises(transport.ProducerFailure, msg="phase-accuracy") as failure:
+            with owner:
+                owner.receive_handshake()
+        self.assertEqual(failure.exception.phase, "handshake", "phase-accuracy")
+        self.reaped(owner)
+        for wire in (b"{bad}\n", b'{"x":"\xff"}\n'):
+            with self.subTest(wire=wire):
+                owner = self.owner("raw")
+                with self.assertRaises(transport.ProducerFailure, msg="phase-accuracy") as failure:
+                    with owner:
+                        owner.exchange({"wire": wire.hex()})
+                self.assertEqual(failure.exception.phase, "exchange", "phase-accuracy")
+                self.reaped(owner)
+
+    def test_stdin_registration_released_when_receive_aborts(self):
+        owner = self.owner("blocked-write", stderr_bytes=4096, exchange_seconds=2)
+        with self.assertRaises(transport.ProducerFailure, msg="stdin-registration"):
+            with owner:
+                self.assertTrue(owner.receive_handshake() == {"ready": True}, "child-ready")
+                try:
+                    owner.exchange({"text": "x" * 400_000})
+                except transport.ProducerFailure as first:
+                    self.assertEqual(first.code, "stderr_limit", "stdin-registration")
+                    self.assertNotIn(owner.process.stdin.fileno(),
+                                     {key.fd for key in owner.selector.get_map().values()},
+                                     "stdin-registration")
+                    raise
+        self.reaped(owner)
+
+    def test_cleanup_budget_outlives_the_invocation_budget(self):
+        # Deliberate: termination and reaping stay available after the invocation expires.
+        slow_cleanup = dict(handshake_seconds=0.3, exchange_seconds=0.3, finish_seconds=0.25,
+                            invocation_seconds=0.4, terminate_seconds=0.5, reap_seconds=1.0)
+        try:
+            limits(**slow_cleanup).validate()
+        except transport.ProducerFailure:
+            self.fail("cleanup-budget")
+        owner = self.owner("ignore", **slow_cleanup)
+        with self.assertRaises(transport.ProducerFailure, msg="cleanup-budget") as failure:
+            with owner:
+                owner.exchange({"x": 1})
+                time.sleep(0.45)
+                owner.check_deadline()
+        self.assertEqual(failure.exception.code, "deadline", "cleanup-budget")
+        self.assertTrue(time.monotonic() > owner.invocation_deadline, "cleanup-budget")
+        self.reaped(owner)
+        self.assertEqual(owner.process.returncode, -signal.SIGKILL, "cleanup-budget")
+
+    def test_mutation_roster_sites_are_unique_and_applicable(self):
+        source = Path(transport.__file__).read_text()
+        seen = {}
+        for name, (old, new, target, marker) in MUTATIONS.items():
+            with self.subTest(mutation=name):
+                self.assertEqual(source.count(old), 1, "mutation-roster")
+                self.assertNotIn((old, new), seen, "mutation-roster")
+                seen[(old, new)] = name
+                self.assertNotEqual(old, new, "mutation-roster")
+                self.assertTrue(callable(getattr(TransportTests, target, None)), "mutation-roster")
+                compile(source.replace(old, new, 1), "<mutant>", "exec")
 
 
 MUTATIONS = {
@@ -448,17 +657,35 @@ MUTATIONS = {
                       "test_stderr_budget", "stderr-budget"),
     "request-cap": ("if len(output) + len(data) > self.limits.request_bytes:", "if False:",
                     "test_request_cap_and_preallocation", "request-preallocation"),
-    "frame-truncation": ("if newline != len(frame) - 1 or (request is not None and offset != len(request)):\n                        raise ProducerFailure(\"protocol\", self.phase)",
-                         "if request is not None and offset != len(request):\n                        raise ProducerFailure(\"protocol\", self.phase)\n                    frame = frame[:newline + 1]",
+    "frame-truncation": ("if newline >= 0:\n                        if newline != len(chunk) - 1:\n                            raise ProducerFailure(\"protocol\", self.phase)\n                        complete = True",
+                         "if newline >= 0:\n                        frame = frame[:len(frame) - len(chunk) + newline + 1]\n                        complete = True",
                          "test_malformed_extra_partial_frames", "frame-refusal"),
-    "deadline": ("if time.monotonic() >= deadline:", "if False:",
+    "deadline": ("    def _check(self, deadline):\n        if time.monotonic() >= deadline:",
+                 "    def _check(self, deadline):\n        if False:",
                  "test_write_blocking_and_absolute_deadlines", "absolute-deadline"),
     "cleanup": ("        if self.process is None:\n            return clean",
                 "        return clean\n        if self.process is None:\n            return clean",
                 "test_cleanup_on_processing_exception", "child-reaping"),
-    "context": ("        except Exception:\n            pass",
+    "context": ("        except Exception:\n            phase = _owner_phase(args, phase)",
                 "        except Exception:\n            raise ProducerFailure('payload_processing') from None",
                 "test_boundary_no_exception_context_in_process", "exception-context"),
+    "ambient-context": ("        closed.__cause__ = None\n        closed.__context__ = None",
+                        "        closed.__cause__ = None",
+                        "test_ambient_caller_context_never_crosses_high_level_calls", "exception-context"),
+    "owner-phase": ("    phase = getattr(args[0], \"phase\", None) if args else None", "    phase = None",
+                    "test_transport_failures_carry_the_owner_phase", "phase-accuracy"),
+    "early-prefix": ("                pending = request is not None and offset != len(request)",
+                     "                pending = False",
+                     "test_early_stdout_prefix_rejected_before_request_completes", "early-prefix"),
+    "stdin-registration": ("            if request is not None:\n                # Never strand a write registration, and never mask the first failure.\n                self._unregister(self.process.stdin)",
+                           "            if False:\n                self._unregister(self.process.stdin)",
+                           "test_stdin_registration_released_when_receive_aborts", "stdin-registration"),
+    "always-fail": ("    def exchange(self, request):\n        if self.finished",
+                    "    def exchange(self, request):\n        raise ProducerFailure(\"protocol\", \"exchange\")\n        if self.finished",
+                    "test_boundary_success_and_failure_sinks", "success-required"),
+    "cleanup-budget": ("        if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds) > self.invocation_seconds:",
+                       "        if max(self.handshake_seconds, self.exchange_seconds, self.finish_seconds,\n               self.terminate_seconds, self.reap_seconds) > self.invocation_seconds:",
+                       "test_cleanup_budget_outlives_the_invocation_budget", "cleanup-budget"),
 }
 
 
@@ -489,7 +716,7 @@ def mutation_proof():
     for name in MUTATIONS:
         environment = {**os.environ, "GAZE_BENCH_TEST_MUTANT": name}
         result = subprocess.run([sys.executable, str(HERE), "--mutant", name],
-                                env=environment, capture_output=True, timeout=20)
+                                env=environment, capture_output=True, timeout=120)
         if result.returncode != 0 or CANARY.encode() in result.stdout + result.stderr:
             print("mutation-proof-failed:" + name)
             return 1

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -2,7 +2,6 @@
 
 import copy
 import hashlib
-import io
 import json
 import socket
 import sys

--- a/scripts/bench/test_openpii_gaze_bench.py
+++ b/scripts/bench/test_openpii_gaze_bench.py
@@ -331,13 +331,14 @@ class ContractTests(unittest.TestCase):
             "timing": {"total_ms": 1.25},
         }
         process = mock.Mock()
-        process.stdin = io.StringIO()
-        process.stdout = io.StringIO(json.dumps(response) + "\n")
-        process.wait.return_value = 0
+        process.__enter__ = mock.Mock(return_value=process)
+        process.__exit__ = mock.Mock(return_value=False)
+        process.message_deadline = 0
+        process.exchange.side_effect = [response]
         repo_root = Path(benchmark.__file__).resolve().parents[2]
 
         with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
-            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+            with mock.patch.object(benchmark, "BenchSubprocess", return_value=process):
                 result = benchmark.run_config(
                     repo_root=repo_root,
                     binary=Path(temporary) / "synthetic-runner",
@@ -570,11 +571,10 @@ class ResponseValidationTests(unittest.TestCase):
             "post_policy_scan_ms": 7.0,
         }
         process = mock.Mock()
-        process.stdin = io.StringIO()
-        process.stdout = io.StringIO(
-            "\n".join((json.dumps(first), json.dumps(second))) + "\n"
-        )
-        process.wait.return_value = 0
+        process.__enter__ = mock.Mock(return_value=process)
+        process.__exit__ = mock.Mock(return_value=False)
+        process.message_deadline = 0
+        process.exchange.side_effect = [first, second]
         repo_root = Path(benchmark.__file__).resolve().parents[2]
         second_document = benchmark.Document(
             uid="synthetic-response-2",
@@ -586,7 +586,7 @@ class ResponseValidationTests(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
-            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+            with mock.patch.object(benchmark, "BenchSubprocess", return_value=process):
                 result = benchmark.run_config(
                     repo_root=repo_root,
                     binary=Path(temporary) / "synthetic-runner",
@@ -639,19 +639,14 @@ class ResponseValidationTests(unittest.TestCase):
             )
             response["strict_would_reject"] = True
         process = mock.Mock()
-        process.stdin = io.StringIO()
-        process.stdout = io.StringIO(
-            "\n".join(
-                json.dumps(response)
-                for response in (warmup_error, warmup_rejection, scored_rejection)
-            )
-            + "\n"
-        )
-        process.wait.return_value = 0
+        process.__enter__ = mock.Mock(return_value=process)
+        process.__exit__ = mock.Mock(return_value=False)
+        process.message_deadline = 0
+        process.exchange.side_effect = [warmup_error, warmup_rejection, scored_rejection]
         repo_root = Path(benchmark.__file__).resolve().parents[2]
 
         with tempfile.TemporaryDirectory(dir=repo_root) as temporary:
-            with mock.patch.object(benchmark.subprocess, "Popen", return_value=process):
+            with mock.patch.object(benchmark, "BenchSubprocess", return_value=process):
                 result = benchmark.run_config(
                     repo_root=repo_root,
                     binary=Path(temporary) / "synthetic-runner",


### PR DESCRIPTION
## What & why

The benchmark scorer wrote child stderr to disk and could block indefinitely while exchanging requests or shutting down. Both scorer and validator-probe calls now use bounded, nonblocking JSONL pipes, discard stderr in memory, and return closed errors after cleaning up the direct child. Malformed, incomplete, oversized or out-of-order responses abort the cell instead of producing a scorecard.

Existing scoring, population identity comparisons and validated pipeline-refusal accounting are preserved. The `diagnostics_dir` argument remains accepted, but new results omit `stderr_log` and `stderr_bytes`; historical scorecards remain readable. Execution is supported on Linux and macOS.

This improves parent-owned diagnostic handling and lifecycle bounds. Producers must still be trusted, and private inputs remain prohibited through the legacy exporters until a separate custody and in-memory evaluation bridge is reviewed. Discarding stderr reduces diagnostic detail; fixed codes and phases remain available.

## Validation

- [x] 250 model-free Python tests passed locally; the single compiled validator probe was explicitly excluded.
- [x] 30 focused real-child transport and caller-boundary tests passed.
- [x] All 16 targeted mutants were killed by named assertions, including failure-path reaping, retained exception context, early output and unconditional failure in success cases.
- [x] Existing scoring, population comparison and evidence evaluator regressions passed.
- [x] Signed commits, DCO, clean diff checks and synthetic fixture hygiene verified.
- [x] Linux CI, full workspace tests, Clippy, MSRV and xtask gates passed. [CI run](https://github.com/CertaMesh/gaze/actions/runs/34380918858)

No Rust or dependency files changed. Cargo checks passed in CI for this Python-only change. Independent review covered the implementation, corrections and final cleanup-test/error-phase delta; all requested fixes are verified, with no outstanding blocking findings.

## Fixtures & commit discipline

- [x] Synthetic fixtures only; no private corpus or model run was performed.
- [x] All commits are signed off and use the `[agent]` prefix; files were staged by name, without amend, force-push or skipped hooks.
