### PR TITLE
[agent] chore(deps): bump quinn-proto to 0.11.16 with DCO sign-off

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,11 +1873,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3484,14 +3486,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3514,7 +3517,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3632,6 +3635,15 @@ checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand 0.10.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]


### PR DESCRIPTION
Recreates Dependabot's quinn-proto 0.11.14 → 0.11.16 lock-only update against main `ea3f59872c732025ba911c663e551386c5700c14`, using a verified SSH-signed commit with matching-author DCO sign-off.

Supersedes #409
Resolves solo todo #3507 (together with the PyArrow/pytest replacement PR).

Generated with `cargo update -p quinn-proto --precise 0.11.16`. Compared every added/removed Cargo.lock line with the original Dependabot PR diff: **exact match**, including rand_pcg 0.10.2, getrandom's wasm edges, and quinn-udp's Windows dependency selection. Direct package-record comparison against Dependabot head `c3dbff890ec59586c7807b678bdabaa57fd9b93c` also matches exactly for quinn-proto 0.11.16, quinn-udp 0.5.14, getrandom 0.4.2, and rand_pcg 0.10.2. The PR changes only Cargo.lock.

Validation (local, macOS arm64), with Cargo, RUSTC, and RUSTDOC explicitly bound to repository-pinned Rust 1.96.0:

```text
cargo fmt --all -- --check
exit 0

cargo deny check
advisories ok, bans ok, licenses ok, sources ok

cargo build --workspace --all-features
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 38s; exit 0

cargo test -p gaze-proxy
exit 0
Final output tail: test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.22s

cargo clippy --workspace --all-features --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 49.91s; exit 0

cargo test --workspace --all-features
exit 0
Final output tail: test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s

Git signature: G
Matching-author Signed-off-by and Codex Co-Authored-By trailers: verified
```

The initial PATH-selected Rust 1.95 run was rejected by the existing compile-fail compiler guard. All listed gates were rerun with the explicit Rust 1.96 bindings documented in CONTRIBUTING.md; no test snapshots or source were changed.

GitHub also reports this commit signature verified and valid, and the required [DCO check passed](https://github.com/CertaMesh/gaze/actions/runs/34530331277/job/103049222384).

This is dependency-graph and workspace validation, not a claim that QUIC/HTTP3 ran on the active platform. No production protection, restoration, or provider configuration code changes. All five north-star axes are preserved; no security or performance improvement is inferred from the version number alone. No visible output changes.

Cleanup review:
- **Verdict:** skip.
- **Opportunity:** none.
- **Why:** Cargo owns the generated dependency graph; no handwritten abstraction removes complexity here.
- **Scope:** Cargo.lock and immediate gaze-proxy dependency selection inspected; no production refactor needed.
- **Validation:** exact original-delta comparison, formatting, cargo-deny, proxy tests, all-feature workspace clippy and tests.

No merge or original-PR closure is requested.
