### PR TITLE
fix(token-shape): match family namespace tokens so prose restore round-trips

### DIFF
--- a/crates/gaze/src/session.rs
+++ b/crates/gaze/src/session.rs
@@ -1937,7 +1937,7 @@ fn parse_ascii_ordinal(raw: &str) -> Option<u32> {
 fn malformed_restore_token_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        Regex::new(r"<(?:[0-9a-f]{8}:)?(?:Email|Name|Location|Organization|email|name|location|organization|Custom:[a-z0-9_]*|custom:[a-z0-9_]*)_?>")
+        Regex::new(r"<(?:[0-9a-f]{8}:)?(?:Email|Name|Location|Organization|email|name|location|organization|Custom:family:[a-z0-9_-]+|Custom:[a-z0-9_]*|custom:family:[a-z0-9_-]+|custom:[a-z0-9_]*)_?>")
             .expect("malformed restore token regex must compile")
     })
 }

--- a/crates/gaze/src/token_shape.rs
+++ b/crates/gaze/src/token_shape.rs
@@ -36,13 +36,17 @@ pub fn sample_token_shapes() -> &'static [&'static str] {
         "<deadbeef:Location_1>",
         "<deadbeef:Organization_1>",
         "<deadbeef:Custom:class_alpha_1>",
+        "<deadbeef:Custom:family:tenant-document_1>",
         "email1.deadbeef@gaze-fake.invalid",
         "deadbeef:email_1",
         "deadbeef:custom:class_alpha_1",
+        "deadbeef:custom:family:tenant-document_1",
         "<Email_1>",
         "<email_1>",
         "<Custom:class_alpha_1>",
+        "<Custom:family:tenant-document_1>",
         "<custom:class_alpha_1>",
+        "custom:family:tenant-document_1",
         "Email_1",
         "email_1",
         "custom:class_alpha_1",
@@ -130,7 +134,7 @@ fn build_pattern() -> String {
         .join("|");
 
     format!(
-        r"<[0-9a-f]{{8}}:(?:{builtin_alt})_[0-9]+>|<[0-9a-f]{{8}}:Custom:[a-z0-9_]*_[0-9]+>|\bemail[0-9]+\.[0-9a-f]{{8}}@gaze-fake\.invalid\b|\b[0-9a-f]{{8}}:(?:{builtin_lower_alt})_[0-9]+\b|\b[0-9a-f]{{8}}:custom:[a-z0-9_]*_[0-9]+\b|<(?:{builtin_alt})_[0-9]+>|<Custom:[a-z0-9_]*_[0-9]+>|\b(?:{builtin_lower_alt})_[0-9]+\b|\bcustom:[a-z0-9_]*_[0-9]+\b|\bemail[0-9]+@example\.test\b|\bemail[0-9]+@gaze-fake\.invalid\b|<[A-Z][a-zA-Z0-9]+_[0-9]+>|<[a-z][a-zA-Z0-9_]*_[0-9]+>|\b[A-Z][a-zA-Z0-9]+_[0-9]+\b|\b[a-z][a-zA-Z0-9_]*_[0-9]+\b",
+        r"<[0-9a-f]{{8}}:(?:{builtin_alt})_[0-9]+>|<[0-9a-f]{{8}}:Custom:family:[a-z0-9_-]+_[0-9]+>|<[0-9a-f]{{8}}:Custom:[a-z0-9_]*_[0-9]+>|\bemail[0-9]+\.[0-9a-f]{{8}}@gaze-fake\.invalid\b|\b[0-9a-f]{{8}}:(?:{builtin_lower_alt})_[0-9]+\b|\b[0-9a-f]{{8}}:custom:family:[a-z0-9_-]+_[0-9]+\b|\b[0-9a-f]{{8}}:custom:[a-z0-9_]*_[0-9]+\b|<(?:{builtin_alt})_[0-9]+>|<Custom:family:[a-z0-9_-]+_[0-9]+>|<Custom:[a-z0-9_]*_[0-9]+>|\b(?:{builtin_lower_alt})_[0-9]+\b|\bcustom:family:[a-z0-9_-]+_[0-9]+\b|\bcustom:[a-z0-9_]*_[0-9]+\b|\bemail[0-9]+@example\.test\b|\bemail[0-9]+@gaze-fake\.invalid\b|<[A-Z][a-zA-Z0-9]+_[0-9]+>|<[a-z][a-zA-Z0-9_]*_[0-9]+>|\b[A-Z][a-zA-Z0-9]+_[0-9]+\b|\b[a-z][a-zA-Z0-9_]*_[0-9]+\b",
         builtin_alt = builtin_alt,
         builtin_lower_alt = builtin_lower_alt,
     )
@@ -177,6 +181,8 @@ mod tests {
             .iter()
             .cloned()
             .chain(std::iter::once(PiiClass::custom("class_alpha")))
+            .chain(std::iter::once(PiiClass::family("tenant-document")))
+            .chain(std::iter::once(PiiClass::family("foo")))
         {
             assert!(contains_token(&tokenized_for(class.clone())));
             assert!(contains_token(&format_preserving_for(class)));
@@ -358,5 +364,38 @@ mod tests {
             restored,
             "See alice@example.invalid. Reply bob@example.invalid"
         );
+    }
+
+    #[test]
+    fn family_token_matches_as_single_full_span() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::family("tenant-document"), "DOC-12345")
+            .expect("family token");
+        assert!(token.contains(":Custom:family:tenant-document_"));
+
+        let haystack = format!("case {token} now");
+        let m = pattern().find(&haystack).expect("family token must match");
+        assert_eq!(m.as_str(), token.as_str());
+    }
+
+    #[test]
+    fn non_hyphenated_family_token_text_restore_roundtrip() {
+        let session = Session::new(Scope::Ephemeral).expect("session");
+        let token = session
+            .tokenize(&PiiClass::family("foo"), "DOC-12345")
+            .expect("token");
+        let prose = format!("See {token} now");
+        assert_eq!(
+            session.restore_strict_text(&prose).expect("restore"),
+            "See DOC-12345 now"
+        );
+    }
+
+    #[test]
+    fn bare_family_arms_do_not_span_across_colon_separator() {
+        let rendered = "custom:family:foo_1:custom:family:bar_2";
+        let matches: Vec<&str> = find_tokens(rendered).collect();
+        assert_eq!(matches, vec!["custom:family:foo_1", "custom:family:bar_2"]);
     }
 }

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -736,6 +736,56 @@ fn precedence_tie_emits_family_level_token_and_ambiguity_record() {
 }
 
 #[test]
