### PR TITLE
fix(ner): ORT NER backend fails closed on missing, malformed, and nonfinite model output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ORT NER backend now fails closed on missing, malformed, or nonfinite model
+  output instead of returning zero detections. A missing output tensor, a
+  tensor whose rank/dimensions are not `[1, seq_len, num_labels]`, a flat
+  buffer whose length does not match those dimensions, and any non-finite
+  (`NaN`/`Inf`) logit each raise a typed `NerRuntimeError::Output`, which the
+  recognizer boundary surfaces as `DetectError::Backend` and the pipeline
+  surfaces as `Error::RecognizerDetect`. Previously the first two cases
+  returned `Ok` with an empty span list and the third was never checked, so a
+  corrupt model output was indistinguishable from a document containing no
+  PII and raw PII was forwarded downstream.
 - Strict restore no longer falsely fails on bare identifier-shaped literals such
   as `Kunde_7`, `ORDER_12345`, or `FOO_12`, or on token-like content produced by
   authorized manifest substitutions. Core pipeline telemetry, Session strict

--- a/crates/gaze-recognizers/src/ner/backend/ort.rs
+++ b/crates/gaze-recognizers/src/ner/backend/ort.rs
@@ -96,22 +96,44 @@ impl NerBackend for OrtBackend {
             .run(inputs)
             .map_err(|err| NerRuntimeError::Inference(err.to_string()))?;
 
-        let logits = match outputs.iter().next() {
-            Some((_, value)) => value,
-            None => return Ok(Vec::new()),
+        let Some((_, value)) = outputs.iter().next() else {
+            return decode_output(labels, id2label, offsets, None, input);
         };
-        let (shape_obj, flat) = logits
+        let (shape, flat) = value
             .try_extract_tensor::<f32>()
-            .map_err(|err| NerRuntimeError::Output(err.to_string()))?;
-        let shape: Vec<usize> = shape_obj.iter().map(|d| *d as usize).collect();
-        if shape.len() != 3 || shape[0] != 1 || shape[1] != seq_len {
-            return Ok(Vec::new());
-        }
-
-        Ok(decode_logits(
-            labels, id2label, offsets, flat, seq_len, shape[2], input,
-        ))
+            .map_err(|_| NerRuntimeError::Output("expected a float32 logits tensor".into()))?;
+        decode_output(labels, id2label, offsets, Some((shape, flat)), input)
     }
+}
+
+/// Validate the model boundary before any label selection or span filtering.
+fn decode_output(
+    labels: &LabelMap,
+    id2label: &[String],
+    offsets: &[(usize, usize)],
+    output: Option<(&[i64], &[f32])>,
+    input: &str,
+) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+    let (shape, logits) =
+        output.ok_or_else(|| NerRuntimeError::Output("missing logits tensor".into()))?;
+    if shape.len() != 3
+        || shape[0] != 1
+        || usize::try_from(shape[1]).ok() != Some(offsets.len())
+        || usize::try_from(shape[2]).ok() != Some(id2label.len())
+    {
+        return Err(NerRuntimeError::Output(
+            "invalid logits tensor shape".into(),
+        ));
+    }
+    decode_logits(
+        labels,
+        id2label,
+        offsets,
+        logits,
+        offsets.len(),
+        id2label.len(),
+        input,
+    )
 }
 
 /// Post-inference decode step: per-subword argmax + softmax confidence, then
