### PR TITLE
refactor: simplify registry builder without breaking public API

### DIFF
--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -549,8 +549,6 @@ fn min_score(_class: &PiiClass) -> f32 {
 #[derive(Default)]
 pub struct RecognizerRegistryBuilder {
     entries: Vec<Arc<dyn Recognizer>>,
-    validators: HashMap<String, Arc<dyn Validator>>,
-    canonicalizers: HashMap<String, Arc<dyn Canonicalizer>>,
     collision_memberships: HashMap<String, CollisionMembership>,
     anchor_resolver: AnchorResolver,
 }
@@ -597,8 +595,8 @@ impl RecognizerRegistryBuilder {
         RecognizerRegistry {
             entries: self.entries,
             recognizers_by_id,
-            validators: self.validators,
-            canonicalizers: self.canonicalizers,
+            validators: HashMap::new(),
+            canonicalizers: HashMap::new(),
             family_policy: FamilyPolicyTable::from_memberships(self.collision_memberships),
             anchor_resolver: self.anchor_resolver,
         }

--- a/crates/gaze/tests/registry_extension_api.rs
+++ b/crates/gaze/tests/registry_extension_api.rs
@@ -1,0 +1,45 @@
+use std::{collections::HashMap, sync::Arc};
+
+use gaze::registry::{
+    Canonicalizer as RegistryCanonicalizer, ValidationResult as RegistryValidationResult,
+    Validator as RegistryValidator,
+};
+use gaze::{Canonicalizer, RecognizerRegistryBuilder, ValidationResult, Validator};
+
+struct Extension;
+
+impl Validator for Extension {
+    fn id(&self) -> &str {
+        "extension"
+    }
+
+    fn validate(&self, _raw: &str) -> ValidationResult {
+        ValidationResult::Indeterminate
+    }
+}
+
+impl Canonicalizer for Extension {
+    fn canonicalize(&self, raw: &str) -> Option<String> {
+        Some(raw.to_owned())
+    }
+}
+
+#[test]
+fn public_extension_paths_and_accessors_remain_compatible() {
+    let validator: &dyn RegistryValidator = &Extension;
+    let canonicalizer: &dyn RegistryCanonicalizer = &Extension;
+    assert_eq!(validator.id(), "extension");
+    assert_eq!(
+        validator.validate("sample"),
+        RegistryValidationResult::Indeterminate
+    );
+    assert_eq!(canonicalizer.canonicalize("sample"), Some("sample".into()));
+    assert_eq!(ValidationResult::Valid, RegistryValidationResult::Valid);
+    assert_eq!(ValidationResult::Invalid, RegistryValidationResult::Invalid);
+
+    let registry = RecognizerRegistryBuilder::default().build();
+    let validators: &HashMap<String, Arc<dyn Validator>> = registry.validators();
+    let canonicalizers: &HashMap<String, Arc<dyn Canonicalizer>> = registry.canonicalizers();
+    assert!(validators.is_empty());
+    assert!(canonicalizers.is_empty());
+}


### PR DESCRIPTION
## What & why

Remove only the private always-empty `validators` and `canonicalizers` maps from `RecognizerRegistryBuilder`, and initialize them once in `build()`. Unlike #461, retain public `Validator`, `Canonicalizer`, `ValidationResult`, both public import paths, registry storage, both map accessors, and the README contract.

Add an external integration regression that implements the public traits, imports the root and `gaze::registry` paths, exercises all three enum variants, calls both typed accessors, and verifies their existing empty-map behavior. Downstream consumers keep compiling.

Supersedes #461
Resolves solo todo #3506

## Local gates

Run in this branch’s isolated anvil worktree with Rust 1.96.0 from rust-toolchain.toml, explicitly bound cargo/RUSTC/RUSTDOC, and its own default target directory. Absolute local worktree prefixes in output are normalized to `<worktree>`.

### fmt: PASS (exit 0)

```text
$ cargo fmt --all -- --check
exit 0
```

### bootstrap: PASS (exit 0)

```text
$ cargo build --workspace --all-features
   Compiling gaze-mcp-rmcp v0.13.0 (<worktree>/crates/gaze-mcp-rmcp)
   Compiling gaze-token-bridge v0.13.0 (<worktree>/crates/gaze-token-bridge)
   Compiling gaze-document v0.13.0 (<worktree>/crates/gaze-document)
   Compiling gaze-mcp-bridge v0.13.0 (<worktree>/crates/gaze-mcp-bridge)
   Compiling gaze-cli v0.13.0 (<worktree>/crates/gaze-cli)
   Compiling xtask v0.0.1 (<worktree>/crates/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 30s
```

### clippy: PASS (exit 0)

```text
$ cargo clippy --workspace --all-features --all-targets -- -D warnings
    Checking gaze-token-bridge v0.13.0 (<worktree>/crates/gaze-token-bridge)
    Checking gaze-mcp-rmcp v0.13.0 (<worktree>/crates/gaze-mcp-rmcp)
    Checking gaze-document v0.13.0 (<worktree>/crates/gaze-document)
    Checking gaze-mcp-bridge v0.13.0 (<worktree>/crates/gaze-mcp-bridge)
    Checking xtask v0.0.1 (<worktree>/crates/xtask)
    Checking gaze-cli v0.13.0 (<worktree>/crates/gaze-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.67s
```

### test: PASS (exit 0)

```text
$ cargo test --workspace --all-features
running 3 tests
test crates/gaze-types/src/lib.rs - RedactionLogger (line 2527) ... ok
test crates/gaze-types/src/lib.rs - CleanDocument (line 2846) ... ok
test crates/gaze-types/src/lib.rs - PiiClass (line 65) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.04s

```

### Public API regression: PASS

```text
running 1 test
test public_extension_paths_and_accessors_remain_compatible ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

The explicit task gate roster above was run; additional xtask/cargo-deny/dylint gates were not run locally. No audit-sink boundary or visible output changes.

## Axes and fixtures

No axis is weakened. Reliability, reversibility, agentic behavior, and deterministic registry semantics are unchanged. Trust and adopter ergonomics are preserved by retaining the public source contract and adding downstream compilation coverage. No real PII added.

## Structure and data-model review

Verdict: implement. Opportunity: initialize invariant-empty maps once in build(). Why: removes mirrored private builder state without deleting the public extension contract. Scope: registry builder and one external integration regression; public removals are excluded. Validation: public lib.rs/README byte-equivalence to main, typed downstream regression, and pinned-toolchain workspace gates.

## Signed commit

Fresh machine-authored SSH-signed commit with matching-author DCO sign-off and `Co-Authored-By: Codex <noreply@openai.com>`. Local verification: `%G? = G` and `gpgsig` present. Original unsigned commit ancestry is not carried into this replacement.
