### PR TITLE
fix(dashboard): clear pairing timeout before idle control

### DIFF
--- a/crates/gaze-proxy-dashboard/src/child.rs
+++ b/crates/gaze-proxy-dashboard/src/child.rs
@@ -165,6 +165,9 @@ impl DashboardChildEntrypoint {
             .map_err(|_| DashboardError::new(DashboardErrorCode::InvalidInheritedHandle))?;
         let secret = PairingSecret::generate()?;
         child_pair(&mut control, authority, &secret)?;
+        control
+            .set_read_timeout(None)
+            .map_err(|_| DashboardError::new(DashboardErrorCode::InvalidInheritedHandle))?;
 
         let state = Arc::new(Mutex::new(ChildState {
             store: EventStore::new(config.retention, InspectionEpochV1::new(0)),

--- a/crates/gaze-proxy-dashboard/tests/runtime_lifecycle.rs
+++ b/crates/gaze-proxy-dashboard/tests/runtime_lifecycle.rs
@@ -146,3 +146,41 @@ fn descriptor_equal_double_swap_fails_closed_disables_producers_and_reaps_childr
     assert_process_reaped(pid_a);
     assert_process_reaped(pid_b);
 }
+
+#[test]
+#[cfg(not(target_os = "macos"))]
+fn child_survives_control_idle_after_pairing() {
+    let temp = tempfile::tempdir().unwrap();
+    let (paired, pid) = spawn_paired_dashboard(&temp.path().join("child.pid"));
+    let (pending, consumer, descriptor) = paired.into_pending_activation().unwrap();
+    let producer = PendingInspectionProducerV1::new(descriptor);
+    let (producer, activated) = install_inspection_v1(producer, consumer).unwrap();
+    let launch = pending.commit(activated).unwrap();
+    let control = launch.control();
+
+    assert_eq!(control.lifecycle(), DashboardLifecycle::Running(0));
+    let start = Instant::now();
+    let idle_deadline = start + Duration::from_secs(5);
+    while Instant::now() < idle_deadline {
+        let alive = Command::new("/bin/kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(
+            alive,
+            "dashboard child (pid {pid}) self-terminated after {:?} of control-idle; \
+             the 2s read timeout leaked from pairing into child_control_loop",
+            start.elapsed()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(control.lifecycle(), DashboardLifecycle::Running(0));
+    control.shutdown().unwrap();
+    assert_eq!(control.lifecycle(), DashboardLifecycle::Stopped);
+    assert!(matches!(
+        producer.begin_logical(),
+        Err(InspectionBeginLogicalErrorV1::Disabled)
+    ));
+    drop(launch);
+    assert_process_reaped(pid);
+}


### PR DESCRIPTION
The dashboard child retained its two-second pairing read timeout in the steady-state control loop and disabled itself when idle. Clear that read timeout after successful initial pairing so normal command waiting does not count as failure.

## Review verdict
CLEAN. Reviewed startup, pairing, control commands, fatal shutdown, and parent timeout/reap handling. The five-second idle test exceeds the original timeout and then verifies cooperative shutdown and producer disablement. Initial pairing and parent response deadlines remain bounded.

## Axes
Reliability and adopter ergonomics improve by preserving a healthy idle dashboard. Control failure still closes the dashboard, purge/zeroization semantics remain, and core token reversibility is unaffected. No axis weakened.

## Structure and data-model review
- Verdict: skip.
- Opportunity: none needed.
- Why: the existing pairing-to-running transition is the correct owner of the timeout change; no extra state or abstraction is necessary.
- Scope: child startup and idle-lifecycle regression.
- Validation: Rust 1.96.0 fmt, workspace all-feature/all-target Clippy with warnings denied, and dashboard all-feature tests pass. Real-child idle test is cfg-disabled on macOS; Linux CI must pass before merge.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO; original unsigned ancestry not carried. Signature G and one gpgsig verified. Created from freshly fetched origin/main in the isolated worktree.

Supersedes #514
Closes #480
Resolves solo todo #3523 (partial; orchestrator completes)
