### PR TITLE
Register collision metadata after recognizer construction

### DIFF
--- a/crates/gaze-assembly/src/detector_wiring.rs
+++ b/crates/gaze-assembly/src/detector_wiring.rs
@@ -111,9 +111,8 @@ pub(crate) fn register_rulepack_recognizers(
             );
             continue;
         }
-        if let Some(collision) = recognizer.collision.clone() {
-            builder.register_collision(recognizer.id.clone(), collision);
-        }
+        let recognizer_id = recognizer.id.clone();
+        let collision = recognizer.collision.clone();
         match recognizer.matcher {
             RawMatch::Regex {
                 pattern,
@@ -260,6 +259,9 @@ pub(crate) fn register_rulepack_recognizers(
                 );
             }
             _ => return Err(RulepackError::UnsupportedMatcher("unknown".to_string()).into()),
+        }
+        if let Some(collision) = collision {
+            builder.register_collision(recognizer_id, collision);
         }
     }
 

--- a/crates/gaze-assembly/src/tests.rs
+++ b/crates/gaze-assembly/src/tests.rs
@@ -245,6 +245,195 @@ cue_position = "before"
     assert!(matches!(err, BuildError::NoRecognizers), "{err:?}");
 }
 
+// Skipped optional-cue recognizers must not lower a live variant's precedence.
+// Otherwise the Preserve variant wins and exposes the synthetic secret.
+#[test]
+fn skipped_anchored_match_does_not_leak_collision_into_family_policy() {
+    let real_rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "real-collision"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "real.alpha"
+class = "custom:alpha"
+enabled = true
+locale_basis = "format"
+
+[recognizers.match]
+kind = "regex"
+pattern = '''SECRET\d+'''
+
+[recognizers.collision]
+family = "doc"
+variant = "alpha"
+precedence = 10
+
+[[recognizers]]
+id = "real.beta"
+class = "custom:beta"
+enabled = true
+locale_basis = "format"
+
+[recognizers.match]
+kind = "regex"
+pattern = '''SECRET\d+'''
+
+[recognizers.collision]
+family = "doc"
+variant = "beta"
+precedence = 20
+"#,
+    )
+    .expect("real rulepack");
+
+    let skip_rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "skipped-collision"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[[recognizers]]
+id = "skip.me"
+class = "custom:beta"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "forward_markers"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.collision]
+family = "doc"
+variant = "beta"
+precedence = 5
+"#,
+    )
+    .expect("skip rulepack");
+
+    let mut policy = empty_policy();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: PiiClass::custom("alpha"),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Class {
+            class: PiiClass::custom("beta"),
+            action: Action::Preserve,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+
+    let text =
+        clean_with_policy_and_rulepacks(&policy, &[real_rulepack, skip_rulepack], "SECRET123");
+
+    assert!(
+        !text.contains("SECRET123"),
+        "skipped metadata must not expose PII: {text}"
+    );
+    assert!(
+        text.contains(":Custom:alpha_"),
+        "alpha (precedence 10) must win the overlap; got: {text}"
+    );
+    assert!(
+        !text.contains(":Custom:beta_"),
+        "the skipped recognizer's leaked collision must not flip arbitration to beta; got: {text}"
+    );
+}
+
+// Built anchored recognizers still need collision metadata to override class priority.
+#[test]
+fn built_anchored_match_registers_collision_so_family_policy_arbitrates() {
+    let rulepack = Rulepack::parse(
+        r#"
+schema_version = "0.1.0"
+rulepack_id = "anchored-collision"
+rulepack_version = "0.1.0"
+default_locales = ["global"]
+
+[locale.forward_markers]
+names = ["Forwarded message from"]
+
+[[recognizers]]
+id = "name.forward_marker"
+class = "Name"
+enabled = true
+
+[recognizers.match]
+kind = "anchored_match"
+cues_bucket = "forward_markers"
+boundary = "punctuation"
+right_window_chars = 64
+name_shape = "person_name"
+cue_position = "before"
+
+[recognizers.collision]
+family = "doc"
+variant = "anchor"
+precedence = 20
+
+[[recognizers]]
+id = "regex.name"
+class = "custom:regex"
+enabled = true
+locale_basis = "format"
+
+[recognizers.match]
+kind = "regex"
+pattern = '''Alice\s+Example'''
+
+[recognizers.scoring]
+base = 0.9
+priority = 0
+
+[recognizers.collision]
+family = "doc"
+variant = "regex"
+precedence = 10
+"#,
+    )
+    .expect("rulepack");
+    let mut policy = empty_policy();
+    policy.rules = vec![
+        RuleSpec::Class {
+            class: PiiClass::Name,
+            action: Action::Tokenize,
+        },
+        RuleSpec::Class {
+            class: PiiClass::custom("regex"),
+            action: Action::Tokenize,
+        },
+        RuleSpec::Default {
+            action: Action::Preserve,
+        },
+    ];
+
+    let text = clean_with_policy_and_rulepacks(
+        &policy,
+        &[rulepack],
+        "Forwarded message from Alice Example:",
+    );
+
+    assert!(
+        regex::Regex::new(r"^Forwarded message from <[0-9a-f]{8}:Custom:regex_\d+>:$")
+            .unwrap()
+            .is_match(&text),
+        "family policy must let the lower-precedence regex win; got: {text}"
+    );
+    assert!(
+        !text.contains(":Name_"),
+        "the higher class-priority anchored recognizer must lose to family policy; got: {text}"
+    );
+}
+
 // Pins #414: a format-basis recognizer registers regardless of the document
 // locale chain, so a format-only rulepack passes the guard under a chain that
 // would filter the same recognizer on document basis (compare

