### PR TITLE
Repair every fragmented OCR email domain label

### DIFF
--- a/crates/gaze-document/src/ocr/normalize.rs
+++ b/crates/gaze-document/src/ocr/normalize.rs
@@ -50,12 +50,15 @@ use regex::Regex;
 /// Returns an owned `String`. The function is allocation-cheap on
 /// already-clean input (only the regex pass walks the string).
 pub(crate) fn normalize_ocr_artifacts(text: &str) -> String {
-    let text = email_separator_regex()
+    let mut text = email_separator_regex()
         .replace_all(text, "$pre@$post")
         .into_owned();
-    email_domain_dot_regex()
-        .replace_all(&text, "$pre$post")
-        .into_owned()
+    // Each repair removes whitespace; stop when the regex finds no remaining gap.
+    let rule2 = email_domain_dot_regex();
+    while let std::borrow::Cow::Owned(next) = rule2.replace_all(&text, "$pre$post") {
+        text = next;
+    }
+    text
 }
 
 fn email_separator_regex() -> &'static Regex {
@@ -118,6 +121,27 @@ mod tests {
         assert_eq!(
             normalize_ocr_artifacts("Email: jane.doe@example. invalid"),
             "Email: jane.doe@example.invalid"
+        );
+    }
+
+    #[test]
+    fn collapses_space_after_every_domain_dot_multilabel() {
+        // A single `replace_all` pass of Rule 2 only closes the first
+        // `dot-space` gap in a multi-label domain; without the fixpoint loop
+        // this would yield `user@mail.corp. example. invalid` and leak the tail.
+        assert_eq!(
+            normalize_ocr_artifacts("user@mail. corp. example. invalid"),
+            "user@mail.corp.example.invalid"
+        );
+    }
+
+    #[test]
+    fn multilabel_fixpoint_does_not_over_collapse_surrounding_whitespace() {
+        // The fixpoint loop must not become aggressive about whitespace
+        // outside the dot-space-in-domain shape.
+        assert_eq!(
+            normalize_ocr_artifacts("Contact: user@mail. corp. example. invalid  Phone: +1 555"),
+            "Contact: user@mail.corp.example.invalid  Phone: +1 555"
         );
     }
 


### PR DESCRIPTION
OCR email repair closed only the first dot-space gap in a fragmented multi-label domain, leaving address suffixes outside detection. Repeat domain-dot repair until no replacement occurs so the detector receives the complete repaired address.

## Review verdict
NITS fixed: shortened the implementation comment, used reserved .invalid fixtures, and used the regex replacement's borrowed/owned result to detect progress without copying unchanged text. Reviewed both normalization rules and document bundle/MCP callers. Regressions require every domain gap to close while preserving surrounding spacing.

## Axes
Reliability improves by closing residual domain-tail leakage. Restoration continues to reconstruct post-normalization text, the existing document contract. Performance tradeoff: repeated scans are quadratic in the worst case of many fragmented labels; each pass removes whitespace and therefore terminates. The correctness fix takes priority over this performance cost.

## Structure and data-model review
- Verdict: implement.
- Opportunity: the existing borrowed/owned replacement result distinguishes unchanged text from another repair.
- Why: avoids a duplicate output comparison and allocation for the unchanged final pass; no mirrored progress flag.
- Scope: OCR normalization and focused tests. Broader normalization redesign is deferred.
- Validation: rustfmt, workspace all-features/all-targets Clippy (-D warnings), and gaze-document all-features tests including doctests pass under Rust1.96.0/-j4. Both multilabel normalization regressions pass.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #519
Closes #486
Resolves solo todo #3523 (partial; orchestrator completes)
