### PR TITLE
docs(agents): require signed commits, drop the [agent] prefix rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Source-of-truth workspace shape table with full role descriptions: [`CONTRIBUTIN
 
 1. **Never weaken an axis without an explicit PR-body note.** If a change regresses reliability, reversibility, agentic fit, trust, or adopter ergonomics — say so in the PR description and justify the tradeoff. Correctness axes 1–4 always beat performance.
 2. **Never leak PII in examples, tests, or fixtures.** Use `alice@example.invalid` / `Dr. Schmidt` / `<Email_1>` — never real PII, even in docs. Phone numbers MUST come from documented synthetic-non-reachable ranges: NANPA `+1-555-01xx` for US, Ofcom `+44-7700-900xxx` for UK, and `+49 1555 0112233`-style mobile shapes for DE (the parser-backed v0.4.5 S2 national-phone recognizers accept these without using real BNetzA-assigned ranges). See [`CONTRIBUTING.md`](CONTRIBUTING.md#phone-number-fixtures) for the canonical rule + rationale.
-3. **Commit discipline:** `[agent]` prefix on every commit. Stage specific files by name. No `git add -A` or `git add .`. No amend, no force-push, no `--no-verify`. Commit after each logical phase, not only at the end.
+3. **Commit discipline:** every commit must be signed (SSH commit signing is configured on this machine; delegates in unsigned sandboxes must have their commits re-created signed before merge). No commit-message prefix is required. Stage specific files by name. No `git add -A` or `git add .`. No amend, no force-push, no `--no-verify`. Commit after each logical phase, not only at the end.
 4. **Branch per task.** Work on a dedicated branch; keep `main` clean.
 5. **Completion signaling:** every agent brief includes a sentinel line (e.g. `IMPL DONE:`, `REVIEW DONE:`, `DOCS DONE:`). Print it on the final stdout line.
 


### PR DESCRIPTION
Resolves the outstanding commit-rule correction: every commit must be signed; no message prefix is required.

Why: the main ruleset enforces verified signatures plus the DCO check. Five open Detail PRs (#457, #458, #460, #461, #462) are unsigned, and the old rule text only asked for a prefix.

Docs-only. Visible output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkuTzXT8jxuyrhchfwz6WM