--- a/crates/gaze/src/registry.rs
+++ b/crates/gaze/src/registry.rs
@@ -430,6 +430,51 @@ mod tests {
             None
         );
     }
+
+    // Dangling memberships can change real variants' precedence through min aggregation.
+    // Assembly must register collision metadata only after building its recognizer.
+    #[test]
+    fn dangling_collision_membership_flips_family_precedence() {
+        let clean = RecognizerRegistry::builder()
+            .register_collision(
+                "ssn.de_cue",
+                CollisionMembership::new("government-id", "ssn", 10, None),
+            )
+            .register_collision(
+                "tax_number.cue_anchored",
+                CollisionMembership::new("government-id", "tax-number", 20, None),
+            )
+            .build();
+
+        assert_eq!(
+            clean
+                .family_policy()
+                .compare("tax_number.cue_anchored", "ssn.de_cue"),
+            Some(false)
+        );
+
+        let polluted = RecognizerRegistry::builder()
+            .register_collision(
+                "ssn.de_cue",
+                CollisionMembership::new("government-id", "ssn", 10, None),
+            )
+            .register_collision(
+                "tax_number.cue_anchored",
+                CollisionMembership::new("government-id", "tax-number", 20, None),
+            )
+            .register_collision(
+                "custom.name_marker",
+                CollisionMembership::new("government-id", "tax-number", 5, None),
+            )
+            .build();
+
+        assert_eq!(
+            polluted
+                .family_policy()
+                .compare("tax_number.cue_anchored", "ssn.de_cue"),
+            Some(true)
+        );
+    }
 }
 
 impl RecognizerRegistry {


### PR DESCRIPTION
An optional cue recognizer could be skipped after its collision metadata had already entered the family policy. That stale membership lowered a live variant's precedence, allowing the wrong Preserve rule to expose PII. Register collision metadata only after recognizer construction succeeds, matching policy detector registration.

## Review verdict
CLEAN after scoped review improvements: strengthened the regression so the incorrect winner has Action::Preserve, and shortened verbose comments. On unchanged main the strengthened test fails with `skipped metadata must not expose PII: SECRET123`. Reviewed every matcher branch, AssemblyBuilder, family-policy aggregation, rule selection, immediate callers, and synthetic fixtures. Built-recognizer and table-precedence controls remain covered.

## Axes
Reliability improves by eliminating skipped-recognizer influence on tokenization. Deterministic classification and audit provenance improve. Reversibility, agentic fit, and ergonomics retain their contracts; no axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: existing construction sequence owns collision registration.
- Why: the successful construction path now guarantees metadata belongs to a built recognizer, eliminating dangling memberships without a new registry abstraction.
- Scope: assembly matcher registration plus assembly/core regression tests. Broader registry API redesign should wait.
- Validation: strengthened leak test fails on main; rustfmt passes. Workspace Clippy passes; all product-crate all-features suites and the complete xtask suite pass under Rust 1.96.0. xtask suite re-run after wrapper fix.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #518
Closes #484
Resolves solo todo #3523 (partial; orchestrator completes)
