### PR TITLE
fix(proxy): guard cross-block response carriers

### DIFF
--- a/crates/gaze-proxy/src/codecs/anthropic.rs
+++ b/crates/gaze-proxy/src/codecs/anthropic.rs
@@ -357,6 +357,7 @@ fn validate_adjacent_response_text(
                 .map(|range| base + range.start..base + range.end),
         );
     }
+    guard_mutable_text_response(&logical)?;
     ctx.validate(&logical, &authorized)
 }
 
@@ -4428,6 +4429,8 @@ fn restore_sse_frames(
             CodecPhase::SseLifecycle,
         ));
     }
+    guard_mutable_text_response(&concatenated_text)
+        .map_err(|code| codec_error(code, CodecPhase::SseLifecycle))?;
     ctx.validate(&concatenated_text, &concatenated_authorized)
         .map_err(|code| codec_error(code, CodecPhase::SseLifecycle))?;
     let mut output = Vec::new();

--- a/crates/gaze-proxy/tests/anthropic_codec.rs
+++ b/crates/gaze-proxy/tests/anthropic_codec.rs
@@ -1001,6 +1001,187 @@ fn angle_wrapped_response_carriers_fail_closed_in_text_and_tool_output() {
 }
 
 #[test]
+fn response_split_url_carrier_across_two_text_blocks_is_rejected() {
+    // Each `text` block individually passes the per-block guard (`"http"` starts no
+    // recognized scheme; `"s://…<token>"` starts no recognized scheme), but they
+    // concatenate, after restoration, into `https://…`. The cross-block guard must
+    // reject the reassembled carrier with ProviderOriginPii — the same code the
+    // single-block form hits at the per-block layer.
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut transaction = session.begin_transaction();
+    let token = transaction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let snapshot = transaction.commit().unwrap();
+    let suffix = serde_json::to_string(&format!("s://evil.example.invalid/{token}")).unwrap();
+    let body = format!(
+        r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":"http"}},{{"type":"text","text":{suffix}}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+    );
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_response(
+            body.as_bytes(),
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Json,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn ndjson_split_url_carrier_within_single_line_is_rejected() {
+    // NDJSON routes each line through the same `validate_adjacent_response_text`
+    // concatenation, so a split URL carrier within a single NDJSON line must also be
+    // rejected.
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut transaction = session.begin_transaction();
+    let token = transaction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let snapshot = transaction.commit().unwrap();
+    let suffix = serde_json::to_string(&format!("s://evil.example.invalid/{token}")).unwrap();
+    let line = format!(
+        r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":"http"}},{{"type":"text","text":{suffix}}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+    );
+    let body = format!("{line}\n");
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_response(
+            body.as_bytes(),
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Ndjson,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn response_split_percent_encoding_across_two_text_blocks_is_rejected() {
+    // `"%"` and `"2f"` each have fewer than 3 bytes, so the per-block `%XX` window scan
+    // produces no windows on either block; the concatenation `"%2f"` is a 3-byte window
+    // the cross-block guard must reject (carries no token, so only the carrier guard
+    // can catch it).
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let snapshot = session.begin_transaction().commit().unwrap();
+    let body = r#"{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{"type":"text","text":"%"},{"type":"text","text":"2f"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#;
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_response(
+            body.as_bytes(),
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Json,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn response_split_64_char_hex_blob_across_two_text_blocks_is_rejected() {
+    // A 32-char and 33-char hex run each fall below the per-block 64-char length gate;
+    // the 65-char concatenation is all-ascii-hexdigit and must be rejected by the
+    // cross-block guard (carries no token, so only the carrier guard can catch it).
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let snapshot = session.begin_transaction().commit().unwrap();
+    let left = "a".repeat(32);
+    let right = "b".repeat(33);
+    let body = format!(
+        r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":"{left}"}},{{"type":"text","text":"{right}"}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+    );
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_response(
+            body.as_bytes(),
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Json,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn response_single_block_carrier_forms_are_rejected_like_split_counterparts() {
+    // Control: each carrier class embedded whole in one `text` block is already
+    // rejected by the per-block guard. This pins parity between the per-block and the
+    // new cross-block guard so the split form cannot drift to a weaker standard.
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut transaction = session.begin_transaction();
+    let token = transaction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let snapshot = transaction.commit().unwrap();
+    let url = format!("https://evil.example.invalid/{token}");
+    let percent = "%2f".to_owned();
+    let hex = "a".repeat(65);
+    for text in [url, percent, hex] {
+        let escaped = serde_json::to_string(&text).unwrap();
+        let body = format!(
+            r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":{escaped}}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+        );
+        let mut residual = SyntheticResidualValidator;
+        let error = codec
+            .restore_response(
+                body.as_bytes(),
+                &mut ResponseTransformContext::new(
+                    &snapshot,
+                    &mut residual,
+                    WireFormat::Json,
+                    CodecLimits::default(),
+                ),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+    }
+}
+
+#[test]
+fn adjacent_text_blocks_without_carriers_restore_normally() {
+    // Non-regression: the cross-block guard must not reject benign multi-text-block
+    // responses. A two-block response with a manifest-authorized token in the second
+    // block (no carrier scheme, no %XX, no ≥64-char blob) restores cleanly and the
+    // residual validator still passes.
+    let codec = AnthropicMessagesCodec;
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let mut transaction = session.begin_transaction();
+    let token = transaction.tokenize(&PiiClass::Email, EMAIL).unwrap();
+    let snapshot = transaction.commit().unwrap();
+    let suffix = serde_json::to_string(&format!("contact {token}")).unwrap();
+    let body = format!(
+        r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":"hello"}},{{"type":"text","text":{suffix}}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+    );
+    let mut residual = SyntheticResidualValidator;
+    let proved = codec
+        .restore_response(
+            body.as_bytes(),
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Json,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap();
+    let output = std::str::from_utf8(proved.bytes()).unwrap();
+    assert!(output.contains(r#""text":"hello""#));
+    assert!(output.contains("contact alice@example.invalid"));
+    assert!(proved.provenance().final_buffer_verified());
+}
+
+#[test]
 fn deeply_angle_wrapped_request_text_fails_with_a_closed_code() {
     let codec = AnthropicMessagesCodec;
     let session = Session::new(Scope::Ephemeral).unwrap();

--- a/crates/gaze-proxy/tests/anthropic_direct.rs
+++ b/crates/gaze-proxy/tests/anthropic_direct.rs
@@ -93,6 +93,7 @@ struct UpstreamState {
     rate_limited: bool,
     invalid_stream: bool,
     delayed_stream: bool,
+    split_carrier: bool,
     provider_text: Option<String>,
 }
 
@@ -201,6 +202,43 @@ async fn capture_anthropic_request(
         body,
     });
 
+    if state.split_carrier {
+        let protected = state.provider_text.as_deref().unwrap_or_else(|| {
+            request_json["messages"][0]["content"]
+                .as_str()
+                .unwrap_or("synthetic")
+        });
+        let suffix = format!("s://evil.example.invalid/{protected}");
+        let escaped_suffix = serde_json::to_string(&suffix).unwrap();
+        if request_json["stream"].as_bool().unwrap_or(false) {
+            let frames = [
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-test\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":1,\"output_tokens\":0}}}\n\n",
+                "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+                "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"http\"}}\n\n",
+                "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+                "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+                &format!("event: content_block_delta\ndata: {{\"type\":\"content_block_delta\",\"index\":1,\"delta\":{{\"type\":\"text_delta\",\"text\":{escaped_suffix}}}}}\n\n"),
+                "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":1}}\n\n",
+                "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            ]
+            .concat();
+            return axum::response::Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .body(Body::from(frames))
+                .unwrap();
+        }
+        let body = format!(
+            r#"{{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[{{"type":"text","text":"http"}},{{"type":"text","text":{escaped_suffix}}}],"stop_reason":"end_turn","stop_sequence":null,"usage":{{"input_tokens":1,"output_tokens":1}}}}"#
+        );
+        return axum::response::Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+    }
+
     if state.rate_limited {
         return axum::response::Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
@@ -263,21 +301,26 @@ async fn capture_anthropic_request(
 }
 
 async fn spawn_upstream() -> MockUpstream {
-    spawn_upstream_with_mode(false, false, false, None).await
+    spawn_upstream_with_mode(false, false, false, false, None).await
 }
 
 async fn spawn_upstream_with_rate_limit(rate_limited: bool) -> MockUpstream {
-    spawn_upstream_with_mode(rate_limited, false, false, None).await
+    spawn_upstream_with_mode(rate_limited, false, false, false, None).await
 }
 
 async fn spawn_upstream_with_provider_text(provider_text: &str) -> MockUpstream {
-    spawn_upstream_with_mode(false, false, false, Some(provider_text.to_string())).await
+    spawn_upstream_with_mode(false, false, false, false, Some(provider_text.to_string())).await
+}
+
+async fn spawn_upstream_with_split_carrier() -> MockUpstream {
+    spawn_upstream_with_mode(false, false, false, true, None).await
 }
 
 async fn spawn_upstream_with_mode(
     rate_limited: bool,
     invalid_stream: bool,
     delayed_stream: bool,
+    split_carrier: bool,
     provider_text: Option<String>,
 ) -> MockUpstream {
     let captures = Arc::new(Mutex::new(Vec::new()));
@@ -288,6 +331,7 @@ async fn spawn_upstream_with_mode(
             rate_limited,
             invalid_stream,
             delayed_stream,
+            split_carrier,
             provider_text,
         });
     let backend_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1095,6 +1139,67 @@ async fn split_opaque_carriers_reject_across_complete_request_views_without_side
 }
 
 #[tokio::test]
+async fn production_pipeline_rejects_split_url_carrier_json() {
+    // End-to-end: the client request carries `alice@example.invalid`; the proxy
+    // pseudonymizes it; the mock upstream returns two `text` blocks assembling
+    // `http` + `s://evil.example.invalid/<token>`. After restoration the concatenation
+    // is `https://evil.example.invalid/alice@example.invalid`, which the cross-block
+    // guard rejects. The response must not reach the client and no PII may leak.
+    let upstream = spawn_upstream_with_split_carrier().await;
+    let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": EMAIL}],
+        "stream": false
+    });
+    let response = Client::new()
+        .post(format!("{}/v1/messages", proxy.base_url))
+        .header("x-api-key", "sdk-synthetic-key")
+        .header("anthropic-version", "2023-06-01")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert!(!response.status().is_success());
+    let body = response.text().await.unwrap();
+    assert!(!body.contains(EMAIL));
+    assert!(!body.contains("s://evil.example.invalid"));
+    assert_eq!(upstream.captures.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn production_pipeline_rejects_split_url_carrier_sse() {
+    // Same split-URL carrier as the JSON case, delivered as two SSE text blocks. The
+    // cross-block guard rejects the reassembled carrier at the end of the stream, so
+    // the proxy replays only the constant safe error frame and the restored PII never
+    // reaches the client.
+    let upstream = spawn_upstream_with_split_carrier().await;
+    let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
+    let request = json!({
+        "model": "claude-test",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": EMAIL}],
+        "stream": true
+    });
+    let response = Client::new()
+        .post(format!("{}/v1/messages", proxy.base_url))
+        .header("x-api-key", "sdk-synthetic-key")
+        .header("anthropic-version", "2023-06-01")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.bytes().await.unwrap();
+    assert_eq!(body, ANTHROPIC_PROXY_ERROR_FRAME);
+    assert!(!body
+        .windows(EMAIL.len())
+        .any(|window| window == EMAIL.as_bytes()));
+    assert_eq!(upstream.captures.lock().await.len(), 1);
+}
+
+#[tokio::test]
 async fn joined_opaque_guard_preserves_signed_bytes_without_a_joined_finding() {
     const SIGNED_BLOCK: &[u8] = br#"{"type":"redacted_thinking","data":"opaque-synthetic-data"}"#;
     let upstream = spawn_upstream().await;
@@ -1277,7 +1382,7 @@ async fn closed_errors_and_debug_omit_credentials_pii_and_upstream_text() {
 
 #[tokio::test]
 async fn late_stream_proof_failure_emits_only_the_constant_safe_error_frame() {
-    let upstream = spawn_upstream_with_mode(false, true, false, None).await;
+    let upstream = spawn_upstream_with_mode(false, true, false, false, None).await;
     let proxy = spawn_proxy(AnthropicAdapter::new(upstream.origin.clone())).await;
     let response = sdk_client_request(&Client::new(), &proxy, true)
         .send()
@@ -1291,7 +1396,7 @@ async fn late_stream_proof_failure_emits_only_the_constant_safe_error_frame() {
 
 #[tokio::test]
 async fn delayed_stream_emits_only_the_compiled_ping_before_proved_replay() {
-    let upstream = spawn_upstream_with_mode(false, false, true, None).await;
+    let upstream = spawn_upstream_with_mode(false, false, true, false, None).await;
     let adapter = AnthropicAdapter::builder(upstream.origin.clone())
         .ping_interval(Duration::from_secs(1))
         .unwrap()
@@ -1318,7 +1423,7 @@ async fn delayed_stream_emits_only_the_compiled_ping_before_proved_replay() {
 async fn unmodified_official_python_sdk_runs_non_stream_and_stream_against_loopback() {
     let python = std::env::var_os("GAZE_OFFICIAL_SDK_PYTHON")
         .expect("GAZE_OFFICIAL_SDK_PYTHON must identify the prepared SDK interpreter");
-    let upstream = spawn_upstream_with_mode(false, false, true, None).await;
+    let upstream = spawn_upstream_with_mode(false, false, true, false, None).await;
     let proxy = spawn_proxy(
         AnthropicAdapter::builder(upstream.origin.clone())
             .ping_interval(Duration::from_secs(1))

--- a/crates/gaze-proxy/tests/anthropic_sse.rs
+++ b/crates/gaze-proxy/tests/anthropic_sse.rs
@@ -352,6 +352,187 @@ fn adjacent_sse_text_blocks_are_scanned_as_one_logical_domain() {
 }
 
 #[test]
+fn adjacent_sse_text_blocks_splitting_url_carrier_are_rejected() {
+    // Two text content blocks whose text deltas each pass the per-block guard
+    // (`"http"` and `"s://…<token>"` start no recognized scheme) but concatenate, after
+    // restoration, into `https://…`. The SSE cross-block concatenation must reject the
+    // reassembled carrier with ProviderOriginPii.
+    let codec = AnthropicMessagesCodec;
+    let (snapshot, token) = snapshot_with_email();
+    let suffix = serde_json::to_string(&format!("s://evil.example.invalid/{token}")).unwrap();
+    let stream = [
+        frame("message_start", r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"http"}}"#),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":0}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", &format!(r#"{{"type":"content_block_delta","index":1,"delta":{{"type":"text_delta","text":{suffix}}}}}"#)),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":1}"#),
+        frame("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#),
+        frame("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_sse_chunks(
+            [stream.as_bytes()],
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Sse,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn adjacent_sse_text_blocks_splitting_percent_encoding_are_rejected() {
+    // `"%"` and `"2f"` each have fewer than 3 bytes so neither per-block guard can form a
+    // `%XX` window; the cross-block concatenation `"%2f"` must be rejected (no token,
+    // so only the carrier guard can catch it).
+    let codec = AnthropicMessagesCodec;
+    let (snapshot, _) = snapshot_with_email();
+    let stream = [
+        frame("message_start", r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"%"}}"#),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":0}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", r#"{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"2f"}}"#),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":1}"#),
+        frame("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#),
+        frame("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_sse_chunks(
+            [stream.as_bytes()],
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Sse,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn adjacent_sse_text_blocks_splitting_64_char_hex_blob_are_rejected() {
+    // A 32-char and 33-char hex run each fall below the per-block 64-char length gate;
+    // the 65-char all-ascii-hexdigit concatenation must be rejected by the cross-block
+    // guard (no token, so only the carrier guard can catch it).
+    let codec = AnthropicMessagesCodec;
+    let (snapshot, _) = snapshot_with_email();
+    let left = "a".repeat(32);
+    let right = "b".repeat(33);
+    let stream = [
+        frame("message_start", r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", &format!(r#"{{"type":"content_block_delta","index":0,"delta":{{"type":"text_delta","text":"{left}"}}}}"#)),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":0}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", &format!(r#"{{"type":"content_block_delta","index":1,"delta":{{"type":"text_delta","text":"{right}"}}}}"#)),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":1}"#),
+        frame("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#),
+        frame("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    let mut residual = SyntheticResidualValidator;
+    let error = codec
+        .restore_sse_chunks(
+            [stream.as_bytes()],
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Sse,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+}
+
+#[test]
+fn adjacent_sse_single_block_carrier_forms_are_rejected_like_split_counterparts() {
+    // Control: each carrier class embedded whole in one text block is already rejected
+    // by the per-block guard. This pins parity between the per-block and the new
+    // cross-block guard so the split form cannot drift to a weaker standard.
+    let codec = AnthropicMessagesCodec;
+    let (snapshot, token) = snapshot_with_email();
+    let url = format!("https://evil.example.invalid/{token}");
+    let percent = "%2f".to_owned();
+    let hex = "a".repeat(65);
+    for text in [url, percent, hex] {
+        let escaped = serde_json::to_string(&text).unwrap();
+        let stream = [
+            frame("message_start", r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}"#),
+            frame("content_block_start", r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#),
+            frame("content_block_delta", &format!(r#"{{"type":"content_block_delta","index":0,"delta":{{"type":"text_delta","text":{escaped}}}}}"#)),
+            frame("content_block_stop", r#"{"type":"content_block_stop","index":0}"#),
+            frame("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#),
+            frame("message_stop", r#"{"type":"message_stop"}"#),
+        ]
+        .concat();
+        let mut residual = SyntheticResidualValidator;
+        let error = codec
+            .restore_sse_chunks(
+                [stream.as_bytes()],
+                &mut ResponseTransformContext::new(
+                    &snapshot,
+                    &mut residual,
+                    WireFormat::Sse,
+                    CodecLimits::default(),
+                ),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), CodecErrorCode::ProviderOriginPii);
+    }
+}
+
+#[test]
+fn adjacent_sse_text_blocks_without_carriers_restore_normally() {
+    // Non-regression: the SSE cross-block guard must not reject benign multi-block
+    // text. Two blocks `"hello"` and `"contact <token>"` (no carrier) restore cleanly,
+    // the residual validator passes, and the restored email reaches the output.
+    let codec = AnthropicMessagesCodec;
+    let (snapshot, token) = snapshot_with_email();
+    let suffix = serde_json::to_string(&format!("contact {token}")).unwrap();
+    let stream = [
+        frame("message_start", r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}"#),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":0}"#),
+        frame("content_block_start", r#"{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#),
+        frame("content_block_delta", &format!(r#"{{"type":"content_block_delta","index":1,"delta":{{"type":"text_delta","text":{suffix}}}}}"#)),
+        frame("content_block_stop", r#"{"type":"content_block_stop","index":1}"#),
+        frame("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}"#),
+        frame("message_stop", r#"{"type":"message_stop"}"#),
+    ]
+    .concat();
+    let mut residual = SyntheticResidualValidator;
+    let proved = codec
+        .restore_sse_chunks(
+            [stream.as_bytes()],
+            &mut ResponseTransformContext::new(
+                &snapshot,
+                &mut residual,
+                WireFormat::Sse,
+                CodecLimits::default(),
+            ),
+        )
+        .unwrap();
+    let output = std::str::from_utf8(proved.bytes()).unwrap();
+    assert!(output.contains(r#""text":"hello""#));
+    assert!(output.contains("contact alice@example.invalid"));
+    assert!(proved.provenance().final_buffer_verified());
+}
+
+#[test]
 fn zero_delta_tool_block_remains_valid_and_empty() {
     let codec = AnthropicMessagesCodec;
     let (snapshot, _) = snapshot_with_email();


### PR DESCRIPTION
Anthropic responses could assemble an opaque carrier across individually safe text blocks and return restored PII inside it. Apply the existing carrier guard to joined restored text in JSON/NDJSON and SSE before residual validation and output proof.

## Review verdict
CLEAN. Reviewed the changed codec paths, guard, block finalization, output proof, and HTTP regressions. On current main with only the new tests applied, all nine carrier regressions fail: four JSON/NDJSON, three SSE codec, and two HTTP tests. Existing controls pass. Fixtures use synthetic .invalid addresses only.

## Axes
Reliability and deterministic trust improve: assembled carriers fail closed before response bytes are emitted. Manifest-authorized benign text retains its restore round-trip. Agentic fit and adopter ergonomics are preserved; no axis weakened.

## Structure and data-model review
- Verdict: recommend.
- Opportunity: a future enum for mock upstream modes in anthropic_direct.rs.
- Why: replace growing positional booleans and encode mutually exclusive fixture responses; production guard reuse already keeps carrier rules centralized.
- Scope: test helper only, deferred to avoid widening this narrow leak fix.
- Validation: reviewed all helper callers; existing modes remain unchanged. Any follow-up should run the anthropic_direct integration suite.

## Validation
Rust 1.96.0; worktree-local target; four build jobs. Formatting, workspace Clippy with all features/targets and warnings denied, and gaze-proxy all-feature tests pass. Nine baseline failures independently confirm the regression tests exercise the fix. No rendered assets or UI layout changed.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried. Verified signature G and one gpgsig header. The checked-out main ref could not be fetched directly; this branch was created from freshly fetched origin/main in the isolated worktree.

Supersedes #533
Closes #504
Resolves solo todo #3523 (partial; orchestrator completes)
