### PR TITLE
chore(gaze-document): remove unreachable no-OCR MCP fallbacks

### DIFF
--- a/crates/gaze-document/src/mcp/mod.rs
+++ b/crates/gaze-document/src/mcp/mod.rs
@@ -284,17 +284,6 @@ fn read_file_response(path: &Path, ctx: &ToolCtx<'_>) -> Result<DocumentToolResp
     })
 }
 
-#[cfg(not(feature = "ocr-tesseract"))]
-fn read_file_response(
-    _path: &PathBuf,
-    _ctx: &ToolCtx<'_>,
-) -> Result<DocumentToolResponse, ToolError> {
-    Err(ToolError::BackendUnavailable(
-        "rebuild gaze-document with `--features ocr-tesseract` to enable `gaze_read_file`"
-            .to_string(),
-    ))
-}
-
 #[cfg(feature = "ocr-tesseract")]
 fn source_kind(kind: InputKind) -> &'static str {
     match crate::bundle::kind_label(kind) {
@@ -319,11 +308,6 @@ fn map_document_error(err: DocumentError) -> ToolError {
         }
         other => ToolError::internal(other),
     }
-}
-
-#[cfg(not(feature = "ocr-tesseract"))]
-fn map_document_error(err: crate::DocumentError) -> ToolError {
-    ToolError::internal(err)
 }
 
 fn format_text_markdown(text: &str) -> String {


### PR DESCRIPTION
## What & why

Remove the two `not(feature = "ocr-tesseract")` fallback functions from the MCP module, reapplying #462 unchanged. The `mcp` feature requires `ocr-tesseract`, and the module is compiled only for `mcp`, so neither fallback can exist in a supported feature graph.

The reachable read-file path still strictly restores the owner path, validates input, runs OCR and staged protection, and preserves typed backend errors.

Supersedes #462
Resolves solo todo #3506

## Local gates

Run in this branch’s isolated anvil worktree with Rust 1.96.0 from rust-toolchain.toml, explicitly bound cargo/RUSTC/RUSTDOC, and its own default target directory. Absolute local worktree prefixes in output are normalized to `<worktree>`.

### fmt: PASS (exit 0)

```text
$ cargo fmt --all -- --check
exit 0
```

### bootstrap: PASS (exit 0)

```text
$ cargo build --workspace --all-features
   Compiling gaze-mcp-rmcp v0.13.0 (<worktree>/crates/gaze-mcp-rmcp)
   Compiling gaze-token-bridge v0.13.0 (<worktree>/crates/gaze-token-bridge)
   Compiling gaze-document v0.13.0 (<worktree>/crates/gaze-document)
   Compiling gaze-mcp-bridge v0.13.0 (<worktree>/crates/gaze-mcp-bridge)
   Compiling gaze-cli v0.13.0 (<worktree>/crates/gaze-cli)
   Compiling xtask v0.0.1 (<worktree>/crates/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 38s
```

### clippy: PASS (exit 0)

```text
$ cargo clippy --workspace --all-features --all-targets -- -D warnings
    Checking gaze-token-bridge v0.13.0 (<worktree>/crates/gaze-token-bridge)
    Checking gaze-mcp-rmcp v0.13.0 (<worktree>/crates/gaze-mcp-rmcp)
    Checking gaze-document v0.13.0 (<worktree>/crates/gaze-document)
    Checking gaze-mcp-bridge v0.13.0 (<worktree>/crates/gaze-mcp-bridge)
    Checking xtask v0.0.1 (<worktree>/crates/xtask)
    Checking gaze-cli v0.13.0 (<worktree>/crates/gaze-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 21s
```

### test: PASS (exit 0)

```text
$ cargo test --workspace --all-features
running 3 tests
test crates/gaze-types/src/lib.rs - CleanDocument (line 2846) ... ok
test crates/gaze-types/src/lib.rs - PiiClass (line 65) ... ok
test crates/gaze-types/src/lib.rs - RedactionLogger (line 2527) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.95s

```

The explicit task gate roster above was run; additional xtask/cargo-deny/dylint gates were not run locally. No audit-sink boundary or visible output changes.

## Axes and fixtures

No axis is weakened. Reliability, reversibility, agentic carriers, and deterministic error behavior are unchanged. Adopter ergonomics improve slightly by removing impossible alternatives. No reachable code path changes. No real PII added.

## Structure and data-model review

Verdict: skip. Opportunity: none beyond the existing feature implication. Why: the Cargo feature graph already excludes these alternatives. Scope: exact two-function deletion only; additional cfg polish is deferred. Validation: feature/module/caller inspection, original-file equivalence, and pinned-toolchain workspace gates.

## Signed commit

Fresh machine-authored SSH-signed commit with matching-author DCO sign-off and `Co-Authored-By: Codex <noreply@openai.com>`. Local verification: `%G? = G` and `gpgsig` present. Original unsigned commit ancestry is not carried into this replacement.