@@ -128,7 +150,18 @@ fn decode_logits(
     seq_len: usize,
     num_labels: usize,
     input: &str,
-) -> Vec<NerSpanResult> {
+) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+    if num_labels == 0
+        || num_labels != id2label.len()
+        || offsets.len() != seq_len
+        || seq_len.checked_mul(num_labels) != Some(logits.len())
+    {
+        return Err(NerRuntimeError::Output("invalid logits dimensions".into()));
+    }
+    // Include O, low-confidence labels, and special tokens: none may hide corruption.
+    if logits.iter().any(|value| !value.is_finite()) {
+        return Err(NerRuntimeError::Output("nonfinite logits".into()));
+    }
     let mut subword_labels: Vec<&str> = Vec::with_capacity(seq_len);
     let mut subword_scores: Vec<f32> = Vec::with_capacity(seq_len);
     for pos in 0..seq_len {
@@ -152,10 +185,16 @@ fn decode_logits(
     // `input` is the text the tokenizer offsets index into; the merge reads
     // joiner bytes between tokens from it. Provenance (`ner/ort`) is attached
     // later by `NerRecognizer` / `NerDetector::try_detect`, never here.
-    NerDetector::merge_bio_span_results(labels, offsets, &subword_labels, &subword_scores, input)
-        .into_iter()
-        .filter(|span| span.span.end <= input.len())
-        .collect()
+    Ok(NerDetector::merge_bio_span_results(
+        labels,
+        offsets,
+        &subword_labels,
+        &subword_scores,
+        input,
+    )
+    .into_iter()
+    .filter(|span| span.span.end <= input.len())
+    .collect())
 }
 
 fn tokenized_chunk_ranges(
@@ -273,6 +312,7 @@ mod tests {
             ID2LABEL.len(),
             input,
         )
+        .unwrap()
     }
 
     /// Axis 1 / axis 3: the joiner between `Anne` and `Marie` is read from the
@@ -335,7 +375,8 @@ mod tests {
             2,
             ID2LABEL.len(),
             input,
-        );
+        )
+        .unwrap();
         assert_eq!(out.len(), 1, "out-of-range span must be dropped: {out:?}");
         assert_eq!(out[0].span, 0..4);
         assert_eq!(out[0].class, PiiClass::Name);
@@ -356,15 +397,13 @@ mod tests {
             if input == "Beta" {
                 values[0] = self.invalid;
             }
-            Ok(decode_logits(
+            decode_output(
                 &labels(),
                 &id2label(),
                 &[(0, 4)],
-                &values,
-                1,
-                5,
+                Some((&[1, 1, 5], &values)),
                 input,
-            ))
+            )
         }
     }
 
