### PR TITLE
[agent] docs: drop stale logs/ output and stderr-logs review step from bench README

### DIFF
--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -98,7 +98,6 @@ Generated artifacts are under ignored `target/bench-data/no-opf/<profile>/`:
 | `regression-status.json` | baseline-relative integer-count ratchet verdict |
 | `release-readiness-status.json` | candidate-only absolute correctness verdict |
 | `performance-status.json` | separately configured p95 `clean_ms` comparison |
-| `logs/` | subprocess stderr by repetition and config |
 
 Regression and release readiness are deliberately independent. Regression uses
 integer counts with zero tolerance and fails closed on missing, empty, invalid,
@@ -162,9 +161,9 @@ uv run --project scripts/bench python scripts/bench/run_no_opf_benchmark.py \
   --accept-baseline-confirm I_HAVE_REVIEWED_FULL_RESULTS
 ```
 
-Review `scorecard-v4.json`, all three status files, `diagnostics.json`, and the
-stderr logs before using that command. Quick results and failed candidates can
-never replace a baseline.
+Review `scorecard-v4.json`, all three status files, and `diagnostics.json`
+before using that command. Quick results and failed candidates can never
+replace a baseline.
 
 To initialize a baseline only when the target does not yet exist, omit
 `--compare-baseline` but keep the full profile and exact confirmation. The


### PR DESCRIPTION
Remove the obsolete `logs/` artifact row and stderr-log review requirement from the benchmark README. The scorer no longer writes those files, so the baseline acceptance checklist should reference only artifacts reviewers can inspect.

Supersedes #471. Recreates its README byte-for-byte with a verified SSH signature and DCO sign-off.

Docs-only; visible output unchanged in code, README text changes.

Validation: exact byte comparison against `6babd634:scripts/bench/README.md`, `git diff --check`, one-file docs-only scope, README inspected for real PII (none), local signature status `G`, and Signed-off-by trailer verified. CI must pass before merge. No project behavior or correctness axis changes.

Structure and data-model review:
- Verdict: skip.
- Opportunity: none.
- Why: documentation correction only; no state, ownership, or runtime invariants change. Scorer and runner references inspected.
- Scope: only `scripts/bench/README.md`; no code cleanup needed.
- Validation: exact file comparison and whitespace checks passed; CI pending.

Rollback: revert the replacement merge through a normal PR.
