### PR TITLE
fix(mcp-core): skip unchanged argument transactions

### DIFF
--- a/crates/gaze-mcp-core/Cargo.toml
+++ b/crates/gaze-mcp-core/Cargo.toml
@@ -36,5 +36,5 @@ operator-tier = []
 
 [dev-dependencies]
 gaze = { path = "../gaze", version = "0.14.0", package = "gaze-pii", features = ["test-support"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 trybuild = "1"

--- a/crates/gaze-mcp-core/src/dispatch.rs
+++ b/crates/gaze-mcp-core/src/dispatch.rs
@@ -169,6 +169,7 @@ impl<'a> PiiEnvelope<'a> {
         descriptor.argument_carriers().preflight(&raw_args)?;
         let context = gaze::ProtectionContext::strict(self.locale_chain, self.dictionaries);
         let mut args_transaction = self.session.begin_transaction();
+        let pre_commit_token_count = args_transaction.tokens().len();
         let redacted_args = protect_json(self.pipeline, &mut args_transaction, context, &raw_args)?;
 
         // Generate the call id once and reuse it as the manifest handle.
@@ -186,16 +187,20 @@ impl<'a> PiiEnvelope<'a> {
             started_at,
         };
         let handle = self.manifest.begin_call(begin_ctx).await?;
-        if let Err(error) = args_transaction.commit() {
-            self.manifest
-                .fail_call(
-                    handle,
-                    FailureReason::RedactionFailed {
-                        message: "session transaction conflict".into(),
-                    },
-                )
-                .await?;
-            return Err(error.into());
+        if args_transaction.tokens().len() != pre_commit_token_count {
+            if let Err(error) = args_transaction.commit() {
+                self.manifest
+                    .fail_call(
+                        handle,
+                        FailureReason::RedactionFailed {
+                            message: "session transaction conflict".into(),
+                        },
+                    )
+                    .await?;
+                return Err(error.into());
+            }
+        } else {
+            std::mem::drop(args_transaction);
         }
 
         // 6. Build the sealed ToolCtx — pub(crate) constructor; this is the

--- a/crates/gaze-mcp-core/tests/concurrent_noop_conflict.rs
+++ b/crates/gaze-mcp-core/tests/concurrent_noop_conflict.rs
@@ -1,0 +1,290 @@
+//! No-op argument-protection dispatch must not spuriously conflict with a
+//! concurrently advancing generation.
+//!
+//! Regression for a dispatcher defect where a dispatch whose args stage no
+//! new token mappings still routed through `SessionTransaction::commit`,
+//! which unconditionally advances the session generation. A no-op dispatch
+//! that captured generation N would then observe a sibling's commit advancing
+//! the live generation to N+1, failing its own commit with
+//! `SessionTransactionError::GenerationConflict` even though it staged
+//! nothing. The fix skips the commit when `protect_json` added no new tokens,
+//! restoring the pre-strict-transaction behavior where no-op args never
+//! touched the generation.
+
+use async_trait::async_trait;
+use gaze::{Action, ClassRule, DefaultRule, Detection, Detector, PiiClass, Scope, Session};
+use gaze_mcp_core::*;
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+
+const EMAIL: &str = "alice@example.invalid";
+const CONCURRENT_RAW: &str = "synthetic concurrent";
+
+#[derive(Clone)]
+struct Primary;
+impl Detector for Primary {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        input
+            .match_indices(EMAIL)
+            .map(|(start, _)| {
+                Detection::new(start..start + EMAIL.len(), PiiClass::Email, "synthetic")
+            })
+            .collect()
+    }
+}
+
+fn pipeline() -> gaze::Pipeline {
+    gaze::Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .build()
+        .unwrap()
+}
+
+struct Auth;
+#[async_trait]
+impl AuthHook for Auth {
+    async fn authorize_agent(&self, _: &Principal, _: &str) -> Result<(), AuthError> {
+        Ok(())
+    }
+    async fn authorize_operator(&self, principal: &Principal, _: &str) -> Result<(), AuthError> {
+        if principal.id == "operator" {
+            Ok(())
+        } else {
+            Err(AuthError::Denied("synthetic".into()))
+        }
+    }
+}
+
+/// Manifest store that records every terminal attempt and optionally mutates
+/// the shared `Session` during `begin_call`, simulating a concurrently
+/// overlapping sibling dispatch committing (and thus advancing the live
+/// generation) between this dispatch's `begin_transaction` (capture) and its
+/// args `commit`/drop decision.
+#[derive(Default)]
+struct Store {
+    events: Arc<Mutex<Vec<&'static str>>>,
+    mutate_begin: Option<Arc<Session>>,
+}
+
+#[async_trait]
+impl ManifestStore for Store {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        self.events.lock().unwrap().push("begin");
+        if let Some(session) = &self.mutate_begin {
+            session.tokenize(&PiiClass::Name, CONCURRENT_RAW).unwrap();
+        }
+        Ok(CallHandle::new(ctx.call_id))
+    }
+    async fn finish_call(&self, _: CallHandle, _: SnapshotRef) -> Result<(), ManifestError> {
+        self.events.lock().unwrap().push("finish");
+        Ok(())
+    }
+    async fn fail_call(&self, _: CallHandle, _: FailureReason) -> Result<(), ManifestError> {
+        self.events.lock().unwrap().push("fail");
+        Ok(())
+    }
+}
+
+/// Manifest store that synchronizes concurrent dispatches at `begin_call`
+/// using a `tokio::sync::Barrier`. `tokio::join!` runs both futures
+/// cooperatively on one task, so a blocking barrier would deadlock; an async
+/// barrier yields, letting both dispatches capture the generation in
+/// `begin_transaction` and run `protect_json` before either is allowed to
+/// reach the commit/drop decision.
+struct BarrierStore {
+    begin: tokio::sync::Barrier,
+}
+
+impl BarrierStore {
+    fn new(n: usize) -> Self {
+        Self {
+            begin: tokio::sync::Barrier::new(n),
+        }
+    }
+}
+
+#[async_trait]
+impl ManifestStore for BarrierStore {
+    async fn begin_call(&self, ctx: BeginCallContext<'_>) -> Result<CallHandle, ManifestError> {
+        self.begin.wait().await;
+        Ok(CallHandle::new(ctx.call_id))
+    }
+    async fn finish_call(&self, _: CallHandle, _: SnapshotRef) -> Result<(), ManifestError> {
+        Ok(())
+    }
+    async fn fail_call(&self, _: CallHandle, _: FailureReason) -> Result<(), ManifestError> {
+        Ok(())
+    }
+}
+
+static STRICT_POLICY: std::sync::LazyLock<SessionIdPolicy> =
+    std::sync::LazyLock::new(SessionIdPolicy::default_strict);
+
+fn envelope<'a>(
+    registry: &'a ToolRegistry,
+    manifest: &'a dyn ManifestStore,
+    pipeline: &'a gaze::Pipeline,
+    session: &'a Session,
+) -> PiiEnvelope<'a> {
+    PiiEnvelope::new(
+        registry,
+        &Auth,
+        manifest,
+        pipeline,
+        session,
+        &[gaze::LocaleTag::Global],
+        &STRICT_POLICY,
+    )
+}
+
+#[cfg(feature = "operator-tier")]
+fn export_registry() -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry
+        .register(gaze_mcp_core::operator_tools::ExportSessionTokensTool::new())
+        .unwrap();
+    registry
+}
+
+/// A no-op args dispatch (empty `{}` for `export_session_tokens`) MUST NOT
+/// fail when a concurrent sibling advances the live generation during
+/// `begin_call`. Pre-fix the unconditional `args_transaction.commit()` saw
+/// the captured generation fall behind the live one and returned
+/// `GenerationConflict`, spuriously failing the call and persisting a
+/// mislabeled `RedactionFailed` audit row. The fix skips the commit when no
+/// new tokens were staged, so no generation is published and no conflict is
+/// possible.
+#[cfg(feature = "operator-tier")]
+#[tokio::test]
+async fn noop_args_dispatch_succeeds_when_sibling_advances_generation() {
+    let session = Arc::new(Session::new(Scope::Ephemeral).unwrap());
+    let store = Store {
+        mutate_begin: Some(session.clone()),
+        ..Default::default()
+    };
+    let pipeline = pipeline();
+    let registry = export_registry();
+    let env = envelope(&registry, &store, &pipeline, &session);
+    let principal = Principal::new("operator");
+
+    let result = env
+        .dispatch(&principal, "export_session_tokens", json!({}), None)
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "no-op args dispatch must not fail on a concurrent generation advance"
+    );
+    assert_eq!(
+        *store.events.lock().unwrap(),
+        ["begin", "finish"],
+        "a successful dispatch records begin then finish, never fail"
+    );
+    assert_eq!(
+        session.tokens().len(),
+        1,
+        "only the sibling's staged token should exist; the no-op args staged nothing"
+    );
+    assert!(
+        session
+            .snapshot_entries()
+            .iter()
+            .all(|entry| entry.raw == CONCURRENT_RAW),
+        "no email token from the no-op args should have been committed"
+    );
+}
+
+/// A dispatch that stages real PII in its args MUST still commit and therefore
+/// still fail closed when a concurrent sibling advances the live generation.
+/// This guards that the no-op skip does not weaken the strict fail-closed
+/// boundary for genuine concurrent mutations.
+#[tokio::test]
+async fn real_args_dispatch_still_fails_closed_when_sibling_advances_generation() {
+    struct Echo {
+        descriptor: ToolDescriptor,
+    }
+    #[async_trait]
+    impl Tool for Echo {
+        fn descriptor(&self) -> &ToolDescriptor {
+            &self.descriptor
+        }
+        async fn invoke(&self, ctx: &ToolCtx<'_>) -> Result<ToolResponse, ToolError> {
+            Ok(ToolResponse::json(ctx.redacted_args().clone()))
+        }
+    }
+    fn echo_registry() -> ToolRegistry {
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Echo {
+                descriptor: ToolDescriptor::agent("echo", json!({}))
+                    .with_carriers(CarrierDeclaration::default(), CarrierDeclaration::default()),
+            })
+            .unwrap();
+        registry
+    }
+
+    let session = Arc::new(Session::new(Scope::Ephemeral).unwrap());
+    let store = Store {
+        mutate_begin: Some(session.clone()),
+        ..Default::default()
+    };
+    let pipeline = pipeline();
+    let registry = echo_registry();
+    let env = envelope(&registry, &store, &pipeline, &session);
+    let principal = Principal::new("agent");
+
+    let result = env.dispatch(&principal, "echo", json!(EMAIL), None).await;
+
+    assert!(
+        matches!(result, Err(DispatchError::Transaction(_))),
+        "real args mutation must fail closed on a concurrent generation advance"
+    );
+    assert_eq!(
+        *store.events.lock().unwrap(),
+        ["begin", "fail"],
+        "a transaction-conflict loss records begin then fail"
+    );
+    assert!(
+        session
+            .snapshot_entries()
+            .iter()
+            .all(|entry| entry.raw != EMAIL),
+        "the losing args token must not be committed"
+    );
+}
+
+/// Two genuinely overlapping no-op args dispatches on one shared `Session`
+/// (synchronized at `begin_call` so both capture the same generation before
+/// either reaches the commit/drop site) MUST both succeed. Pre-fix exactly
+/// one failed with `DispatchError::Transaction`; the fix lets both skip the
+/// no-op commit and complete independently.
+#[cfg(feature = "operator-tier")]
+#[tokio::test]
+async fn concurrent_noop_args_dispatches_both_succeed() {
+    let session = Session::new(Scope::Ephemeral).unwrap();
+    let manifest = BarrierStore::new(2);
+    let pipeline = pipeline();
+    let registry = export_registry();
+    let env = envelope(&registry, &manifest, &pipeline, &session);
+    let principal = Principal::new("operator");
+
+    let (r1, r2) = tokio::join!(
+        env.dispatch(&principal, "export_session_tokens", json!({}), None),
+        env.dispatch(&principal, "export_session_tokens", json!({}), None),
+    );
+
+    assert!(
+        r1.is_ok(),
+        "first overlapping no-op dispatch should succeed: {r1:?}"
+    );
+    assert!(
+        r2.is_ok(),
+        "second overlapping no-op dispatch should succeed: {r2:?}"
+    );
+    assert!(
+        session.tokens().is_empty(),
+        "no-op dispatches must stage no tokens"
+    );
+}

