### PR TITLE
Match regex exclusions consistently across ASCII case

### DIFF
--- a/crates/gaze-recognizers/src/regex.rs
+++ b/crates/gaze-recognizers/src/regex.rs
@@ -106,7 +106,10 @@ impl RegexDetector {
             priority,
             token_family: token_family.to_string(),
             capture_groups,
-            exclusions,
+            exclusions: exclusions
+                .into_iter()
+                .map(|value| value.to_ascii_lowercase())
+                .collect(),
             validator_kind,
             normalizer_kind,
             ascii_email_boundary,
@@ -202,9 +205,13 @@ impl Recognizer for RegexDetector {
 
 impl RegexDetector {
     fn is_excluded(&self, matched: &str) -> bool {
+        if self.exclusions.is_empty() {
+            return false;
+        }
+        let lowered = matched.to_ascii_lowercase();
         self.exclusions
             .iter()
-            .any(|excluded| matched.eq_ignore_ascii_case(excluded) || matched.contains(excluded))
+            .any(|excluded| lowered.contains(excluded))
     }
 
     fn canonical_form(&self, matched: &str) -> Option<String> {
@@ -362,6 +369,42 @@ mod tests {
             detections[0].canonical_form.as_deref(),
             Some("alice@example.invalid")
         );
+    }
+
+    fn detector_with_exclusions(exclusions: &[&str]) -> RegexDetector {
+        RegexDetector::with_rulepack_fields(
+            r"(?i)(?-u:\b)([a-z0-9._%+\-]+@(?:test\.local|example\.invalid))(?-u:\b)",
+            PiiClass::Email,
+            "email.global",
+            vec![LocaleTag::Global],
+            0.70,
+            90,
+            "counter",
+            Some(vec![1]),
+            exclusions.iter().map(|&s| s.to_string()).collect(),
+            Some(ValidatorKind::EmailRfc),
+            Some(NormalizerKind::EmailCanonical),
+        )
+        .expect("regex detector")
+    }
+
+    #[test]
+    fn is_excluded_is_ascii_case_insensitive_for_both_branches_and_cased_exclusion_values() {
+        // Substring and exact-match branches must both be ASCII-case-insensitive,
+        // and a cased exclusion value must match a differently-cased matched text.
+        let detector = detector_with_exclusions(&["test.local"]);
+        assert!(detector.is_excluded("user@test.local"));
+        assert!(detector.is_excluded("User@Test.Local"));
+        assert!(detector.is_excluded("USER@TEST.LOCAL"));
+        assert!(detector.is_excluded("test.local"));
+        assert!(detector.is_excluded("Test.Local"));
+        assert!(!detector.is_excluded("user@example.invalid"));
+        assert!(!detector.is_excluded("example.invalid"));
+
+        let detector = detector_with_exclusions(&["TEST.LOCAL"]);
+        assert!(detector.is_excluded("user@test.local"));
+        assert!(detector.is_excluded("User@Test.Local"));
+        assert!(!detector.is_excluded("user@example.invalid"));
     }
 
     #[test]

--- a/crates/gaze-recognizers/tests/core_extended.rs
+++ b/crates/gaze-recognizers/tests/core_extended.rs
@@ -1521,6 +1521,46 @@ fn core_email_global_matches_non_ascii_and_punctuation_boundaries() {
 }
 
 #[test]
+fn core_email_global_excludes_test_local_regardless_of_case() {
+    let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
+    let email_spec = core
+        .recognizers
+        .iter()
+        .find(|recognizer| recognizer.id == "email.global")
+        .expect("email.global");
+    assert_eq!(
+        email_spec
+            .context
+            .as_ref()
+            .map(|context| context.exclusions.clone())
+            .unwrap_or_default(),
+        vec!["test.local".to_string()]
+    );
+
+    for input in [
+        "Email user@test.local please",
+        "Email User@Test.Local please",
+        "Email USER@TEST.LOCAL please",
+    ] {
+        assert!(
+            detect_recognizer(&core, "email.global", input, LocaleTag::EnUs).is_empty(),
+            "test.local must be excluded regardless of casing: {input}"
+        );
+    }
+
+    assert_eq!(
+        detect_recognizer(
+            &core,
+            "email.global",
+            "Email Alice@Example.invalid please",
+            LocaleTag::EnUs
+        ),
+        vec!["Alice@Example.invalid".to_string()],
+        "non-excluded emails must still tokenize"
+    );
+}
+
+#[test]
 fn core_and_core_extended_compose_without_counter_collision() {
     let core = Rulepack::load(RulepackSource::Embedded(embedded("core").unwrap())).unwrap();
     let extended = core_extended();


### PR DESCRIPTION
Regex exclusions used case-insensitive equality but case-sensitive substring matching, so differently cased values bypassed configured exclusions. Apply ASCII-insensitive substring matching consistently, including mixed-case exclusion configuration.

## Review verdict
NITS fixed: normalize exclusion strings once during construction, skip allocation when no exclusions exist, and remove equality already implied by substring matching. Reviewed construction and Recognizer::detect filtering. Tests cover lower/mixed/upper-case input and configuration, bundled test.local exclusions, and non-excluded .invalid addresses.

## Axes
Trust and adopter ergonomics improve through consistent configured exclusion semantics. The exclusion contract remains explicit; normal detection outside configured exclusions is retained. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: store exclusions in their canonical ASCII-lowercase form.
- Why: removes repeated normalization per match and a redundant equality branch; one representation implements one matching rule.
- Scope: private exclusion storage/construction and matching, plus focused unit/bundled tests.
- Validation: Rust 1.96 wrapper: cargo fmt --all -- --check; cargo clippy -j 4 --workspace --all-features --all-targets -- -D warnings; cargo test -j 4 --workspace --all-features. All passed, including exclusion regressions, xtask integration checks, and doctests.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #512
Closes #478
Resolves solo todo #3523 (partial; orchestrator completes)