+fn family_token_text_restore_roundtrip_via_pipeline() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let logger = MemoryLogger::default();
+    let family_class = PiiClass::Custom("family:tenant-document".to_string());
+    let pipeline = Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_source(
+                "DOC-[0-9]+",
+                PiiClass::Custom("alpha_doc".to_string()),
+                "doc.alpha",
+            )
+            .expect("alpha detector"),
+        )
+        .register_collision(
+            "doc.alpha",
+            CollisionMembership::new("tenant-document", "alpha", 10, None),
+        )
+        .recognizer(
+            RegexDetector::with_source(
+                "DOC-[0-9]+",
+                PiiClass::Custom("beta_doc".to_string()),
+                "doc.beta",
+            )
+            .expect("beta detector"),
+        )
+        .register_collision(
+            "doc.beta",
+            CollisionMembership::new("tenant-document", "beta", 10, None),
+        )
+        .rule(ClassRule::new(family_class, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .redaction_logger(logger)
+        .build()
+        .expect("pipeline");
+
+    let clean = pipeline
+        .redact(&session, RawDocument::Text("case DOC-12345".to_string()))
+        .expect("redact");
+    let CleanDocument::Text(clean) = clean else {
+        panic!("expected text document");
+    };
+
+    assert!(clean.contains(":Custom:family:tenant-document_"));
+    assert_eq!(
+        session.restore_strict_text(&clean).expect("restore"),
+        "case DOC-12345"
+    );
+}
+
+#[test]
 fn mandatory_anchor_missing_emits_family_token_and_no_anchor_ambiguity() {
     let session = Session::new(Scope::Ephemeral).expect("session");
     let logger = MemoryLogger::default();


### PR DESCRIPTION
Family namespace tokens were matched only at their tail during prose restoration. Match the complete bracketed or format-preserving family token so manifest lookup restores the original value, while keeping colon-separated tokens distinct.

## Review verdict
CLEAN. Read the shape builder, strict scanner, manifest restoration, proxy legacy restore caller, family constructor, and collision pipeline tests. The old expression matches only `document_1` inside a family token, so the new full-span assertion and pipeline round-trip test detect the original bug. New fixtures are synthetic. No unrelated changes or visible UI changes.

## Axes
Strengthens reversibility and agentic family-token handling. Reliability remains fail-closed in strict restoration; trust remains deterministic and manifest-bound. Adopter ergonomics improves through working round trips. No axis weakened.

## Structure and data-model review
- Verdict: skip.
- Opportunity: none.
- Why: the canonical token-shape matcher already owns scanning for all immediate callers; family-specific alternatives repair that shared grammar without adding competing state.
- Scope: three files, token grammar, malformed-token recognition, and regression tests. No larger reorganization needed.
- Validation: rustc 1.96.0; formatting and workspace all-feature/all-target clippy passed. All crate suites passed in the full workspace run; see the local limitation below.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried. Signature verified G, one gpgsig header, Signed-off-by present.

Supersedes #534
Resolves solo todo #3523 (partial; orchestrator completes)

## Local limitation
The initial parallel `cargo test --workspace --all-features -j 4` run failed only `bundle_tokenization_drift_gate_fails_when_enabled_recognizer_id_drifts` before stopping. After `cargo clean -p xtask`, `cargo test -p xtask -j 4 bundle_tokenization_drift_gate_fails_when_enabled_recognizer_id_drifts` passed on both branch commit `615e5bf` and clean main `616e8a10`, each with exit 0. Every command used `/Users/krishankoenig/.anvil/g196.sh`; `cargo metadata --format-version 1 --no-deps` confirmed the worktree-local target directory.

Remaining xtask/doc suites were not re-run locally. The clean results rule out a branch-specific regression; the initial nested-Cargo concurrency flake is documented rather than treated as a green full run. CI `test` (full workspace suite), `xtask gates`, and `Check DCO sign-off` must all pass before merge. Orchestrator approval: W3-534-RULING-2.
