### PR TITLE
Preserve prior losing recognizers in family-level provenance

### DIFF
--- a/crates/gaze/src/resolver.rs
+++ b/crates/gaze/src/resolver.rs
@@ -333,10 +333,10 @@ fn family_tie_candidate(
     policy: &FamilyPolicyTable,
 ) -> Option<Candidate> {
     let family = policy.precedence_tie_family(&candidate.recognizer_id, &existing.recognizer_id)?;
-    let mut merged_sources = vec![
-        existing.recognizer_id.clone(),
-        candidate.recognizer_id.clone(),
-    ];
+    let mut merged_sources = existing.merged_sources.clone();
+    merged_sources.extend(candidate.merged_sources.iter().cloned());
+    merged_sources.push(existing.recognizer_id.clone());
+    merged_sources.push(candidate.recognizer_id.clone());
     merged_sources.sort();
     merged_sources.dedup();
     Some(Candidate::new(
@@ -380,6 +380,13 @@ fn family_fallback_candidate(
     decided_by: ConflictTier,
 ) -> Candidate {
     let original_recognizer_id = candidate.recognizer_id.clone();
+    let mut merged_sources = candidate.merged_sources;
+    if !merged_sources
+        .iter()
+        .any(|source| source == &original_recognizer_id)
+    {
+        merged_sources.push(original_recognizer_id);
+    }
     Candidate::new(
         candidate.span,
         PiiClass::family(&family),
@@ -390,7 +397,7 @@ fn family_fallback_candidate(
         format!("collision-family:{family}"),
         candidate.source,
         decided_by,
-        vec![original_recognizer_id],
+        merged_sources,
     )
 }
 
@@ -642,6 +649,61 @@ mod tests {
         );
     }
 
+    /// A non-family rival that loses to the first family-tie partner before the
+    /// second partner arrives must survive in `merged_sources` after the tie
+    /// collapses the two partners into the family-level candidate. The audit
+    /// trail derives loser accounting exclusively from `merged_sources`, so a
+    /// reset here would silently drop the earlier loser from `conflict_loser`
+    /// rows and `AmbiguityRecord.losing_candidates`.
+    #[test]
+    fn family_tie_preserves_prior_nonfamily_loser_in_merged_sources() {
+        let registry = tenant_document_registry();
+
+        let resolved = resolve_candidates_with_policy(
+            vec![
+                candidate(0..5, PiiClass::custom("alpha_doc"), 0.95, "doc.alpha"),
+                candidate(0..5, PiiClass::custom("nonfamily"), 0.92, "aaa.nonfamily"),
+                candidate(0..5, PiiClass::custom("beta_doc"), 0.90, "doc.beta"),
+            ],
+            registry.family_policy(),
+        );
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0].class,
+            PiiClass::Custom("family:tenant-document".to_string())
+        );
+        assert_eq!(
+            resolved[0].recognizer_id,
+            "collision-family:tenant-document"
+        );
+        assert_eq!(resolved[0].decided_by, ConflictTier::CollisionPolicy);
+        assert!(
+            resolved[0]
+                .merged_sources
+                .iter()
+                .any(|src| src == "aaa.nonfamily"),
+            "prior non-family loser must survive the family tie: {:?}",
+            resolved[0].merged_sources
+        );
+        assert!(
+            resolved[0]
+                .merged_sources
+                .iter()
+                .any(|src| src == "doc.alpha"),
+            "first tie partner must be recorded: {:?}",
+            resolved[0].merged_sources
+        );
+        assert!(
+            resolved[0]
+                .merged_sources
+                .iter()
+                .any(|src| src == "doc.beta"),
+            "second tie partner must be recorded: {:?}",
+            resolved[0].merged_sources
+        );
+    }
+
     /// Positive control for `counting_removals`. A non-exact winner widens the
     /// slot it took, so it must enter overlap removal; without this, the two
     /// zero-call assertions below would also pass on a counter that never
@@ -843,6 +905,62 @@ mod tests {
         assert_eq!(resolved[0].recognizer_id, "iban.structural");
         assert_eq!(resolved[0].span, 6..10);
         assert_eq!(resolved[0].decided_by, ConflictTier::Score);
+    }
+
+    /// When an anchored recognizer's mandatory anchor is `Missing`, the
+    /// winner is rebuilt as the family-level fallback candidate. A rival that
+    /// lost to the winner on the base ladder *before* the fallback fired must
+    /// survive in `merged_sources` — the audit trail derives loser accounting
+    /// exclusively from `merged_sources`, so a reset here would drop the actual
+    /// loser from `conflict_loser` rows and `AmbiguityRecord.losing_candidates`
+    /// and mis-attribute the loser slot to the original winner's recognizer id.
+    #[test]
+    fn missing_anchor_fallback_preserves_prior_loser_in_merged_sources() {
+        let registry = crate::RecognizerRegistry::builder()
+            .register_collision(
+                "iban.structural",
+                crate::CollisionMembership::new(
+                    "payment-card-or-iban",
+                    "iban",
+                    10,
+                    Some("iban".to_string()),
+                ),
+            )
+            .build();
+        // No anchor cue bundle registered → anchor resolves to `Missing`.
+        let resolved = resolve_candidates_with_policy_and_anchors(
+            vec![
+                candidate(6..10, PiiClass::custom("iban"), 0.90, "iban.structural"),
+                candidate(6..10, PiiClass::custom("digits"), 0.50, "digits.generic"),
+            ],
+            registry.family_policy(),
+            &AnchorResolver::default(),
+            "field DE89",
+            &[LocaleTag::DeDe],
+        );
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0].recognizer_id,
+            "collision-family:payment-card-or-iban"
+        );
+        assert_eq!(resolved[0].decided_by, ConflictTier::AnchoredContext);
+        assert!(
+            resolved[0]
+                .merged_sources
+                .iter()
+                .any(|src| src == "digits.generic"),
+            "prior rival that lost on score must survive the fallback: {:?}",
+            resolved[0].merged_sources
+        );
+        assert!(
+            resolved[0]
+                .merged_sources
+                .iter()
+                .any(|src| src == "iban.structural"),
+            "the demoted original variant must still be recorded: {:?}",
+            resolved[0].merged_sources
+        );
     }
 
     /// When the ladder is exhausted (identical recognizer id, class, priority,

