### PR TITLE
release: v0.14.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -32,6 +32,14 @@ Run from `main` after all release-blocker PRs are merged.
 8. Verify benchmark claims in the changelog or release PR body link to the
    script and hardware specification that produced them. This preserves the
    `feedback-bench-claims-reproducible` memory.
+9. Pair every release with its own benchmark: version X ships with benchmark X.
+   Run the scorecard harness on the release commit in a fresh anvil worktree
+   (see the `docs/reference/benchmarks` README for the command and the hardware
+   spec), store the result as
+   `docs/reference/benchmarks/scorecard-vX.Y.Z.json`, and add one row and one
+   chart point keyed by `vX.Y.Z` to the consolidated benchmark document, with
+   commit sha, script, and hardware as secondary columns. Dogfood the updated
+   document. A release without a fresh benchmark is blocked.
 
 If any step fails, stop and fix the release branch. Do not tag around a red
 checklist.
@@ -51,7 +59,10 @@ unmerged branch head, or a dirty working tree.
 The tag push auto-fires two workflows:
 
 - `release.yml`: builds binaries and creates the GitHub Release.
-- `publish-crates.yml`: publishes the 11 crates via OIDC trusted publishing.
+- `publish-crates.yml`: publishes every workspace member with `publish != false`
+  via OIDC trusted publishing. The set and its topological order are derived from
+  `cargo metadata` by `cargo run -p xtask -- publish-plan`, so new crates are
+  included automatically.
 
 Do not publish to crates.io manually. The workflow owns publication order and
 idempotent retries.
@@ -62,12 +73,15 @@ After the workflows finish:
 
 1. Confirm `gh release view vX.Y.Z` returns the release.
 2. Confirm both workflow runs succeeded: `release.yml` and `publish-crates.yml`.
-3. Confirm all 11 crates are published by checking
-   `https://crates.io/api/v1/crates/<name>` and expecting
-   `max_version == X.Y.Z` for:
-   `gaze-types`, `gaze-audit`, `gaze-recognizers`, `gaze-pii`,
-   `gaze-assembly`, `gaze-mcp-core`, `gaze-mcp-rmcp`, `gaze-mcp-bridge`,
-   `gaze-document`, `gaze-proxy`, and `gaze-cli`.
+3. Confirm every published crate reports the new version. Derive the expected
+   set with `cargo run -p xtask -- publish-plan` rather than a hard-coded list,
+   then check `https://crates.io/api/v1/crates/<name>` and expect
+   `max_version == X.Y.Z` for each. As of v0.14.0 the plan covers 15 crates:
+   `gaze-pii`, `gaze-types`, `gaze-audit`, `gaze-inspection`, `gaze-recognizers`,
+   `gaze-assembly`, `gaze-model-setup`, `gaze-mcp-core`, `gaze-mcp-rmcp`,
+   `gaze-mcp-bridge`, `gaze-document`, `gaze-proxy`, `gaze-proxy-dashboard`,
+   `gaze-token-bridge`, and `gaze-cli`. A count that does not match the plan is a
+   partial publish, not a pass.
 4. Update the orchestrator scratchpad with released URLs:
    GitHub Release URL plus the 11 crates.io URLs.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -83,7 +83,7 @@ After the workflows finish:
    `gaze-token-bridge`, and `gaze-cli`. A count that does not match the plan is a
    partial publish, not a pass.
 4. Update the orchestrator scratchpad with released URLs:
-   GitHub Release URL plus the 11 crates.io URLs.
+   GitHub Release URL plus one crates.io URL per crate in the publish plan.
 
 ## Escalation Rules
 
@@ -101,5 +101,5 @@ After the workflows finish:
 
 Do not just push a tag and hope. A Gaze release is complete only when the
 pre-flight gates are green, the tag was explicitly authorized, both workflows
-succeeded, all 11 crates report the expected version, and the orchestrator
+succeeded, every crate in the publish plan reports the expected version, and the orchestrator
 scratchpad records the shipped URLs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,112 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-11
+
 ### Fixed
 
