### PR TITLE
docs: correct MCP transaction ordering and operator bypass

### DIFF
--- a/docs/explanation/mcp/mcp-runtime.md
+++ b/docs/explanation/mcp/mcp-runtime.md
@@ -2,7 +2,7 @@
 
 ### Scope
 
-`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.
+`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an agent-tier MCP tool to the model** passes through `PiiEnvelope::dispatch` and is protected before the model sees it. Authorized operator-tier tools can explicitly bypass response protection for restore/export semantics; their raw responses must stay on the operator surface.
 
 `gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, see `gaze-proxy` (planned for v0.8 — multi-vendor reverse proxy supporting Anthropic, OpenAI, Gemini).
 
@@ -26,14 +26,15 @@ Every tool call traverses this sequence in order:
 | 1 | Validate transport-supplied session id via `SessionIdPolicy` | `DispatchError::SessionId`; **no manifest row** |
 | 2 | Look up tool in `ToolRegistry` | `DispatchError::UnknownTool`; **no manifest row** |
 | 3 | Authorize via `AuthHook::authorize_agent` or `_operator` (driven by `ToolDescriptor::tier`) | `DispatchError::Auth`; **no manifest row** |
-| 4 | Redact raw args via `gaze::Pipeline::redact` (string leaves) | `DispatchError::Redaction`; **no manifest row** |
+| 4 | Preflight argument carriers, then protect raw args via `gaze::Pipeline::protect_text_transaction` (the staged args transaction commits after `begin_call`) | `DispatchError::Carrier` / `DispatchError::Protection` for preflight and protect — **no manifest row**; `DispatchError::Transaction` for the post-begin commit — **fail_call written first** |
 | 5 | `ManifestStore::begin_call(BeginCallContext)` | `DispatchError::Manifest`; **no manifest row written** |
 | 6 | Build the sealed `ToolCtx` (only construction site in the crate) | — |
 | 7 | `Tool::invoke(&ctx).await` | `DispatchError::ToolError`; **fail_call written first** |
-| 8 | Redact response payload | `DispatchError::Redaction`; **fail_call written first** |
-| 9 | Compute out-of-row `SnapshotRef` over redacted bytes | `DispatchError::ResponseSerialization`; **fail_call written first** |
-| 10 | `ManifestStore::finish_call(handle, snapshot)` | `DispatchError::Manifest` |
-| — | Return redacted response | — |
+| 8 | For `ResponseRedaction::Apply`, preflight response carriers, then stage response protection via `gaze::Pipeline::protect_text_transaction`. Operator-tier `BypassByOperator` uses the raw payload with no preflight, protection, or response transaction; agent-tier bypass is rejected | `DispatchError::Carrier` / `DispatchError::Protection`, or `DispatchError::Redaction` for the agent-bypass rejection; **fail_call written first** |
+| 9 | Compute out-of-row `SnapshotRef` over the response payload (protected for `Apply`, raw for operator bypass) | `DispatchError::ResponseSerialization`; **fail_call written first** |
+| 10 | Commit the staged response transaction, if present, after snapshot computation | `DispatchError::Transaction`; **fail_call written first** |
+| 11 | `ManifestStore::finish_call(handle, snapshot)` | `DispatchError::Manifest` |
+| — | Return the response payload (protected for `Apply`, raw for operator bypass) | — |
 
 The first three steps are pre-manifest by design: a denied request leaves
 no audit-log noise. Once `begin_call` returns Ok, the dispatcher


### PR DESCRIPTION
## What & why

Correct the MCP chokepoint documentation to describe carrier preflight and staged protection, with the current `Carrier`, `Protection`, and `Transaction` failures. Response snapshot computation now precedes a separate transaction-commit step, which precedes `finish_call`. This makes clear that snapshot failure does not commit staged response mappings.

Operator-tier `BypassByOperator` returns the raw payload with no response preflight, protection, or transaction. The scope statement and returned-payload wording now explicitly distinguish that authorized operator path from the protected agent path. Runtime code is unchanged.

Supersedes #457
Resolves solo todo #3506

## Local gates

Cargo gates skipped as authorized for this docs-only change. Cross-checked the ordered table against current-base `crates/gaze-mcp-core/src/dispatch.rs`.

```text
git diff --check: PASS
Dispatch source cross-check: PASS
Playwright local Markdown preview: 8 passed (both docs PRs, before/after, desktop/mobile)
```

## Axes and fixtures

No axis is weakened. Reliability and reversibility runtime behavior are unchanged; documentation now accurately names the operator bypass and transaction boundary. Agentic integration, auditability/trust, and adopter ergonomics improve through precise error and lifecycle guidance. No PII added.

## Structure and data-model review

Verdict: implement. Opportunity: explicit ordered phases in the existing table. Why: removes ambiguity between response preparation, snapshot, and commit. Scope: this documentation page only; no runtime refactor. Validation: source cross-check, whitespace check, and rendered content inspection.

## Signed commit

Fresh commit authored on this machine, SSH-signed and DCO-signed-off. Local verification: `%G? = G`, `gpgsig` present, sign-off matches commit author, and `Co-Authored-By: Codex <noreply@openai.com>` present. No original unsigned commit is carried in this branch's new ancestry.

## Visual evidence

Playwright captures of local Markdown previews, not a deployed docs site. Before is current `origin/main`; after is this commit.





![MCP runtime before desktop](https://github.com/user-attachments/assets/27cd7fef-e2ed-4c2a-aec9-0a86836d28a2)

![MCP runtime after desktop](https://github.com/user-attachments/assets/dba0d9da-12c4-478e-a189-13f6a1f1b27b)

![MCP runtime before mobile](https://github.com/user-attachments/assets/87ec3f62-24d2-45ff-af0e-0f271e8c386f)

![MCP runtime after mobile](https://github.com/user-attachments/assets/f83b2fe5-8a63-429b-a4da-653c6cd289c7)