--- a/crates/gaze/tests/contracts.rs
+++ b/crates/gaze/tests/contracts.rs
@@ -916,6 +916,262 @@ fn anchored_iban_beating_a_rival_on_score_logs_score_not_anchored_context() {
     }
 }
 
+/// Regression for the anchor-missing fallback path. When an anchored
+/// recognizer's mandatory anchor is `Missing` at resolve time, the winner is
+/// rebuilt as the family-level fallback candidate. A rival that lost to the
+/// winner on the base ladder *before* the fallback fired must still be logged
+/// as a `conflict_loser` and appear in `AmbiguityRecord.losing_candidates`.
+/// Before the fix, `family_fallback_candidate` reset `merged_sources` to only
+/// the original winner's recognizer id, silently dropping the actual loser and
+/// mis-attributing the loser slot to the original winner.
+#[test]
+fn anchor_missing_fallback_preserves_prior_loser_in_audit() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let logger = MemoryLogger::default();
+    let family_class = PiiClass::Custom("family:payment-card-or-iban".to_string());
+    let pipeline = Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                r"\b[A-Z]{2}\d{2}(?: ?[A-Z0-9]{4}){2,7} ?[A-Z0-9]{1,4}\b",
+                PiiClass::Custom("iban".to_string()),
+                "iban.structural",
+                vec![gaze::LocaleTag::Global],
+                0.70,
+                80,
+                "counter",
+                None,
+                Vec::new(),
+                Some(ValidatorKind::IbanMod97),
+                Some(NormalizerKind::IbanCanonical),
+            )
+            .expect("iban detector"),
+        )
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                r"\b\d{4}\b",
+                PiiClass::Custom("digits".to_string()),
+                "digits.generic",
+                vec![gaze::LocaleTag::Global],
+                0.50,
+                80,
+                "counter",
+                None,
+                Vec::new(),
+                None,
+                None,
+            )
+            .expect("digits detector"),
+        )
+        .register_collision(
+            "iban.structural",
+            CollisionMembership::new("payment-card-or-iban", "iban", 10, Some("iban".to_string())),
+        )
+        // No register_anchor_cue_bundle -> anchor always Missing for iban.
+        .rule(ClassRule::new(
+            PiiClass::Custom("iban".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(
+            PiiClass::Custom("digits".to_string()),
+            Action::Tokenize,
+        ))
+        .rule(ClassRule::new(family_class.clone(), Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .redaction_logger(logger.clone())
+        .build()
+        .expect("pipeline");
+
+    let clean = pipeline
+        .pseudonymize_with_context(
+            &session,
+            RawDocument::Text("DE89 3704 0044 0532 0130 00".to_string()),
+            &[gaze::LocaleTag::DeDe],
+        )
+        .expect("redact");
+    let CleanDocument::Text(_clean) = clean else {
+        panic!("expected text document");
+    };
+
+    let entries = logger.entries();
+    let winner = entries
+        .iter()
+        .find(|entry| !entry.conflict_loser)
+        .expect("winner");
+    assert_eq!(winner.class, family_class);
+    assert_eq!(winner.decided_by, gaze::ConflictTier::AnchoredContext);
+
+    let ambiguity = winner.ambiguity_record.as_ref().expect("ambiguity record");
+    assert_eq!(ambiguity.reason, AmbiguityReason::NoAnchor);
+
+    // The actual prior loser (digits.generic) must be present, not dropped.
+    let digits_loser = ambiguity
+        .losing_candidates
+        .iter()
+        .find(|lc| lc.recognizer_id == "digits.generic")
+        .expect("digits.generic must appear in losing_candidates");
+    assert_eq!(
+        digits_loser.class,
+        PiiClass::Custom("digits".to_string()),
+        "losing candidate must be attributed to the correct recognizer"
+    );
+    // The demoted original variant (iban.structural) is also a losing candidate
+    // per the NoAnchor contract, so it must still be present.
+    assert!(
+        ambiguity
+            .losing_candidates
+            .iter()
+            .any(|lc| lc.recognizer_id == "iban.structural"),
+        "demoted variant must remain in losing_candidates"
+    );
+
+    // The conflict_loser audit rows must include the actual prior loser.
+    assert!(
+        entries.iter().any(|entry| {
+            entry.conflict_loser && entry.recognizer_id.as_deref() == Some("digits.generic")
+        }),
+        "digits.generic must be logged as a conflict_loser"
+    );
+    assert!(
+        entries.iter().any(|entry| {
+            entry.conflict_loser && entry.recognizer_id.as_deref() == Some("iban.structural")
+        }),
+        "demoted variant must be logged as a conflict_loser"
+    );
+}
+
+/// Regression for the family precedence-tie path. A non-family rival that
+/// loses to the first family-tie partner before the second partner arrives
+/// must survive the family-tie collapse and remain in the audit trail. Before
+/// the fix, `family_tie_candidate` rebuilt `merged_sources` from only the two
+/// variant recognizer ids, silently dropping the earlier non-family loser.
+#[test]
+fn family_tie_preserves_prior_nonfamily_loser_in_audit() {
+    let session = Session::new(Scope::Ephemeral).expect("session");
+    let logger = MemoryLogger::default();
+    let alpha_class = PiiClass::Custom("alpha_doc".to_string());
+    let nonfamily_class = PiiClass::Custom("nonfamily".to_string());
+    let beta_class = PiiClass::Custom("beta_doc".to_string());
+    let family_class = PiiClass::Custom("family:tenant-document".to_string());
+    let pipeline = Pipeline::builder()
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                "DOC-[0-9]+",
+                alpha_class.clone(),
+                "doc.alpha",
+                vec![gaze::LocaleTag::Global],
+                0.95,
+                0,
+                "counter",
+                None,
+                Vec::new(),
+                None,
+                None,
+            )
+            .expect("alpha detector"),
+        )
+        .register_collision(
+            "doc.alpha",
+            CollisionMembership::new("tenant-document", "alpha", 10, None),
+        )
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                "DOC-[0-9]+",
+                nonfamily_class.clone(),
+                "aaa.nonfamily",
+                vec![gaze::LocaleTag::Global],
+                0.92,
+                0,
+                "counter",
+                None,
+                Vec::new(),
+                None,
+                None,
+            )
+            .expect("nonfamily detector"),
+        )
+        .recognizer(
+            RegexDetector::with_rulepack_fields(
+                "DOC-[0-9]+",
+                beta_class.clone(),
+                "doc.beta",
+                vec![gaze::LocaleTag::Global],
+                0.90,
+                0,
+                "counter",
+                None,
+                Vec::new(),
+                None,
+                None,
+            )
+            .expect("beta detector"),
+        )
+        .register_collision(
+            "doc.beta",
+            CollisionMembership::new("tenant-document", "beta", 10, None),
+        )
+        .rule(ClassRule::new(family_class.clone(), Action::Tokenize))
+        .rule(ClassRule::new(alpha_class, Action::Tokenize))
+        .rule(ClassRule::new(beta_class, Action::Tokenize))
+        .rule(ClassRule::new(nonfamily_class, Action::Tokenize))
+        .rule(DefaultRule::new(Action::Preserve))
+        .redaction_logger(logger.clone())
+        .build()
+        .expect("pipeline");
+
+    let clean = pipeline
+        .redact(&session, RawDocument::Text("DOC-12345".to_string()))
+        .expect("redact");
+    let CleanDocument::Text(_clean) = clean else {
+        panic!("expected text document");
+    };
+
+    let entries = logger.entries();
+    let winner = entries
+        .iter()
+        .find(|entry| !entry.conflict_loser)
+        .expect("winner");
+    assert_eq!(winner.class, family_class);
+    assert_eq!(winner.decided_by, gaze::ConflictTier::CollisionPolicy);
+
+    let ambiguity = winner.ambiguity_record.as_ref().expect("ambiguity record");
+    assert_eq!(ambiguity.reason, AmbiguityReason::PrecedenceTie);
+
+    // The actual pre-tie loser (aaa.nonfamily) must be present, not dropped.
+    let nonfamily_loser = ambiguity
+        .losing_candidates
+        .iter()
+        .find(|lc| lc.recognizer_id == "aaa.nonfamily")
+        .expect("aaa.nonfamily must appear in losing_candidates");
+    assert_eq!(
+        nonfamily_loser.class,
+        PiiClass::Custom("nonfamily".to_string()),
+        "losing candidate must be attributed to the correct recognizer"
+    );
+    // Both tie partners must also remain.
+    assert!(
+        ambiguity
+            .losing_candidates
+            .iter()
+            .any(|lc| lc.recognizer_id == "doc.alpha"),
+        "first tie partner must remain in losing_candidates"
+    );
+    assert!(
+        ambiguity
+            .losing_candidates
+            .iter()
+            .any(|lc| lc.recognizer_id == "doc.beta"),
+        "second tie partner must remain in losing_candidates"
+    );
+
+    // The conflict_loser audit rows must include the actual pre-tie loser.
+    assert!(
+        entries.iter().any(|entry| {
+            entry.conflict_loser && entry.recognizer_id.as_deref() == Some("aaa.nonfamily")
+        }),
+        "aaa.nonfamily must be logged as a conflict_loser"
+    );
+}
+
 fn mandatory_anchor_iban_pipeline(logger: MemoryLogger) -> Pipeline {
     Pipeline::builder()
         .recognizer(


### PR DESCRIPTION
Family-tie and missing-anchor fallback candidates discarded previously accumulated losing recognizers. Preserve those sources when constructing the family candidate so conflict-loser audit rows and ambiguity records retain the actual prior rivals.

## Review verdict
NITS fixed: made the missing-anchor unit fixture's text cover its declared 6..10 span. Reviewed both constructors, arbitration callers, merged_losers, hybrid_fallback::emit, and synthetic fixtures. Regression tests cover prior nonfamily losers in precedence ties and prior score losers in missing-anchor fallback, including both audit surfaces.

## Axes
Trust improves through complete provenance. Candidate selection and tokenization behavior remain unchanged, preserving reliability and reversibility. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: retain the existing accumulated source list through family-candidate construction.
- Why: reconstruction no longer resets provenance already owned by the surviving candidate; tie sorting/deduplication remains deterministic.
- Scope: two resolver constructors and focused unit/audit-contract tests. No new collection abstraction.
- Validation: rustfmt, workspace all-features/all-targets Clippy (-D warnings), and full workspace all-features tests including xtask/doctests pass under Rust1.96.0/-j4. All four provenance regressions pass.

CI run 34685048315 passed every xtask gate, then the runner ran out of disk during post-cache cleanup. Refreshed from main with signed, DCO-bearing merge commit 720398e1149138c18c8bd8d92deb1654b26186e3 and pushed for a fresh CI run. The PR diff remains the two family-provenance constructors and regression tests.

## Separate recommendation
The pre-existing generic CandidateWins branch in insert_candidate replaces an incumbent without carrying its earlier merged_sources. A separate three-way unequal-precedence regression should check that path; this PR covers the two family-level constructors.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #516
Closes #482
Resolves solo todo #3523 (partial; orchestrator completes)