-- ORT NER backend now fails closed on missing, malformed, or nonfinite model
-  output instead of returning zero detections. A missing output tensor, a
-  tensor whose rank/dimensions are not `[1, seq_len, num_labels]`, a flat
-  buffer whose length does not match those dimensions, and any non-finite
-  (`NaN`/`Inf`) logit each raise a typed `NerRuntimeError::Output`, which the
-  recognizer boundary surfaces as `DetectError::Backend` and the pipeline
-  surfaces as `Error::RecognizerDetect`. Previously the first two cases
-  returned `Ok` with an empty span list and the third was never checked, so a
-  corrupt model output was indistinguishable from a document containing no
-  PII and raw PII was forwarded downstream.
-- Strict restore no longer falsely fails on bare identifier-shaped literals such
-  as `Kunde_7`, `ORDER_12345`, or `FOO_12`, or on token-like content produced by
-  authorized manifest substitutions. Core pipeline telemetry, Session strict
-  restore, the MCP `restore_strict` tool, and CLI restore share the counter split:
-  Strict no longer blocks on bare identifier-shaped literals outside authorized
-  ranges (moved to audit-only `manifest_bypass`); it still blocks on any unmapped
-  canonical placeholder (own-prefix, foreign-prefix, legacy wrapped) and on
-  incomplete prefixed wrappers. Legacy emitted formats remain blocking too.
-  This deliberately narrows the heuristic rejection boundary. Added
-  serde-defaulted `trap_shape_count` telemetry and nullable
-  `restore_trap_shape_count` audit metadata. Snapshot formats and token grammar
-  are unchanged. Some historical `failed` decisions become `success` on new
-  runs; byte-exact restore and PII detection metrics are independent.
+- **The ORT NER backend fails closed on missing, malformed, and nonfinite model
+  output** (#474). A missing output tensor, a tensor whose rank or dimensions are
+  not `[1, seq_len, num_labels]`, a flat buffer whose length does not match those
+  dimensions, and any non-finite (`NaN` or `Inf`) logit each raise a typed
+  `NerRuntimeError::Output`, which the recognizer boundary surfaces as
+  `DetectError::Backend` and the pipeline surfaces as `Error::RecognizerDetect`.
+  The first two cases previously returned `Ok` with an empty span list and the
+  third was never checked, so a corrupt model output was indistinguishable from a
+  document that contains no PII, and raw PII was forwarded downstream with no
+  error and no audit trail. `NaN` was the sharpest case: it loses every comparison
+  in the argmax fold, so a fully corrupt logit row decoded as label `O` at maximum
+  apparent confidence. The backend also validates `shape[2]` against `id2label`
+  instead of trusting it, removing an out-of-bounds slice. Detection is fail-closed
+  again on this path. See
+  [NER fail-closed](docs/explanation/detection/ner-failclosed.md).
+- **Strict restore no longer falsely fails on identifier-shaped literals** (#473).
+  A byte-exact inverse containing `Kunde_7`, `ORDER_12345`, or `FOO_12` previously
+  reported `failed` because one post-restore lexical count was assigned to both
+  `unknown_token_count` and `manifest_bypass_count`. Core pipeline telemetry,
+  Session strict restore, the MCP `restore_strict` tool, and CLI restore now share
+  one provenance-aware classifier: bare identifier-shaped literals outside
+  authorized ranges are audit-only `manifest_bypass`, while every unmapped
+  canonical placeholder (own-prefix, foreign-prefix, legacy wrapped) and every
+  incomplete prefixed wrapper still blocks. Legacy emitted formats remain
+  blocking. The change deliberately narrows the heuristic rejection boundary and
+  keeps the release aligned with the project contract: fail closed, preserve
+  reversibility, keep PII out of agent-visible surfaces. Serde-defaulted
+  `trap_shape_count` telemetry and nullable `restore_trap_shape_count` audit
+  metadata are additive. Snapshot formats and token grammar are unchanged. Some
+  historical `failed` decisions become `success` on new runs; byte-exact restore
+  and PII detection metrics are independent.
+
+### Changed
+
+- **`RecognizerRegistryBuilder` dropped its private always-empty `validators` and
+  `canonicalizers` maps** (#469) and initializes both once in `build()`. The
+  public surface is preserved: `Validator`, `Canonicalizer`, `ValidationResult`,
+  both the root and `gaze::registry` import paths, registry storage, both typed
+  map accessors, and the README contract. An external integration regression
+  implements the public traits and pins the existing empty-map behaviour.
+- **The benchmark scorer and validator-probe calls bounded their subprocess I/O**
+  (#455). Both use bounded, nonblocking JSONL pipes, discard child stderr in
+  memory, and return closed errors after cleaning up the direct child.
+  Malformed, incomplete, oversized, or out-of-order responses abort the cell
+  instead of producing a scorecard. The `diagnostics_dir` argument is still
+  accepted, but new results omit `stderr_log` and `stderr_bytes`; historical
+  scorecards remain readable.
+- **PyArrow moved to 23.0.1 and pytest to 9.0.3** (#466), with a regression that
+  writes a synthetic Parquet file through real PyArrow and drives the existing
+  `dataiku_en_de_gaze_bench.load_documents` integrity path. The new PyArrow lock
+  keeps `manylinux_2_28` wheels and drops `manylinux_2_17`, so prebuilt wheels on
+  glibc-based Linux require glibc 2.28 or newer. Production loader code is
+  unchanged.
+- **`quinn-proto` moved from 0.11.14 to 0.11.16** (#470) as a lock-only update.
+
+### Added
+
+- **Offline evidence contracts and a scored synthetic MCP evaluation** (#454).
+  A strict aggregate receipt validator, a private grouped paired evaluator,
+  fixture-only class commitments, and one scored real rmcp duplex route keep
+  planned inventory, observed counts, missing observations, provenance, and gate
+  results distinct. Missing observations never become measured zero, and
+  incomplete checks cannot produce PASS. The addition is synthetic harness
+  capability only; no production source, detector, rulepack, workflow, or
+  dependency changed.
+- **A synthetic bridge connecting scored MCP observations to paired evaluation**
+  (#456), built on the same Rust scorer, parent-owned occurrence slots, and an
+  in-memory evaluator. The bridge rejects inconsistent identities, missing
+  measurement coverage, and invalid outcome rows; protocol, processing, deadline,
+  or child-cleanup failures abort the cell before success can be returned.
+- **Verified isolated builds for synthetic producer artifacts** (#459). A
+  parent-owned build session creates a verified Git snapshot and empty target,
+  validates Cargo's selected artifact, retains its file descriptor, runs that
+  exact path through the bridge, and re-checks identity and bytes before cleanup
+  can report success.
+
+### Removed
+
+- **`crates/gaze/build.rs` and its Cargo registration** (#467). The pinned
+  `ort-sys` native-link implementation already owns the Darwin clang runtime
+  search path and link library, so the removal retires duplicate native-link
+  ownership rather than an absent transitive dependency.
+- **Two unreachable `not(feature = "ocr-tesseract")` fallback functions in the
+  `gaze-document` MCP module** (#468). The `mcp` feature requires
+  `ocr-tesseract` and the module compiles only for `mcp`, so neither fallback
+  can exist in a supported feature graph.
+
+### Documentation
+
+- AGENTS.md requires signed commits and no longer requires a message prefix (#463).
+- The benchmark index gained rows for `evidence-protocol-v1.md` and
+  `class-commitments-v1.json` (#464).
+- The MCP chokepoint documentation describes carrier preflight and staged
+  protection, and places response snapshot computation before transaction commit
+  and `finish_call`; operator-tier `BypassByOperator` is distinguished from the
+  protected agent path (#465). Runtime code is unchanged.
+- The benchmark README dropped the stale `logs/` artifact row and its
+  stderr-log review step (#472).
+
+### Benchmarks
+
+- Benchmarks: see `docs/reference/benchmarks` (v0.14.0 scorecard).
 
 ## [0.13.0] - 2026-09-09
 
@@ -2060,6 +2141,7 @@ parallel — the CLI protocol is the stable seam.
   darwin binaries; follow-up commit fills them.
 
 [Unreleased]: https://github.com/CertaMesh/gaze/compare/v0.13.0...HEAD
+[0.14.0]: https://github.com/CertaMesh/gaze/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/CertaMesh/gaze/compare/v0.12.0...v0.13.0
 [0.6.4]: https://github.com/EmpireTwo/gaze/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/EmpireTwo/gaze/compare/v0.6.2...v0.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2140,7 +2140,7 @@ parallel — the CLI protocol is the stable seam.
 - **Homebrew SHAs are placeholders** until the workflow publishes the
   darwin binaries; follow-up commit fills them.
 
-[Unreleased]: https://github.com/CertaMesh/gaze/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/CertaMesh/gaze/compare/v0.14.0...HEAD
 [0.14.0]: https://github.com/CertaMesh/gaze/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/CertaMesh/gaze/compare/v0.12.0...v0.13.0
 [0.6.4]: https://github.com/EmpireTwo/gaze/compare/v0.6.3...v0.6.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-assembly"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-audit"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "gaze-types",
  "rusqlite",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-document"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ab_glyph",
  "async-trait",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-inspection"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "gaze-types",
  "serde",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-bridge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "gaze-assembly",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-mcp-rmcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-model-setup"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "gaze-recognizers",
  "libc",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-proxy-dashboard"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "gaze-inspection",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aho-corasick",
  "candle-core",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-token-bridge"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chacha20poly1305",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "phonenumber",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ homepage = "https://github.com/CertaMesh/gaze"
 license = "Apache-2.0 OR MIT"
 
 [workspace.dependencies]
-gaze-audit = { path = "crates/gaze-audit", version = "0.13.0" }
-gaze-inspection = { path = "crates/gaze-inspection", version = "0.13.0" }
-gaze = { path = "crates/gaze", version = "0.13.0", package = "gaze-pii" }
-gaze-assembly = { path = "crates/gaze-assembly", version = "0.13.0" }
-gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.13.0" }
-gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.13.0" }
-gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.13.0" }
-gaze-model-setup = { path = "crates/gaze-model-setup", version = "0.13.0" }
-gaze-recognizers = { path = "crates/gaze-recognizers", version = "0.13.0" }
-gaze-proxy = { path = "crates/gaze-proxy", version = "0.13.0" }
-gaze-proxy-dashboard = { path = "crates/gaze-proxy-dashboard", version = "0.13.0" }
-gaze-types = { path = "crates/gaze-types", version = "0.13.0" }
+gaze-audit = { path = "crates/gaze-audit", version = "0.14.0" }
+gaze-inspection = { path = "crates/gaze-inspection", version = "0.14.0" }
+gaze = { path = "crates/gaze", version = "0.14.0", package = "gaze-pii" }
+gaze-assembly = { path = "crates/gaze-assembly", version = "0.14.0" }
+gaze-mcp-bridge = { path = "crates/gaze-mcp-bridge", version = "0.14.0" }
+gaze-mcp-core = { path = "crates/gaze-mcp-core", version = "0.14.0" }
+gaze-mcp-rmcp = { path = "crates/gaze-mcp-rmcp", version = "0.14.0" }
+gaze-model-setup = { path = "crates/gaze-model-setup", version = "0.14.0" }
+gaze-recognizers = { path = "crates/gaze-recognizers", version = "0.14.0" }
+gaze-proxy = { path = "crates/gaze-proxy", version = "0.14.0" }
+gaze-proxy-dashboard = { path = "crates/gaze-proxy-dashboard", version = "0.14.0" }
+gaze-types = { path = "crates/gaze-types", version = "0.14.0" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1" }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your agent never sees a real email, phone number, or order ID. Your server keeps
 Three commands from zero to redacting real PII:
 
 ```sh
-cargo install gaze-cli --version 0.13.0                     # `gaze setup` ships in the default build
+cargo install gaze-cli --version 0.14.0                     # `gaze setup` ships in the default build
 gaze setup                                                   # installs + SHA-verifies the NER model, writes ./gaze.toml, runs a doctor check
 echo "Contact Markus Gottschaue at markus@acme.com" | gaze clean --policy gaze.toml
 ```
@@ -139,7 +139,7 @@ Architecture overview with eight Key Design Decisions: [`ARCHITECTURE.md`](ARCHI
 Install the CLI from crates.io:
 
 ```sh
-cargo install gaze-cli --version 0.13.0
+cargo install gaze-cli --version 0.14.0
 ```
 
 Or build from source (latest `main`, or to enable extra features):

--- a/crates/gaze-assembly/Cargo.toml
+++ b/crates/gaze-assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-assembly"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,8 +16,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0" }
 regex = "1"
 serde_json = "1"
 thiserror = "1"

--- a/crates/gaze-assembly/README.md
+++ b/crates/gaze-assembly/README.md
@@ -22,9 +22,9 @@ adopter, or every consumer would need to duplicate policy assembly logic.
 
 ```toml
 [dependencies]
-gaze-pii = "0.13.0"
-gaze-assembly = "0.13.0"
-gaze-recognizers = "0.13.0"
+gaze-pii = "0.14.0"
+gaze-assembly = "0.14.0"
+gaze-recognizers = "0.14.0"
 serde_json = "1"
 ```
 

--- a/crates/gaze-audit/Cargo.toml
+++ b/crates/gaze-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-audit"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-audit/README.md
+++ b/crates/gaze-audit/README.md
@@ -29,8 +29,8 @@ Do **not** use the audit log to restore PII. The restore contract lives in `Sens
 
 ```toml
 [dependencies]
-gaze-pii = "0.13.0"
-gaze-audit = "0.13.0"
+gaze-pii = "0.14.0"
+gaze-audit = "0.14.0"
 ```
 
 Wire the logger when building the pipeline. Note: `SqliteLogger` is **not** `Clone`;

--- a/crates/gaze-cli/Cargo.toml
+++ b/crates/gaze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-cli"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -48,18 +48,18 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 async-trait = { version = "0.1", optional = true }
 directories-next = { version = "2", optional = true }
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.14.0" }
 gaze-audit = { workspace = true }
-gaze-document = { path = "../gaze-document", version = "0.13.0", optional = true }
+gaze-document = { path = "../gaze-document", version = "0.14.0", optional = true }
 gaze-mcp-bridge = { workspace = true, optional = true }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.13.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.14.0", optional = true }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.14.0", optional = true }
 gaze-model-setup = { workspace = true, optional = true }
 gaze-proxy = { workspace = true, optional = true }
 gaze-proxy-dashboard = { workspace = true, optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
-gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.13.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0" }
+gaze-token-bridge = { path = "../gaze-token-bridge", version = "0.14.0", optional = true }
 gaze-types = { workspace = true }
 getrandom = { version = "0.3", optional = true }
 pdfium-render = { version = "0.9", optional = true }
@@ -76,7 +76,7 @@ url = "2"
 assert_cmd = "2"
 base64 = "0.22"
 gaze-audit = { workspace = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0", features = ["test-support"] }
 rusqlite = { workspace = true }
 serde_json = "1"
 serial_test = { version = "3", features = ["file_locks"] }

--- a/crates/gaze-cli/README.md
+++ b/crates/gaze-cli/README.md
@@ -21,7 +21,7 @@ raw input or backtraces into caller logs.
 Install from crates.io:
 
 ```console
-$ cargo install gaze-cli --version 0.13.0
+$ cargo install gaze-cli --version 0.14.0
 ```
 
 Build from the workspace root:
@@ -111,7 +111,7 @@ The `mcp` feature embeds the rmcp stdio server into the `gaze` binary and
 registers `gaze-document` tools:
 
 ```console
-$ cargo install gaze-cli --version 0.13.0 --features mcp
+$ cargo install gaze-cli --version 0.14.0 --features mcp
 $ gaze mcp install --client=claude-code
 $ gaze mcp doctor
 ```

--- a/crates/gaze-document/Cargo.toml
+++ b/crates/gaze-document/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-document"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license = "Apache-2.0 OR MIT"
@@ -21,9 +21,9 @@ name = "gaze_document"
 path = "src/lib.rs"
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.14.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0" }
 gaze-types = { workspace = true }
 async-trait = { version = "0.1", optional = true }
 regex = "1"
@@ -45,7 +45,7 @@ render-image = []
 [dev-dependencies]
 gaze-assembly = { workspace = true }
 ab_glyph = "0.2"
-gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.13.0" }
+gaze-mcp-rmcp = { path = "../gaze-mcp-rmcp", version = "0.14.0" }
 image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.26", default-features = false, features = ["text"] }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }

--- a/crates/gaze-document/README.md
+++ b/crates/gaze-document/README.md
@@ -20,13 +20,13 @@ contract that always restores. OCR is a subprocess call to the standard
 
 ```toml
 [dependencies]
-gaze-document = "0.13.0"
+gaze-document = "0.14.0"
 ```
 
 ### CLI
 
 ```bash
-cargo install gaze-cli --version 0.13.0 --features document
+cargo install gaze-cli --version 0.14.0 --features document
 ```
 
 The `document` feature is opt-in on `gaze-cli` so the default install stays

--- a/crates/gaze-inspection/Cargo.toml
+++ b/crates/gaze-inspection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-inspection"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/Cargo.toml
+++ b/crates/gaze-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-bridge"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-mcp-bridge/README.md
+++ b/crates/gaze-mcp-bridge/README.md
@@ -1,6 +1,6 @@
 # gaze-mcp-bridge
 
-`gaze-mcp-bridge = "0.13.0"` is the optional policy-gated MCP bridge for Gaze.
+`gaze-mcp-bridge = "0.14.0"` is the optional policy-gated MCP bridge for Gaze.
 
 The bridge is intentionally fail-closed: agents see only pseudonymous tokens,
 downstream MCP tools receive restored PII only for explicitly allowed argument

--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-core"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,10 +16,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii" }
 gaze-types = { workspace = true }
-gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.14.0" }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0" }
 async-trait = "0.1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -35,6 +35,6 @@ core-tools = []
 operator-tier = []
 
 [dev-dependencies]
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii", features = ["test-support"] }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii", features = ["test-support"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1"

--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/gaze-mcp-core/badge.svg)](https://docs.rs/gaze-mcp-core)
 [![License](https://img.shields.io/crates/l/gaze-mcp-core.svg)](https://github.com/CertaMesh/gaze#license)
 
-> **Adding `gaze-mcp-core` (v0.13.0) to your crate enables:** the transport-free
+> **Adding `gaze-mcp-core` (v0.14.0) to your crate enables:** the transport-free
 > MCP chokepoint runtime — `Tool` trait, `PiiEnvelope::dispatch`,
 > `ToolRegistry`, `ManifestStore` / `AuthHook` / `SessionIdPolicy` plug-in
 > points, and the optional `core-tools` agent-tier tool set.

--- a/crates/gaze-mcp-rmcp/Cargo.toml
+++ b/crates/gaze-mcp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-mcp-rmcp"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.89"
 license.workspace = true
@@ -12,7 +12,7 @@ keywords = ["pii", "mcp", "rmcp", "agent"]
 categories = ["development-tools"]
 
 [dependencies]
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0" }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.14.0" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = "0.1"
@@ -23,7 +23,7 @@ axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
 gaze-assembly = { workspace = true }
-gaze = { package = "gaze-pii", path = "../gaze", version = "0.13.0" }
+gaze = { package = "gaze-pii", path = "../gaze", version = "0.14.0" }
 rmcp = { version = "1.6.0", features = ["client", "server", "macros", "transport-async-rw"] }
 
 [features]

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -23,8 +23,8 @@
 
 ```toml
 [dependencies]
-gaze-mcp-core = "0.13.0"
-gaze-mcp-rmcp = "0.13.0"
+gaze-mcp-core = "0.14.0"
+gaze-mcp-rmcp = "0.14.0"
 ```
 
 ```rust

--- a/crates/gaze-model-setup/Cargo.toml
+++ b/crates/gaze-model-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-model-setup"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-proxy-dashboard/Cargo.toml
+++ b/crates/gaze-proxy-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy-dashboard"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"
@@ -10,8 +10,8 @@ repository = "https://github.com/CertaMesh/gaze"
 [dependencies]
 base64 = "0.22.1"
 getrandom = "0.3.4"
-gaze-inspection = { path = "../gaze-inspection", version = "0.13.0" }
-gaze-types = { path = "../gaze-types", version = "0.13.0" }
+gaze-inspection = { path = "../gaze-inspection", version = "0.14.0" }
+gaze-types = { path = "../gaze-types", version = "0.14.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"

--- a/crates/gaze-proxy/Cargo.toml
+++ b/crates/gaze-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-proxy"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -27,8 +27,8 @@ chrono = { version = "0.4", optional = true, default-features = false, features 
 dirs = { version = "6", optional = true }
 fs2 = { version = "0.4", optional = true }
 futures-util = "0.3"
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii" }
-gaze-assembly = { path = "../gaze-assembly", version = "0.13.0" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii" }
+gaze-assembly = { path = "../gaze-assembly", version = "0.14.0" }
 gaze-inspection = { workspace = true }
 gaze-types = { workspace = true }
 getrandom = "0.3"
@@ -51,7 +51,7 @@ uuid = { version = "1", features = ["v4"] }
 zeroize = "1"
 
 [dev-dependencies]
-gaze = { path = "../gaze", version = "0.13.0", package = "gaze-pii", features = ["test-support"] }
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0" }
+gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii", features = ["test-support"] }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0" }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/gaze-proxy/README.md
+++ b/crates/gaze-proxy/README.md
@@ -12,13 +12,13 @@ PII-bearing fields before calling the supplied `gaze::Pipeline`.
 
 ```toml
 [dependencies]
-gaze-proxy = "0.13.0"
+gaze-proxy = "0.14.0"
 ```
 
 ## Quickstart
 
 ```bash
-cargo install gaze-cli --version 0.13.0
+cargo install gaze-cli --version 0.14.0
 gaze proxy start
 ```
 

--- a/crates/gaze-recognizers/Cargo.toml
+++ b/crates/gaze-recognizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-recognizers"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-recognizers/README.md
+++ b/crates/gaze-recognizers/README.md
@@ -17,8 +17,8 @@ tokenizer dependencies.
 
 ```toml
 [dependencies]
-gaze-pii = "0.13.0"
-gaze-recognizers = "0.13.0"
+gaze-pii = "0.14.0"
+gaze-recognizers = "0.14.0"
 ```
 
 Library users that need parser-backed E.164 phone validation must opt in to the
@@ -26,7 +26,7 @@ Library users that need parser-backed E.164 phone validation must opt in to the
 
 ```toml
 [dependencies]
-gaze-recognizers = { version = "0.13.0", features = ["phone-parser"] }
+gaze-recognizers = { version = "0.14.0", features = ["phone-parser"] }
 ```
 
 `gaze-cli` enables `phone-parser` by default. Without the feature, the

--- a/crates/gaze-token-bridge/Cargo.toml
+++ b/crates/gaze-token-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-token-bridge"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -16,7 +16,7 @@ categories = ["text-processing"]
 # parallel track permitted to touch Cargo.toml). A new dependency that is not a
 # pure addition, or any edit by Track A, is a master decision (raise NEED DIRECTION).
 [dependencies]
-gaze = { path = "../gaze", package = "gaze-pii", version = "0.13.0" }
+gaze = { path = "../gaze", package = "gaze-pii", version = "0.14.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 chacha20poly1305 = { version = "0.10", features = ["std"] }
@@ -27,7 +27,7 @@ rand = "0.8"
 zeroize = "1"
 # Track C chokepoint integration — optional, OFF by default. Pulled in only by
 # the `chokepoint` feature below; the default build/test graph is byte-identical.
-gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.13.0", optional = true }
+gaze-mcp-core = { path = "../gaze-mcp-core", version = "0.14.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]

--- a/crates/gaze-token-bridge/README.md
+++ b/crates/gaze-token-bridge/README.md
@@ -1,11 +1,11 @@
 # gaze-token-bridge
 
-> **Status:** experimental and published as `gaze-token-bridge = "0.13.0"`.
+> **Status:** experimental and published as `gaze-token-bridge = "0.14.0"`.
 > API is pre-1.0 and may change.
 
 ```toml
 [dependencies]
-gaze-token-bridge = "0.13.0"
+gaze-token-bridge = "0.14.0"
 ```
 
 The token bridge is the **owner-side authorization + translation layer** that lets an

--- a/crates/gaze-types/Cargo.toml
+++ b/crates/gaze-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-types"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true

--- a/crates/gaze-types/README.md
+++ b/crates/gaze-types/README.md
@@ -24,7 +24,7 @@ Otherwise depend on `gaze` — it re-exports the public types from this crate.
 
 ```toml
 [dependencies]
-gaze-types = "0.13.0"
+gaze-types = "0.14.0"
 ```
 
 ## Key types

--- a/crates/gaze/Cargo.toml
+++ b/crates/gaze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaze-pii"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.89"
 license.workspace = true
@@ -30,7 +30,7 @@ anyhow = "1"
 base64 = "0.22"
 dashmap = "6"
 ed25519-dalek = "2"
-gaze-recognizers = { path = "../gaze-recognizers", version = "0.13.0", optional = true }
+gaze-recognizers = { path = "../gaze-recognizers", version = "0.14.0", optional = true }
 gaze-types = { workspace = true }
 hex = "0.4"
 libc = "0.2"

--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -16,9 +16,9 @@ The crate is published as `gaze-pii`; the import path remains `use gaze::...` be
 
 ```toml
 [dependencies]
-gaze-pii = "0.13.0"
-gaze-assembly = "0.13.0"
-gaze-recognizers = "0.13.0"
+gaze-pii = "0.14.0"
+gaze-assembly = "0.14.0"
+gaze-recognizers = "0.14.0"
 ```
 
 `gaze-assembly` provides `CorePipelineConfig` — bundled defaults so you don't hand-wire the `core` rulepack (emails, names, locations, organizations, locale cues).

--- a/docs/how-to/maintainers/release-process.md
+++ b/docs/how-to/maintainers/release-process.md
@@ -54,7 +54,7 @@ Post-repair hashes and owner/mode inventory are retained in the receipts. Exact 
 a zero-test cargo result cannot pass the gate.
 
 After review, dispatch with `gh workflow run release.yml --ref <preparation-branch>
--f version=0.13.0 -f pr_number=<release-pr>`. Require a successful
+-f version=0.14.0 -f pr_number=<release-pr>`. Require a successful
 `model-setup-ownership-preflight` job for that exact preparation head before
 tagging. Its `model-setup-ownership-<commit>` artifact
 records the commit, commands, toolchain, model hashes, owner/mode inventory,

--- a/scripts/bench/validator_recall_probe/Cargo.lock
+++ b/scripts/bench/validator_recall_probe/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "gaze-assembly"
-version = "0.12.0"
+version = "0.14.0"
 dependencies = [
  "gaze-pii",
  "gaze-recognizers",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-pii"
-version = "0.12.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-recognizers"
-version = "0.12.1"
+version = "0.14.0"
 dependencies = [
  "aho-corasick",
  "gaze-types",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "gaze-types"
-version = "0.12.0"
+version = "0.14.0"
 dependencies = [
  "phonenumber",
  "serde",


### PR DESCRIPTION
## What & why

Prepare the coordinated Gaze v0.14.0 release. All 15 publishable crates move from
0.13.0 to 0.14.0, the `Unreleased` changelog block becomes `## [0.14.0] - 2026-09-11`,
and the release skill gains a new pre-flight gate binding every release to its own
benchmark.

This is a release-preparation change. No detector, rulepack, recognizer, policy
surface, or runtime code path is modified; correctness axes 1-4 are untouched.

### Scope

- **Version bump 0.13.0 to 0.14.0** across the root `[workspace.dependencies]`
  pins, every per-crate `[package] version`, each crate's inter-crate path
  dependency pins, the published README install and dependency strings that
  `readme-version-check` inspects, and the `release.yml` dispatch example in the
  maintainer release runbook. `Cargo.lock` was refreshed with
  `cargo update --workspace`, which re-resolved the 15 workspace packages and
  left all 204 third-party dependencies unchanged.
- **CHANGELOG `## [0.14.0] - 2026-09-11`** curated from the 15 merges since
  v0.13.0. `## [Unreleased]` is left empty and a `[0.14.0]` compare link reference
  was added.
- **Release pre-flight gate 9** in `.claude/skills/release/SKILL.md`: version X
  ships with benchmark X. The release commit's scorecard is stored as
  `docs/reference/benchmarks/scorecard-vX.Y.Z.json` and the consolidated benchmark
  document gains one row and one chart point keyed by `vX.Y.Z`, with commit sha,
  script, and hardware as secondary columns. A release without a fresh benchmark
  is blocked.

### Commits in this PR (3)

| # | Sha | Subject | Files |
|---|---|---|---|
| 1 | `f66a3f2b` | `release: prepare v0.14.0` | 15 crate manifests + root `Cargo.toml` + `Cargo.lock` + READMEs, `CHANGELOG.md`, `.claude/skills/release/SKILL.md` |
| 2 | `fdc3be26` | `release: sweep remaining hard-coded crate count and fix Unreleased compare link` | `.claude/skills/release/SKILL.md`, `CHANGELOG.md` (3 lines) |
| 3 | `da364572` | `bench: re-pin validator_recall_probe lockfile to workspace 0.14.0` | `scripts/bench/validator_recall_probe/Cargo.lock` (4 lines) |

Commits 2 and 3 landed after the first review round; both are described in their
own sections below. All three are signed and carry `Signed-off-by`.

### Changelog contents (15 merges since v0.13.0)

Fixed: #474, #473. Changed: #469, #455, #466, #470. Added: #454, #456, #459.
Removed: #467, #468. Documentation: #463, #464, #465, #472.

This branch is rebased onto `main` at `5a48d3db` (the #474 merge), so #474 is
included. The rebase conflicted only in `CHANGELOG.md`, where #474 had added an
entry under `## [Unreleased]` while this branch empties that block and moves
everything into `## [0.14.0]`. The resolution keeps the `[0.14.0]` section, which
already carries a curated, PR-anchored #474 entry, and leaves `[Unreleased]`
empty. It was verified structurally rather than by reading: the resolved file is
byte-identical to this branch's pre-rebase `CHANGELOG.md`, and no conflict marker
of any of the four zdiff3 types remains.

`### Fixed` lists #474 before #473. Both are restore/detection correctness fixes,
but they fail in opposite directions: #474 was a silent under-detection (a corrupt
model output was indistinguishable from a document containing no PII, so raw PII
was forwarded downstream with no error and no audit trail), while #473 was an
over-strict false failure on a byte-exact restore. Against the project contract of
fail closed, preserve reversibility, keep PII out of agent-visible surfaces, the
silent leak is the more severe of the two, so it leads. Reorder if the release
narrative should lead with #473 instead.

## Pre-flight gates

Run on the rebased head in an isolated anvil worktree with its own target
directory, against the repository-pinned Rust 1.96.0 from `rust-toolchain.toml`
with `RUSTC`/`RUSTDOC` explicitly bound (the `RUSTUP_TOOLCHAIN` variable alone is
not sufficient here; a Homebrew `rustc` otherwise shadows the rustup shim).
Absolute local paths are normalised to `<worktree>`.

The roster below was run on the commit-1 head. Commits 2 and 3 add seven changed
lines across three files, none of them compiled by the workspace build
(`SKILL.md`, `CHANGELOG.md`, and a detached crate's lockfile), so the local
results carry over unchanged. PR CI on `da364572` is the authority for the
current head; the gates table is supporting evidence, not a substitute.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | PASS (exit 0) |
| `cargo clippy --workspace --all-features --all-targets -- -D warnings` | PASS (exit 0) |
| `cargo test --workspace --all-features` | PASS (exit 0) |
| `cargo run -p xtask -- readme-version-check` | PASS (exit 0) |
| `cargo run -p xtask -- ci-feature-matrix` | PASS (exit 0) |
| `git grep -E '/Users/[a-z]+'` | PASS (zero tracked matches) |
| `cargo build -p gaze-cli --all-features` | PASS (exit 0) |

```text
$ cargo run -p xtask -- readme-version-check
test readme_version_check::tests::readme_version_check_rejects_mismatched_fixture ... ok
readme-version-check: passed (15 published crates)

$ cargo clippy --workspace --all-features --all-targets -- -D warnings
    Checking gaze-recognizers v0.14.0 (<worktree>/crates/gaze-recognizers)
    Checking gaze-cli v0.14.0 (<worktree>/crates/gaze-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.45s

$ cargo test --workspace --all-features
1634 passed; 0 failed; 15 ignored, across 140 test binaries
```

The test count rose from 1628 to 1634 across the rebase. Diffing the test-name
sets shows exactly six added and none removed, all of them #474's boundary:

```text
ner::backend::ort::tests::invalid_output_blocks_pipeline_clean_output
ner::backend::ort::tests::invalid_output_infallible_detector_panics
ner::backend::ort::tests::invalid_output_reaches_fallible_callers_before_filtering
ner::backend::ort::tests::invalid_output_rejects_every_nonfinite_label_and_special_token
ner::backend::ort::tests::invalid_output_rejects_missing_and_malformed_tensors
ner::backend::ort::tests::valid_output_preserves_empty_special_tokens_and_finite_score_oracle
```

## Dogfood (gate 7)

Gate 7 as written pipes the changed `CHANGELOG.md` section through `gaze clean`
and requires zero detections. Run with the branch-built `gaze 0.14.0`:

```text
$ target/debug/gaze --version
gaze 0.14.0

$ target/debug/gaze clean < <the 0.14.0 CHANGELOG section>
detections: 0
locale_chain: ["global"]
clean_text: byte-identical to input
```

PASS as specified. The same command over the final PR body also reports
`detections: 0`.

### Gate 7 is weaker than it looks (needs a follow-up decision)

The default `gaze clean` invocation that gate 7 specifies does not load the
bundled `core` rulepack, so it detects almost nothing. Measured on this branch's
own binary:

```text
gaze 0.14.0 (branch build)

input shape                          default   --rulepack core
-----------------------------------  --------  ---------------
RFC 1918 IPv4 literal                0         1
IPv6 literal                         0         1
German IBAN literal                  0         1
US phone literal                     0         1
US SSN literal                       0         1
email literal                        1         1
```

Sample values are described by shape rather than quoted, so that this PR body
itself passes gate 7. Reproduce with real literals locally:

```bash
B=target/debug/gaze
for t in 'Server at <ipv4> went down.' 'IBAN <iban> please.' 'SSN <ssn> on file.'; do
  printf '%s\n' "$t" | $B clean                        | jq -r .stats.detections
  printf '%s\n' "$t" | $B clean --rulepack-bundled core | jq -r .stats.detections
done
```

A release note containing a real IBAN, SSN, IPv4 or phone number would therefore
pass gate 7 unchanged. That is the same failure shape as the #360 IBAN leak,
which shipped through a gate whose verification flag was never wired up: the gate
existed and was invoked, but its invocation could not fail.

Deliberately **not** fixed in this PR, because the correct fix depends on a
question this branch cannot answer: whether "no bundled rulepack unless asked"
is the intended CLI default (in which case gate 7's wording should require an
explicit `--rulepack-bundled core`) or a defect in default activation (in which
case the CLI is what should change, and the documented default-activation table
in `docs/reference/redaction-classes.md#shipped-default-activation` no longer
matches observed behaviour). Routing this for a decision rather than guessing.

### Hardened dogfood result

Re-run with an explicit rulepack, the section reports four detections, all of
them false positives, and no real PII:

```text
$ target/debug/gaze clean --rulepack-bundled core < <the 0.14.0 CHANGELOG section>
detections: 4
  class=Custom:ip_address  raw="::"     token=<...:Custom:ip_address_1>
  class=Custom:ip_address  raw="::Bac"  token=<...:Custom:ip_address_2>
  class=Custom:ip_address  raw="e::"    token=<...:Custom:ip_address_3>
```

Four detections map to three manifest entries because `detections` counts
occurrences while entries are unique raw-to-token mappings: the bare `::` occurs
in both `NerRuntimeError::Output` and `Error::RecognizerDetect` and collapses to
one token, which is the stable mapping restore depends on.

The `ip.v6` recognizer (`crates/gaze-recognizers/embedded/core.toml`, class
`custom:ip_address`) matches the Rust path separator `::` in
`NerRuntimeError::Output`, `DetectError::Backend`, `Error::RecognizerDetect`, and
`gaze::registry`. IPv6 zero-compression plus an adjacent hex-range character
(`Bac`, `e`) is enough to satisfy the pattern. The changelog text was **not**
reworded to dodge this: the release-notes voice requires exact type names
verbatim, and mangling prose to work around a recognizer false positive would
hide the defect rather than fix it. Recognizer follow-up, not a release blocker.

### Additional fix: stale post-tag verification list

`readme-version-check` reports 15 published crates, but the release skill's
post-tag verification step hard-coded a list of 11 crate names, omitting
`gaze-inspection`, `gaze-model-setup`, `gaze-proxy-dashboard`, and
`gaze-token-bridge`. Publication itself was never at risk: `publish-crates.yml`
derives its set and order from `cargo metadata` via
`cargo run -p xtask -- publish-plan`, so all 15 are published automatically. The
defect was in verification only, where confirming 11 crates would have read as a
pass across a partial publish of 15.

The step now derives the expected set from `publish-plan` instead of restating
it, and records the current 15 names as a snapshot rather than a source of truth.
This is outside the literal prep brief; revert this hunk if it should land
separately.

### Commit 2: review sweep — remaining crate counts and the compare link

Review of this PR found that making post-tag verification step 3 publish-plan-derived
(commit 1, above) left two sibling sites in the same file still asserting the stale
count of 11, and that the `CHANGELOG.md` `[Unreleased]` compare link was still
anchored at `v0.13.0`.

Three lines, documentation only:

- `.claude/skills/release/SKILL.md` step 4 — "GitHub Release URL plus the 11
  crates.io URLs" becomes "plus one crates.io URL per crate in the publish plan".
- `.claude/skills/release/SKILL.md` Counter-Pattern — "all 11 crates report the
  expected version" becomes "every crate in the publish plan reports the expected
  version".
- `CHANGELOG.md` — `[Unreleased]: .../compare/v0.13.0...HEAD` becomes
  `compare/v0.14.0...HEAD`, so that once `v0.14.0` is tagged the `[Unreleased]`
  link shows what actually landed after this release rather than re-showing this
  release's own contents.

This is the same drift class commit 1 set out to remove. Fixing one of three
copies and leaving two would have re-created the defect the moment the next
crate is added, so the sweep belongs with the original change rather than in a
follow-up.

### Commit 3: re-pin the validator_recall_probe lockfile

`scripts/bench/validator_recall_probe/` is a detached crate with its own
`Cargo.lock`, so the workspace version bump does not reach it. That lockfile
still pinned `gaze-assembly`, `gaze-pii`, `gaze-recognizers` and `gaze-types` at
`0.12.x`, which predates even v0.13.0 — meaning the canonical benchmark harness
has aborted on `cargo build --locked` from any clean checkout since the v0.13
bump, and would have aborted again on the v0.14.0 benchmark this release's
gate 9 requires.

Four lines, version pins only; all third-party pins are unchanged. The locked
probe build was verified against the pinned 1.96.0 toolchain.

This is release-blocking in practice rather than cosmetic: gate 9 pairs version X
with benchmark X, and the harness that produces benchmark X could not build.

## Structure and data-model review

1. **Verdict:** implement (bounded to the runbook hunk above).
2. **Opportunity:** replace the duplicated publish-set list in the release skill
   with a derivation from the existing `xtask publish-plan` single source of truth.
3. **Why:** the list was a second copy of a fact `cargo metadata` already owns. It
   had drifted from 15 to 11, and a drifted verification checklist converts a
   partial publish into a reported success. Deleting the copy removes the drift
   class rather than correcting one instance of it.
4. **Scope:** `.claude/skills/release/SKILL.md` only. Documentation and runbook
   text; no runtime behaviour, no public API, no detector or policy surface.
   Landed here because this release's own post-tag verification depends on it.
5. **Validation:** `readme-version-check` reports 15 published crates; the
   `PublishPlan` command is present in `crates/xtask/src/main.rs`; the full gate
   roster below is green.

The version bump itself introduces no structure: it is 83 changed lines, every
one a version pin, plus 15 workspace version lines in `Cargo.lock`.

## Tagging

Tagging is **not** part of this PR. After this merges, the tag is created on the
merge commit per the Tag Procedure in `.claude/skills/release/SKILL.md`, and only
after an explicit user lock signal. New pre-flight gate 9 additionally blocks the
tag until the scorecard harness has run on the release commit and the
consolidated benchmark document carries a `v0.14.0` row and chart point.

## Visual evidence

None. This change alters no visible output: it is version pins, changelog prose,
and runbook text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdGYhQmXyMuKA5HojyKCRZ

