### PR TITLE
docs: correct stale restore pass-through claim in GDPR adopter guidance

### DIFF
--- a/docs/how-to/compliance/gdpr-adopter-guidance.md
+++ b/docs/how-to/compliance/gdpr-adopter-guidance.md
@@ -120,7 +120,7 @@ Re-materialising original values from tokens is a **privileged operation**, not 
 **What Gaze guarantees at the boundary:**
 
 - A token is restored to its original value **only if** the currently-active session manifest authorises that exact token-to-value mapping.
-- **Unknown tokens, tokens minted in another session, tokens from another tenant boundary, and malformed tokens all fail closed** — they return a typed restore failure. Restore never guesses, never falls back to a best-effort value, and never passes a token-shaped string through as raw.
+- **Unknown tokens, tokens minted in another session, tokens from another tenant boundary, and malformed tokens all fail closed** — they return a typed restore failure. Restore never guesses a mapping, never falls back to a best-effort value, and never reconstructs a sensitive value the active manifest did not authorise.
 - Restore decisions are **deterministic and auditable**: a restore can be logged with metadata (recognizer identity, session, timestamp, the typed outcome) without ever writing the raw value to the audit sink (see [§7](#7-audit-logs-and-metadata)).
 
 **Restore is not "on by default" — it is a capability you must deliberately wire and constrain.** For adopters this means:


### PR DESCRIPTION
Correct the restore guarantee in adopter guidance: restoration never reconstructs a sensitive value without the active manifest authorizing it. This matches the canonical boundary documentation, where ordinary bare identifier-shaped literals may pass through as audit-only signals.

## Review verdict
CLEAN. Compared the sentence with docs/explanation/core/restore-boundary.md and current restore assessment/classification. Existing audit-section anchor resolves. Documentation only; no legal requirements changed.

## Axes
Improves trust by describing the actual manifest authority precisely. No runtime boundary or axis weakened.

## Structure and data-model review
Verdict: skip.
Opportunity: none.
Why: one stale guarantee is corrected to the established runtime invariant.
Scope: one documentation sentence.
Validation: canonical source and nearby anchor review; no cargo gate per docs-only brief.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried.

Supersedes #538
Resolves solo todo #3523 (partial; orchestrator completes)
