### PR TITLE
Fix Strict restore false failures by splitting unknown and audit counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict restore no longer falsely fails on bare identifier-shaped literals such
+  as `Kunde_7`, `ORDER_12345`, or `FOO_12`, or on token-like content produced by
+  authorized manifest substitutions. Core pipeline telemetry, Session strict
+  restore, the MCP `restore_strict` tool, and CLI restore share the counter split:
+  unresolved own-prefix and foreign-prefix placeholders still fail; unprefixed
+  and legacy placeholder shapes are now audited rather than blocking. Added
+  serde-defaulted `trap_shape_count` telemetry and nullable
+  `restore_trap_shape_count` audit metadata. Snapshot formats and token grammar
+  are unchanged. Some historical `failed` decisions become `success` on new
+  runs; byte-exact restore and PII detection metrics are independent.
+
 ## [0.13.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as `Kunde_7`, `ORDER_12345`, or `FOO_12`, or on token-like content produced by
   authorized manifest substitutions. Core pipeline telemetry, Session strict
   restore, the MCP `restore_strict` tool, and CLI restore share the counter split:
-  unresolved own-prefix and foreign-prefix placeholders still fail; unprefixed
-  and legacy placeholder shapes are now audited rather than blocking. Added
+  Strict no longer blocks on bare identifier-shaped literals outside authorized
+  ranges (moved to audit-only `manifest_bypass`); it still blocks on any unmapped
+  canonical placeholder (own-prefix, foreign-prefix, legacy wrapped) and on
+  incomplete prefixed wrappers. Legacy emitted formats remain blocking too.
+  This deliberately narrows the heuristic rejection boundary. Added
   serde-defaulted `trap_shape_count` telemetry and nullable
   `restore_trap_shape_count` audit metadata. Snapshot formats and token grammar
   are unchanged. Some historical `failed` decisions become `success` on new

