### PR TITLE
fix(gaze-document): count formatted clean.md in BundleReport.clean_char_count

### DIFF
--- a/crates/gaze-document/src/bundle/mod.rs
+++ b/crates/gaze-document/src/bundle/mod.rs
@@ -458,10 +458,12 @@ fn clean_with_options(
     let counts = count_pii_by_class(&spans);
     let pii_token_count: u32 = counts.iter().map(|c| c.count).sum();
 
+    let clean_markdown = format_clean_markdown(&clean_text, kind);
+
     let report = BundleReport::new(
         kind_label(kind),
         &extraction.ocr_result,
-        clean_text.chars().count(),
+        clean_markdown.chars().count(),
         pii_token_count,
         counts,
         extraction.pdf_page_count,
@@ -470,7 +472,6 @@ fn clean_with_options(
         options.low_confidence_threshold,
     );
 
-    let clean_markdown = format_clean_markdown(&clean_text, kind);
     write_bundle(&agent_out, &owner_out, &clean_markdown, &manifest, &report)?;
 
     Ok(SafeBundle::new(
@@ -1055,6 +1056,65 @@ mod tests {
             !bundle.clean_markdown.contains("alice@example.invalid"),
             "{}",
             bundle.clean_markdown
+        );
+    }
+
+    #[test]
+    fn clean_char_count_matches_persisted_clean_md_length() {
+        let backend = MockBackend {
+            spans: vec![
+                span("Bill", 20, 10, 0.92),
+                span("to:", 116, 10, 0.92),
+                span("Jane", 20, 36, 0.92),
+                span("Doe", 116, 36, 0.92),
+                span("Email:", 360, 10, 0.92),
+                // fixture-cited(crates/gaze-document/src/bundle/mod.rs:bundle::tests::clean_char_count_matches_persisted_clean_md_length)
+                span("alice@example.invalid", 360, 36, 0.92),
+            ],
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let input = tmp.path().join("input.png");
+        fs::write(&input, b"\x89PNG\r\n\x1A\nnot-real-image").expect("write input");
+        let (agent_out, owner_out) = bundle_dirs(&tmp);
+        let clean_md_path = agent_out.as_path().join(CLEAN_MARKDOWN_FILE);
+
+        let bundle = Pipeline::new()
+            .clean_with_ocr_backend(&input, agent_out, owner_out, &backend)
+            .expect("clean succeeds");
+
+        let on_disk = fs::read_to_string(&clean_md_path).expect("clean.md readable");
+        assert_eq!(
+            bundle.report.clean_char_count,
+            bundle.clean_markdown.chars().count(),
+            "clean_char_count must match SafeBundle.clean_markdown, got report={} vs markdown={}",
+            bundle.report.clean_char_count,
+            bundle.clean_markdown.chars().count(),
+        );
+        assert_eq!(
+            bundle.report.clean_char_count,
+            on_disk.chars().count(),
+            "clean_char_count must match the on-disk clean.md length, got report={} vs disk={}",
+            bundle.report.clean_char_count,
+            on_disk.chars().count(),
+        );
+        assert!(
+            bundle
+                .clean_markdown
+                .starts_with("# gaze-document safe bundle\n"),
+            "clean_markdown must carry the bundle header: {}",
+            bundle.clean_markdown,
+        );
+        let body = bundle
+            .clean_markdown
+            .strip_prefix("# gaze-document safe bundle\n\nSource kind: `png`\n\n---\n\n")
+            .expect("header prefix present");
+        let bare = body.trim_end_matches('\n').chars().count();
+        assert!(
+            bundle.report.clean_char_count > bare,
+            "clean_char_count ({}) must exceed the bare redacted body length ({}) \
+             because the header + appended trailing newline are part of the persisted artifact",
+            bundle.report.clean_char_count,
+            bare,
         );
     }
 

--- a/crates/gaze-document/tests/e2e.rs
+++ b/crates/gaze-document/tests/e2e.rs
@@ -145,7 +145,16 @@ fn assert_clean_bundle(input: &Path, expect_pdf_fields: bool) {
     let report: BundleReport = serde_json::from_slice(&report_bytes).expect("report deserializes");
     assert_eq!(report.bundle_version, BUNDLE_VERSION);
     assert!(report.pii_token_count >= 2);
-    assert!(report.clean_char_count > 0);
+    assert_eq!(
+        report.clean_char_count,
+        clean_text.chars().count(),
+        "report.clean_char_count must match the on-disk clean.md length"
+    );
+    assert_eq!(
+        report.clean_char_count,
+        bundle.clean_markdown.chars().count(),
+        "report.clean_char_count must match SafeBundle.clean_markdown length"
+    );
     assert_eq!(report.low_confidence_threshold, 0.65);
     assert_eq!(report.pages.len(), 1);
     assert_eq!(report.pages[0].page_index, 0);


### PR DESCRIPTION
The document bundle report now counts characters in the final clean.md artifact, including its header and final newline. Previously it counted only the redacted body before formatting, so the report understated the file it described. The generated Markdown content and manifest are unchanged.

## Review verdict
NITS fixed. Read the full bundle-cleaning path, Markdown formatter, report constructor, persisted bundle writer, and CLI metric consumer. The new mock-OCR test and strengthened e2e test compare the report with both in-memory and on-disk Markdown; both equalities fail with the original body-only count. Synthetic fixtures only. Removed a redundant second disk-read assertion.

## Axes
Strengthens trust and accurate reporting. Reliability and reversibility are unchanged; no axis weakened. The field schema stays unchanged.

## Structure and data-model review
Verdict: implement.
Opportunity: derive the report metric from the final artifact already written by the bundle writer.
Why: this ordering removes drift between an intermediate body and the artifact described; the e2e check reuses its existing disk read instead of duplicating I/O.
Scope: clean_with_options ordering and bundle tests only. No new state or abstraction.
Validation: formatting, workspace all-feature/all-target clippy, and gaze-document all-feature tests.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried.

Supersedes #513
Resolves solo todo #3523 (partial; orchestrator completes)
