### PR TITLE
Close the --rulepack-path no-policy PII leak in the synthesized policy

### DIFF
--- a/crates/gaze-cli/src/pipeline/build.rs
+++ b/crates/gaze-cli/src/pipeline/build.rs
@@ -127,7 +127,7 @@ fn has_rulepack_overrides(overrides: &CleanOverrides) -> bool {
 fn policy_for_rulepack_overrides(
     overrides: &CleanOverrides,
 ) -> std::result::Result<Policy, CliError> {
-    let mut rules = class_rules_for_bundled_overrides(overrides)?;
+    let mut rules = class_rules_for_rulepack_overrides(overrides)?;
     rules.push(RuleSpec::Default {
         action: Action::Preserve,
     });
@@ -141,39 +141,25 @@ fn policy_for_rulepack_overrides(
     Ok(overrides.apply_to(&base))
 }
 
-fn class_rules_for_bundled_overrides(
+fn class_rules_for_rulepack_overrides(
     overrides: &CleanOverrides,
 ) -> std::result::Result<Vec<RuleSpec>, CliError> {
-    let Some(bundled) = &overrides.rulepack_bundled else {
-        return Ok(Vec::new());
-    };
     let mut classes = std::collections::BTreeSet::new();
-    for bundle in bundled {
-        let contents = gaze_recognizers::embedded(bundle).ok_or_else(|| {
-            CliError::PolicyConfigDetail(format!("unknown bundled rulepack: {bundle}"))
-        })?;
-        let rulepack = Rulepack::load(RulepackSource::Embedded(contents)).map_err(|err| {
-            CliError::PolicyConfigDetail(format!("embedded rulepack '{bundle}': {err}"))
-        })?;
+    if let Some(bundled) = &overrides.rulepack_bundled {
+        for bundle in bundled {
+            let contents = gaze_recognizers::embedded(bundle).ok_or_else(|| {
+                CliError::PolicyConfigDetail(format!("unknown bundled rulepack: {bundle}"))
+            })?;
+            let rulepack = Rulepack::load(RulepackSource::Embedded(contents)).map_err(|err| {
+                CliError::PolicyConfigDetail(format!("embedded rulepack '{bundle}': {err}"))
+            })?;
+            classes.extend(rulepack.activated_classes());
+        }
+    }
+    for path in &overrides.rulepack_paths {
+        let rulepack = Rulepack::load(RulepackSource::Path(path.clone()))
+            .map_err(|err| map_pipeline_error(gaze::Error::Rulepack(err)))?;
         classes.extend(rulepack.activated_classes());
-        classes.extend(
-            rulepack
-                .recognizers
-                .iter()
-                .filter(|recognizer| recognizer.enabled)
-                .filter_map(|recognizer| {
-                    recognizer
-                        .collision
-                        .as_ref()
-                        .and_then(|collision| {
-                            collision
-                                .mandatory_anchor
-                                .as_ref()
-                                .map(|_| &collision.family)
-                        })
-                        .map(|family| PiiClass::family(family))
-                }),
-        );
     }
     Ok(classes
         .into_iter()

--- a/crates/gaze-cli/tests/cli_pipe.rs
+++ b/crates/gaze-cli/tests/cli_pipe.rs
@@ -2277,6 +2277,122 @@ action = "preserve"
     assert_symmetric_policy_config(cli_out, toml_out);
 }
 
+// Path-only overrides must tokenize detected classes and preserve restore/audit behavior.
+#[test]
+fn s1_rulepack_path_only_no_policy_tokenizes_custom_class() {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("class-alpha.toml");
+    fs::write(&rulepack_path, class_alpha_rulepack()).unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+    let input = "ticket class-alpha-123";
+
+    let v = clean_json_with_args(
+        &[
+            &format!("--rulepack-path={}", rulepack_path.display()),
+            &format!("--audit-db={}", audit_path.display()),
+        ],
+        input,
+    );
+
+    let clean = v["clean_text"].as_str().unwrap();
+    assert!(
+        clean.starts_with("ticket <"),
+        "path-only no-policy run must redact the detected span; got: {clean}"
+    );
+    assert!(
+        clean.ends_with(":Custom:class_alpha_1>"),
+        "expected a custom:class_alpha token; got: {clean}"
+    );
+    assert_ne!(
+        clean, input,
+        "PII span must be tokenized, not preserved verbatim (silent leak)"
+    );
+    assert_eq!(v["stats"]["detections"], 1);
+
+    assert_eq!(
+        restore_success_text(v["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+
+    let logger = SqliteLogger::new(&audit_path).expect("audit log opens");
+    let entries = logger.entries().expect("audit entries");
+    assert_eq!(entries.len(), 1, "the recognizer must fire exactly once");
+    assert_eq!(
+        entries[0].action,
+        gaze::Action::Tokenize,
+        "path-only no-policy redaction must tokenize, not preserve"
+    );
+    assert!(
+        matches!(entries[0].class, PiiClass::Custom(ref name) if name == "class_alpha"),
+        "unexpected detection class: {:?}",
+        entries[0].class
+    );
+    assert_eq!(
+        entries[0].recognizer_id.as_deref(),
+        Some("class-alpha.regex"),
+        "unexpected recognizer_id: {:?}",
+        entries[0].recognizer_id
+    );
+}
+
+// Combining sources must protect classes from both bundled and path rulepacks.
+#[test]
+fn s1_rulepack_bundled_and_path_no_policy_tokenize_both_sources() {
+    let dir = tempdir().unwrap();
+    let rulepack_path = dir.path().join("class-alpha.toml");
+    fs::write(&rulepack_path, class_alpha_rulepack()).unwrap();
+    let audit_path = dir.path().join("audit.sqlite");
+    let input = "Phone +1 555 0100 ticket class-alpha-123";
+
+    let v = clean_json_with_args(
+        &[
+            "--rulepack-bundled",
+            "core",
+            &format!("--rulepack-path={}", rulepack_path.display()),
+            &format!("--audit-db={}", audit_path.display()),
+        ],
+        input,
+    );
+
+    let clean = v["clean_text"].as_str().unwrap();
+    assert!(
+        !clean.contains("class-alpha-123"),
+        "path rulepack PII must be tokenized, not preserved (leak): {clean}"
+    );
+    assert!(
+        !clean.contains("+1 555 0100"),
+        "bundled core phone must still be tokenized when a path rulepack is also present: {clean}"
+    );
+    assert_eq!(
+        v["stats"]["detections"], 2,
+        "both the bundled phone and the path custom class must be detected"
+    );
+    assert_eq!(
+        restore_success_text(v["session_blob"].as_str().unwrap(), clean),
+        input
+    );
+
+    let logger = SqliteLogger::new(&audit_path).expect("audit log opens");
+    let entries = logger.entries().expect("audit entries");
+    assert_eq!(entries.len(), 2, "both detections must be audited");
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.action == gaze::Action::Tokenize),
+        "every audited detection must be tokenized, none preserved: {entries:?}"
+    );
+    let path_entry = entries
+        .iter()
+        .find(|entry| matches!(entry.class, PiiClass::Custom(ref name) if name == "class_alpha"))
+        .expect("the path rulepack's custom:class_alpha detection must be audited");
+    assert_eq!(
+        path_entry.recognizer_id.as_deref(),
+        Some("class-alpha.regex"),
+        "unexpected path recognizer_id: {:?}",
+        path_entry.recognizer_id
+    );
+}
+
 #[test]
 fn s1_invalid_ner_locale_is_symmetric_between_cli_and_toml() {
     let (_valid_dir, valid_policy) = write_policy_with_ner_locale("en-US");


### PR DESCRIPTION
Without an explicit policy, path rulepacks detected custom PII but the synthesized policy preserved it. Generate tokenization rules from every bundled and path rulepack so both path-only and combined invocations protect detected classes and retain restore/audit behavior.

## Review verdict
NITS fixed: shortened verbose test comments. Reviewed pipeline resolution, override application, rulepack loading, activated classes, immediate callers, and synthetic fixtures. Both new regression tests fail against unchanged origin/main with raw custom PII in the output; the bundled-only control passes. The regression tests also assert restoration and Tokenize audit provenance.

## Axes
Reliability improves by closing the path-rulepack leak. Reversibility and deterministic audit attribution remain covered. Agentic fit and adopter ergonomics improve for policy-free CLI use. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: existing BTreeSet of activated classes as the single source of generated class rules.
- Why: removes the duplicate mandatory-anchor family traversal; activated_classes already includes those families and deduplicates both sources.
- Scope: two CLI files; no new abstraction or unrelated behavior.
- Validation: tests reproduce both leaks on main; rustfmt passes. Workspace Clippy with all features/targets and -D warnings passes; the complete gaze-cli all-features suite passes, including 113 cli_pipe tests. All cargo checks ran with Rust 1.96.0 and -j 4.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; original unsigned ancestry not carried. Signature verified as G with one gpgsig header.

Supersedes #535
Closes #509
Resolves solo todo #3523 (partial; orchestrator completes)