@@ -420,5 +459,113 @@ mod tests {
     fn invalid_output_infallible_detector_panics() {
         use gaze_types::Detector;
         corrupt_recognizer(f32::NAN).detector.detect("Anna Beta");
+    }
+
+    #[test]
+    fn invalid_output_rejects_every_nonfinite_label_and_special_token() {
+        for tag in ID2LABEL {
+            for index in 0..ID2LABEL.len() {
+                for invalid in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                    let mut values = logits(&[tag]);
+                    values[index] = invalid;
+                    for (input, offsets) in [("Anna", [(0, 4)]), ("", [(0, 0)])] {
+                        let err = decode_output(
+                            &labels(),
+                            &id2label(),
+                            &offsets,
+                            Some((&[1, 1, 5], &values)),
+                            input,
+                        )
+                        .unwrap_err();
+                        assert!(matches!(err, NerRuntimeError::Output(_)));
+                        assert_eq!(err.to_string(), "logits extract failed: nonfinite logits");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_output_rejects_missing_and_malformed_tensors() {
+        assert!(matches!(
+            decode_output(&labels(), &id2label(), &[(0, 4)], None, "Anna"),
+            Err(NerRuntimeError::Output(_))
+        ));
+        for shape in [
+            vec![],
+            vec![1, 5],
+            vec![2, 1, 5],
+            vec![1, 2, 5],
+            vec![1, 1, 0],
+            vec![1, 1, 4],
+            vec![1, 1, 6],
+            vec![1, -1, 5],
+            vec![1, 1, -1],
+        ] {
+            assert!(matches!(
+                decode_output(
+                    &labels(),
+                    &id2label(),
+                    &[(0, 4)],
+                    Some((&shape, &[0.0; 5])),
+                    "Anna"
+                ),
+                Err(NerRuntimeError::Output(_))
+            ));
+        }
+        for values in [vec![], vec![0.0; 4], vec![0.0; 6]] {
+            assert!(matches!(
+                decode_output(
+                    &labels(),
+                    &id2label(),
+                    &[(0, 4)],
+                    Some((&[1, 1, 5], &values)),
+                    "Anna"
+                ),
+                Err(NerRuntimeError::Output(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn valid_output_preserves_empty_special_tokens_and_finite_score_oracle() {
+        assert!(
+            decode_output(&labels(), &id2label(), &[], Some((&[1, 0, 5], &[])), "")
+                .unwrap()
+                .is_empty()
+        );
+        assert!(decode_output(
+            &labels(),
+            &id2label(),
+            &[(0, 0)],
+            Some((&[1, 1, 5], &logits(&["B-PER"]))),
+            ""
+        )
+        .unwrap()
+        .is_empty());
+        assert!(decode_output(
+            &labels(),
+            &id2label(),
+            &[(0, 4)],
+            Some((&[1, 1, 5], &[0.0; 5])),
+            "Anna"
+        )
+        .unwrap()
+        .is_empty());
+        // Independent f64 probability oracle, without the decoder's max subtraction.
+        let values = [0.0f32, 2.0, 1.0, -1.0, -2.0];
+        let expected = 2.0f64.exp() / values.iter().map(|v| f64::from(*v).exp()).sum::<f64>();
+        let out = decode_output(
+            &labels(),
+            &id2label(),
+            &[(0, 4)],
+            Some((&[1, 1, 5], &values)),
+            "Anna",
+        )
+        .unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].span, 0..4);
+        assert_eq!(out[0].class, PiiClass::Name);
+        assert!((f64::from(out[0].score) - expected).abs() < 1e-6);
     }
 }

--- a/crates/gaze-recognizers/src/ner/backend/ort.rs
+++ b/crates/gaze-recognizers/src/ner/backend/ort.rs
@@ -340,4 +340,85 @@ mod tests {
         assert_eq!(out[0].span, 0..4);
         assert_eq!(out[0].class, PiiClass::Name);
     }
+
+    struct SyntheticLogitsBackend {
+        invalid: f32,
+    }
+
+    impl NerBackend for SyntheticLogitsBackend {
+        fn chunk_ranges(&self, _input: &str) -> Result<Vec<Range<usize>>, NerRuntimeError> {
+            Ok(vec![0..4, 5..9])
+        }
+
+        fn detect(&self, input: &str) -> Result<Vec<NerSpanResult>, NerRuntimeError> {
+            let mut values = logits(&["B-PER"]);
+            // A valid first chunk must not escape if a later chunk is corrupt.
+            if input == "Beta" {
+                values[0] = self.invalid;
+            }
+            Ok(decode_logits(
+                &labels(),
+                &id2label(),
+                &[(0, 4)],
+                &values,
+                1,
+                5,
+                input,
+            ))
+        }
+    }
+
+    fn corrupt_recognizer(invalid: f32) -> crate::ner::NerRecognizer {
+        crate::ner::NerRecognizer {
+            detector: NerDetector {
+                model_dir: std::path::PathBuf::new(),
+                backend_kind: crate::ner::NerBackendKind::Ort,
+                recognizer_version_id: "ner.synthetic.v1".into(),
+                locale: None,
+                threshold: 0.99,
+                backend: std::sync::Arc::new(SyntheticLogitsBackend { invalid }),
+            },
+        }
+    }
+
+    #[test]
+    fn invalid_output_reaches_fallible_callers_before_filtering() {
+        use gaze_types::{DetectContext, Detector, DictionaryBundle, Recognizer};
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[], &dictionaries);
+        for invalid in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let recognizer = corrupt_recognizer(invalid);
+            assert!(
+                recognizer.detector.try_detect("Anna Beta").is_err(),
+                "corrupt logits must fail the whole chunked detection"
+            );
+            assert!(
+                Recognizer::detect(&recognizer, "Anna Beta", &ctx).is_err(),
+                "threshold filtering must not hide corrupt logits"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_output_blocks_pipeline_clean_output() {
+        use gaze::{Pipeline, RawDocument, Scope, Session};
+        let pipeline = Pipeline::builder()
+            .recognizer(corrupt_recognizer(f32::NAN))
+            .build()
+            .unwrap();
+        let session = Session::new(Scope::Ephemeral).unwrap();
+        assert!(matches!(
+            pipeline.redact(&session, RawDocument::Text("Anna Beta".into())),
+            Err(gaze::Error::RecognizerDetect(
+                gaze_types::DetectError::Backend { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "ner detector backend failure is fail-closed")]
+    fn invalid_output_infallible_detector_panics() {
+        use gaze_types::Detector;
+        corrupt_recognizer(f32::NAN).detector.detect("Anna Beta");
+    }
 }

--- a/docs/explanation/detection/ner-failclosed.md
+++ b/docs/explanation/detection/ner-failclosed.md
@@ -18,7 +18,8 @@ and the pipeline aborts outbound redaction on recognizer failure.
 - `gaze`: `RecognizerRegistry::detect_all` and `detect_all_resolved` propagate
   errors; `pipeline::Error` gains a recognizer-detection variant.
 - `gaze-recognizers`: regex, dictionary, anchored, and NER recognizers implement
-  the fallible contract. NER no longer maps backend failure to an empty result.
+  the fallible contract. NER maps neither backend failure nor malformed
+  model output to an empty result (see Model Output Boundary).
 - `gaze-cli`, `gaze-assembly`, and `gaze-mcp-core`: consume the existing core
   pipeline `Result`, so recognizer failures surface as core pipeline errors.
 
@@ -32,6 +33,39 @@ from leaving the pipeline.
 
 Long NER input is scanned through bounded overlapping chunks before backend
 execution; chunk failures are propagated as recognizer errors.
+
+## Model Output Boundary
+
+The fallible contract above only holds if the backend actually reports a
+failure. Between the ONNX session and the BIO decode there is a second
+boundary -- the raw output tensor -- and a malformed tensor there must not be
+read as "this document contains no PII".
+
+`OrtBackend::detect` funnels every model result through one validation
+function before any label selection, softmax, or span filtering runs. These
+four conditions each fail closed with `NerRuntimeError::Output`, never with an
+empty span list:
+
+| Model output | Outcome |
+| --- | --- |
+| No output tensor at all | `Output("missing logits tensor")` |
+| Rank/dimensions other than `[1, seq_len, num_labels]` | `Output("invalid logits tensor shape")` |
+| Flat buffer length != `seq_len * num_labels` | `Output("invalid logits dimensions")` |
+| Any non-finite value (`NaN`, `+Inf`, `-Inf`) | `Output("nonfinite logits")` |
+
+The non-finite scan covers every value in the tensor, including `O` rows,
+low-confidence rows, and special-token rows. Restricting it to the argmax
+label or to above-threshold rows would let corruption hide behind exactly the
+rows the decoder discards -- and `NaN` loses every `>` comparison in the
+argmax fold, so a corrupt row silently reports `O` with maximum plausibility.
+
+An empty result stays representable only where it is genuinely correct: an
+empty token sequence, zero-width offsets, or a well-formed tensor whose spans
+all fall outside the document.
+
+This mirrors the Kiji DistilBERT safety-net decoder, which already rejects
+invalid classifier width, mismatched offsets, bad logit length, and non-finite
+values. The ORT NER path was the outlier, not the precedent.
 
 ## Long-Input Chunking Invariant
 


### PR DESCRIPTION
## What & why

The ORT NER backend turned a malformed model output into a **successful empty
detection list**. An empty span list is indistinguishable from "this document
contains no PII", so a corrupt model output made `Pipeline::redact` return
clean text and forward raw PII downstream — with no error, and no audit trail.

Three escape hatches existed in `crates/gaze-recognizers/src/ner/backend/ort.rs`:

| Model output | Behavior on `main` |
| --- | --- |
| No output tensor at all | `return Ok(Vec::new())` |
| Rank/shape not `[1, seq_len, num_labels]` | `return Ok(Vec::new())` |
| `NaN` / `+Inf` / `-Inf` logits | never checked |

The `NaN` case is the nastiest: `NaN` loses every `>` comparison in the argmax
fold, so a fully corrupt logit row silently decoded as label index `0` (`O`) at
maximum apparent confidence. Nothing downstream could tell that apart from a
real "no entities here" verdict.

`shape[2]` was also taken from the tensor on faith as `num_labels` without
being checked against `id2label`, so an oversized value would slice
`&logits[base..base + num_labels]` past the end of the flat buffer and panic.

This was **not** a plumbing gap. P0-908 already made `Recognizer::detect`
fallible end-to-end: `NerRuntimeError` maps to `DetectError::Backend`, and the
pipeline already aborts redaction on `Error::RecognizerDetect`. The fallible
contract was intact — the ORT model-output boundary simply never reported the
failure into it. `docs/explanation/detection/ner-failclosed.md` even claimed
*"NER no longer maps backend failure to an empty result"*, which held at the
recognizer boundary but not at the model-output boundary.

## Fix

Every model result now passes through a single `decode_output` gate before any
label selection, softmax, or span filtering runs. Four conditions fail closed
with the **existing typed** `NerRuntimeError::Output` variant — no new error
type, no stringly error, no change to the closed error set:

| Condition | Typed outcome |
| --- | --- |
| Missing output tensor | `Output("missing logits tensor")` |
| Rank / batch / `seq_len` / `num_labels` mismatch | `Output("invalid logits tensor shape")` |
| Flat length != `seq_len * num_labels` | `Output("invalid logits dimensions")` |
| Any non-finite value | `Output("nonfinite logits")` |

The non-finite scan covers **every** value in the tensor, including `O` rows,
low-confidence rows, and special-token rows. Restricting it to the argmax label
or to above-threshold rows would let corruption hide behind exactly the rows the
decoder discards.

`decode_output` takes `Option<(&[i64], &[f32])>` rather than an `ort` value, so
the whole boundary is exercised with synthetic logits and **no model download**.

This brings the ORT NER path in line with the Kiji DistilBERT safety-net decoder
(`crates/gaze-recognizers/src/safety_net/kiji_distilbert/backend/decode.rs`),
which already rejects invalid classifier width, mismatched offsets, bad logit
length, and non-finite values. The ORT NER path was the outlier, not the
precedent.

Empty results stay representable where they are genuinely correct: an empty
token sequence, zero-width offsets, and a well-formed tensor whose spans all
fall outside the document. The fix cannot pass by rejecting everything —
`valid_output_preserves_empty_special_tokens_and_finite_score_oracle` pins the
decoded probability against an independent `f64` softmax oracle computed without
the decoder's max-subtraction.

## Tests

TDD: commit 1 adds the failing tests, commit 2 makes them pass.

**RED before the fix** (`5fb64ef`, 3 failing / 4 pre-existing passing):

```
test ner::backend::ort::tests::invalid_output_infallible_detector_panics - should panic ... FAILED
test ner::backend::ort::tests::invalid_output_reaches_fallible_callers_before_filtering ... FAILED
test ner::backend::ort::tests::invalid_output_blocks_pipeline_clean_output ... FAILED
test result: FAILED. 4 passed; 3 failed; 0 ignored; 0 measured; 119 filtered out
```

The leak is demonstrated directly by `invalid_output_blocks_pipeline_clean_output`,
which failed because `Pipeline::redact` returned **`Ok` with clean output** for a
document whose NER backend produced `NaN` logits.

**GREEN after the fix** (`3f8e7d8`, 10 passing):

```
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 119 filtered out
```

Six new tests: the three RED ones above, plus exhaustive non-finite coverage
across every label index and special token, malformed/missing-tensor coverage
across nine bad shapes and three bad buffer lengths, and the valid-output
oracle test.

### Proof the tests execute under the CI gate

`cargo test --workspace --all-features -- --list`:

```
ner::backend::ort::tests::invalid_output_blocks_pipeline_clean_output: test
ner::backend::ort::tests::invalid_output_infallible_detector_panics: test
ner::backend::ort::tests::invalid_output_reaches_fallible_callers_before_filtering: test
ner::backend::ort::tests::invalid_output_rejects_every_nonfinite_label_and_special_token: test
ner::backend::ort::tests::invalid_output_rejects_missing_and_malformed_tensors: test
ner::backend::ort::tests::valid_output_preserves_empty_special_tokens_and_finite_score_oracle: test
```

## Mutation probe

Each of the four checks was disabled individually (one `str.replace` per run,
edit site asserted unique first), then restored, to prove no check is decorative.
A check that no test notices the removal of is a check nobody is guarding.

```
| Mutation | What it disables | Result | Tests that went red |
| --- | --- | --- | --- |
| M1 | missing output tensor -> `Ok(Vec::new())` | KILLED | `invalid_output_rejects_missing_and_malformed_tensors` |
| M2 | tensor-shape predicate -> `if false {` | KILLED | `invalid_output_rejects_missing_and_malformed_tensors` |
| M3 | decode-dimensions predicate -> `if false {` | KILLED | `invalid_output_rejects_missing_and_malformed_tensors` |
| M3a | flat-length arm only -> `|| false` | KILLED | `invalid_output_rejects_missing_and_malformed_tensors` |
| M4 | non-finite predicate -> `if false {` | KILLED | `invalid_output_blocks_pipeline_clean_output`, `invalid_output_infallible_detector_panics`, `invalid_output_reaches_fallible_callers_before_filtering`, `invalid_output_rejects_every_nonfinite_label_and_special_token` |

`SURVIVORS: none` / `DID NOT COMPILE: none` / `VERDICT: PASS`

The probe was itself validated before being trusted. A first version replaced
only the **first arm** of each multi-arm `||` chain with `false &&`; because `&&`
binds tighter than `||` in Rust, the remaining arms stayed live and M3 reported a
false survivor. Each mutation now replaces the predicate whole, and the runner
asserts every edit site is unique and that the mutated file actually differs from
the baseline. Restoration is from an in-memory baseline, never `git checkout --`,
which would revert to the committed tree rather than undoing just the mutation.
```

Full revert of the fix commit (`git revert --no-commit 3f8e7d8`) returns all three
original RED tests to failing.

## Gate tails

```
$ cargo fmt --all -- --check
EXIT_CODE=0

$ cargo clippy --workspace --all-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 28.65s
EXIT_CODE=0
(449 crates checked, 0 warnings, 0 errors)

$ cargo test --workspace --all-features
EXIT_CODE=0
(140 suites ok, 0 suites FAILED, 1634 tests passed)
crates/gaze-recognizers lib suite: test result: ok. 128 passed; 0 failed; 1 ignored

All six new tests executed and passed inside that full-workspace run:
test ner::backend::ort::tests::invalid_output_rejects_missing_and_malformed_tensors ... ok
test ner::backend::ort::tests::invalid_output_rejects_every_nonfinite_label_and_special_token ... ok
test ner::backend::ort::tests::valid_output_preserves_empty_special_tokens_and_finite_score_oracle ... ok
test ner::backend::ort::tests::invalid_output_reaches_fallible_callers_before_filtering ... ok
test ner::backend::ort::tests::invalid_output_blocks_pipeline_clean_output ... ok
test ner::backend::ort::tests::invalid_output_infallible_detector_panics - should panic ... ok
```

Plus the xtask gates that actually cover a `crates/gaze-recognizers/src` change:

```
$ cargo run -p xtask -- fixture-citation-lint   ->  fixture_citation_lint: passed
$ cargo run -p xtask -- no-tenant-knowledge     ->  no_tenant_knowledge: passed
$ cargo run -p xtask -- symmetric-potemkin      ->  symmetric_potemkin_gate: passed
```

`fixture-citation-lint` matters here specifically: the new tests live inside
`crates/gaze-recognizers/src/`, which that gate scans, and they add name-shaped
literals. The remaining roster (`ci-feature-matrix`, `cargo-deny`, MSRV,
bundle-drift, locale/family coherence, `readme-version-check`) is left to
PR-triggered CI, which runs it on every relevant PR.

Toolchain note: the gates above ran on the repo-pinned **1.96.0**, not the
Homebrew `cargo`/`rustc` 1.95.0 that shadows rustup on PATH. `RUSTC` and
`RUSTDOC` were bound explicitly per CONTRIBUTING's trybuild ritual, so the
trybuild drivers' pinned-channel assertion passed rather than erroring.

## Five axes

- **Axis 1 (reliability / never leak) — strengthened.** Malformed model output can
  no longer produce clean output. The fail-open path that turned the worst model
  state into the most permissive result is closed.
- **Axis 2 (reversibility) — unchanged.** No manifest, token, or restore behavior
  is touched. No new token is emitted; the change only converts a wrong `Ok` into
  an `Err` before any span reaches the manifest.
- **Axis 3 (agentic-first) — unchanged.**
- **Axis 4 (trust / auditable + deterministic) — strengthened.** The failure is a
  typed variant in the existing closed `NerRuntimeError` set, surfaced as
  `DetectError::Backend` and `Error::RecognizerDetect`. One silent-mismatch class
  is removed, and the doc now describes the boundary that actually exists.
- **Axis 5 (adopter ergonomics) — small deliberate cost.** An adopter whose NER
  model or runtime emits a malformed tensor now gets a typed error where they
  previously got zero detections. That is the point: the previous behavior was a
  silent leak. Recorded under CHANGELOG Unreleased/Fixed.

## Structure and data-model review (per repo review gate)

1. **Verdict:** `implement` — done in this PR.
2. **Opportunity:** a single model-output validation gate (`decode_output`)
   replacing three scattered exit points spread across two functions, with the
   boundary typed as `Option<(&[i64], &[f32])>` instead of an `ort` value.
3. **Why:** it deletes the representable state "malformed output == successful
   empty result" rather than patching each escape hatch; it makes `num_labels`
   provenance explicit (`id2label`, not the tensor), which removes the
   out-of-bounds slice risk; and it makes the boundary unit-testable without a
   model, which is why six tests exist at all.
4. **Scope:** one production file plus docs/CHANGELOG. Behavior changes only for
   malformed model output. No manifest, token, restore, policy, or audit surface
   touched. Shipped now rather than deferred, because it *is* the fix.
5. **Validation:** `cargo fmt --all -- --check`, `cargo clippy --workspace
   --all-features --all-targets -- -D warnings`, `cargo test --workspace
   --all-features`, plus the `--list` execution proof and the four-mutation probe
   above.

## Provenance

Ported from measured branch `agent/baseline-lock-quality-7414` commits
`6f3d842` (RED tests), `c691374` (runtime fix), and `bc787ad` (CHANGELOG hunk
only). `ort.rs` on `main` was byte-identical to `6f3d842^`, so commits 1 and 2
cherry-picked cleanly with `-x`. `bc787ad`'s other hunk edits
`crates/gaze-recognizers/tests/span_batch_probe.rs`, a file that does not exist
on `main`, so it is out of scope here.

No screenshots: no visible output changes.

Part of solo todo #3510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEK96161PAKmkEA8ut9NXQ
