### PR TITLE
docs: sync crate MCP boundary copies with canonical agent/operator-tier split

### DIFF
--- a/crates/gaze-mcp-core/README.md
+++ b/crates/gaze-mcp-core/README.md
@@ -15,7 +15,7 @@
 
 ### Scope
 
-`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.
+`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an agent-tier MCP tool to the model** passes through `PiiEnvelope::dispatch` and is protected before the model sees it. Authorized operator-tier tools can explicitly bypass response protection for restore/export semantics; their raw responses must stay on the operator surface.
 
 `gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, use `gaze-proxy`, the v0.8+ multi-vendor reverse proxy supporting OpenAI, Anthropic, and Gemini SDK base-URL swaps.
 

--- a/crates/gaze-mcp-core/src/lib.rs
+++ b/crates/gaze-mcp-core/src/lib.rs
@@ -3,8 +3,10 @@
 //! ### Scope
 //!
 //! `gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data
-//! flowing **from a source through an MCP tool to the model** passes through
-//! `PiiEnvelope::dispatch` and is redacted before the model sees it.
+//! flowing **from a source through an agent-tier MCP tool to the model** passes
+//! through `PiiEnvelope::dispatch` and is protected before the model sees it.
+//! Authorized operator-tier tools can explicitly bypass response protection for
+//! restore/export semantics; their raw responses must stay on the operator surface.
 //!
 //! `gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded
 //! files, and screenshots in the agent host's chat UI reach the model unredacted.

--- a/crates/gaze-mcp-rmcp/README.md
+++ b/crates/gaze-mcp-rmcp/README.md
@@ -6,7 +6,7 @@
 
 ### Scope
 
-`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch` and is redacted before the model sees it.
+`gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing **from a source through an agent-tier MCP tool to the model** passes through `PiiEnvelope::dispatch` and is protected before the model sees it. Authorized operator-tier tools can explicitly bypass response protection for restore/export semantics; their raw responses must stay on the operator surface.
 
 `gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and screenshots in the agent host's chat UI reach the model unredacted. For that axis, use `gaze-proxy`, the v0.8+ multi-vendor reverse proxy supporting OpenAI, Anthropic, and Gemini SDK base-URL swaps.
 

--- a/crates/gaze-mcp-rmcp/src/lib.rs
+++ b/crates/gaze-mcp-rmcp/src/lib.rs
@@ -3,8 +3,9 @@
 //! ### Scope
 //!
 //! `gaze-mcp` enforces the chokepoint on the **data-source ↔ model** path. Any data flowing
-//! **from a source through an MCP tool to the model** passes through `PiiEnvelope::dispatch`
-//! and is redacted before the model sees it.
+//! **from a source through an agent-tier MCP tool to the model** passes through `PiiEnvelope::dispatch`
+//! and is protected before the model sees it. Authorized operator-tier tools can explicitly bypass
+//! response protection for restore/export semantics; their raw responses must stay on the operator surface.
 //!
 //! `gaze-mcp` **does not** cover the **user ↔ model** path. Pasted text, uploaded files, and
 //! screenshots in the agent host's chat UI reach the model unredacted. For that axis, see


### PR DESCRIPTION
Synchronize four MCP crate boundary descriptions with the canonical runtime documentation: agent-tier responses are protected, while authorized operator-tier restore/export tools may return raw responses only to the operator surface.

## Review verdict
CLEAN. Compared both READMEs and module comments with docs/explanation/mcp/mcp-runtime.md and dispatch authorization/response-redaction branches. Documentation only; no new links or fixtures.

## Axes
Clarifies reliability and adopter responsibilities without changing runtime enforcement. No axis weakened.

## Structure and data-model review
Verdict: skip.
Opportunity: none.
Why: documentation mirrors the existing typed ToolTier/ResponseRedaction decision.
Scope: four documentation copies; no executable changes.
Validation: careful source comparison and local documentation link/target check; cargo gates omitted per docs-only brief.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried.

Supersedes #540
Resolves solo todo #3523 (partial; orchestrator completes)