--- a/scripts/bench/producer_build_binding.py
+++ b/scripts/bench/producer_build_binding.py
@@ -373,8 +373,9 @@ def snapshot(repo, revision, destination, deadline):
                 and parts.as_posix() == path and path not in expected)
         expected[path] = (int(mode, 8) & 0o777, oid.decode('ascii'), int(size))
         ancestors.update(str(p) for p in parts.parents if str(p) != '.')
+    # Include end markers before rounding to the next 10 KiB tar record.
     bound = min(64*MIB, sum(((v[2]+511)//512+1)*512 for v in expected.values())
-                + len(ancestors)*512 + 10240)
+                + len(ancestors)*512 + 12288)
     archive = bytearray()
     def collect(chunk):
         require(len(archive)+len(chunk) <= bound, 'output_limit')

--- a/scripts/bench/test_producer_build_binding.py
+++ b/scripts/bench/test_producer_build_binding.py
@@ -157,12 +157,20 @@ class CargoSelectionTests(unittest.TestCase):
 class SnapshotTests(unittest.TestCase):
     def test_exact_git_files_and_ancestor_directories(self):
         files = {'a/Cargo.toml': b'[package]\nname="fixture"\n', 'Cargo.lock': b'version = 4\n'}
+        self.assert_snapshot(files)
+
+    def test_tar_end_markers_before_record_padding(self):
+        # Header plus payload is 9,728 bytes. End markers need another record.
+        self.assert_snapshot({'Cargo.lock': b'#'+b'x'*8704})
+
+    def assert_snapshot(self, files):
         rows = []
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w') as tar:
-            directory = tarfile.TarInfo('a')
-            directory.type = tarfile.DIRTYPE
-            tar.addfile(directory)
+            if any(name.startswith('a/') for name in files):
+                directory = tarfile.TarInfo('a')
+                directory.type = tarfile.DIRTYPE
+                tar.addfile(directory)
             for name, content in files.items():
                 oid = binding.hashlib.sha1(f'blob {len(content)}\0'.encode()+content).hexdigest()
                 rows.append(f'100644 blob {oid} {len(content)}\t{name}'.encode())


### PR DESCRIPTION
Concurrent dispatches with unchanged argument mappings could conflict because every argument transaction advanced the session generation. Skip publishing unchanged mappings; transactions that add mappings still commit atomically and reject generation conflicts before tool invocation.

## Review verdict
NITS corrected: added a regression for the original archive-bound adjustment. The CI source snapshot hit `output_limit` because tar end markers precede 10 KiB record padding; the additional 2 KiB allowance fixes that boundary without changing the 64 MiB cap or strict archive checks. Reviewed dispatch, protect_json, append-only session mapping operations, manifest terminal handling, and the deterministic concurrency tests. The barrier tests force overlapping transactions; the mutation test preserves fail-closed behavior for real additions. Optional prefix-cache updates may be discarded with unchanged mappings, without changing output correctness.

## Axes
Adopter ergonomics and agentic concurrency improve. Reliability, reversible mappings, and deterministic transaction conflict handling remain intact; no axis weakened.

## Structure and data-model review
- Verdict: skip.
- Opportunity: none needed for this scope.
- Why: a local commit decision preserves the existing transaction and manifest lifecycle; mapping count is valid because argument protection only adds mappings.
- Scope: dispatch and its concurrency tests, plus the Tokio test sync feature. The source-snapshot padding correction and synthetic boundary test are also required for this branch to pass CI. No production API expansion.
- Validation: Rust 1.96.0 formatting, workspace all-feature/all-target Clippy with warnings denied, and gaze-mcp-core all-feature tests pass, including strict-contract and compile-fail checks. All 44 model-free binding tests pass on Python 3.13; the added boundary test fails with `output_limit` when the allowance is reverted.

## Signed commit
Fresh machine-authored SSH-signed commits with DCO sign-off; original unsigned ancestry not carried. Signature G and one gpgsig verified. Branch starts from freshly fetched origin/main; the dirty checked-out main working tree was not changed.

Supersedes #543
Closes #542
Resolves solo todo #3523 (partial; orchestrator completes)
