### PR TITLE
Keep byte-adjacent NER entities as separate pseudonyms

### DIFF
--- a/crates/gaze-recognizers/src/ner/detector.rs
+++ b/crates/gaze-recognizers/src/ner/detector.rs
@@ -190,7 +190,7 @@ fn merge_overlapping_spans(mut spans: Vec<NerSpanResult>) -> Vec<NerSpanResult> 
     let mut merged: Vec<NerSpanResult> = Vec::new();
     for span in spans {
         if let Some(last) = merged.last_mut() {
-            if last.class == span.class && last.span.end >= span.span.start {
+            if last.class == span.class && last.span.end > span.span.start {
                 last.span.end = last.span.end.max(span.span.end);
                 last.score = last.score.max(span.score);
                 continue;
@@ -199,4 +199,63 @@ fn merge_overlapping_spans(mut spans: Vec<NerSpanResult>) -> Vec<NerSpanResult> 
         merged.push(span);
     }
     merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_overlapping_spans, NerSpanResult};
+    use gaze_types::PiiClass;
+
+    /// Regression: touching half-open same-class ranges (`[0..3)` and `[3..7)`
+    /// share zero bytes) must remain separate so the downstream pipeline mints
+    /// one pseudonym per entity. Introduced by the fail-closed chunking change
+    /// in ca90f53, which used `>=` and collapsed byte-adjacent same-class PII.
+    #[test]
+    fn touching_same_class_spans_remain_separate() {
+        let spans = vec![
+            NerSpanResult {
+                span: 0..3,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+            NerSpanResult {
+                span: 3..7,
+                class: PiiClass::Name,
+                score: 0.8,
+            },
+        ];
+        let merged = merge_overlapping_spans(spans);
+        assert_eq!(
+            merged.len(),
+            2,
+            "touching same-class spans must not merge: {merged:?}"
+        );
+        assert_eq!(merged[0].span, 0..3);
+        assert_eq!(merged[1].span, 3..7);
+        assert_eq!(merged[0].score, 0.9);
+        assert_eq!(merged[1].score, 0.8);
+    }
+
+    #[test]
+    fn strictly_overlapping_same_class_spans_still_merge() {
+        let spans = vec![
+            NerSpanResult {
+                span: 10..20,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+            NerSpanResult {
+                span: 15..25,
+                class: PiiClass::Name,
+                score: 0.7,
+            },
+        ];
+        let merged = merge_overlapping_spans(spans);
+        assert_eq!(
+            merged.len(),
+            1,
+            "strictly overlapping same-class spans must merge: {merged:?}"
+        );
+        assert_eq!(merged[0].span, 10..25);
+    }
 }

--- a/crates/gaze-recognizers/src/ner/mod.rs
+++ b/crates/gaze-recognizers/src/ner/mod.rs
@@ -844,4 +844,91 @@ mod tests {
         assert_eq!(default_candidates[0].score, 0.40);
         assert!(stricter_candidates.is_empty());
     }
+
+    /// Regression (ca90f53): two byte-adjacent same-class PII entities —
+    /// `[0..3)` and `[3..7)` share zero bytes — must reach the resolver as two
+    /// separate `Candidate`s. Before the fix `merge_overlapping_spans` used `>=`
+    /// and collapsed them into one `Candidate`, so the pipeline minted a single
+    /// pseudonym instead of two.
+    #[test]
+    fn touching_same_class_entities_emit_two_candidates() {
+        let input = "BobMary";
+        let recognizer = recognizer_with_spans(vec![
+            NerSpanResult {
+                span: 0..3,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+            NerSpanResult {
+                span: 3..7,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+        ]);
+        let dictionaries = DictionaryBundle::default();
+        let ctx = DetectContext::new(&[LocaleTag::Global], &dictionaries);
+
+        let candidates = Recognizer::detect(&recognizer, input, &ctx).unwrap();
+
+        assert_eq!(
+            candidates.len(),
+            2,
+            "touching same-class entities must be two candidates: {candidates:?}"
+        );
+        assert_eq!(candidates[0].span, 0..3);
+        assert_eq!(candidates[1].span, 3..7);
+    }
+
+    /// End-to-end manifestation of the touching-spans bug: the pipeline mints
+    /// one pseudonym per surviving `Candidate`. Two touching same-class Names
+    /// must produce two distinct `:Name_` pseudonyms (not one), and restoring
+    /// must reconstruct the original byte string.
+    #[test]
+    fn touching_same_class_entities_mint_two_distinct_pseudonyms() {
+        let input = "BobMary";
+        let recognizer = recognizer_with_spans(vec![
+            NerSpanResult {
+                span: 0..3,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+            NerSpanResult {
+                span: 3..7,
+                class: PiiClass::Name,
+                score: 0.9,
+            },
+        ]);
+        let pipeline = tokenizing_pipeline(recognizer);
+        let session = Session::new(Scope::Ephemeral).expect("session");
+
+        let redacted = clean_text(
+            pipeline
+                .redact(&session, RawDocument::Text(input.to_string()))
+                .expect("redact"),
+        );
+
+        let name_tokens = redacted.matches(":Name_").count();
+        assert_eq!(
+            name_tokens, 2,
+            "two touching same-class entities must mint two pseudonyms: {redacted}"
+        );
+        assert!(
+            !redacted.contains("Bob"),
+            "Bob was not pseudonymized: {redacted}"
+        );
+        assert!(
+            !redacted.contains("Mary"),
+            "Mary was not pseudonymized: {redacted}"
+        );
+
+        let restored = pipeline
+            .restore_with_telemetry(&session, &redacted)
+            .expect("restore")
+            .0
+            .text;
+        assert_eq!(
+            restored, input,
+            "restore must reconstruct the original bytes"
+        );
+    }
 }


### PR DESCRIPTION
Byte-adjacent same-class NER entities were merged despite sharing no bytes. Use strict overlap for half-open ranges so each entity retains its own pseudonym while genuinely overlapping chunk results still merge.

## Review verdict
CLEAN. Reviewed chunk offset translation, span sorting/merging, candidate emission, and downstream resolver overlap semantics. Model-free tests cover adjacent spans, overlapping spans, two emitted candidates, two pseudonyms, and exact restoration. The previous >= comparison fails the adjacent-entity assertions.

## Axes
Reversibility and agentic identity granularity improve. Detection coverage and fail-closed backend behavior remain unchanged; no axis weakened.

## Structure and data-model review
- Verdict: skip.
- Opportunity: none.
- Why: the existing ordered interval merge is sufficient; strict comparison encodes the half-open-range invariant without new state.
- Scope: one comparison and focused recognizer tests; no broader resolver change needed.
- Validation: rustfmt, workspace all-features/all-targets Clippy (-D warnings), and complete workspace all-features tests including xtask/doctests pass with Rust1.96.0/-j4. All four adjacent/overlap/candidate/restore regressions pass.

CI run 34684442002 passed every xtask gate, including the feature matrix, then the runner ran out of disk during post-cache cleanup. Merged current main with signed, DCO-bearing merge commit 14c038aa882a9c10b5298070f573dafcdaae111b and pushed for a fresh CI run. The PR diff remains limited to the NER overlap fix and its tests.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #520
Closes #487
Resolves solo todo #3523 (partial; orchestrator completes)
