### PR TITLE
Handle dictionary boundaries around hyphenated identifiers

### DIFF
--- a/crates/gaze-recognizers/src/dictionary.rs
+++ b/crates/gaze-recognizers/src/dictionary.rs
@@ -185,17 +185,23 @@ fn is_token_boundary_match(input: &str, start: usize, end: usize) -> bool {
 }
 
 fn has_identifier_char_before(input: &str, start: usize) -> bool {
-    input[..start]
-        .chars()
-        .next_back()
-        .is_some_and(is_identifier_char)
+    has_identifier_component(input[..start].chars().rev())
 }
 
 fn has_identifier_char_after(input: &str, end: usize) -> bool {
-    input[end..].chars().next().is_some_and(is_identifier_char)
+    has_identifier_component(input[end..].chars())
 }
 
-fn is_identifier_char(ch: char) -> bool {
+fn has_identifier_component(mut chars: impl Iterator<Item = char>) -> bool {
+    match chars.next() {
+        // A hyphen connects components only when a base identifier character follows.
+        Some('-') => chars.next().is_some_and(is_base_identifier_char),
+        Some(ch) => is_base_identifier_char(ch),
+        None => false,
+    }
+}
+
+fn is_base_identifier_char(ch: char) -> bool {
     ch == '_' || ch.is_alphanumeric()
 }
 
@@ -386,5 +392,59 @@ mod tests {
             .unwrap();
 
         assert!(hits.is_empty(), "unexpected dictionary hits: {hits:?}");
+    }
+
+    fn aaa_spans(input: &str) -> Vec<std::ops::Range<usize>> {
+        let ctx = TypedContext {
+            dictionaries: HashMap::from([(
+                "dict_alpha".to_string(),
+                ContextDictionary {
+                    terms: vec!["AAA".to_string()],
+                    case_sensitive: true,
+                },
+            )]),
+            class_map: HashMap::new(),
+            fields: Map::new(),
+        };
+        let bundle = dictionary_bundle_from_context(&ctx);
+        let detect_context = DetectContext::new(&[LocaleTag::Global], &bundle);
+        let recognizer = DictionaryRecognizer::new(
+            "dict/dict_alpha",
+            PiiClass::Custom("class_alpha".to_string()),
+            "dict_alpha",
+            true,
+            "counter",
+        );
+        recognizer
+            .detect(input, &detect_context)
+            .unwrap()
+            .into_iter()
+            .map(|h| h.span)
+            .collect()
+    }
+
+    #[test]
+    fn dictionary_recognizer_does_not_match_prefix_inside_hyphenated_identifier() {
+        let spans = aaa_spans("AAA then AAA-12345");
+        assert_eq!(spans, vec![0..3], "expected only standalone AAA");
+    }
+
+    #[test]
+    fn dictionary_recognizer_matches_term_with_leading_standalone_hyphen() {
+        let spans = aaa_spans("-AAA AAA-");
+        assert_eq!(
+            spans,
+            vec![1..4, 5..8],
+            "expected both AAA spans in -AAA AAA-"
+        );
+    }
+
+    #[test]
+    fn dictionary_recognizer_does_not_match_suffix_inside_hyphenated_identifier() {
+        let spans = aaa_spans("prefix-AAA-suffix");
+        assert!(
+            spans.is_empty(),
+            "expected no match for AAA inside connected identifier, got {spans:?}"
+        );
     }
 }


### PR DESCRIPTION
Dictionary terms could match partial components of hyphenated identifiers. Treat a hyphen as a connector only when another identifier character is adjacent, so partial connected components are rejected while standalone punctuation such as -AAA and AAA- preserves detection.

## Review verdict
CLEAN after re-review of the revised patch. The initial flat-hyphen proposal failed an independently added punctuation regression; the revised connector-aware behavior addresses that blocker. Reviewed dictionary match filtering, both boundary directions, Unicode character iteration, and existing full-hyphenated-term coverage. Positive punctuation and negative connected-prefix/suffix cases are covered.

## Axes
Trust improves by rejecting partial identifier matches while preserving detection next to punctuation. Full known terms remain detectable. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: one two-character connector predicate shared by forward and reverse character iterators.
- Why: removes mirrored branch rules and manual byte slicing, keeping prefix and suffix behavior identical and UTF-8 safe.
- Scope: local dictionary boundary helpers and focused tests; no new public configuration or abstraction.
- Validation: Rust 1.96 wrapper: cargo fmt --all -- --check; cargo clippy -j 4 --workspace --all-features --all-targets -- -D warnings; cargo test -j 4 --workspace --all-features. All passed, including punctuation/connected-identifier/full-term regressions, xtask temporary-checkout drift gates, and doctests. The independent -AAA AAA- regression passed unchanged main and failed the original proposal before this revision.

CI run 34686123577 hit the existing proxy_compat_golden health-test port reservation race (AddrInUse), outside this dictionary-only diff. Refreshed from main with signed, DCO-bearing merge commit 3c040ad3d7d9d1f77cbedef11b60625a4edf2a7c and pushed for a fresh CI run.

## Signed commit
Fresh machine-authored SSH-signed commit with matching DCO sign-off; no unsigned ancestry carried. Verified G and one gpgsig header.

Supersedes #532
Closes #502
Resolves solo todo #3523 (partial; orchestrator completes)
