### PR TITLE
docs: correct restore workflow from per-token scan to restore_strict_text

### DIFF
--- a/crates/gaze/README.md
+++ b/crates/gaze/README.md
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-For restore, scan the LLM response with `gaze::token_shape::pattern()` and call `session.restore_strict(token)` per match. Full walk-through: [`docs/tutorials/getting-started.md`](https://github.com/CertaMesh/gaze/blob/main/docs/tutorials/getting-started.md).
+For restore, call `Session::restore_strict_text` on the complete LLM response and keep its restored output on the owner side. Full walk-through: [`docs/tutorials/getting-started.md`](https://github.com/CertaMesh/gaze/blob/main/docs/tutorials/getting-started.md).
 
 ## What this crate owns
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -83,22 +83,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## 4. Restore after the LLM responds
 
-There is no `Pipeline::restore_text`. Scan the response for tokens with
-`gaze::token_shape::pattern()` and call `Session::restore_strict` per token:
+Call `Session::restore_strict_text` on the complete LLM response and keep its
+restored output on the owner side:
 
 ```rust,no_run
-use gaze::{token_shape, SensitiveSnapshot, Session};
+use gaze::{SensitiveSnapshot, Session};
 
 fn restore_text(session: &Session, text: &str) -> Result<String, gaze::Error> {
-    let mut out = String::with_capacity(text.len());
-    let mut last = 0;
-    for m in token_shape::pattern().find_iter(text) {
-        out.push_str(&text[last..m.start()]);
-        out.push_str(&session.restore_strict(m.as_str())?);
-        last = m.end();
-    }
-    out.push_str(&text[last..]);
-    Ok(out)
+    session.restore_strict_text(text)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Use Session::restore_strict_text for the complete LLM response in the getting-started tutorial and crate README. Keep restored values on the owner side and remove the manual token-scan loop from the example.

## Review verdict
CLEAN. Checked the public Session method and RestoreError alias against the tutorial signature. The README tutorial target exists. Documentation only; synthetic examples retained.

## Axes
Strengthens adopter ergonomics and use of the shared manifest-bound restore path. No axis weakened.

## Structure and data-model review
Verdict: implement.
Opportunity: existing complete-text restore API replaces a duplicated scanning loop.
Why: restores shared validation ownership and removes manual cursor/substitution bookkeeping from adopter code.
Scope: tutorial example and README guidance only.
Validation: API/signature and link-target review; no cargo gate per docs-only brief.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried.

Supersedes #539
Resolves solo todo #3523 (partial; orchestrator completes)
