### PR TITLE
Skip empty safety-net registries consistently at runtime

### DIFF
--- a/crates/gaze/src/pipeline.rs
+++ b/crates/gaze/src/pipeline.rs
@@ -1185,63 +1185,13 @@ impl Pipeline {
         }
         #[cfg(feature = "bundled-recognizers")]
         if let Some(registry) = &self.safety_net_registry {
-            let locale = locale_chain
-                .first()
-                .cloned()
-                .unwrap_or(crate::LocaleTag::Global);
-            let selected = registry
-                .resolve(&locale, ModelStage::Pass3SafetyNet)
-                .map_err(|error| {
-                    if mandatory
-                        && matches!(
-                            error,
-                            ModelError::NoLocaleModelCoverage { .. }
-                                | ModelError::LocaleNotSupported(_)
-                        )
-                    {
-                        Error::Protection(ProtectionError::UnsupportedCoverage)
-                    } else {
-                        Error::SafetyNet(model_error_to_safety_net_error(error))
-                    }
-                })?;
-            if mandatory && !registry.is_empty() && selected.is_empty() {
-                return Err(ProtectionError::UnsupportedCoverage.into());
-            }
-            if !mandatory && selected.len() > 1 {
-                let selected_backend = selected[0].name();
-                let dropped = selected
-                    .iter()
-                    .skip(1)
-                    .map(|backend| backend.name().to_string())
-                    .collect::<Vec<_>>();
-                tracing::debug!(
-                    selected_backend,
-                    backend_silently_dropped = ?dropped,
-                    "locale-aware safety-net registry resolved multiple backends; using first"
-                );
-                self.log_backend_silently_dropped(
-                    target,
-                    document_kind,
-                    field_path,
-                    selected_backend,
-                    dropped,
-                )?;
-            }
-            for model in selected
-                .iter()
-                .take(if mandatory { selected.len() } else { 1 })
-            {
-                let spans = model
-                    .infer(
-                        ModelInput {
-                            text: clean_text.to_string(),
-                            locale: locale.clone(),
-                        },
-                        ModelHints {
-                            stage: ModelStage::Pass3SafetyNet,
-                            max_spans: None,
-                        },
-                    )
+            if !registry.is_empty() {
+                let locale = locale_chain
+                    .first()
+                    .cloned()
+                    .unwrap_or(crate::LocaleTag::Global);
+                let selected = registry
+                    .resolve(&locale, ModelStage::Pass3SafetyNet)
                     .map_err(|error| {
                         if mandatory
                             && matches!(
@@ -1255,17 +1205,69 @@ impl Pipeline {
                             Error::SafetyNet(model_error_to_safety_net_error(error))
                         }
                     })?;
-                for span in spans {
-                    if mandatory
-                        && (span.byte_range.start >= span.byte_range.end
-                            || clean_text.get(span.byte_range.clone()).is_none())
-                    {
-                        return Err(ProtectionError::Residual.into());
-                    }
-                    if let Some(suspect) =
-                        model_span_to_suspect(span, model.name(), manifest, field_path)
-                    {
-                        suspects.push(suspect);
+                if mandatory && selected.is_empty() {
+                    return Err(ProtectionError::UnsupportedCoverage.into());
+                }
+                if !mandatory && selected.len() > 1 {
+                    let selected_backend = selected[0].name();
+                    let dropped = selected
+                        .iter()
+                        .skip(1)
+                        .map(|backend| backend.name().to_string())
+                        .collect::<Vec<_>>();
+                    tracing::debug!(
+                        selected_backend,
+                        backend_silently_dropped = ?dropped,
+                        "locale-aware safety-net registry resolved multiple backends; using first"
+                    );
+                    self.log_backend_silently_dropped(
+                        target,
+                        document_kind,
+                        field_path,
+                        selected_backend,
+                        dropped,
+                    )?;
+                }
+                for model in selected
+                    .iter()
+                    .take(if mandatory { selected.len() } else { 1 })
+                {
+                    let spans = model
+                        .infer(
+                            ModelInput {
+                                text: clean_text.to_string(),
+                                locale: locale.clone(),
+                            },
+                            ModelHints {
+                                stage: ModelStage::Pass3SafetyNet,
+                                max_spans: None,
+                            },
+                        )
+                        .map_err(|error| {
+                            if mandatory
+                                && matches!(
+                                    error,
+                                    ModelError::NoLocaleModelCoverage { .. }
+                                        | ModelError::LocaleNotSupported(_)
+                                )
+                            {
+                                Error::Protection(ProtectionError::UnsupportedCoverage)
+                            } else {
+                                Error::SafetyNet(model_error_to_safety_net_error(error))
+                            }
+                        })?;
+                    for span in spans {
+                        if mandatory
+                            && (span.byte_range.start >= span.byte_range.end
+                                || clean_text.get(span.byte_range.clone()).is_none())
+                        {
+                            return Err(ProtectionError::Residual.into());
+                        }
+                        if let Some(suspect) =
+                            model_span_to_suspect(span, model.name(), manifest, field_path)
+                        {
+                            suspects.push(suspect);
+                        }
                     }
                 }
             }

--- a/crates/gaze/tests/repro_empty_registry.rs
+++ b/crates/gaze/tests/repro_empty_registry.rs
@@ -1,0 +1,211 @@
+#![cfg(feature = "bundled-recognizers")]
+
+use gaze::{
+    Action, ClassRule, DefaultRule, Detection, Detector, DictionaryBundle, LeakSuspect, LocaleTag,
+    PiiClass, Pipeline, ProtectionContext, ProtectionError, SafetyNet, SafetyNetContext,
+    SafetyNetError, Scope, Session,
+};
+use gaze_recognizers::{
+    LocaleAwareModel, LocaleAwareModelRegistry, ModelError, ModelHints, ModelInput, ModelSpan,
+};
+use std::sync::{Arc, Mutex};
+
+const EMAIL: &str = "alice@example.invalid";
+
+#[derive(Clone)]
+struct Primary;
+impl Detector for Primary {
+    fn detect(&self, input: &str) -> Vec<Detection> {
+        input
+            .match_indices(EMAIL)
+            .map(|(start, _)| {
+                Detection::new(start..start + EMAIL.len(), PiiClass::Email, "synthetic")
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone)]
+struct RecordingNet {
+    seen: Arc<Mutex<Vec<String>>>,
+    locale: LocaleTag,
+}
+impl SafetyNet for RecordingNet {
+    fn id(&self) -> &str {
+        "recording"
+    }
+    fn supported_locales(&self) -> &[LocaleTag] {
+        std::slice::from_ref(&self.locale)
+    }
+    fn check(
+        &self,
+        text: &str,
+        _: SafetyNetContext<'_>,
+    ) -> Result<Vec<LeakSuspect>, SafetyNetError> {
+        self.seen.lock().unwrap().push(text.to_string());
+        Ok(vec![])
+    }
+}
+
+struct DeOnlyModel;
+impl LocaleAwareModel for DeOnlyModel {
+    fn name(&self) -> &str {
+        "de-only"
+    }
+    fn native_locales(&self) -> &[LocaleTag] {
+        &[LocaleTag::DeDe]
+    }
+    fn infer(&self, _: ModelInput, _: ModelHints) -> Result<Vec<ModelSpan>, ModelError> {
+        Ok(vec![])
+    }
+}
+
+fn empty_registry() -> LocaleAwareModelRegistry {
+    LocaleAwareModelRegistry::new()
+}
+
+#[test]
+fn some_empty_registry_without_custom_nets_succeeds_via_early_return() {
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net_registry(empty_registry())
+        .build()
+        .expect("pipeline");
+    let dictionaries = DictionaryBundle::default();
+    let context = ProtectionContext::strict(&[LocaleTag::Global], &dictionaries);
+    assert_eq!(pipeline.validate_protection_context(context), Ok(()));
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let mut tx = session.begin_transaction();
+    assert!(pipeline
+        .protect_text_transaction(&mut tx, "benign", context)
+        .is_ok());
+}
+
+#[test]
+fn some_empty_registry_with_custom_net_passes_validate_and_runtime() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(RecordingNet {
+            seen: seen.clone(),
+            locale: LocaleTag::Global,
+        })
+        .register_safety_net_registry(empty_registry())
+        .build()
+        .expect("pipeline");
+    let dictionaries = DictionaryBundle::default();
+    let context = ProtectionContext::strict(&[LocaleTag::EnUs], &dictionaries);
+    assert_eq!(pipeline.validate_protection_context(context), Ok(()));
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let mut tx = session.begin_transaction();
+    assert!(pipeline
+        .protect_text_transaction(&mut tx, "benign", context)
+        .is_ok());
+    assert_eq!(seen.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn none_registry_with_custom_net_runs_custom_net() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(RecordingNet {
+            seen: seen.clone(),
+            locale: LocaleTag::Global,
+        })
+        .build()
+        .expect("pipeline");
+    let dictionaries = DictionaryBundle::default();
+    let context = ProtectionContext::strict(&[LocaleTag::EnUs], &dictionaries);
+    assert_eq!(pipeline.validate_protection_context(context), Ok(()));
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let mut tx = session.begin_transaction();
+    assert!(pipeline
+        .protect_text_transaction(&mut tx, "benign", context)
+        .is_ok());
+    assert_eq!(seen.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn nonempty_registry_without_coverage_still_fails_closed() {
+    let registry = LocaleAwareModelRegistry::from_backends(vec![
+        Box::new(DeOnlyModel) as Box<dyn LocaleAwareModel>
+    ]);
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net_registry(registry)
+        .build()
+        .expect("pipeline");
+    let dictionaries = DictionaryBundle::default();
+    let context = ProtectionContext::strict(&[LocaleTag::EnUs], &dictionaries);
+    assert_eq!(
+        pipeline.validate_protection_context(context),
+        Err(ProtectionError::UnsupportedCoverage)
+    );
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let mut tx = session.begin_transaction();
+    assert_eq!(
+        pipeline.protect_text_transaction(&mut tx, "benign", context),
+        Err(ProtectionError::UnsupportedCoverage)
+    );
+}
+
+#[test]
+fn some_empty_registry_with_custom_net_observer_scan_succeeds() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(RecordingNet {
+            seen: seen.clone(),
+            locale: LocaleTag::Global,
+        })
+        .register_safety_net_registry(empty_registry())
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let result = pipeline.scan_safety_nets(&session, "benign", &[LocaleTag::EnUs]);
+    assert!(
+        result.is_ok(),
+        "observer scan over an empty registry should skip, not fail: {result:?}"
+    );
+    assert_eq!(seen.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn some_empty_registry_with_custom_net_observer_scan_with_dictionaries_succeeds() {
+    let seen = Arc::new(Mutex::new(vec![]));
+    let pipeline = Pipeline::builder()
+        .detector(Primary)
+        .rule(ClassRule::new(PiiClass::Email, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .register_safety_net(RecordingNet {
+            seen: seen.clone(),
+            locale: LocaleTag::Global,
+        })
+        .register_safety_net_registry(empty_registry())
+        .build()
+        .expect("pipeline");
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let dictionaries = DictionaryBundle::default();
+    let result = pipeline.scan_safety_nets_with_dictionaries(
+        &session,
+        "benign",
+        &[LocaleTag::EnUs],
+        &dictionaries,
+    );
+    assert!(
+        result.is_ok(),
+        "observer scan_with_dictionaries over an empty registry should skip, not fail: {result:?}"
+    );
+    assert_eq!(seen.lock().unwrap().len(), 1);
+}


### PR DESCRIPTION
An empty optional model registry was accepted during protection validation but resolved at runtime when custom safety nets existed, causing an avoidable coverage error. Skip empty model registries at runtime while continuing to execute installed custom safety nets and reject unsupported coverage in nonempty registries.

## Review verdict
NITS fixed: removed the redundant inner registry-is-empty check inside the new nonempty guard. Reviewed validation, runtime mandatory/observer paths, backend selection, and synthetic test doubles. Regression coverage includes absent/empty registries, custom-net execution, both observer APIs, and uncovered nonempty registries.

## Axes
Adopter ergonomics improve because validation and execution agree. Reliability remains fail-closed for installed backends without locale coverage. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: existing optional registry guard.
- Why: zero installed backends now mean the same thing during validation and execution; the redundant nested condition is removed.
- Scope: pipeline runtime and one focused integration test file. No new state or abstraction.
- Validation: rustfmt, workspace all-feature/all-target Clippy (-D warnings), and complete workspace all-feature tests including xtask and doctests pass under Rust 1.96.0 with -j 4. All six new regression cases pass.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #521
Closes #489
Resolves solo todo #3523 (partial; orchestrator completes)