--- a/crates/gaze-audit/src/query.rs
+++ b/crates/gaze-audit/src/query.rs
@@ -89,6 +89,7 @@ pub struct AuditLogRow {
     pub restore_manifest_bypass_count: Option<i64>,
     pub restore_fresh_pii_count: Option<i64>,
     pub restore_phase_mask: Option<i64>,
+    pub restore_trap_shape_count: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -156,6 +157,7 @@ pub const AUDIT_RESTRICTED_COLUMNS: &[&str] = &[
     "restore_manifest_bypass_count",
     "restore_fresh_pii_count",
     "restore_phase_mask",
+    "restore_trap_shape_count",
 ];
 
 pub const SAFETY_NET_RESTRICTED_COLUMNS: &[&str] = &[
@@ -573,11 +575,11 @@ mod tests {
     fn generated_sql_is_byte_identical_for_column_presence_matrix() {
         assert_eq!(
             build_with_columns(&OPTIONAL_COLUMNS),
-            "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, snapshot_scheme, snapshot_alg, snapshot_key_version, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask FROM redaction_log ORDER BY rowid"
+            "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, snapshot_scheme, snapshot_alg, snapshot_key_version, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask, NULL AS restore_trap_shape_count FROM redaction_log ORDER BY rowid"
         );
         assert_eq!(
             build_with_columns(&[]),
-            "SELECT source, NULL AS recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, NULL AS created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, 'SHA-256' AS snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, NULL AS ambiguity_record, NULL AS collision_family, NULL AS collision_variant, NULL AS fallback_triggered, NULL AS provenance_stage, NULL AS provenance_model_id, NULL AS provenance_model_version, NULL AS provenance_artifact_sha256, NULL AS provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, NULL AS provenance_locale_match_kind, NULL AS provenance_canonical_class, NULL AS provenance_native_class, NULL AS provenance_confidence, NULL AS provenance_merged_from, NULL AS restore_policy, NULL AS restore_decision, NULL AS restore_unknown_token_count, NULL AS restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, NULL AS restore_phase_mask FROM redaction_log ORDER BY rowid"
+            "SELECT source, NULL AS recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, NULL AS created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, 'SHA-256' AS snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, NULL AS ambiguity_record, NULL AS collision_family, NULL AS collision_variant, NULL AS fallback_triggered, NULL AS provenance_stage, NULL AS provenance_model_id, NULL AS provenance_model_version, NULL AS provenance_artifact_sha256, NULL AS provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, NULL AS provenance_locale_match_kind, NULL AS provenance_canonical_class, NULL AS provenance_native_class, NULL AS provenance_confidence, NULL AS provenance_merged_from, NULL AS restore_policy, NULL AS restore_decision, NULL AS restore_unknown_token_count, NULL AS restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, NULL AS restore_phase_mask, NULL AS restore_trap_shape_count FROM redaction_log ORDER BY rowid"
         );
         let mixed = [
             "created_at",
@@ -597,7 +599,7 @@ mod tests {
         ];
         assert_eq!(
             build_with_columns(&mixed),
-            "SELECT source, recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, ambiguity_record, NULL AS collision_family, collision_variant, NULL AS fallback_triggered, provenance_stage, NULL AS provenance_model_id, provenance_model_version, NULL AS provenance_artifact_sha256, provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, provenance_locale_match_kind, NULL AS provenance_canonical_class, provenance_native_class, NULL AS provenance_confidence, provenance_merged_from, NULL AS restore_policy, restore_decision, NULL AS restore_unknown_token_count, restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, restore_phase_mask FROM redaction_log ORDER BY rowid"
+            "SELECT source, recognizer_id, NULL AS recognizer_version_id, class, action, field_name, document_kind, conflict_loser, 'none' AS decided_by, created_at, NULL AS session_id, 'gaze.snapshot.v1.sha256-salted' AS snapshot_scheme, snapshot_alg, NULL AS snapshot_key_version, NULL AS validator_fail_reason, ambiguity_record, NULL AS collision_family, collision_variant, NULL AS fallback_triggered, provenance_stage, NULL AS provenance_model_id, provenance_model_version, NULL AS provenance_artifact_sha256, provenance_tokenizer_sha256, NULL AS provenance_locale_resolved, provenance_locale_match_kind, NULL AS provenance_canonical_class, provenance_native_class, NULL AS provenance_confidence, provenance_merged_from, NULL AS restore_policy, restore_decision, NULL AS restore_unknown_token_count, restore_manifest_bypass_count, NULL AS restore_fresh_pii_count, restore_phase_mask, NULL AS restore_trap_shape_count FROM redaction_log ORDER BY rowid"
         );
     }
 

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -992,12 +992,16 @@ mod tests {
         let logger = SqliteLogger::new(temp_db.path()).unwrap();
         let mut telemetry = RestoreTelemetry::new(RestorePolicy::Lenient);
         telemetry.unknown_token_count = 2;
-        telemetry.manifest_bypass_count = 2;
+        telemetry.manifest_bypass_count = 3;
         telemetry.fresh_pii_detected_count = 0;
         telemetry.restore_decision = RestoreDecision::Partial;
         telemetry.phase_execution_mask = RESTORE_PHASE_MANIFEST_LOOKUP
             | RESTORE_PHASE_UNKNOWN_TOKEN_SCAN
             | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
+
+        let mut wire = serde_json::to_value(&telemetry).unwrap();
+        wire["trap_shape_count"] = serde_json::json!(4);
+        let telemetry: RestoreTelemetry = serde_json::from_value(wire).unwrap();
 
         logger
             .log(
@@ -1025,10 +1029,19 @@ mod tests {
         )
         .unwrap();
         assert_eq!(rows.len(), 1);
+        let connection = Connection::open(temp_db.path()).unwrap();
+        let traps: Option<i64> = connection
+            .query_row(
+                "SELECT restore_trap_shape_count FROM redaction_log",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(traps, Some(4));
         assert_eq!(rows[0].restore_policy.as_deref(), Some("lenient"));
         assert_eq!(rows[0].restore_decision.as_deref(), Some("partial"));
         assert_eq!(rows[0].restore_unknown_token_count, Some(2));
-        assert_eq!(rows[0].restore_manifest_bypass_count, Some(2));
+        assert_eq!(rows[0].restore_manifest_bypass_count, Some(3));
         assert_eq!(rows[0].restore_fresh_pii_count, Some(0));
         assert_eq!(
             rows[0].restore_phase_mask,

--- a/crates/gaze-audit/src/sqlite.rs
+++ b/crates/gaze-audit/src/sqlite.rs
@@ -196,6 +196,7 @@ const REDACTION_LOG_COLUMNS: &[ColumnSpec] = &[
     ColumnSpec { name: "restore_manifest_bypass_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
     ColumnSpec { name: "restore_fresh_pii_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
     ColumnSpec { name: "restore_phase_mask", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
+    ColumnSpec { name: "restore_trap_shape_count", sql_type: "INTEGER", constraint: ColumnConstraint::Nullable, migrate: true, backfill: None },
 ];
 impl SqliteLogger {
     pub fn new(path: &Path) -> Result<Self> {
@@ -274,7 +275,7 @@ impl SqliteLogger {
             .lock()
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         conn.execute(
-            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34)",
+            "INSERT INTO redaction_log (source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, provenance_stage, provenance_model_id, provenance_model_version, provenance_artifact_sha256, provenance_tokenizer_sha256, provenance_locale_resolved, provenance_locale_match_kind, provenance_canonical_class, provenance_native_class, provenance_confidence, provenance_merged_from, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask, restore_trap_shape_count) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35)",
             params![
                 entry.source,
                 entry.recognizer_id,
@@ -310,6 +311,7 @@ impl SqliteLogger {
                 entry.restore_manifest_bypass_count.map(|value| value as i64),
                 entry.restore_fresh_pii_count.map(|value| value as i64),
                 entry.restore_phase_mask.map(i64::from),
+                entry.restore_trap_shape_count.map(|value| value as i64),
             ],
         )
         .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -323,7 +325,7 @@ impl SqliteLogger {
             .map_err(|_| AuditError::Sqlite("sqlite mutex poisoned".to_string()))?;
         let mut stmt = conn
             .prepare(
-                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask FROM redaction_log",
+                "SELECT source, recognizer_id, recognizer_version_id, class, action, field_name, document_kind, conflict_loser, decided_by, created_at, session_id, validator_fail_reason, ambiguity_record, collision_family, collision_variant, fallback_triggered, backend_silently_dropped, restore_policy, restore_decision, restore_unknown_token_count, restore_manifest_bypass_count, restore_fresh_pii_count, restore_phase_mask, restore_trap_shape_count FROM redaction_log",
             )
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
         let rows = stmt
@@ -369,6 +371,8 @@ impl SqliteLogger {
                 entry.restore_fresh_pii_count =
                     row.get::<_, Option<i64>>(21)?.map(|value| value as u64);
                 entry.restore_phase_mask = row.get::<_, Option<i64>>(22)?.map(|value| value as u32);
+                entry.restore_trap_shape_count =
+                    row.get::<_, Option<i64>>(23)?.map(|value| value as u64);
                 Ok(entry)
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;
@@ -431,6 +435,7 @@ impl SqliteLogger {
                     restore_manifest_bypass_count: row.get(33)?,
                     restore_fresh_pii_count: row.get(34)?,
                     restore_phase_mask: row.get(35)?,
+                    restore_trap_shape_count: row.get(36)?,
                 })
             })
             .map_err(|err| AuditError::Sqlite(err.to_string()))?;

--- a/crates/gaze-audit/tests/safety_net_log.rs
+++ b/crates/gaze-audit/tests/safety_net_log.rs
@@ -317,6 +317,7 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             restore_manifest_bypass_count: None,
             restore_fresh_pii_count: None,
             restore_phase_mask: None,
+            restore_trap_shape_count: None,
         },
         AuditLogRow {
             source: "dictionary".to_string(),
@@ -355,6 +356,7 @@ fn legacy_rows() -> Vec<AuditLogRow> {
             restore_manifest_bypass_count: None,
             restore_fresh_pii_count: None,
             restore_phase_mask: None,
+            restore_trap_shape_count: None,
         },
     ]
 }

--- a/crates/gaze-cli/src/commands/audit.rs
+++ b/crates/gaze-cli/src/commands/audit.rs
@@ -70,7 +70,7 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
     }
     for row in rows {
         let base = format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             row.source,
             row.recognizer_id.as_deref().unwrap_or(""),
             row.recognizer_version_id.as_deref().unwrap_or(""),
@@ -120,6 +120,9 @@ pub(crate) fn query(args: Args) -> std::result::Result<(), CliError> {
                 .unwrap_or_default(),
             row.restore_phase_mask
                 .map(|mask| mask.to_string())
+                .unwrap_or_default(),
+            row.restore_trap_shape_count
+                .map(|count| count.to_string())
                 .unwrap_or_default()
         );
         if include_ambiguity {

--- a/crates/gaze-cli/src/restore/mod.rs
+++ b/crates/gaze-cli/src/restore/mod.rs
@@ -6,12 +6,12 @@ use std::path::Path;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 
-use gaze::{Pipeline, RestorePolicy, RestoreTelemetry, SensitiveSnapshot, Session};
+use gaze::{RestorePolicy, RestoreTelemetry, SensitiveSnapshot, Session};
 
 use crate::error::{CliError, RestoreMode};
 use crate::io::{read_stdin_bytes, require_json_format};
 use crate::restore::manifest::{RestoreRequest, RestoreResponse};
-use crate::restore::session::{restore_pass1, restore_pass2_validate};
+use crate::restore::session::restore_pass2_validate;
 
 pub(crate) fn run_restore(
     format: &str,
@@ -44,14 +44,11 @@ pub(crate) fn run_restore(
             _ => CliError::Pipeline,
         })?;
 
-    let pass1 = restore_pass1(&session, &request.text)?;
+    let assessment = session
+        .assess_restore_text(&request.text)
+        .map_err(|_| CliError::Pipeline)?;
     let restore_telemetry = if telemetry_enabled || audit_db.is_some() {
-        let pipeline = Pipeline::builder()
-            .build()
-            .map_err(|_| CliError::Pipeline)?;
-        let (_, telemetry) = pipeline
-            .restore_with_policy_telemetry(&session, &request.text, restore_policy(restore_mode))
-            .map_err(|_| CliError::Pipeline)?;
+        let telemetry = assessment.telemetry(restore_policy(restore_mode));
         if let Some(path) = audit_db {
             persist_restore_telemetry(path, &session, telemetry.clone())?;
         }
@@ -59,15 +56,10 @@ pub(crate) fn run_restore(
     } else {
         None
     };
-    let restore_warning = restore_pass2_validate(
-        &pass1.text,
-        &pass1.substitution_spans,
-        &session,
-        restore_mode,
-    )?;
+    let restore_warning = restore_pass2_validate(&assessment, restore_mode)?;
 
     let response = RestoreResponse {
-        text: pass1.text,
+        text: assessment.into_restored().text,
         restore_warning,
         restore_telemetry,
     };

--- a/crates/gaze-cli/src/restore/session.rs
+++ b/crates/gaze-cli/src/restore/session.rs
@@ -1,234 +1,73 @@
-use std::ops::Range;
-
-use regex::Regex;
-
-use gaze::Session;
+use gaze::RestoreAssessment;
 
 use crate::error::{CliError, RestoreMode, RestoreWarning};
 
-/// Pass 1 — exact-literal alternation built from `session.tokens()`.
-///
-/// Sorts tokens longest-first so a format-preserved email like
-/// `email1.<session>@gaze-fake.invalid` wins over a substring match like `<Email_1>`. Bare
-/// format-preserving tokens stay wrapped in `\b` word boundaries so a token
-/// cannot be swallowed inside an adjacent identifier (the
-/// `hostName_1s-record` regression described in the consolidated roadmap.
-/// Wrapped counter tokens intentionally skip `\b`: `<` and
-/// `>` are explicit delimiters, and `\b` would miss `See <Email_1>.` because
-/// it does not fire across non-word characters. Empty session map is a no-op:
-/// `Regex::new("")` would match everywhere, so short-circuit.
-pub(crate) struct RestorePass1 {
-    pub(crate) text: String,
-    pub(crate) substitution_spans: Vec<Range<usize>>,
-}
-
-pub(crate) fn restore_pass1(
-    session: &Session,
-    text: &str,
-) -> std::result::Result<RestorePass1, CliError> {
-    let mut tokens = session.tokens();
-    if tokens.is_empty() {
-        return Ok(RestorePass1 {
-            text: text.to_string(),
-            substitution_spans: Vec::new(),
-        });
-    }
-    tokens.sort_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
-
-    let pattern = tokens
-        .iter()
-        .map(|token| {
-            let escaped = regex::escape(token);
-            if token.starts_with('<') && token.ends_with('>') {
-                escaped
-            } else {
-                format!(r"\b(?:{escaped})\b")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("|");
-    let re = Regex::new(&pattern).map_err(|_| CliError::Pipeline)?;
-
-    let mut out = String::with_capacity(text.len());
-    let mut substitution_spans = Vec::new();
-    let mut last = 0usize;
-    for m in re.find_iter(text) {
-        out.push_str(&text[last..m.start()]);
-        let real = session
-            .restore_strict(m.as_str())
-            .map_err(|_| CliError::Pipeline)?;
-        let substitution_start = out.len();
-        out.push_str(&real);
-        substitution_spans.push(substitution_start..out.len());
-        last = m.end();
-    }
-    out.push_str(&text[last..]);
-    Ok(RestorePass1 {
-        text: out,
-        substitution_spans,
-    })
-}
-
-/// Pass 2 — shape-validator over Pass-1 output.
-///
-/// Any remaining token-shaped substring means the LLM invented a token the
-/// session never emitted → `UnknownToken`. The canonical grammar lives in
-/// `gaze::token_shape`, so the CLI no longer re-encodes token shapes locally.
+/// Apply CLI exit/warning policy to the core's provenance-aware classification.
 pub(crate) fn restore_pass2_validate(
-    text: &str,
-    substitution_spans: &[Range<usize>],
-    session: &Session,
+    assessment: &RestoreAssessment,
     mode: RestoreMode,
-) -> std::result::Result<Vec<RestoreWarning>, CliError> {
+) -> Result<Vec<RestoreWarning>, CliError> {
     let mut warnings = Vec::new();
-    let mut substitution_cursor = 0usize;
-    for matched in gaze::token_shape::pattern().find_iter(text) {
-        if is_inside_substitution_span(
-            matched.start(),
-            matched.end(),
-            substitution_spans,
-            &mut substitution_cursor,
-        ) {
-            continue;
-        }
-        let matched_text = matched.as_str();
-        if gaze::token_shape::is_trap(matched_text) {
-            continue;
-        }
-        if session.contains_token(matched_text) {
-            continue;
-        }
+    for token in assessment.unknown_tokens() {
         match mode {
             RestoreMode::Strict => {
                 return Err(CliError::UnknownToken {
-                    token: matched_text.to_string(),
+                    token: token.clone(),
                 })
             }
             RestoreMode::Tolerant => warnings.push(RestoreWarning {
                 variant: "UnknownToken".to_string(),
-                token: matched_text.to_string(),
+                token: token.clone(),
             }),
         }
     }
     Ok(warnings)
 }
 
-fn is_inside_substitution_span(
-    start: usize,
-    end: usize,
-    spans: &[Range<usize>],
-    cursor: &mut usize,
-) -> bool {
-    while spans.get(*cursor).is_some_and(|span| span.end <= start) {
-        *cursor += 1;
-    }
-
-    spans
-        .get(*cursor)
-        .is_some_and(|span| span.start <= start && end <= span.end)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
     use super::*;
-    use gaze::Scope;
+    use gaze::{PiiClass, Scope, Session};
 
-    fn empty_session() -> Session {
-        Session::new(Scope::Ephemeral).expect("session")
+    #[test]
+    fn pass2_accepts_dense_authorized_shapes_and_audits_bare_literals() {
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let token = session
+            .tokenize(&PiiClass::Name, "<deadbeef:Email_999>")
+            .unwrap();
+        let input = format!("{} Kunde_7", vec![token; 1_000].join(" "));
+        let assessment = session.assess_restore_text(&input).unwrap();
+        assert!(restore_pass2_validate(&assessment, RestoreMode::Strict)
+            .unwrap()
+            .is_empty());
+        let telemetry = assessment.telemetry(gaze::RestorePolicy::Strict);
+        assert_eq!(telemetry.unknown_token_count, 0);
+        assert_eq!(telemetry.manifest_bypass_count, 1);
     }
 
     #[test]
-    fn pass2_cursor_scan_handles_dense_substitution_spans() {
-        let spans = (0..1_000)
-            .map(|i| {
-                let start = i * 16;
-                start..start + 8
-            })
-            .collect::<Vec<_>>();
-        let mut cursor = 0usize;
-        let started = Instant::now();
-
-        for (expected_cursor, span) in spans.iter().enumerate() {
-            assert!(
-                is_inside_substitution_span(span.start, span.end, &spans, &mut cursor),
-                "span {expected_cursor} should be exempt"
-            );
-            assert_eq!(
-                cursor, expected_cursor,
-                "cursor must advance monotonically to the current span"
-            );
-        }
-
-        assert!(
-            started.elapsed() < Duration::from_millis(50),
-            "dense cursor scan exceeded the regression budget"
-        );
-    }
-
-    #[test]
-    fn pass2_cursor_scan_handles_token_shaped_text_inside_substituted_span() {
-        let session = empty_session();
-        let text = "tenant_class_a";
-        let spans = std::iter::once(0..text.len()).collect::<Vec<_>>();
-        let mut cursor = 0usize;
-
-        assert!(is_inside_substitution_span(
-            0,
-            text.len(),
-            &spans,
-            &mut cursor
-        ));
-        assert_eq!(cursor, 0, "cursor stays on the containing span");
-        let warnings = restore_pass2_validate(text, &spans, &session, RestoreMode::Strict).unwrap();
-
-        assert!(warnings.is_empty());
-    }
-
-    #[test]
-    fn pass2_cursor_scan_traps_adjacent_hallucinated_tokens_outside_substituted_span() {
-        let session = empty_session();
-        let text = "Alice_1<deadbeef:Email_999>";
-        let spans = std::iter::once(0..7).collect::<Vec<_>>();
-        let mut cursor = 0usize;
-
-        assert!(is_inside_substitution_span(0, 7, &spans, &mut cursor));
-        assert_eq!(cursor, 0);
-        assert!(!is_inside_substitution_span(
-            7,
-            text.len(),
-            &spans,
-            &mut cursor
-        ));
-        assert_eq!(
-            cursor, 1,
-            "cursor must advance past the adjacent completed substitution span"
-        );
-        match restore_pass2_validate(text, &spans, &session, RestoreMode::Strict) {
+    fn pass2_traps_adjacent_unknown_outside_authorized_output() {
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let token = session.tokenize(&PiiClass::Name, "Alice_1").unwrap();
+        let assessment = session
+            .assess_restore_text(&format!("{token}<deadbeef:Email_999>"))
+            .unwrap();
+        match restore_pass2_validate(&assessment, RestoreMode::Strict) {
             Err(CliError::UnknownToken { token }) => assert_eq!(token, "<deadbeef:Email_999>"),
-            Err(other) => panic!("unexpected error: {other:?}"),
-            Ok(_) => panic!("expected adjacent hallucinated token to fail"),
+            _ => panic!("adjacent unresolved prefix must fail"),
         }
     }
 
     #[test]
-    fn pass2_cursor_scan_tolerant_mode_reports_first_unknown_token() {
-        let session = empty_session();
-        let text = "Alice_1 <deadbeef:Email_999> <deadbeef:Name_100>";
-        let spans = std::iter::once(0..7).collect::<Vec<_>>();
-        let mut cursor = 0usize;
-
-        assert!(is_inside_substitution_span(0, 7, &spans, &mut cursor));
-        assert!(!is_inside_substitution_span(8, 19, &spans, &mut cursor));
-        assert_eq!(
-            cursor, 1,
-            "cursor remains advanced after leaving the substitution span"
-        );
-        let warnings =
-            restore_pass2_validate(text, &spans, &session, RestoreMode::Tolerant).unwrap();
-
+    fn pass2_tolerant_reports_unknown_tokens_in_output_order() {
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let assessment = session
+            .assess_restore_text("Alice_1 <deadbeef:Email_999> <deadbeef:Name_100>")
+            .unwrap();
+        let warnings = restore_pass2_validate(&assessment, RestoreMode::Tolerant).unwrap();
+        assert_eq!(warnings.len(), 2);
         assert_eq!(warnings[0].variant, "UnknownToken");
         assert_eq!(warnings[0].token, "<deadbeef:Email_999>");
+        assert_eq!(warnings[1].token, "<deadbeef:Name_100>");
     }
 }

--- a/crates/gaze-cli/src/restore/session.rs
+++ b/crates/gaze-cli/src/restore/session.rs
@@ -93,17 +93,6 @@ pub(crate) fn restore_pass2_validate(
         }
         let matched_text = matched.as_str();
         if gaze::token_shape::is_trap(matched_text) {
-            match mode {
-                RestoreMode::Strict => {
-                    return Err(CliError::UnknownToken {
-                        token: matched_text.to_string(),
-                    })
-                }
-                RestoreMode::Tolerant => warnings.push(RestoreWarning {
-                    variant: "UnknownToken".to_string(),
-                    token: matched_text.to_string(),
-                }),
-            }
             continue;
         }
         if session.contains_token(matched_text) {

--- a/crates/gaze-cli/src/restore/session.rs
+++ b/crates/gaze-cli/src/restore/session.rs
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn pass2_cursor_scan_traps_adjacent_hallucinated_tokens_outside_substituted_span() {
         let session = empty_session();
-        let text = "Alice_1<Email_999>";
+        let text = "Alice_1<deadbeef:Email_999>";
         let spans = std::iter::once(0..7).collect::<Vec<_>>();
         let mut cursor = 0usize;
 
@@ -217,7 +217,7 @@ mod tests {
             "cursor must advance past the adjacent completed substitution span"
         );
         match restore_pass2_validate(text, &spans, &session, RestoreMode::Strict) {
-            Err(CliError::UnknownToken { token }) => assert_eq!(token, "<Email_999>"),
+            Err(CliError::UnknownToken { token }) => assert_eq!(token, "<deadbeef:Email_999>"),
             Err(other) => panic!("unexpected error: {other:?}"),
             Ok(_) => panic!("expected adjacent hallucinated token to fail"),
         }
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn pass2_cursor_scan_tolerant_mode_reports_first_unknown_token() {
         let session = empty_session();
-        let text = "Alice_1 <Email_999> <Name_100>";
+        let text = "Alice_1 <deadbeef:Email_999> <deadbeef:Name_100>";
         let spans = std::iter::once(0..7).collect::<Vec<_>>();
         let mut cursor = 0usize;
 
@@ -240,6 +240,6 @@ mod tests {
             restore_pass2_validate(text, &spans, &session, RestoreMode::Tolerant).unwrap();
 
         assert_eq!(warnings[0].variant, "UnknownToken");
-        assert_eq!(warnings[0].token, "<Email_999>");
+        assert_eq!(warnings[0].token, "<deadbeef:Email_999>");
     }
 }

--- a/crates/gaze-cli/tests/audit_cross_version.rs
+++ b/crates/gaze-cli/tests/audit_cross_version.rs
@@ -429,7 +429,7 @@ fn legacy_schema_without_decided_by_is_queryable() {
     );
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\trestore_trap_shape_count\n"
     ));
     assert!(stdout.contains("dictionary:audit_terms[#0]"));
     assert!(stdout.contains("custom:term"));

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -808,8 +808,8 @@ fn t02_canary_absent_in_clean_reappears_in_restore() {
 #[test]
 fn t03_unknown_token_pascalcase_shape() {
     let (_, blob, _) = clean_ok("Email is alice@example.invalid please.");
-    // Session has <Email_1>. LLM invents <Email_999>.
-    let (code, stdout, stderr) = restore_json(&blob, "Your <Email_999> is queued.");
+    // Session has <Email_1>. LLM invents <deadbeef:Email_999>.
+    let (code, stdout, stderr) = restore_json(&blob, "Your <deadbeef:Email_999> is queued.");
     assert_eq!(
         code,
         Some(3),
@@ -819,7 +819,7 @@ fn t03_unknown_token_pascalcase_shape() {
     );
     assert_eq!(
         parse_stderr_variant(&stderr),
-        json!({ "error": "UnknownToken", "exit": 3, "token": "<Email_999>" })
+        json!({ "error": "UnknownToken", "exit": 3, "token": "<deadbeef:Email_999>" })
     );
 }
 
@@ -830,11 +830,12 @@ fn t03_unknown_token_pascalcase_shape() {
 #[test]
 fn t04_unknown_token_lowercase_formatpreserve_shape() {
     // Stub pipeline has only an email Tokenize rule — it cannot emit
-    // lowercase FormatPreserve shapes like `location_7`. Session therefore
+    // lowercase FormatPreserve shapes like `deadbeef:location_7`. Session therefore
     // has no matching token; Pass 1 is a no-op and Pass 2's lowercase-shape
     // arm catches the LLM hallucination.
     let (_, blob, _) = clean_ok("No PII here.");
-    let (code, stdout, stderr) = restore_json(&blob, "Your location_7 order arrives soon.");
+    let (code, stdout, stderr) =
+        restore_json(&blob, "Your deadbeef:location_7 order arrives soon.");
     assert_eq!(
         code,
         Some(3),
@@ -844,14 +845,14 @@ fn t04_unknown_token_lowercase_formatpreserve_shape() {
     );
     assert_eq!(
         parse_stderr_variant(&stderr),
-        json!({ "error": "UnknownToken", "exit": 3, "token": "location_7" })
+        json!({ "error": "UnknownToken", "exit": 3, "token": "deadbeef:location_7" })
     );
 }
 
 #[test]
 fn t04b_tolerant_restore_reports_warning_and_preserves_text() {
     let (_, blob, _) = clean_ok("No PII here.");
-    let text = "Your location_7 order arrives soon.";
+    let text = "Your deadbeef:location_7 order arrives soon.";
     let (code, stdout, stderr) = restore_json_with_args(&["--restore-mode=tolerant"], &blob, text);
 
     assert_eq!(code, Some(0), "stderr={}", String::from_utf8_lossy(&stderr));
@@ -860,7 +861,7 @@ fn t04b_tolerant_restore_reports_warning_and_preserves_text() {
     assert_eq!(resp["text"].as_str().unwrap(), text);
     assert_eq!(
         resp["restore_warning"],
-        json!([{ "variant": "UnknownToken", "token": "location_7" }])
+        json!([{ "variant": "UnknownToken", "token": "deadbeef:location_7" }])
     );
 }
 
@@ -4447,4 +4448,77 @@ action = "tokenize"
         stderr.contains("warning:") && stderr.contains("custom:family:payment-card-or-iban"),
         "warning must keep firing while the leak is live, got: {stderr}"
     );
+}
+
+#[test]
+fn strict_literal_roundtrip_agrees_with_telemetry_and_audit() {
+    let raw = "Grüße Kunde_7 ORDER_12345 FOO_12 alice@example.invalid";
+    let (clean, blob, _) = clean_ok(raw);
+    let dir = tempdir().unwrap();
+    for telemetry in [false, true] {
+        for audit in [false, true] {
+            let audit_path = dir
+                .path()
+                .join(format!("restore-{telemetry}-{audit}.sqlite"));
+            let audit_arg = format!("--audit-db={}", audit_path.display());
+            let mut args = vec!["--restore-mode=strict"];
+            if telemetry {
+                args.push("--telemetry");
+            }
+            if audit {
+                args.push(&audit_arg);
+            }
+            let (code, stdout, stderr) = restore_json_with_args(&args, &blob, &clean);
+            assert_eq!(code, Some(0), "{}", String::from_utf8_lossy(&stderr));
+            let response: Value = serde_json::from_slice(&stdout).unwrap();
+            assert_eq!(response["text"], raw);
+            if telemetry {
+                assert_eq!(response["restore_telemetry"]["restore_decision"], "success");
+                assert_eq!(response["restore_telemetry"]["unknown_token_count"], 0);
+                assert_eq!(response["restore_telemetry"]["manifest_bypass_count"], 3);
+                assert_eq!(response["restore_telemetry"]["trap_shape_count"], 3);
+            }
+            if audit {
+                let rows = SqliteLogger::query(
+                    &audit_path,
+                    &AuditFilter {
+                        restore_events_only: true,
+                        ..AuditFilter::default()
+                    },
+                )
+                .unwrap();
+                assert_eq!(rows.len(), 1);
+                assert_eq!(rows[0].restore_decision.as_deref(), Some("success"));
+                assert_eq!(rows[0].restore_unknown_token_count, Some(0));
+                assert_eq!(rows[0].restore_manifest_bypass_count, Some(3));
+            }
+        }
+    }
+    for mode in ["--restore-mode=strict", "--restore-mode=tolerant"] {
+        let input = format!("{clean} <deadbeef:Email_999>");
+        let (code, stdout, _) = restore_json_with_args(&[mode, "--telemetry"], &blob, &input);
+        if mode.ends_with("=strict") {
+            assert_eq!(code, Some(3));
+        } else {
+            assert_eq!(code, Some(0));
+            let response: Value = serde_json::from_slice(&stdout).unwrap();
+            assert_eq!(response["restore_telemetry"]["restore_decision"], "partial");
+            assert_eq!(
+                response["restore_warning"][0]["token"],
+                "<deadbeef:Email_999>"
+            );
+        }
+    }
+}
+
+#[test]
+fn strict_legacy_placeholder_is_audited_without_warning() {
+    let (_, blob, _) = clean_ok("ordinary prose");
+    let (code, stdout, _) = restore_json_with_args(&["--telemetry"], &blob, "<Email_1>");
+    assert_eq!(code, Some(0));
+    let response: Value = serde_json::from_slice(&stdout).unwrap();
+    assert_eq!(response["text"], "<Email_1>");
+    assert_eq!(response["restore_telemetry"]["manifest_bypass_count"], 1);
+    assert_eq!(response["restore_telemetry"]["restore_decision"], "success");
+    assert!(response.get("restore_warning").is_none());
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1309,7 +1309,7 @@ fn s4_audit_query_and_export_return_filtered_metadata_rows() {
     );
     let stdout = String::from_utf8(query.stdout).unwrap();
     assert!(stdout.starts_with(
-        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\n"
+        "source\trecognizer_id\trecognizer_version_id\tclass\taction\tfield_name\tdocument_kind\tconflict_loser\tdecided_by\tcreated_at\tsession_id\tsnapshot_scheme\tsnapshot_alg\tsnapshot_key_version\tvalidator_fail_reason\tambiguity_record\tcollision_family\tcollision_variant\tfallback_triggered\tprovenance_stage\tprovenance_model_id\tprovenance_model_version\tprovenance_artifact_sha256\tprovenance_tokenizer_sha256\tprovenance_locale_resolved\tprovenance_locale_match_kind\tprovenance_canonical_class\tprovenance_native_class\tprovenance_confidence\tprovenance_merged_from\trestore_policy\trestore_decision\trestore_unknown_token_count\trestore_manifest_bypass_count\trestore_fresh_pii_count\trestore_phase_mask\trestore_trap_shape_count\n"
     ));
     assert!(
         stdout

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -1002,7 +1002,7 @@ fn cascade_llm_hallucination_still_trapped() {
     });
     assert_session_scoped_custom_token(&tokens[0]);
 
-    let text = format!("Known {} and unknown <unknown:Email_99>.", tokens[0]);
+    let text = format!("Known {} and unknown <deadbeef:Email_99>.", tokens[0]);
     let (code, stdout, stderr) = restore_json(&blob, &text);
 
     assert_eq!(
@@ -1014,14 +1014,17 @@ fn cascade_llm_hallucination_still_trapped() {
     );
     assert_eq!(
         parse_stderr_variant(&stderr),
-        json!({ "error": "UnknownToken", "exit": 3, "token": "Email_99" })
+        json!({ "error": "UnknownToken", "exit": 3, "token": "<deadbeef:Email_99>" })
     );
 }
 
 #[test]
 fn cascade_trap_boundary_crossing_not_exempted() {
-    let (blob, tokens) =
-        build_blob_and_tokens(|s| vec![s.tokenize(&PiiClass::custom("name_ref"), "Foo").unwrap()]);
+    let (blob, tokens) = build_blob_and_tokens(|s| {
+        vec![s
+            .tokenize(&PiiClass::custom("name_ref"), "deadbeef:email")
+            .unwrap()]
+    });
     assert_session_scoped_custom_token(&tokens[0]);
 
     let text = format!("{}_7", tokens[0]);
@@ -1036,7 +1039,7 @@ fn cascade_trap_boundary_crossing_not_exempted() {
     );
     assert_eq!(
         parse_stderr_variant(&stderr),
-        json!({ "error": "UnknownToken", "exit": 3, "token": "Foo_7" })
+        json!({ "error": "UnknownToken", "exit": 3, "token": "deadbeef:email_7" })
     );
 }
 
@@ -3937,7 +3940,10 @@ fn t20_restore_custom_hallucination_exits_3() {
         vec![s.tokenize(&PiiClass::custom("class_alpha"), "42").unwrap()]
     });
 
-    let text = format!("Order {} and <Custom:fake_id_99> are shipped.", tokens[0]);
+    let text = format!(
+        "Order {} and <deadbeef:Custom:fake_id_99> are shipped.",
+        tokens[0]
+    );
     let (code, stdout, stderr) = restore_json(&blob, &text);
     assert_eq!(
         code,
@@ -3948,7 +3954,7 @@ fn t20_restore_custom_hallucination_exits_3() {
     );
     assert_eq!(
         parse_stderr_variant(&stderr),
-        json!({ "error": "UnknownToken", "exit": 3, "token": "<Custom:fake_id_99>" })
+        json!({ "error": "UnknownToken", "exit": 3, "token": "<deadbeef:Custom:fake_id_99>" })
     );
 }
 

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -4518,13 +4518,26 @@ fn strict_literal_roundtrip_agrees_with_telemetry_and_audit() {
 }
 
 #[test]
-fn strict_legacy_placeholder_is_audited_without_warning() {
-    let (_, blob, _) = clean_ok("ordinary prose");
-    let (code, stdout, _) = restore_json_with_args(&["--telemetry"], &blob, "<Email_1>");
-    assert_eq!(code, Some(0));
-    let response: Value = serde_json::from_slice(&stdout).unwrap();
-    assert_eq!(response["text"], "<Email_1>");
-    assert_eq!(response["restore_telemetry"]["manifest_bypass_count"], 1);
-    assert_eq!(response["restore_telemetry"]["restore_decision"], "success");
-    assert!(response.get("restore_warning").is_none());
+fn strict_legacy_placeholder_fails_and_tolerant_warns() {
+    let (clean, blob, _) = clean_ok("alice@example.invalid");
+    for shape in [
+        "<Email_1>",
+        "location_7",
+        "email1@gaze-fake.invalid",
+        "<Custom:class_alpha_1>",
+    ] {
+        let input = format!("{clean} {shape}");
+        let (code, stdout, stderr) = restore_json_with_args(&["--telemetry"], &blob, &input);
+        assert_eq!(code, Some(3));
+        assert!(stdout.is_empty());
+        assert_eq!(parse_stderr_variant(&stderr)["error"], "UnknownToken");
+        let (code, stdout, _) =
+            restore_json_with_args(&["--telemetry", "--restore-mode=tolerant"], &blob, &input);
+        assert_eq!(code, Some(0));
+        let response: Value = serde_json::from_slice(&stdout).unwrap();
+        assert_eq!(response["restore_telemetry"]["unknown_token_count"], 1);
+        assert_eq!(response["restore_telemetry"]["manifest_bypass_count"], 0);
+        assert_eq!(response["restore_telemetry"]["restore_decision"], "partial");
+        assert_eq!(response["restore_warning"][0]["token"], shape);
+    }
 }

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -4541,3 +4541,12 @@ fn strict_legacy_placeholder_fails_and_tolerant_warns() {
         assert_eq!(response["restore_warning"][0]["token"], shape);
     }
 }
+
+#[test]
+fn strict_incomplete_prefixed_wrapper_fails() {
+    let (_, blob, _) = clean_ok("ordinary prose");
+    let (code, stdout, stderr) = restore_json(&blob, "<deadbeef:Custom:class_alpha_1 suffix");
+    assert_eq!(code, Some(3));
+    assert!(stdout.is_empty());
+    assert_eq!(parse_stderr_variant(&stderr)["error"], "UnknownToken");
+}

--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -150,6 +150,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_strict_rejects_canonical_legacy_after_mapped_token() {
+        let pipeline = gaze::Pipeline::builder().build().unwrap();
+        let session = gaze::Session::new(gaze::Scope::Ephemeral).unwrap();
+        let token = session
+            .tokenize(&gaze::PiiClass::Email, "alice@example.invalid")
+            .unwrap();
+        for shape in [
+            "<Email_1>",
+            "location_7",
+            "email1@gaze-fake.invalid",
+            "<Custom:class_alpha_1>",
+        ] {
+            let err = RestoreStrictTool::new()
+                .invoke(&ctx(
+                    &pipeline,
+                    &session,
+                    &NullManifest,
+                    json!({"text": format!("{token} {shape}")}),
+                ))
+                .await
+                .expect_err("unmapped canonical placeholder must fail");
+            assert_eq!(err.class(), "not-found");
+        }
+    }
+
+    #[tokio::test]
     async fn restore_strict_fails_closed_on_unknown_token() {
         let pipeline = gaze::Pipeline::builder().build().expect("pipeline");
         let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");

--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -1,10 +1,11 @@
 //! `restore_strict` operator-tier tool. Like `restore` but rejects partial
-//! restorations: every unresolved session-prefixed placeholder causes failure.
+//! restorations: every unmapped canonical placeholder causes failure.
 //! Ordinary bare identifier shapes are preserved.
 //!
 //! The body delegates to the core pipeline strict restore path, which uses
 //! manifest substitution provenance and rejects malformed/nested token input.
-//! Any unresolved prefixed span fails closed with `ToolError::NotFound`;
+//! Unmapped canonical placeholders and incomplete prefixed wrappers fail closed
+//! with `ToolError::NotFound`;
 //! otherwise the response bypasses agent
 //! redaction under the operator-tier contract.
 

--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_strict_round_trips_clean_then_restore() {
+    async fn restore_strict_round_trips_identifier_literal_and_mapped_token() {
         let pipeline = gaze::Pipeline::builder().build().expect("pipeline");
         let session = gaze::Session::new(gaze::Scope::Ephemeral).expect("session");
         let token = session
@@ -138,14 +138,14 @@ mod tests {
                 &pipeline,
                 &session,
                 &manifest,
-                json!({ "text": format!("Hi {token}") }),
+                json!({ "text": format!("Kunde_7 Hi {token}") }),
             ))
             .await
             .expect("restore response");
 
         assert_eq!(
             response.payload,
-            json!({ "text": "Hi alice@example.invalid" })
+            json!({ "text": "Kunde_7 Hi alice@example.invalid" })
         );
     }
 

--- a/crates/gaze-mcp-core/src/tools/restore_strict.rs
+++ b/crates/gaze-mcp-core/src/tools/restore_strict.rs
@@ -1,11 +1,11 @@
 //! `restore_strict` operator-tier tool. Like `restore` but rejects partial
-//! restorations — every token in the input string must be in the manifest
-//! or the call fails.
+//! restorations: every unresolved session-prefixed placeholder causes failure.
+//! Ordinary bare identifier shapes are preserved.
 //!
-//! The body takes a `text` argument, scans it with `gaze::token_shape::pattern`,
-//! and delegates restoration to the private `restore_strict_text` helper below.
-//! If any token-shaped span is not owned by the session, the whole call fails
-//! closed with `ToolError::NotFound`; otherwise the response bypasses agent
+//! The body delegates to the core pipeline strict restore path, which uses
+//! manifest substitution provenance and rejects malformed/nested token input.
+//! Any unresolved prefixed span fails closed with `ToolError::NotFound`;
+//! otherwise the response bypasses agent
 //! redaction under the operator-tier contract.
 
 use async_trait::async_trait;

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -170,8 +170,13 @@ impl RestoreDecision {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct RestoreTelemetry {
+    /// Unresolved session-prefixed shapes outside authorized restore output.
     pub unknown_token_count: u64,
+    /// Audit-only trap shapes outside authorized restore output.
     pub manifest_bypass_count: u64,
+    /// All unprefixed trap shapes in restored text, including authorized values.
+    #[serde(default)]
+    pub trap_shape_count: u64,
     pub fresh_pii_detected_count: u64,
     pub restore_policy: RestorePolicy,
     pub restore_decision: RestoreDecision,
@@ -183,6 +188,7 @@ impl RestoreTelemetry {
         Self {
             unknown_token_count: 0,
             manifest_bypass_count: 0,
+            trap_shape_count: 0,
             fresh_pii_detected_count: 0,
             restore_policy,
             restore_decision: RestoreDecision::Success,
@@ -2232,6 +2238,7 @@ pub struct RedactionEntry {
     pub restore_manifest_bypass_count: Option<u64>,
     pub restore_fresh_pii_count: Option<u64>,
     pub restore_phase_mask: Option<u32>,
+    pub restore_trap_shape_count: Option<u64>,
 }
 
 impl Serialize for RedactionEntry {
@@ -2276,6 +2283,7 @@ impl Serialize for RedactionEntry {
             self.restore_manifest_bypass_count.is_some(),
             self.restore_fresh_pii_count.is_some(),
             self.restore_phase_mask.is_some(),
+            self.restore_trap_shape_count.is_some(),
         ]
         .into_iter()
         .filter(|value| *value)
@@ -2352,6 +2360,9 @@ impl Serialize for RedactionEntry {
         if let Some(value) = self.restore_fresh_pii_count {
             state.serialize_field("restore_fresh_pii_count", &value)?;
         }
+        if let Some(value) = self.restore_trap_shape_count {
+            state.serialize_field("restore_trap_shape_count", &value)?;
+        }
         if let Some(value) = self.restore_phase_mask {
             state.serialize_field("restore_phase_mask", &value)?;
         }
@@ -2408,6 +2419,7 @@ impl RedactionEntry {
             restore_manifest_bypass_count: None,
             restore_fresh_pii_count: None,
             restore_phase_mask: None,
+            restore_trap_shape_count: None,
         }
     }
 
@@ -2453,6 +2465,7 @@ impl RedactionEntry {
         self.restore_manifest_bypass_count = Some(telemetry.manifest_bypass_count);
         self.restore_fresh_pii_count = Some(telemetry.fresh_pii_detected_count);
         self.restore_phase_mask = Some(telemetry.phase_execution_mask);
+        self.restore_trap_shape_count = Some(telemetry.trap_shape_count);
         self
     }
 
@@ -3279,6 +3292,7 @@ mod redaction_logger_tests {
             restore_manifest_bypass_count: None,
             restore_fresh_pii_count: None,
             restore_phase_mask: None,
+            restore_trap_shape_count: None,
         };
 
         let trait_object: &dyn RedactionLogger = &logger;

--- a/crates/gaze-types/src/lib.rs
+++ b/crates/gaze-types/src/lib.rs
@@ -170,9 +170,9 @@ impl RestoreDecision {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct RestoreTelemetry {
-    /// Unresolved session-prefixed shapes outside authorized restore output.
+    /// Unmapped canonical placeholders or incomplete prefixed wrappers outside authorized output.
     pub unknown_token_count: u64,
-    /// Audit-only trap shapes outside authorized restore output.
+    /// Audit-only broad bare identifier shapes outside authorized restore output.
     pub manifest_bypass_count: u64,
     /// All unprefixed trap shapes in restored text, including authorized values.
     #[serde(default)]

--- a/crates/gaze/src/lib.rs
+++ b/crates/gaze/src/lib.rs
@@ -66,7 +66,7 @@ pub use sandbox::{
     ExecPolicy, Sandbox, SandboxError, SandboxPlan, UntrustedExecRequest, ValidatedExecRequest,
 };
 pub use session::{
-    CommittedSessionSnapshot, RestoreError, RestoreEvent, RestoreEventKind,
+    CommittedSessionSnapshot, RestoreAssessment, RestoreError, RestoreEvent, RestoreEventKind,
     RestoredTextWithProvenance, Scope, SensitiveSnapshot, Session, SessionSnapshotEntry,
     SessionTransaction, SessionTransactionError,
 };

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -477,19 +477,20 @@ impl Pipeline {
     ) -> Result<(RestoredText, RestoreTelemetry)> {
         let mut telemetry = RestoreTelemetry::new(policy);
         telemetry.phase_execution_mask |= RESTORE_PHASE_MANIFEST_LOOKUP;
-        let restored = restore_known_tokens(session, text)?;
+        let assessment = session.assess_restore_text(text)?;
         telemetry.phase_execution_mask |=
             RESTORE_PHASE_UNKNOWN_TOKEN_SCAN | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
-        let unknown_token_count = count_unknown_restore_tokens(session, &restored);
+        let unknown_token_count = assessment.unknown_tokens.len() as u64;
         telemetry.unknown_token_count = unknown_token_count;
-        telemetry.manifest_bypass_count = unknown_token_count;
+        telemetry.manifest_bypass_count = assessment.manifest_bypass_count;
+        telemetry.trap_shape_count = assessment.trap_shape_count;
         telemetry.restore_decision = match (policy, unknown_token_count) {
             (_, 0) => RestoreDecision::Success,
             (RestorePolicy::Strict, _) => RestoreDecision::Failed,
             (RestorePolicy::Lenient, _) => RestoreDecision::Partial,
             (_, _) => RestoreDecision::Failed,
         };
-        Ok((RestoredText::new(restored), telemetry))
+        Ok((RestoredText::new(assessment.restored.text), telemetry))
     }
 
     pub fn with_pipeline_optimizations(mut self, config: PipelineOptimizationConfig) -> Pipeline {
@@ -2673,31 +2674,6 @@ fn replace_clean_span_checked(
     }
     replace_clean_span(clean, span, replacement, emitted);
     Ok(())
-}
-
-fn restore_known_tokens(session: &Session, text: &str) -> Result<String> {
-    let Some(re) = session.restore_regex()? else {
-        return Ok(text.to_string());
-    };
-    let mut out = String::with_capacity(text.len());
-    let mut last = 0usize;
-    for matched in re.find_iter(text) {
-        out.push_str(&text[last..matched.start()]);
-        out.push_str(&session.restore_strict(matched.as_str())?);
-        last = matched.end();
-    }
-    out.push_str(&text[last..]);
-    Ok(out)
-}
-
-fn count_unknown_restore_tokens(session: &Session, text: &str) -> u64 {
-    crate::token_shape::pattern()
-        .find_iter(text)
-        .filter(|matched| {
-            let matched_text = matched.as_str();
-            crate::token_shape::is_trap(matched_text) || !session.contains_token(matched_text)
-        })
-        .count() as u64
 }
 
 fn adjust_emitted_span(

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -3557,7 +3557,7 @@ mod tests {
         let CleanDocument::Text(clean) = clean else {
             panic!("expected text");
         };
-        let input = format!("{clean} <Email_999> <Name_100>");
+        let input = format!("{clean} <deadbeef:Email_999> <deadbeef:Name_100> FOO_12 run_1");
 
         let (restored, telemetry) = pipeline
             .restore_with_policy_telemetry(&session, &input, RestorePolicy::Lenient)

--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -12,9 +12,8 @@ use gaze_recognizers::{
 use gaze_types::{
     AmbiguityReason, AmbiguityRecord, CollisionMembership, EmittedTokenSpan, FallbackReason,
     LeakKind, LeakReport, LeakReportTelemetry, LeakSuspect, Manifest, RedactionLogError,
-    RedactionLogger, RestoreDecision, RestorePolicy, RestoreTelemetry, RestoredText, SafetyNet,
-    SafetyNetContext, SafetyNetError, RESTORE_PHASE_MANIFEST_BYPASS_SCAN,
-    RESTORE_PHASE_MANIFEST_LOOKUP, RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
+    RedactionLogger, RestorePolicy, RestoreTelemetry, RestoredText, SafetyNet, SafetyNetContext,
+    SafetyNetError,
 };
 use thiserror::Error;
 
@@ -475,22 +474,12 @@ impl Pipeline {
         text: &str,
         policy: RestorePolicy,
     ) -> Result<(RestoredText, RestoreTelemetry)> {
-        let mut telemetry = RestoreTelemetry::new(policy);
-        telemetry.phase_execution_mask |= RESTORE_PHASE_MANIFEST_LOOKUP;
         let assessment = session.assess_restore_text(text)?;
-        telemetry.phase_execution_mask |=
-            RESTORE_PHASE_UNKNOWN_TOKEN_SCAN | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
-        let unknown_token_count = assessment.unknown_tokens.len() as u64;
-        telemetry.unknown_token_count = unknown_token_count;
-        telemetry.manifest_bypass_count = assessment.manifest_bypass_count;
-        telemetry.trap_shape_count = assessment.trap_shape_count;
-        telemetry.restore_decision = match (policy, unknown_token_count) {
-            (_, 0) => RestoreDecision::Success,
-            (RestorePolicy::Strict, _) => RestoreDecision::Failed,
-            (RestorePolicy::Lenient, _) => RestoreDecision::Partial,
-            (_, _) => RestoreDecision::Failed,
-        };
-        Ok((RestoredText::new(assessment.restored.text), telemetry))
+        let telemetry = assessment.telemetry(policy);
+        Ok((
+            RestoredText::new(assessment.into_restored().text),
+            telemetry,
+        ))
     }
 
     pub fn with_pipeline_optimizations(mut self, config: PipelineOptimizationConfig) -> Pipeline {
@@ -3294,6 +3283,10 @@ mod tests {
     use crate::detector::{Detection, PiiClass};
     use crate::rule::{ClassRule, DefaultRule};
     use crate::session::{Scope, Session};
+    use gaze_types::{
+        RestoreDecision, RESTORE_PHASE_MANIFEST_BYPASS_SCAN, RESTORE_PHASE_MANIFEST_LOOKUP,
+        RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
+    };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
 

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -17,7 +17,11 @@ use sha2::{Digest, Sha256};
 use crate::detector::PiiClass;
 use crate::policy::{Policy, SessionScope};
 use crate::{Error, Result};
-use gaze_types::DocumentExtension;
+use gaze_types::{
+    DocumentExtension, RestoreDecision, RestorePolicy, RestoreTelemetry,
+    RESTORE_PHASE_MANIFEST_BYPASS_SCAN, RESTORE_PHASE_MANIFEST_LOOKUP,
+    RESTORE_PHASE_UNKNOWN_TOKEN_SCAN,
+};
 
 const DEFAULT_PERSISTENT_TTL_SECS: u64 = 86_400;
 const DEFAULT_COUNTER_FAMILY: &str = "counter";
@@ -227,11 +231,42 @@ pub struct RestoredTextWithProvenance {
 
 /// Owner-side restoration and the classification of its remaining token shapes.
 /// No debug or serialization surface: restored values and unknown shapes may be sensitive.
-pub(crate) struct RestoreAssessment {
+#[non_exhaustive]
+pub struct RestoreAssessment {
     pub(crate) restored: RestoredTextWithProvenance,
     pub(crate) unknown_tokens: Vec<String>,
     pub(crate) manifest_bypass_count: u64,
     pub(crate) trap_shape_count: u64,
+}
+
+impl RestoreAssessment {
+    /// Unresolved prefixed shapes in output order, never suitable for audit logging.
+    pub fn unknown_tokens(&self) -> &[String] {
+        &self.unknown_tokens
+    }
+
+    /// Consume the assessment and return owner-side text with substitution provenance.
+    pub fn into_restored(self) -> RestoredTextWithProvenance {
+        self.restored
+    }
+
+    /// Derive metadata-only counters and the existing strict/lenient decision vocabulary.
+    pub fn telemetry(&self, policy: RestorePolicy) -> RestoreTelemetry {
+        let mut telemetry = RestoreTelemetry::new(policy);
+        telemetry.phase_execution_mask = RESTORE_PHASE_MANIFEST_LOOKUP
+            | RESTORE_PHASE_UNKNOWN_TOKEN_SCAN
+            | RESTORE_PHASE_MANIFEST_BYPASS_SCAN;
+        telemetry.unknown_token_count = self.unknown_tokens.len() as u64;
+        telemetry.manifest_bypass_count = self.manifest_bypass_count;
+        telemetry.trap_shape_count = self.trap_shape_count;
+        telemetry.restore_decision = match (policy, telemetry.unknown_token_count) {
+            (_, 0) => RestoreDecision::Success,
+            (RestorePolicy::Strict, _) => RestoreDecision::Failed,
+            (RestorePolicy::Lenient, _) => RestoreDecision::Partial,
+            (_, _) => RestoreDecision::Failed,
+        };
+        telemetry
+    }
 }
 
 /// Closed failures produced while committing a staged session transaction.
@@ -555,28 +590,30 @@ impl Session {
         self.state_snapshot().prefix_cache.len()
     }
 
-    pub(crate) fn restore_regex(&self) -> Result<Option<Arc<Regex>>> {
+    fn restore_state_snapshot(&self) -> Result<Arc<SessionState>> {
         let captured = self.state_snapshot();
-        if let Some((cache_generation, regex)) = &captured.restore_regex_cache {
-            if *cache_generation == captured.generation {
-                return Ok(Some(Arc::clone(regex)));
-            }
+        if captured
+            .restore_regex_cache
+            .as_ref()
+            .is_some_and(|(generation, _)| *generation == captured.generation)
+        {
+            return Ok(captured);
         }
-
         let Some(regex) = build_restore_regex(&captured)? else {
-            return Ok(None);
+            return Ok(captured);
         };
-
+        let mut next = (*captured).clone();
+        next.restore_regex_cache = Some((next.generation, regex));
+        let next = Arc::new(next);
         let mut boundary = self
             .state
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if boundary.generation == captured.generation {
-            let mut next = (**boundary).clone();
-            next.restore_regex_cache = Some((next.generation, Arc::clone(&regex)));
-            *boundary = Arc::new(next);
+            *boundary = Arc::clone(&next);
         }
-        Ok(Some(regex))
+        // A concurrent writer must not switch the map beneath this restore.
+        Ok(next)
     }
 
     pub fn contains_token(&self, token: &str) -> bool {
@@ -632,7 +669,7 @@ impl Session {
     }
 
     pub fn restore_strict_text(&self, text: &str) -> std::result::Result<String, RestoreError> {
-        restore_classified_strict_text_from_state(&self.state_snapshot(), text)
+        restore_classified_strict_text_from_state(self.restore_state_snapshot()?.as_ref(), text)
             .map(|restored| restored.text)
     }
 
@@ -640,22 +677,27 @@ impl Session {
         &self,
         text: &str,
     ) -> std::result::Result<RestoredTextWithProvenance, RestoreError> {
-        restore_classified_strict_text_from_state(&self.state_snapshot(), text)
+        restore_classified_strict_text_from_state(self.restore_state_snapshot()?.as_ref(), text)
     }
 
     pub fn restore_strict_text_with_events(
         &self,
         text: &str,
     ) -> std::result::Result<(String, Vec<RestoreEvent>), RestoreError> {
-        let state = self.state_snapshot();
+        let state = self.restore_state_snapshot()?;
         let events =
             restore_boundary_events(text, &authorized_structural_values_from_state(&state));
         let restored = restore_classified_strict_text_from_state(&state, text)?.text;
         Ok((restored, events))
     }
 
-    pub(crate) fn assess_restore_text(&self, text: &str) -> Result<RestoreAssessment> {
-        assess_restore_text_from_state(&self.state_snapshot(), text)
+    /// Restore known manifest tokens and classify remaining shapes using one immutable view.
+    ///
+    /// Unknown prefixed shapes are reported in the assessment rather than returned as an
+    /// error. Use `restore_strict_text` when malformed input and unresolved tokens must
+    /// return a typed error. Bare/legacy shapes are audit-only in both APIs.
+    pub fn assess_restore_text(&self, text: &str) -> Result<RestoreAssessment> {
+        assess_restore_text_from_state(self.restore_state_snapshot()?.as_ref(), text)
     }
 
     pub fn restore_boundary_events(&self, text: &str) -> Vec<RestoreEvent> {
@@ -2834,10 +2876,11 @@ mod tests {
         );
         assert!(Arc::ptr_eq(&session.identity, &snapshot.identity));
 
-        let regex = session
-            .restore_regex()
-            .expect("restore regex")
-            .expect("non-empty restore regex");
+        let restore_state = session.restore_state_snapshot().expect("restore state");
+        let (_, regex) = restore_state
+            .restore_regex_cache
+            .as_ref()
+            .expect("non-empty regex");
         assert!(regex.is_match(&token));
         let state = session.state_snapshot();
         assert_eq!(state.token_by_value.len(), state.value_by_token.len());

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1350,6 +1350,19 @@ fn restore_classified_strict_text_from_state(
 ) -> Result<RestoredTextWithProvenance> {
     // Keep malformed/nested input rejection before any owner-side substitution.
     strict_restore_tokens(text)?;
+    for (start, _) in text.match_indices('<') {
+        let candidate = &text[start..];
+        if !crate::token_shape::starts_with_session_prefix(candidate) {
+            continue;
+        }
+        // An incomplete wrapper can otherwise be seen as only a bare inner trap.
+        let end = candidate[1..]
+            .find(|ch: char| ch == '<' || ch == '>' || ch.is_whitespace())
+            .map_or(candidate.len(), |offset| offset + 1);
+        if candidate.as_bytes().get(end) != Some(&b'>') {
+            return Err(unknown_token_error(&candidate[..end]));
+        }
+    }
     let assessment = assess_restore_text_from_state(state, text)?;
     if let Some(unknown) = assessment.unknown_tokens.first() {
         return Err(unknown_token_error(unknown));

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1330,7 +1330,7 @@ fn classify_restore_output(
         {
             continue;
         }
-        if trap {
+        if crate::token_shape::is_bare_identifier(matched.as_str()) {
             manifest_bypass_count += 1;
         } else if !state.value_by_token.contains_key(matched.as_str()) {
             unknown_tokens.push(matched.as_str().to_owned());

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -240,7 +240,8 @@ pub struct RestoreAssessment {
 }
 
 impl RestoreAssessment {
-    /// Unresolved prefixed shapes in output order, never suitable for audit logging.
+    /// Unresolved canonical placeholders or incomplete wrappers in output order.
+    /// Never suitable for audit logging.
     pub fn unknown_tokens(&self) -> &[String] {
         &self.unknown_tokens
     }
@@ -354,11 +355,8 @@ pub struct CommittedSessionSnapshot {
 ///    original PII.
 /// 4. Send only the cleaned text to the LLM.
 /// 5. After the LLM responds, call [`Session::import`] with `SensitiveSnapshot::from(bytes)`.
-/// 6. For each token in the LLM response, call [`Session::restore_strict`] (or
-///    [`Session::restore`]).
-///
-/// There is no `Pipeline::restore_text` method - full-text restore is performed by scanning tokens
-/// with [`crate::token_shape::pattern`] and calling `restore_strict` per token.
+/// 6. Call [`Session::restore_strict_text`] on the complete LLM response. Keep its
+///    restored output on the owner side.
 ///
 /// Document workflows use the same restore root. Call [`Session::export_with_extension`] only when
 /// writing a `gaze-document` bundle that needs signed integrity hashes and codec provenance; plain
@@ -368,7 +366,7 @@ pub struct CommittedSessionSnapshot {
 ///
 /// ```rust
 /// use gaze::{
-///     token_shape, Action, ClassRule, CleanDocument, DefaultRule, Detection, Detector, PiiClass,
+///     Action, ClassRule, CleanDocument, DefaultRule, Detection, Detector, PiiClass,
 ///     Pipeline, RawDocument, Scope, SensitiveSnapshot, Session,
 /// };
 ///
@@ -405,15 +403,8 @@ pub struct CommittedSessionSnapshot {
 ///
 /// // Restore on the owner side after the LLM responds.
 /// let restored_session = Session::import(SensitiveSnapshot::from(blob))?;
-/// let mut restored = String::new();
-/// let mut last = 0;
-/// for m in token_shape::pattern().find_iter(&clean) {
-///     restored.push_str(&clean[last..m.start()]);
-///     restored.push_str(&restored_session.restore_strict(m.as_str())?);
-///     last = m.end();
-/// }
-/// restored.push_str(&clean[last..]);
-/// assert_eq!(restored, "alice@example.invalid"); // fixture-cited(crates/gaze/src/session.rs:session::tests::snapshot_round_trip_two_families_same_class_raw_preserved_under_shared_counter)
+/// let restored = restored_session.restore_strict_text(&format!("Kunde_7 {clean}"))?;
+/// assert_eq!(restored, "Kunde_7 alice@example.invalid"); // fixture-cited(crates/gaze/src/session.rs:session::tests::snapshot_round_trip_two_families_same_class_raw_preserved_under_shared_counter)
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
@@ -693,9 +684,9 @@ impl Session {
 
     /// Restore known manifest tokens and classify remaining shapes using one immutable view.
     ///
-    /// Unknown prefixed shapes are reported in the assessment rather than returned as an
+    /// Unknown canonical placeholders are reported in the assessment rather than returned as an
     /// error. Use `restore_strict_text` when malformed input and unresolved tokens must
-    /// return a typed error. Bare/legacy shapes are audit-only in both APIs.
+    /// return a typed error. Only broad bare identifiers are audit-only in both APIs.
     pub fn assess_restore_text(&self, text: &str) -> Result<RestoreAssessment> {
         assess_restore_text_from_state(self.restore_state_snapshot()?.as_ref(), text)
     }
@@ -1313,27 +1304,41 @@ fn classify_restore_output(
     let mut manifest_bypass_count = 0;
     let mut trap_shape_count = 0;
     let mut cursor = 0;
-    for matched in crate::token_shape::pattern().find_iter(&restored.text) {
-        let trap = crate::token_shape::is_trap(matched.as_str());
-        trap_shape_count += u64::from(trap);
+    let mut matches = crate::token_shape::pattern()
+        .find_iter(&restored.text)
+        .map(|matched| {
+            trap_shape_count += u64::from(crate::token_shape::is_trap(matched.as_str()));
+            matched.range()
+        })
+        .chain(incomplete_prefixed_wrappers(&restored.text))
+        .collect::<Vec<_>>();
+    // A wrapper and its inner lexical match represent one unresolved placeholder.
+    matches.sort_unstable_by_key(|range| (range.start, std::cmp::Reverse(range.end)));
+    let mut previous_end = 0;
+    for matched in matches {
+        if matched.start < previous_end {
+            continue;
+        }
+        previous_end = matched.end;
+        let matched_text = &restored.text[matched.clone()];
         while restored
             .authorized_output_ranges
             .get(cursor)
-            .is_some_and(|range| range.end <= matched.start())
+            .is_some_and(|range| range.end <= matched.start)
         {
             cursor += 1;
         }
         if restored
             .authorized_output_ranges
             .get(cursor)
-            .is_some_and(|range| range.start <= matched.start() && matched.end() <= range.end)
+            .is_some_and(|range| range.start <= matched.start && matched.end <= range.end)
         {
             continue;
         }
-        if crate::token_shape::is_bare_identifier(matched.as_str()) {
+        if crate::token_shape::is_bare_identifier(matched_text) {
             manifest_bypass_count += 1;
-        } else if !state.value_by_token.contains_key(matched.as_str()) {
-            unknown_tokens.push(matched.as_str().to_owned());
+        } else if !state.value_by_token.contains_key(matched_text) {
+            unknown_tokens.push(matched_text.to_owned());
         }
     }
     RestoreAssessment {
@@ -1344,25 +1349,25 @@ fn classify_restore_output(
     }
 }
 
+fn incomplete_prefixed_wrappers(text: &str) -> impl Iterator<Item = Range<usize>> + '_ {
+    text.match_indices('<').filter_map(|(start, _)| {
+        let candidate = &text[start..];
+        if !crate::token_shape::starts_with_session_prefix(candidate) {
+            return None;
+        }
+        let end = candidate[1..]
+            .find(|ch: char| ch == '<' || ch == '>' || ch.is_whitespace())
+            .map_or(candidate.len(), |offset| offset + 1);
+        (candidate.as_bytes().get(end) != Some(&b'>')).then_some(start..start + end)
+    })
+}
+
 fn restore_classified_strict_text_from_state(
     state: &SessionState,
     text: &str,
 ) -> Result<RestoredTextWithProvenance> {
     // Keep malformed/nested input rejection before any owner-side substitution.
     strict_restore_tokens(text)?;
-    for (start, _) in text.match_indices('<') {
-        let candidate = &text[start..];
-        if !crate::token_shape::starts_with_session_prefix(candidate) {
-            continue;
-        }
-        // An incomplete wrapper can otherwise be seen as only a bare inner trap.
-        let end = candidate[1..]
-            .find(|ch: char| ch == '<' || ch == '>' || ch.is_whitespace())
-            .map_or(candidate.len(), |offset| offset + 1);
-        if candidate.as_bytes().get(end) != Some(&b'>') {
-            return Err(unknown_token_error(&candidate[..end]));
-        }
-    }
     let assessment = assess_restore_text_from_state(state, text)?;
     if let Some(unknown) = assessment.unknown_tokens.first() {
         return Err(unknown_token_error(unknown));

--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -225,6 +225,15 @@ pub struct RestoredTextWithProvenance {
     pub authorized_output_ranges: Vec<Range<usize>>,
 }
 
+/// Owner-side restoration and the classification of its remaining token shapes.
+/// No debug or serialization surface: restored values and unknown shapes may be sensitive.
+pub(crate) struct RestoreAssessment {
+    pub(crate) restored: RestoredTextWithProvenance,
+    pub(crate) unknown_tokens: Vec<String>,
+    pub(crate) manifest_bypass_count: u64,
+    pub(crate) trap_shape_count: u64,
+}
+
 /// Closed failures produced while committing a staged session transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -623,7 +632,7 @@ impl Session {
     }
 
     pub fn restore_strict_text(&self, text: &str) -> std::result::Result<String, RestoreError> {
-        restore_strict_text_with_provenance_from_state(&self.state_snapshot(), text)
+        restore_classified_strict_text_from_state(&self.state_snapshot(), text)
             .map(|restored| restored.text)
     }
 
@@ -631,7 +640,7 @@ impl Session {
         &self,
         text: &str,
     ) -> std::result::Result<RestoredTextWithProvenance, RestoreError> {
-        restore_strict_text_with_provenance_from_state(&self.state_snapshot(), text)
+        restore_classified_strict_text_from_state(&self.state_snapshot(), text)
     }
 
     pub fn restore_strict_text_with_events(
@@ -641,8 +650,12 @@ impl Session {
         let state = self.state_snapshot();
         let events =
             restore_boundary_events(text, &authorized_structural_values_from_state(&state));
-        let restored = restore_strict_text_with_provenance_from_state(&state, text)?.text;
+        let restored = restore_classified_strict_text_from_state(&state, text)?.text;
         Ok((restored, events))
+    }
+
+    pub(crate) fn assess_restore_text(&self, text: &str) -> Result<RestoreAssessment> {
+        assess_restore_text_from_state(&self.state_snapshot(), text)
     }
 
     pub fn restore_boundary_events(&self, text: &str) -> Vec<RestoreEvent> {
@@ -1187,6 +1200,14 @@ fn restore_strict_text_with_provenance_from_state(
     text: &str,
 ) -> std::result::Result<RestoredTextWithProvenance, RestoreError> {
     let tokens = validated_restore_tokens(state, text)?;
+    Ok(restore_tokens_with_provenance(state, text, tokens))
+}
+
+fn restore_tokens_with_provenance(
+    state: &SessionState,
+    text: &str,
+    tokens: Vec<StrictRestoreToken>,
+) -> RestoredTextWithProvenance {
     let mut restored = String::with_capacity(text.len());
     let mut authorized_output_ranges = Vec::<Range<usize>>::with_capacity(tokens.len());
     let mut cursor = 0usize;
@@ -1213,10 +1234,85 @@ fn restore_strict_text_with_provenance_from_state(
         cursor = token.end;
     }
     restored.push_str(&text[cursor..]);
-    Ok(RestoredTextWithProvenance {
+    RestoredTextWithProvenance {
         text: restored,
         authorized_output_ranges,
-    })
+    }
+}
+
+fn assess_restore_text_from_state(state: &SessionState, text: &str) -> Result<RestoreAssessment> {
+    // Substitution and classification share one immutable manifest generation.
+    let regex = match &state.restore_regex_cache {
+        Some((generation, regex)) if *generation == state.generation => Some(Arc::clone(regex)),
+        _ => build_restore_regex(state)?,
+    };
+    let tokens = regex
+        .as_ref()
+        .map(|regex| {
+            regex
+                .find_iter(text)
+                .map(|matched| StrictRestoreToken {
+                    start: matched.start(),
+                    end: matched.end(),
+                    parsed: parsed_restore_token(matched.as_str()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let restored = restore_tokens_with_provenance(state, text, tokens);
+    Ok(classify_restore_output(state, restored))
+}
+
+fn classify_restore_output(
+    state: &SessionState,
+    restored: RestoredTextWithProvenance,
+) -> RestoreAssessment {
+    let mut unknown_tokens = Vec::new();
+    let mut manifest_bypass_count = 0;
+    let mut trap_shape_count = 0;
+    let mut cursor = 0;
+    for matched in crate::token_shape::pattern().find_iter(&restored.text) {
+        let trap = crate::token_shape::is_trap(matched.as_str());
+        trap_shape_count += u64::from(trap);
+        while restored
+            .authorized_output_ranges
+            .get(cursor)
+            .is_some_and(|range| range.end <= matched.start())
+        {
+            cursor += 1;
+        }
+        if restored
+            .authorized_output_ranges
+            .get(cursor)
+            .is_some_and(|range| range.start <= matched.start() && matched.end() <= range.end)
+        {
+            continue;
+        }
+        if trap {
+            manifest_bypass_count += 1;
+        } else if !state.value_by_token.contains_key(matched.as_str()) {
+            unknown_tokens.push(matched.as_str().to_owned());
+        }
+    }
+    RestoreAssessment {
+        restored,
+        unknown_tokens,
+        manifest_bypass_count,
+        trap_shape_count,
+    }
+}
+
+fn restore_classified_strict_text_from_state(
+    state: &SessionState,
+    text: &str,
+) -> Result<RestoredTextWithProvenance> {
+    // Keep malformed/nested input rejection before any owner-side substitution.
+    strict_restore_tokens(text)?;
+    let assessment = assess_restore_text_from_state(state, text)?;
+    if let Some(unknown) = assessment.unknown_tokens.first() {
+        return Err(unknown_token_error(unknown));
+    }
+    Ok(assessment.restored)
 }
 
 fn validate_token_shapes_from_state(

--- a/crates/gaze/src/token_shape.rs
+++ b/crates/gaze/src/token_shape.rs
@@ -104,6 +104,23 @@ pub fn is_trap(match_text: &str) -> bool {
     !starts_with_session_prefix(match_text)
 }
 
+/// Whether a token-shape match is only a broad bare identifier literal.
+/// Wrapped, prefixed, and legacy emitted formats still require manifest authority.
+/// This does not narrow the global token-shape grammar or its DLP consumers.
+pub fn is_bare_identifier(match_text: &str) -> bool {
+    let Some((name, ordinal)) = match_text.rsplit_once('_') else {
+        return false;
+    };
+    name.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+        && name.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        && !ordinal.is_empty()
+        && ordinal.bytes().all(|byte| byte.is_ascii_digit())
+        // Built-in class names also identify legacy bracketless placeholders.
+        && !BUILTIN_CLASS_NAMES.iter().any(|class| {
+            name == *class || name == class.to_ascii_lowercase()
+        })
+}
+
 fn build_pattern() -> String {
     let builtin_alt = BUILTIN_CLASS_NAMES.join("|");
     let builtin_lower_alt = BUILTIN_CLASS_NAMES

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -149,7 +149,7 @@ fn restore_text_ignores_unicode_digits_in_innocent_token_like_text() {
 fn restore_strict_text_still_rejects_ascii_shaped_unknown_token() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let err = session
-        .restore_strict_text("Email_999")
+        .restore_strict_text("<deadbeef:Email_999>")
         .expect_err("strict restore must reject absent ASCII token shapes");
 
     match err {
@@ -160,7 +160,7 @@ fn restore_strict_text_still_rejects_ascii_shaped_unknown_token() {
         } => {
             assert_eq!(class, PiiClass::Email);
             assert_eq!(ordinal, 999);
-            assert_eq!(raw, "Email_999");
+            assert_eq!(raw, "<deadbeef:Email_999>");
         }
         other => panic!("expected UnknownToken, got {other:?}"),
     }
@@ -172,24 +172,9 @@ fn token_shape_finds_bare_generic_literal_in_raw_text() {
 }
 
 #[test]
-fn restore_strict_text_rejects_bare_generic_unknown_token() {
+fn restore_strict_text_accepts_bare_generic_literal() {
     let session = Session::new(Scope::Ephemeral).expect("session");
-    let err = session
-        .restore_strict_text("a_0%")
-        .expect_err("strict restore must reject unmanifested bare generic token shapes");
-
-    match err {
-        Error::UnknownToken {
-            class,
-            ordinal,
-            raw,
-        } => {
-            assert_eq!(class, PiiClass::Custom("a".to_string()));
-            assert_eq!(ordinal, 0);
-            assert_eq!(raw, "a_0");
-        }
-        other => panic!("expected UnknownToken, got {other:?}"),
-    }
+    assert_eq!(session.restore_strict_text("a_0%").unwrap(), "a_0%");
 }
 
 #[test]

--- a/crates/gaze/tests/prop_manifest_invariants.rs
+++ b/crates/gaze/tests/prop_manifest_invariants.rs
@@ -11,6 +11,15 @@ use gaze_recognizers::RegexDetector;
 use proptest::prelude::*;
 use proptest::test_runner::Config as ProptestConfig;
 
+#[path = "support/restore_filler.rs"]
+mod restore_filler;
+
+#[test]
+fn generated_corpus_contains_identifier_literals() {
+    restore_filler::assert_identifier_coverage(restore_filler::filler());
+    restore_filler::assert_identifier_coverage(document_case().prop_map(|case| case.text));
+}
+
 #[derive(Debug, Clone)]
 struct DocumentCase {
     text: String,
@@ -50,25 +59,7 @@ fn deterministic_pipeline() -> Pipeline {
 }
 
 fn filler_segment() -> impl Strategy<Value = Segment> {
-    proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
-        .expect("valid filler regex")
-        .prop_filter(
-            "filler contains no tracked PII, restore-token delimiters, or prefixed placeholders",
-            |text| {
-                !text.contains('@')
-                    && !text.contains('<')
-                    && !text.contains('>')
-                    && !text.contains("+1-555")
-                    && !text.contains("+44-7700")
-                    && !text.contains("+49 1555")
-                    && !text.contains("Dr. Schmidt")
-                    // Bare identifiers are ordinary source text. Only prefixed
-                    // placeholders require an active manifest grant.
-                    && !gaze::token_shape::pattern().find_iter(text).any(|matched|
-                        gaze::token_shape::starts_with_session_prefix(matched.as_str()))
-            },
-        )
-        .prop_map(Segment::Filler)
+    restore_filler::filler().prop_map(Segment::Filler)
 }
 
 fn detected_pii_segment() -> impl Strategy<Value = Segment> {
@@ -83,8 +74,7 @@ fn detected_pii_segment() -> impl Strategy<Value = Segment> {
 
 fn document_case() -> impl Strategy<Value = DocumentCase> {
     prop::collection::vec(
-        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment(),
-            2 => "[A-Za-z][a-z]{1,8}_[0-9]{1,5}".prop_map(Segment::Filler)],
+        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment()],
         1..24,
     )
     .prop_map(|segments| {

--- a/crates/gaze/tests/prop_manifest_invariants.rs
+++ b/crates/gaze/tests/prop_manifest_invariants.rs
@@ -53,7 +53,7 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
     proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
         .expect("valid filler regex")
         .prop_filter(
-            "filler contains no tracked PII, restore-token delimiters, or token-shaped literals",
+            "filler contains no tracked PII, restore-token delimiters, or prefixed placeholders",
             |text| {
                 !text.contains('@')
                     && !text.contains('<')
@@ -62,11 +62,10 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
                     && !text.contains("+44-7700")
                     && !text.contains("+49 1555")
                     && !text.contains("Dr. Schmidt")
-                    // Random filler can spell a bracketless token shape (e.g. `j_6`),
-                    // which strict restore correctly rejects fail-closed as an
-                    // `UnknownToken`. Exclude anything the product's own token-shape
-                    // DLP net would trap so the round-trip invariant holds.
-                    && !gaze::token_shape::contains_token(text)
+                    // Bare identifiers are ordinary source text. Only prefixed
+                    // placeholders require an active manifest grant.
+                    && !gaze::token_shape::pattern().find_iter(text).any(|matched|
+                        gaze::token_shape::starts_with_session_prefix(matched.as_str()))
             },
         )
         .prop_map(Segment::Filler)
@@ -84,7 +83,8 @@ fn detected_pii_segment() -> impl Strategy<Value = Segment> {
 
 fn document_case() -> impl Strategy<Value = DocumentCase> {
     prop::collection::vec(
-        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment()],
+        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment(),
+            2 => "[A-Za-z][a-z]{1,8}_[0-9]{1,5}".prop_map(Segment::Filler)],
         1..24,
     )
     .prop_map(|segments| {

--- a/crates/gaze/tests/prop_roundtrip.rs
+++ b/crates/gaze/tests/prop_roundtrip.rs
@@ -10,6 +10,15 @@ use gaze_recognizers::RegexDetector;
 use proptest::prelude::*;
 use proptest::test_runner::Config as ProptestConfig;
 
+#[path = "support/restore_filler.rs"]
+mod restore_filler;
+
+#[test]
+fn generated_corpus_contains_identifier_literals() {
+    restore_filler::assert_identifier_coverage(restore_filler::filler());
+    restore_filler::assert_identifier_coverage(document_case().prop_map(|case| case.text));
+}
+
 #[derive(Debug, Clone)]
 struct DocumentCase {
     text: String,
@@ -50,25 +59,7 @@ fn deterministic_pipeline() -> Pipeline {
 }
 
 fn filler_segment() -> impl Strategy<Value = Segment> {
-    proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
-        .expect("valid filler regex")
-        .prop_filter(
-            "filler contains no tracked PII, restore-token delimiters, or prefixed placeholders",
-            |text| {
-                !text.contains('@')
-                    && !text.contains('<')
-                    && !text.contains('>')
-                    && !text.contains("+1-555")
-                    && !text.contains("+44-7700")
-                    && !text.contains("+49 1555")
-                    && !text.contains("Dr. Schmidt")
-                    // Bare identifiers are ordinary source text. Only prefixed
-                    // placeholders require an active manifest grant.
-                    && !gaze::token_shape::pattern().find_iter(text).any(|matched|
-                        gaze::token_shape::starts_with_session_prefix(matched.as_str()))
-            },
-        )
-        .prop_map(Segment::Filler)
+    restore_filler::filler().prop_map(Segment::Filler)
 }
 
 fn detected_pii_segment() -> impl Strategy<Value = Segment> {
@@ -83,8 +74,7 @@ fn detected_pii_segment() -> impl Strategy<Value = Segment> {
 
 fn document_case() -> impl Strategy<Value = DocumentCase> {
     prop::collection::vec(
-        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment(),
-            2 => "[A-Za-z][a-z]{1,8}_[0-9]{1,5}".prop_map(Segment::Filler)],
+        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment()],
         1..24,
     )
     .prop_map(|segments| {

--- a/crates/gaze/tests/prop_roundtrip.rs
+++ b/crates/gaze/tests/prop_roundtrip.rs
@@ -53,7 +53,7 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
     proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
         .expect("valid filler regex")
         .prop_filter(
-            "filler contains no tracked PII, restore-token delimiters, or token-shaped literals",
+            "filler contains no tracked PII, restore-token delimiters, or prefixed placeholders",
             |text| {
                 !text.contains('@')
                     && !text.contains('<')
@@ -62,11 +62,10 @@ fn filler_segment() -> impl Strategy<Value = Segment> {
                     && !text.contains("+44-7700")
                     && !text.contains("+49 1555")
                     && !text.contains("Dr. Schmidt")
-                    // Random filler can spell a bracketless token shape (e.g. `j_6`),
-                    // which strict restore correctly rejects fail-closed as an
-                    // `UnknownToken`. Exclude anything the product's own token-shape
-                    // DLP net would trap so the round-trip invariant holds.
-                    && !gaze::token_shape::contains_token(text)
+                    // Bare identifiers are ordinary source text. Only prefixed
+                    // placeholders require an active manifest grant.
+                    && !gaze::token_shape::pattern().find_iter(text).any(|matched|
+                        gaze::token_shape::starts_with_session_prefix(matched.as_str()))
             },
         )
         .prop_map(Segment::Filler)
@@ -84,7 +83,8 @@ fn detected_pii_segment() -> impl Strategy<Value = Segment> {
 
 fn document_case() -> impl Strategy<Value = DocumentCase> {
     prop::collection::vec(
-        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment()],
+        prop_oneof![5 => filler_segment(), 2 => detected_pii_segment(),
+            2 => "[A-Za-z][a-z]{1,8}_[0-9]{1,5}".prop_map(Segment::Filler)],
         1..24,
     )
     .prop_map(|segments| {

--- a/crates/gaze/tests/restore_counter_split.rs
+++ b/crates/gaze/tests/restore_counter_split.rs
@@ -236,6 +236,26 @@ fn strict_session_malformed_nested_and_atomic_failure_contracts_remain() {
 }
 
 #[test]
+fn incomplete_prefixed_wrappers_fail_shared_assessment() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    for text in [
+        "<deadbeef:Email_1 suffix",
+        "<deadbeef:Custom:class_alpha_1 suffix",
+    ] {
+        assert_unknown(&session, text);
+        let token = session
+            .tokenize(&PiiClass::custom("class_alpha"), text)
+            .unwrap();
+        assert_success(&session, &token, text, 0);
+        let (_, telemetry) = pipeline()
+            .restore_with_telemetry(&session, &format!("{token} {text}"))
+            .unwrap();
+        assert_eq!(telemetry.unknown_token_count, 1);
+        assert_eq!(telemetry.manifest_bypass_count, 0);
+    }
+}
+
+#[test]
 fn strict_literal_restore_survives_existing_snapshot_format() {
     let session = Session::new(Scope::Conversation("synthetic-restore".into())).unwrap();
     let raw = "Kunde_7 alice@example.invalid";

--- a/crates/gaze/tests/restore_counter_split.rs
+++ b/crates/gaze/tests/restore_counter_split.rs
@@ -331,14 +331,18 @@ fn differential_enumeration_only_relaxes_bare_identifiers_and_authorized_output(
         "own_mapped",
         "own_unmapped",
         "foreign",
-        "legacy",
+        "legacy_wrapped",
         "fp_mapped",
         "fp_foreign",
         "authorized_trap",
         "authorized_prefixed",
         "fp_own_unmapped",
+        "legacy_lowercase",
+        "legacy_email",
+        "legacy_custom",
+        "legacy_generic_wrapped",
     ];
-    let mut divergences = [0usize; 11];
+    let mut divergences = [0usize; 15];
     let p = pipeline();
     for ordinal in 1..=400 {
         let session = Session::new(Scope::Ephemeral).unwrap();
@@ -375,6 +379,10 @@ fn differential_enumeration_only_relaxes_bare_identifiers_and_authorized_output(
             trap,
             authorized,
             format!("email{}.{own}@gaze-fake.invalid", ordinal + 1000),
+            format!("location_{ordinal}"),
+            format!("email{ordinal}@gaze-fake.invalid"),
+            format!("custom:class_alpha_{ordinal}"),
+            format!("<literal_{ordinal}>"),
         ];
         for (category, input) in inputs.iter().enumerate() {
             let (restored, telemetry) = p.restore_with_telemetry(&session, input).unwrap();
@@ -385,7 +393,7 @@ fn differential_enumeration_only_relaxes_bare_identifiers_and_authorized_output(
                 });
             let new_failed = telemetry.restore_decision == RestoreDecision::Failed;
             let expected_old = !matches!(category, 2 | 6);
-            let expected_new = matches!(category, 3 | 4 | 5 | 7 | 10);
+            let expected_new = matches!(category, 3 | 4 | 5 | 7 | 10..=14);
             assert_eq!(old_failed, expected_old, "old {}", labels[category]);
             assert_eq!(new_failed, expected_new, "new {}", labels[category]);
             if old_failed != new_failed {
@@ -395,7 +403,10 @@ fn differential_enumeration_only_relaxes_bare_identifiers_and_authorized_output(
             }
         }
     }
-    assert_eq!(divergences, [400, 400, 0, 0, 0, 0, 0, 0, 400, 400, 0]);
+    assert_eq!(
+        divergences,
+        [400, 400, 0, 0, 0, 0, 0, 0, 400, 400, 0, 0, 0, 0, 0]
+    );
     for (label, count) in labels.iter().zip(divergences) {
         println!("{label}: cases=400 failed_to_success={count}");
     }

--- a/crates/gaze/tests/restore_counter_split.rs
+++ b/crates/gaze/tests/restore_counter_split.rs
@@ -66,22 +66,55 @@ fn strict_restore_accepts_lowercase_log_identifiers() {
 #[test]
 fn strict_roundtrip_accepts_authorized_value_containing_shape() {
     let session = Session::new(Scope::Ephemeral).unwrap();
-    for raw in ["record ORDER_12345", "record <deadbeef:Email_999>"] {
+    for raw in [
+        "record ORDER_12345",
+        "record <deadbeef:Email_999>",
+        "record <Email_1>",
+        "record location_7",
+    ] {
         let token = session.tokenize(&PiiClass::custom("record"), raw).unwrap();
         assert_success(&session, &format!("π/{token}."), &format!("π/{raw}."), 0);
     }
 }
 
 #[test]
-fn strict_restore_counts_legacy_placeholder_without_blocking() {
+fn strict_restore_rejects_unmapped_canonical_legacy_formats() {
     let session = Session::new(Scope::Ephemeral).unwrap();
     for text in [
         "<Email_1>",
         "<Name_99>",
+        "<Foo_5>",
+        "<foo_1>",
+        "<Custom:class_alpha_1>",
+        "custom:class_alpha_1",
+        "Email_7",
         "email1@example.test",
+        "email1@gaze-fake.invalid",
         "location_7",
+        "name_1",
+        "organization_1",
+        "email_1",
     ] {
-        assert_success(&session, text, text, 1);
+        assert_unknown(&session, text);
+    }
+}
+
+#[test]
+fn appended_canonical_placeholders_fail_after_valid_clean() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let p = pipeline();
+    let clean = clean(&p, &session, "alice@example.invalid");
+    for unknown in [
+        "<Email_1>".to_string(),
+        format!("<{}:Email_999>", session.session_hex()),
+        "<deadbeef:Email_999>".to_string(),
+    ] {
+        let input = format!("{clean} {unknown}");
+        let (_, telemetry) = p.restore_with_telemetry(&session, &input).unwrap();
+        assert_eq!(telemetry.restore_decision, RestoreDecision::Failed);
+        assert_eq!(telemetry.unknown_token_count, 1);
+        assert_eq!(telemetry.manifest_bypass_count, 0);
+        assert!(session.restore_strict_text(&input).is_err());
     }
 }
 
@@ -270,7 +303,7 @@ fn synthetic_trace_matches_production_restore_decision() {
 }
 
 #[test]
-fn differential_enumeration_only_relaxes_traps_and_authorized_output() {
+fn differential_enumeration_only_relaxes_bare_identifiers_and_authorized_output() {
     // Expected directions come from the counter-split contract, independently of the classifier.
     let labels = [
         "bare_upper",
@@ -332,17 +365,17 @@ fn differential_enumeration_only_relaxes_traps_and_authorized_output() {
                 });
             let new_failed = telemetry.restore_decision == RestoreDecision::Failed;
             let expected_old = !matches!(category, 2 | 6);
-            let expected_new = matches!(category, 3 | 4 | 7 | 10);
+            let expected_new = matches!(category, 3 | 4 | 5 | 7 | 10);
             assert_eq!(old_failed, expected_old, "old {}", labels[category]);
             assert_eq!(new_failed, expected_new, "new {}", labels[category]);
             if old_failed != new_failed {
                 assert!(old_failed && !new_failed);
-                assert!(matches!(category, 0 | 1 | 5 | 8 | 9));
+                assert!(matches!(category, 0 | 1 | 8 | 9));
                 divergences[category] += 1;
             }
         }
     }
-    assert_eq!(divergences, [400, 400, 0, 0, 0, 400, 0, 0, 400, 400, 0]);
+    assert_eq!(divergences, [400, 400, 0, 0, 0, 0, 0, 0, 400, 400, 0]);
     for (label, count) in labels.iter().zip(divergences) {
         println!("{label}: cases=400 failed_to_success={count}");
     }

--- a/crates/gaze/tests/restore_counter_split.rs
+++ b/crates/gaze/tests/restore_counter_split.rs
@@ -1,0 +1,347 @@
+#![cfg(feature = "bundled-recognizers")]
+
+use gaze::{
+    Action, ClassRule, CleanDocument, DefaultRule, DictionaryBundle, PiiClass, Pipeline,
+    RawDocument, RestoreDecision, RestorePolicy, RestoreTelemetry, SafetyNetPolicy, Scope, Session,
+};
+use gaze_recognizers::RegexDetector;
+
+fn pipeline() -> Pipeline {
+    Pipeline::builder()
+        .detector(RegexDetector::emails().unwrap())
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+
+fn clean(pipeline: &Pipeline, session: &Session, raw: &str) -> String {
+    let (CleanDocument::Text(text), _, _) = pipeline
+        .clean_with_safety_net(session, RawDocument::Text(raw.into()), &[])
+        .unwrap()
+    else {
+        panic!("text document")
+    };
+    text
+}
+
+fn assert_success(session: &Session, input: &str, expected: &str, bypass: u64) {
+    let (restored, telemetry) = pipeline().restore_with_telemetry(session, input).unwrap();
+    assert_eq!(restored.text, expected);
+    assert_eq!(telemetry.restore_decision, RestoreDecision::Success);
+    assert_eq!(telemetry.unknown_token_count, 0);
+    assert_eq!(telemetry.manifest_bypass_count, bypass);
+    assert_eq!(session.restore_strict_text(input).unwrap(), expected);
+    assert_eq!(
+        session.restore_strict_text_with_events(input).unwrap().0,
+        expected
+    );
+}
+
+#[test]
+fn strict_roundtrip_accepts_original_bare_literal_en() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let raw = "Keep FOO_12 and ORDER_12345; email alice@example.invalid.";
+    assert_success(&session, &clean(&pipeline(), &session, raw), raw, 2);
+}
+
+#[test]
+fn strict_roundtrip_accepts_original_bare_literal_de() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let raw = "Grüße: Kunde_7 bleibt; Kontakt alice@example.invalid.";
+    assert_success(&session, &clean(&pipeline(), &session, raw), raw, 1);
+}
+
+#[test]
+fn strict_restore_accepts_lowercase_log_identifiers() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    assert_success(
+        &session,
+        "run_1 finished, see log_2",
+        "run_1 finished, see log_2",
+        2,
+    );
+}
+
+#[test]
+fn strict_roundtrip_accepts_authorized_value_containing_shape() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    for raw in ["record ORDER_12345", "record <deadbeef:Email_999>"] {
+        let token = session.tokenize(&PiiClass::custom("record"), raw).unwrap();
+        assert_success(&session, &format!("π/{token}."), &format!("π/{raw}."), 0);
+    }
+}
+
+#[test]
+fn strict_restore_counts_legacy_placeholder_without_blocking() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    for text in [
+        "<Email_1>",
+        "<Name_99>",
+        "email1@example.test",
+        "location_7",
+    ] {
+        assert_success(&session, text, text, 1);
+    }
+}
+
+fn assert_unknown(session: &Session, text: &str) {
+    for (policy, decision) in [
+        (RestorePolicy::Strict, RestoreDecision::Failed),
+        (RestorePolicy::Lenient, RestoreDecision::Partial),
+    ] {
+        let (restored, telemetry) = pipeline()
+            .restore_with_policy_telemetry(session, text, policy)
+            .unwrap();
+        assert_eq!(restored.text, text);
+        assert_eq!(telemetry.restore_decision, decision);
+        assert_eq!(telemetry.unknown_token_count, 1);
+        assert_eq!(telemetry.manifest_bypass_count, 0);
+    }
+    assert!(session.restore_strict_text(text).is_err());
+    assert!(session.restore_strict_text_with_events(text).is_err());
+}
+
+#[test]
+fn strict_restore_rejects_missing_own_mapping() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    session
+        .tokenize(&PiiClass::Email, "alice@example.invalid")
+        .unwrap();
+    assert_unknown(&session, &format!("<{}:Email_999>", session.session_hex()));
+}
+
+#[test]
+fn strict_restore_rejects_foreign_session_token_in_every_format() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let foreign = Session::new(Scope::Ephemeral).unwrap();
+    for class in [PiiClass::Email, PiiClass::Name, PiiClass::custom("record")] {
+        assert_unknown(
+            &session,
+            &foreign.tokenize(&class, "synthetic value").unwrap(),
+        );
+        assert_unknown(
+            &session,
+            &foreign
+                .format_preserving_fake(&class, "synthetic value")
+                .unwrap(),
+        );
+    }
+}
+
+#[test]
+fn strict_restore_rejects_new_same_prefix_but_audits_generic_shapes() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    assert_unknown(
+        &session,
+        &format!("{}:custom:record_987654", session.session_hex()),
+    );
+    assert_success(&session, "FOO_13", "FOO_13", 1);
+}
+
+#[test]
+fn lenient_restore_counters_are_independent_and_deterministic() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let input = format!("FOO_12 run_1 <{}:Email_999>", session.session_hex());
+    let p = pipeline();
+    let (_, a) = p
+        .restore_with_policy_telemetry(&session, &input, RestorePolicy::Lenient)
+        .unwrap();
+    let (_, b) = p
+        .restore_with_policy_telemetry(&session, &input, RestorePolicy::Lenient)
+        .unwrap();
+    assert_eq!(a, b);
+    assert_eq!(a.unknown_token_count, 1);
+    assert_eq!(a.manifest_bypass_count, 2);
+    assert_eq!(a.restore_decision, RestoreDecision::Partial);
+    assert_eq!(a.fresh_pii_detected_count, 0);
+    assert_eq!(
+        a.phase_execution_mask & gaze_types::RESTORE_PHASE_FRESH_PII_SCAN,
+        0
+    );
+    let (_, literal) = p
+        .restore_with_policy_telemetry(&session, "FOO_12", RestorePolicy::Lenient)
+        .unwrap();
+    assert_eq!(literal.restore_decision, RestoreDecision::Success);
+}
+
+#[test]
+fn authorized_ranges_do_not_exempt_adjacent_or_boundary_composed_unknowns() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let raw = "<deadbeef:Email_999>";
+    let token = session.tokenize(&PiiClass::Name, raw).unwrap();
+    let input = format!("{token} {raw}");
+    let (_, telemetry) = pipeline().restore_with_telemetry(&session, &input).unwrap();
+    assert_eq!(telemetry.unknown_token_count, 1);
+    assert_eq!(telemetry.restore_decision, RestoreDecision::Failed);
+    assert!(session.restore_strict_text(&input).is_err());
+
+    let prefix = session.tokenize(&PiiClass::Location, "deadbeef:").unwrap();
+    let seam = format!("{prefix}email_999");
+    let (_, telemetry) = pipeline().restore_with_telemetry(&session, &seam).unwrap();
+    assert_eq!(telemetry.unknown_token_count, 1);
+    assert_eq!(telemetry.restore_decision, RestoreDecision::Failed);
+    assert!(session.restore_strict_text(&seam).is_err());
+}
+
+#[test]
+fn strict_session_malformed_nested_and_atomic_failure_contracts_remain() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let token = session
+        .tokenize(&PiiClass::Email, "alice@example.invalid")
+        .unwrap();
+    for input in [
+        "<Email_>".to_string(),
+        format!("<{token}>"),
+        format!("{token} <deadbeef:Email_999>"),
+    ] {
+        assert!(session.restore_strict_text(&input).is_err());
+        assert!(session.restore_strict_text_with_events(&input).is_err());
+    }
+}
+
+#[test]
+fn strict_literal_restore_survives_existing_snapshot_format() {
+    let session = Session::new(Scope::Conversation("synthetic-restore".into())).unwrap();
+    let raw = "Kunde_7 alice@example.invalid";
+    let clean = clean(&pipeline(), &session, raw);
+    let blob = session.export().unwrap();
+    let imported = Session::import(blob).unwrap();
+    assert_success(&imported, &clean, raw, 1);
+}
+
+#[test]
+fn restore_telemetry_serde_legacy_defaults_and_decision_spellings() {
+    let legacy = serde_json::json!({
+        "unknown_token_count": 0, "manifest_bypass_count": 1,
+        "fresh_pii_detected_count": 0, "restore_policy": "strict",
+        "restore_decision": "success", "phase_execution_mask": 7
+    });
+    let decoded: RestoreTelemetry = serde_json::from_value(legacy).unwrap();
+    let serialized = serde_json::to_value(&decoded).unwrap();
+    assert_eq!(serialized["trap_shape_count"], 0);
+    assert_eq!(
+        serde_json::from_value::<RestoreTelemetry>(serialized).unwrap(),
+        decoded
+    );
+    for (decision, spelling) in [
+        (RestoreDecision::Success, "success"),
+        (RestoreDecision::Partial, "partial"),
+        (RestoreDecision::Failed, "failed"),
+    ] {
+        assert_eq!(serde_json::to_value(decision).unwrap(), spelling);
+    }
+}
+
+#[test]
+fn synthetic_trace_matches_production_restore_decision() {
+    let p = pipeline();
+    for raw in [
+        "Keep FOO_12; alice@example.invalid",
+        "Grüße Kunde_7; alice@example.invalid",
+    ] {
+        for traced in [false, true] {
+            let session = Session::new(Scope::Ephemeral).unwrap();
+            let clean = if traced {
+                let (CleanDocument::Text(text), _, _, _) = p
+                    .clean_text_with_safety_net_policy_detect_context_and_protection_trace(
+                        &session,
+                        raw,
+                        &[],
+                        &DictionaryBundle::default(),
+                        SafetyNetPolicy::default(),
+                    )
+                    .unwrap()
+                else {
+                    panic!("text")
+                };
+                text
+            } else {
+                clean(&p, &session, raw)
+            };
+            assert_success(&session, &clean, raw, 1);
+            let input = format!("{clean} <deadbeef:Email_999>");
+            let (_, telemetry) = p.restore_with_telemetry(&session, &input).unwrap();
+            assert_eq!(telemetry.restore_decision, RestoreDecision::Failed);
+        }
+    }
+}
+
+#[test]
+fn differential_enumeration_only_relaxes_traps_and_authorized_output() {
+    // Expected directions come from the counter-split contract, independently of the classifier.
+    let labels = [
+        "bare_upper",
+        "bare_lower",
+        "own_mapped",
+        "own_unmapped",
+        "foreign",
+        "legacy",
+        "fp_mapped",
+        "fp_foreign",
+        "authorized_trap",
+        "authorized_prefixed",
+        "fp_own_unmapped",
+    ];
+    let mut divergences = [0usize; 11];
+    let p = pipeline();
+    for ordinal in 1..=400 {
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        let own = session.session_hex();
+        let foreign = if own == "deadbeef" {
+            "cafebabe"
+        } else {
+            "deadbeef"
+        };
+        let mapped = session
+            .tokenize(&PiiClass::Email, "alice@example.invalid")
+            .unwrap();
+        let fp = session
+            .format_preserving_fake(&PiiClass::Name, "Dr. Schmidt")
+            .unwrap();
+        let trap = session
+            .tokenize(&PiiClass::custom("record"), &format!("ORDER_{ordinal}"))
+            .unwrap();
+        let authorized = session
+            .tokenize(
+                &PiiClass::custom("reference"),
+                &format!("<{foreign}:Email_{ordinal}>"),
+            )
+            .unwrap();
+        let inputs = [
+            format!("FOO_{ordinal}"),
+            format!("run_{ordinal}"),
+            mapped,
+            format!("<{own}:Email_{}>", ordinal + 1000),
+            format!("<{foreign}:Email_{ordinal}>"),
+            format!("<Email_{ordinal}>"),
+            fp,
+            format!("email{ordinal}.{foreign}@gaze-fake.invalid"),
+            trap,
+            authorized,
+            format!("email{}.{own}@gaze-fake.invalid", ordinal + 1000),
+        ];
+        for (category, input) in inputs.iter().enumerate() {
+            let (restored, telemetry) = p.restore_with_telemetry(&session, input).unwrap();
+            let old_failed = gaze::token_shape::pattern()
+                .find_iter(&restored.text)
+                .any(|m| {
+                    gaze::token_shape::is_trap(m.as_str()) || !session.contains_token(m.as_str())
+                });
+            let new_failed = telemetry.restore_decision == RestoreDecision::Failed;
+            let expected_old = !matches!(category, 2 | 6);
+            let expected_new = matches!(category, 3 | 4 | 7 | 10);
+            assert_eq!(old_failed, expected_old, "old {}", labels[category]);
+            assert_eq!(new_failed, expected_new, "new {}", labels[category]);
+            if old_failed != new_failed {
+                assert!(old_failed && !new_failed);
+                assert!(matches!(category, 0 | 1 | 5 | 8 | 9));
+                divergences[category] += 1;
+            }
+        }
+    }
+    assert_eq!(divergences, [400, 400, 0, 0, 0, 400, 0, 0, 400, 400, 0]);
+    for (label, count) in labels.iter().zip(divergences) {
+        println!("{label}: cases=400 failed_to_success={count}");
+    }
+}

--- a/crates/gaze/tests/restore_counter_split.rs
+++ b/crates/gaze/tests/restore_counter_split.rs
@@ -192,6 +192,8 @@ fn strict_session_malformed_nested_and_atomic_failure_contracts_remain() {
         .unwrap();
     for input in [
         "<Email_>".to_string(),
+        "<deadbeef:Email_1 suffix".to_string(),
+        "<deadbeef:Custom:record_1 suffix".to_string(),
         format!("<{token}>"),
         format!("{token} <deadbeef:Email_999>"),
     ] {

--- a/crates/gaze/tests/support/restore_filler.rs
+++ b/crates/gaze/tests/support/restore_filler.rs
@@ -1,0 +1,39 @@
+use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
+
+pub fn filler() -> impl Strategy<Value = String> {
+    prop_oneof![
+        5 => proptest::string::string_regex(r"[\p{L}\p{N}\p{P}\p{Z}\p{M}\x{1F600}-\x{1F64F}]{0,40}")
+            .expect("valid filler regex"),
+        2 => "[A-Za-z][a-z]{1,8}_[0-9]{1,5}",
+    ]
+    .prop_filter("no tracked PII or canonical placeholders", |text| {
+        !text.contains('@')
+            && !text.contains('<')
+            && !text.contains('>')
+            && !text.contains("+1-555")
+            && !text.contains("+44-7700")
+            && !text.contains("+49 1555")
+            && !text.contains("Dr. Schmidt")
+            && !gaze::token_shape::pattern()
+                .find_iter(text)
+                .any(|matched| gaze::token_shape::starts_with_session_prefix(matched.as_str()))
+    })
+}
+
+pub fn assert_identifier_coverage(strategy: impl Strategy<Value = String>) {
+    let mut runner = TestRunner::deterministic();
+    let identifier = regex::Regex::new(r"\b[A-Za-z][A-Za-z0-9_]*_[0-9]+\b").unwrap();
+    let count = (0..128)
+        .map(|_| {
+            strategy
+                .new_tree(&mut runner)
+                .expect("generated case")
+                .current()
+        })
+        .filter(|text| identifier.is_match(text))
+        .count();
+    assert!(count > 0, "filtered corpus lost identifier-shaped literals");
+    println!("identifier-shaped cases: {count}/128");
+}

--- a/crates/gaze/tests/support/restore_filler.rs
+++ b/crates/gaze/tests/support/restore_filler.rs
@@ -18,7 +18,7 @@ pub fn filler() -> impl Strategy<Value = String> {
             && !text.contains("Dr. Schmidt")
             && !gaze::token_shape::pattern()
                 .find_iter(text)
-                .any(|matched| gaze::token_shape::starts_with_session_prefix(matched.as_str()))
+                .any(|matched| !gaze::token_shape::is_bare_identifier(matched.as_str()))
     })
 }
 

--- a/docs/explanation/core/restore-boundary.md
+++ b/docs/explanation/core/restore-boundary.md
@@ -19,7 +19,7 @@ The restore boundary is where pseudonymous content becomes owner-side sensitive 
 The invariant is:
 
 1. A sensitive value may be re-materialized only when the active restore context has a manifest entry that authorizes that exact token-to-value mapping.
-2. Unresolved session-prefixed placeholders fail closed. Session strict APIs also reject malformed and nested token syntax. Bare identifier-like text is an audit signal, never authority to re-materialize a value.
+2. Unmapped canonical placeholders and incomplete prefixed wrappers fail closed. Session strict APIs also reject malformed and nested token syntax. Bare identifier-like text is an audit signal, never authority to re-materialize a value.
 3. Restore-side checks must be deterministic and auditable. A restore decision must be traceable to the active manifest, the structural recognizer that observed unauthorized raw sensitive data, or restore telemetry metadata.
 4. Restore must not silently expand scope. If a later phase wants identity-sensitive policy, it must be explicit, opt-in, and separately approved.
 
@@ -41,16 +41,23 @@ Phase A makes the manifest the only authority for re-materialization.
 Expected behavior:
 
 - Known token in the active manifest: restore to the manifest-authorized value.
-- Unresolved token with a session prefix, including an unissued ordinal under the active prefix: return a typed restore failure.
+- Unmapped canonical placeholder, including own-prefix, foreign-prefix, legacy wrapped, and legacy emitted formats: return a typed restore failure.
+- Incomplete prefixed wrapper: return a typed restore failure.
 - Token known to another session or tenant: return a typed restore failure.
 - Malformed token: return a typed restore failure.
 
-Restore never guesses a mapping. A token-shaped value without an active manifest
-grant is not proof of authorization. Ordinary unprefixed literals such as
-`Kunde_7`, `ORDER_12345`, `run_1`, and legacy `<Email_1>` are preserved and counted
-as audit-only traps; they are not treated as unresolved session placeholders.
-This reverses the previous bare-shape blocking behavior in pipeline, Session,
-and CLI restore.
+Restore never guesses a mapping. Strict no longer blocks on bare identifier-shaped
+literals outside authorized ranges (moved to audit-only `manifest_bypass`); it still
+blocks on any unmapped canonical placeholder (own-prefix, foreign-prefix, legacy
+wrapped) and on incomplete prefixed wrappers. Legacy emitted formats such as
+`location_7`, `custom:class_alpha_1`, and `email1@gaze-fake.invalid` also remain
+blocking. Only broad bare identifiers such as `Kunde_7`, `ORDER_12345`, and `run_1`
+move to audit-only.
+
+This deliberately removes the former bare-identifier rejection boundary in
+pipeline, Session/MCP, and CLI restore. The trade improves exact round-trips and
+ordinary prose handling without granting any new token-to-value mapping. It is
+a narrower heuristic rejection net, not evidence of improved PII detection.
 
 The classifier is owned by `Session::assess_restore_text`. It restores exact
 manifest keys and scans the result using one immutable session view. Matches
@@ -65,9 +72,10 @@ The API failure contracts remain distinct:
   A positive `unknown_token_count` produces `failed` under Strict or `partial`
   under Lenient; zero produces the existing exact spelling `success`.
 - `Session::restore_strict_text`, its provenance/events variants, and the MCP
-  operator `restore_strict` tool return a typed error on unresolved prefixed
-  tokens. Session strict parsing also retains malformed/nested input rejection.
-- CLI strict restore exits 3 for unresolved prefixed tokens. Tolerant restore
+  operator `restore_strict` tool return a typed error on unmapped canonical
+  placeholders and incomplete prefixed wrappers. Session strict parsing also retains malformed/nested input rejection.
+- CLI strict restore exits 3 for unmapped canonical placeholders and incomplete
+  prefixed wrappers. Tolerant restore
   preserves them and returns warnings plus `partial` telemetry when requested.
   CLI uses the same assessment for output, warnings, telemetry, and audit.
 - Transaction token validation and committed-snapshot restore used by the proxy
@@ -92,10 +100,10 @@ Phase B distinguishes:
 Blocking behavior is deferred until telemetry shows an acceptable false-positive
 profile. Structural raw-PII checks remain audit-only and opt-in. The lightweight
 token-shape audit scan in restore telemetry is always run: `manifest_bypass_count`
-counts unprefixed trap shapes outside authorized substitutions. It is a lexical
+counts broad bare identifier shapes outside authorized substitutions. It is a lexical
 suspicion count, not proof that raw PII bypassed the manifest. It never drives
 the Strict decision. `trap_shape_count` counts all unprefixed trap matches,
-including those inside authorized values. A bare literal can therefore produce
+including canonical legacy shapes and those inside authorized values. A bare literal can therefore produce
 `unknown_token_count = 0`, `manifest_bypass_count = 1`, and `success`.
 
 Neither counter claims that a fresh-PII detector executed. The fresh-PII phase bit

--- a/docs/explanation/core/restore-boundary.md
+++ b/docs/explanation/core/restore-boundary.md
@@ -19,7 +19,7 @@ The restore boundary is where pseudonymous content becomes owner-side sensitive 
 The invariant is:
 
 1. A sensitive value may be re-materialized only when the active restore context has a manifest entry that authorizes that exact token-to-value mapping.
-2. Unknown, stale, cross-session, or malformed tokens fail closed instead of being guessed or passed through as raw values.
+2. Unresolved session-prefixed placeholders fail closed. Session strict APIs also reject malformed and nested token syntax. Bare identifier-like text is an audit signal, never authority to re-materialize a value.
 3. Restore-side checks must be deterministic and auditable. A restore decision must be traceable to the active manifest, the structural recognizer that observed unauthorized raw sensitive data, or restore telemetry metadata.
 4. Restore must not silently expand scope. If a later phase wants identity-sensitive policy, it must be explicit, opt-in, and separately approved.
 
@@ -41,11 +41,41 @@ Phase A makes the manifest the only authority for re-materialization.
 Expected behavior:
 
 - Known token in the active manifest: restore to the manifest-authorized value.
-- Unknown token: return a typed restore failure.
+- Unresolved token with a session prefix, including an unissued ordinal under the active prefix: return a typed restore failure.
 - Token known to another session or tenant: return a typed restore failure.
 - Malformed token: return a typed restore failure.
 
-The important property is that restore never guesses. A token-shaped value without an active manifest grant is not proof of authorization.
+Restore never guesses a mapping. A token-shaped value without an active manifest
+grant is not proof of authorization. Ordinary unprefixed literals such as
+`Kunde_7`, `ORDER_12345`, `run_1`, and legacy `<Email_1>` are preserved and counted
+as audit-only traps; they are not treated as unresolved session placeholders.
+This reverses the previous bare-shape blocking behavior in pipeline, Session,
+and CLI restore.
+
+The classifier is owned by `Session::assess_restore_text`. It restores exact
+manifest keys and scans the result using one immutable session view. Matches
+fully contained in `authorized_output_ranges`, the UTF-8 output ranges written
+by authorized substitutions, do not count as unknowns or manifest bypasses.
+Adjacent unknowns and matches crossing a substitution boundary remain subject
+to classification. No original-text allowlist or new snapshot state is stored.
+
+The API failure contracts remain distinct:
+
+- `Pipeline::restore_with_policy_telemetry` returns restored text and telemetry.
+  A positive `unknown_token_count` produces `failed` under Strict or `partial`
+  under Lenient; zero produces the existing exact spelling `success`.
+- `Session::restore_strict_text`, its provenance/events variants, and the MCP
+  operator `restore_strict` tool return a typed error on unresolved prefixed
+  tokens. Session strict parsing also retains malformed/nested input rejection.
+- CLI strict restore exits 3 for unresolved prefixed tokens. Tolerant restore
+  preserves them and returns warnings plus `partial` telemetry when requested.
+  CLI uses the same assessment for output, warnings, telemetry, and audit.
+- Transaction token validation and committed-snapshot restore used by the proxy
+  retain their separate strict contract. Proxy residual DLP is unchanged.
+
+A `success` decision is a restore-classification result, not a byte-equality
+claim or a detection-quality certificate. Byte-exact inverse equality and PII
+detection metrics must be evaluated independently.
 
 ## Phase B: Unauthorized Raw-PII Detection
 
@@ -59,7 +89,17 @@ Phase B distinguishes:
 - Fresh raw sensitive data: a model, tool, or integration inserts a new structural sensitive value during restore.
 - Wrong-context restore: an integration uses the wrong manifest, session, or tenant boundary.
 
-Blocking behavior is deferred until telemetry shows an acceptable false-positive profile. v0.10 Phase B records evidence without turning restore into a broad judgment layer.
+Blocking behavior is deferred until telemetry shows an acceptable false-positive
+profile. Structural raw-PII checks remain audit-only and opt-in. The lightweight
+token-shape audit scan in restore telemetry is always run: `manifest_bypass_count`
+counts unprefixed trap shapes outside authorized substitutions. It is a lexical
+suspicion count, not proof that raw PII bypassed the manifest. It never drives
+the Strict decision. `trap_shape_count` counts all unprefixed trap matches,
+including those inside authorized values. A bare literal can therefore produce
+`unknown_token_count = 0`, `manifest_bypass_count = 1`, and `success`.
+
+Neither counter claims that a fresh-PII detector executed. The fresh-PII phase bit
+remains unset when that detector did not run.
 
 ## Phase D: Restore Audit Telemetry
 
@@ -73,7 +113,13 @@ Telemetry should support questions like:
 - Which structural recognizer observed unauthorized raw sensitive data?
 - Was Phase B running in audit-only mode?
 
-The audit surface must preserve Gaze's existing trust posture: no raw sensitive values in audit rows, explicit provenance, and closed typed outcomes where practical.
+The audit surface contains counts and existing decision/policy spellings, never
+matched text, offsets, original values, or hashes of those values. The additive
+`restore_trap_shape_count` audit column is nullable for historical rows; existing
+rows are not rewritten. Telemetry JSON defaults a missing `trap_shape_count` to
+zero for compatibility. Session snapshot payload versions and token grammar
+are unchanged. See the [metrics reference](../../reference/metrics.md#restore-telemetry)
+for field semantics.
 
 ## Risks Addressed By Phase A And Phase B
 

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -752,12 +752,12 @@ selected with `--audit-db`. The counter split and `trap_shape_count` are Unrelea
 
 | Field | Meaning | Audit column |
 |---|---|---|
-| `unknown_token_count` | Session-prefixed token-shape matches absent from the active map and outside authorized output ranges. This alone drives Strict/Lenient decisions. | `restore_unknown_token_count` |
-| `manifest_bypass_count` | Unprefixed trap matches outside authorized output ranges. Audit-only lexical suspicion, not proof of PII bypass. | `restore_manifest_bypass_count` |
+| `unknown_token_count` | Canonical placeholders absent from the active map, plus incomplete prefixed wrappers, outside authorized output ranges. This alone drives Strict/Lenient decisions. | `restore_unknown_token_count` |
+| `manifest_bypass_count` | Broad bare identifier matches outside authorized output ranges. Audit-only lexical suspicion, not proof of PII bypass. | `restore_manifest_bypass_count` |
 | `trap_shape_count` | All unprefixed trap matches in restored text, including authorized output. Additive JSON field with a serde default of zero. | `restore_trap_shape_count`, nullable for old rows |
 | `fresh_pii_detected_count` | Fresh-PII scan findings. Zero in the token-shape assessment, which does not execute that detector. | `restore_fresh_pii_count` |
 
-`restore_policy` retains `strict` and `lenient`. With no unknown prefixed tokens,
+`restore_policy` retains `strict` and `lenient`. With no unknown canonical placeholders or incomplete prefixed wrappers,
 `restore_decision` is `success`, even when trap/bypass counts are positive.
 Otherwise Strict reports `failed` and Lenient reports `partial`. These spellings
 are unchanged, including the exact observer-facing string `success`. Audit uses

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -743,6 +743,47 @@ error: `{"error":"<Variant>","exit":<N>, ...}`.
 > adopter-facing surface and is documented in
 > [`crates/gaze-cli/README.md`](../../crates/gaze-cli/README.md).
 
+## Restore telemetry
+
+Source: [`RestoreTelemetry`](../../crates/gaze-types/src/lib.rs) and the shared
+[`Session` restore assessment](../../crates/gaze/src/session.rs). Available through
+pipeline restore telemetry and CLI `restore --telemetry`; audit persistence is
+selected with `--audit-db`. The counter split and `trap_shape_count` are Unreleased.
+
+| Field | Meaning | Audit column |
+|---|---|---|
+| `unknown_token_count` | Session-prefixed token-shape matches absent from the active map and outside authorized output ranges. This alone drives Strict/Lenient decisions. | `restore_unknown_token_count` |
+| `manifest_bypass_count` | Unprefixed trap matches outside authorized output ranges. Audit-only lexical suspicion, not proof of PII bypass. | `restore_manifest_bypass_count` |
+| `trap_shape_count` | All unprefixed trap matches in restored text, including authorized output. Additive JSON field with a serde default of zero. | `restore_trap_shape_count`, nullable for old rows |
+| `fresh_pii_detected_count` | Fresh-PII scan findings. Zero in the token-shape assessment, which does not execute that detector. | `restore_fresh_pii_count` |
+
+`restore_policy` retains `strict` and `lenient`. With no unknown prefixed tokens,
+`restore_decision` is `success`, even when trap/bypass counts are positive.
+Otherwise Strict reports `failed` and Lenient reports `partial`. These spellings
+are unchanged, including the exact observer-facing string `success`. Audit uses
+`restore_policy` and `restore_decision` with the same values.
+
+`phase_execution_mask` (audit: `restore_phase_mask`) records manifest lookup
+(bit 0), unknown-token scan (bit 1), and trap/manifest-bypass scan (bit 2).
+The shared assessment sets these three bits, mask `7`. It does not set the
+fresh-PII scan bit (bit 3). Structural restore events remain a separate opt-in
+path; the lexical trap scan does not imply that structural detection ran.
+
+Authorized ranges are output byte ranges produced by manifest substitutions.
+Only fully contained matches are exempt from unknown/bypass counts. The ranges
+and matched strings are owner-side data and are never audit telemetry.
+
+Previously `unknown_token_count` and `manifest_bypass_count` were aliases of one
+post-restore count. Historical rows retain that old meaning and remain unchanged.
+Some historical `failed` decisions become `success` on new runs because bare or
+authorized token-like literals no longer block. This is a restore-semantics change,
+not evidence of better detection. Byte-exact restoration and detection metrics
+remain independent. New telemetry readers accept missing `trap_shape_count`;
+strict older JSON readers that reject unknown fields may require an update.
+Audit queries project missing columns as NULL; writers add the nullable column
+without backfilling historical rows. Rust callers constructing `AuditLogRow`
+literals must supply the new optional field. Snapshot payload versions are unchanged.
+
 ## Companion architecture docs
 
 - [`docs/explanation/detection/ambiguity-side-channel.md`](../explanation/detection/ambiguity-side-channel.md) — `ambiguity_record`, `validator_fail_reason`, `collision_*` schema.


### PR DESCRIPTION
Strict restore previously assigned one post-restore lexical count to both `unknown_token_count` and `manifest_bypass_count`. A byte-exact inverse containing `Kunde_7`, `ORDER_12345`, or `FOO_12` could therefore report `failed`; Session/MCP strict restore and CLI also rejected ordinary identifier-shaped prose.

The shared Session assessment now separates Phase A blocking canonical placeholders from Phase B audit-only bare identifiers. It restores against one immutable manifest generation and exempts matches fully contained in authorized substitution ranges. Pipeline telemetry, Session/MCP strict restore, and CLI consume the same classification. Adjacent and boundary-crossing canonical placeholders remain blocking. Incomplete prefixed wrappers are included in the shared assessment, with overlapping inner matches counted once; Session strict parsing additionally retains malformed/nested-input rejection.

`trap_shape_count` is additive and serde-defaulted. It counts all unprefixed grammar matches, including canonical legacy placeholders and authorized output. Only broad bare identifiers outside authorized output contribute to `manifest_bypass_count`. The nullable audit column leaves historical rows unchanged. Decision spellings remain `success`, `partial`, and `failed`; snapshot versions, the global token-shape grammar, proxy residual DLP, and the frozen quality tree are unchanged. Strict older JSON readers and Rust callers constructing `AuditLogRow` literals may need the additive field update.

**Axis note:** Strict no longer blocks on bare identifier-shaped literals outside authorized ranges (moved to audit-only manifest_bypass); it still blocks on any unmapped canonical placeholder (own-prefix, foreign-prefix, legacy wrapped) and on incomplete prefixed wrappers. Legacy emitted formats such as `location_7`, `custom:class_alpha_1`, and `email1@gaze-fake.invalid` remain blocking too. This deliberately narrows the axis-1 heuristic rejection boundary to remove false failures on ordinary prose. It grants no new token-to-value mapping and retains the bare-identifier audit count. Authorized manifest values remain exempt by provenance. Reversibility and agentic prose handling improve; shared classification and separate counters improve trust and adopter consistency. A changed restore decision does not establish improved PII detection or reinterpret earlier benchmark receipts. Byte-exact restoration and detection quality remain independent measurements.

**Differential enumeration:** 6,000 synthetic cases, 400 per category, compared with the old `is_trap || !contains_token` classifier. Expected directions are specified independently of the new classifier.

| Categories | Cases | Old → final decision | Changes |
|---|---:|---|---:|
| Bare uppercase / lowercase identifiers | 800 | Failed → Success | 800 |
| Canonical legacy: built-in wrapped, generic wrapped, lowercase, email, custom | 2,000 | Failed → Failed, UNCHANGED | 0 |
| Authorized restored bare / prefixed content | 800 | Failed → Success | 800 |
| Own mapped wrapped / format-preserving tokens | 800 | Success → Success | 0 |
| Own unmapped and foreign wrapped / format-preserving tokens | 1,600 | Failed → Failed | 0 |

Review v2 corrects the former 400-case legacy row from a relaxation to UNCHANGED and adds 1,600 legacy-format cases. Only bare identifiers relax among unauthorized matches. The authorized-output rows retain the prior provenance change. No baseline Success → Failed divergence occurs in this enumeration. Separate regressions cover incomplete wrappers, custom classes, adjacency, boundary composition, malformed/nested wrappers, atomic failure, and cross-session ownership.

**TDD evidence:**

- Original signed RED commit `d7de06e` precedes the counter split.
- Review RED commit `2edc537`: core canonical regressions failed (3 failures, 13 passes), MCP legacy rejection failed, and CLI legacy rejection failed with exit 0 instead of 3. Shared-classifier fix `e423ed5` made these GREEN.
- Mutation m5, re-widening the actual shared filler filter to exclude all token shapes, fails independently in both property targets with `filtered corpus lost identifier-shaped literals` (exit 101). The normal deterministic sample contains identifier literals in 41/128 filler cases and 104/128 generated documents in each target. Both property suites use this filtered strategy; no unfiltered identifier alternative bypasses the guard.
- Signed RED `dff9d7f` pins incomplete custom-wrapper acceptance in CLI/telemetry. Shared-assessment fix `be40f39` makes it blocking while preserving the authorized-value exemption.

**Coverage:**

- Core: 17 restore-counter regressions include `<Email_1>` appended after valid clean, unmapped own/foreign prefixes, legacy emitted formats, successful identifier prose, authorized values containing bare/canonical shapes, incomplete wrappers, and the 6,000-case differential enumeration.
- Both property suites verify their actual filtered filler and generated document corpus contain identifier literals, then run the existing round-trip/manifest properties.
- MCP rejects canonical legacy placeholders after a mapped token; the identifier round-trip and foreign-token rejection controls remain.
- CLI rejects legacy formats and incomplete prefixed wrappers with exit 3; tolerant mode returns `partial` and warnings. Identifier telemetry/audit on/off coverage remains.
- The public Session restore example now calls `restore_strict_text` on the full response and includes `Kunde_7`, preserving owner-side handling.
- Existing audit schema/query and legacy NULL-row compatibility coverage remains.

**Gates:** pinned Cargo/rustc/rustdoc 1.96.0, default worktree `target/`. No Cargo before 15:27 UTC. Workspace bootstrap passed. Final verified head: `9109fa023ccd93d8a57a768138b24ae9ada1ec78`. All six review-fix commits have G signatures, DCO sign-offs, and the requested co-author trailer.

```text
$ cargo fmt --all -- --check
FMT_EXIT=0 (no output)

$ cargo clippy --workspace --all-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
CLIPPY_EXIT=0

$ cargo test --workspace --all-features
   Doc-tests gaze_types

running 3 tests
test crates/gaze-types/src/lib.rs - CleanDocument (line 2859) ... ok
test crates/gaze-types/src/lib.rs - RedactionLogger (line 2540) ... ok
test crates/gaze-types/src/lib.rs - PiiClass (line 65) ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.45s
WORKSPACE_TEST_EXIT=0
```

Workspace totals: 1,628 passed, 0 failed, 15 ignored across 140 result summaries; 9m54s wall time. The updated Session doctest passed. The separate CI feature-matrix command was not run locally.

**Structure/data-model review:**

1. Verdict: implement.
2. Opportunity: a shared filtered test generator and one Session-owned restore classification, including incomplete-wrapper candidates.
3. Why: removes duplicated filter rules and the unfiltered generator escape hatch; prevents silent loss of identifier coverage. Shared classification keeps CLI, MCP, and telemetry aligned, with one authorized-range rule and one count per overlapping placeholder.
4. Scope: core classifier, immediate API documentation, the two property targets, and focused core/MCP/CLI regressions. Transaction and committed-snapshot validation used by the proxy remain separate; no broader runtime abstraction was added.
5. Validation: signed RED→GREEN evidence, m5 killed in both targets, deterministic corpus coverage, differential enumeration, and final gate output below.

Resolves solo todo #3508
