### PR TITLE
Keep name endpoints valid when trimming trailing particles

### DIFF
--- a/crates/gaze-recognizers/src/anchored_match.rs
+++ b/crates/gaze-recognizers/src/anchored_match.rs
@@ -234,7 +234,7 @@ fn person_name_at(
     let mut end = start;
     let mut components = 0usize;
     let mut uppercase_components = 0usize;
-    let mut pending_particles: Vec<(usize, usize)> = Vec::new();
+    let mut pending_particles = 0usize;
     let mut cursor = start;
 
     while components < 4 {
@@ -253,14 +253,14 @@ fn person_name_at(
         if is_upper_component(token) {
             components += 1;
             uppercase_components += 1;
-            pending_particles.clear();
+            pending_particles = 0;
             end = effective_end;
             cursor = token_end;
             continue;
         }
 
         if components > 0 && is_particle(token) {
-            pending_particles.push((token_start, effective_end));
+            pending_particles += 1;
             components += 1;
             cursor = token_end;
             continue;
@@ -268,10 +268,7 @@ fn person_name_at(
         break;
     }
 
-    if !pending_particles.is_empty() {
-        end = pending_particles[0].0.saturating_sub(1);
-        components = components.saturating_sub(pending_particles.len());
-    }
+    components = components.saturating_sub(pending_particles);
 
     let candidate = &input[start..end];
     if has_organization_suffix(candidate) {
@@ -800,6 +797,61 @@ mod tests {
             find_cue_ranges("aaaa", &folded("aa")),
             Vec::<std::ops::Range<usize>>::new()
         );
+    }
+
+    #[test]
+    fn trailing_particle_after_multi_byte_whitespace_does_not_panic() {
+        // The normalizer passes NBSP / em-space / narrow-NBSP through unchanged,
+        // so a trailing particle separated from the last uppercase component by
+        // such a multi-byte whitespace reaches `person_name_at`. The rollback
+        // must keep `end` on the component's char boundary instead of backing
+        // one byte (which used to land inside the multi-byte char and panic).
+        for ws in [
+            '\u{00A0}', '\u{2003}', '\u{202F}', '\u{2007}', '\u{2009}', '\u{205F}',
+        ] {
+            let input = format!("Alice{ws}de");
+            let span =
+                is_person_name_candidate(&input).expect("trailing particle must match, not panic");
+            assert_eq!(
+                span,
+                0..5,
+                "multi-byte ws {ws:?} must trim to the component"
+            );
+            assert_eq!(&input[span], "Alice");
+        }
+    }
+
+    #[test]
+    fn trailing_particle_after_double_ascii_space_trims_to_component() {
+        // Two ASCII spaces used to retain one separator byte in the span
+        // ("Alice "); keeping `end` at the component boundary trims it.
+        let input = "Alice  de";
+        let span = is_person_name_candidate(input).expect("should match Alice");
+        assert_eq!(span, 0..5);
+        assert_eq!(&input[span.clone()], "Alice");
+        assert!(!input[span].ends_with(' '), "no trailing separator in span");
+    }
+
+    #[test]
+    fn detect_through_cue_does_not_panic_on_unicode_whitespace_particle() {
+        let recognizer = test_recognizer(
+            "test.from",
+            vec!["from"],
+            AnchoredBoundary::Punctuation,
+            CuePosition::Before,
+            "from",
+        );
+        // Trailing particle after NBSP with min_components=2: the trimmed
+        // candidate has one component -> no match. This used to panic inside
+        // `candidate_after_cue` before reaching the boundary check.
+        let hits = recognizer.detect("from Alice\u{00A0}de:", &ctx()).unwrap();
+        assert!(hits.is_empty());
+
+        // A complete name through NBSP separators is still recognised.
+        let text = "from Alice\u{00A0}de la Cruz:";
+        let hits = recognizer.detect(text, &ctx()).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(&text[hits[0].span.clone()], "Alice\u{00A0}de la Cruz");
     }
 
     fn test_recognizer(


### PR DESCRIPTION
A trailing name particle separated by multibyte whitespace could move the span endpoint into a UTF-8 character and panic. Keep the endpoint already recorded for the last uppercase component and discount trailing particles from the component count.

## Review verdict
NITS fixed: replaced pending particle byte-range storage with a count because no particle offsets are needed after the correction. Reviewed person_name_at, whitespace scanning, candidate/cue callers, component limits, and synthetic fixtures. Tests cover six multibyte separators, repeated ASCII spaces, skipped incomplete names, and complete anchored names.

## Axes
Reliability improves by avoiding an input-triggered panic. Span boundaries remain valid and restoration retains the original detected bytes. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: a count instead of a Vec of unused particle byte ranges.
- Why: only the number of pending particles affects eligibility; the endpoint already belongs to the last complete component.
- Scope: local name parser state and regression tests. No new abstraction.
- Validation: rustfmt, workspace all-features/all-targets Clippy (-D warnings), and complete workspace all-features tests including xtask/doctests pass under Rust1.96.0/-j4. All three new Unicode/spacing regressions pass.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #526
Closes #495
Resolves solo todo #3523 (partial; orchestrator completes)
