### PR TITLE
Search all domain classes without hiding explicit policy denials

### DIFF
--- a/crates/gaze-cli/src/commands/index.rs
+++ b/crates/gaze-cli/src/commands/index.rs
@@ -130,35 +130,50 @@ pub(crate) fn search(args: SearchArgs) -> Result<(), CliError> {
 
     let principal = local_principal(&domain);
     let session = RedactionSession::ephemeral_for(&principal.id).map_err(map_bridge_error)?;
-    let class = args.class.unwrap_or_else(|| infer_class(&args.entity));
-    let source_token = session
-        .tokenize(&class, &args.entity)
-        .map_err(map_bridge_error)?;
-    let request = BridgeRequest {
-        principal: principal.clone(),
-        tenant_id: principal.tenant_id.clone(),
-        workspace_id: principal.workspace_id.clone(),
-        agent_run_id: "gaze-index-cli".to_string(),
-        conversation_session_id: session.session_id().to_string(),
-        tool_name: LOCAL_TOOL_NAME.to_string(),
-        action: LOCAL_ACTION.to_string(),
-        purpose: LOCAL_PURPOSE.to_string(),
-        source_token,
-        target_domain: args.domain,
-        requested_scope: RequestedScope::SameDomain,
+
+    // When `--class` is omitted, do not guess a single class: the PII class is a
+    // hard discriminator through tokenize/canonicalize/project, so a wrong guess
+    // (e.g. `Name` for an `Organization` entity) deterministically misses. Probe
+    // every class the target domain is configured to hold, and aggregate hits.
+    let candidate_classes: Vec<PiiClass> = match args.class {
+        Some(class) => vec![class],
+        None => domain.allowed_entity_classes.clone(),
     };
 
-    match bridge.search(&session, &request) {
-        BridgeSearchOutcome::Allowed(response) if !response.results.is_empty() => {
-            for hit in response.results {
-                println!("doc: {}", hit.doc_id);
-                println!("snippet: {}", hit.snippet);
+    let mut seen_doc_ids = BTreeSet::new();
+    for class in candidate_classes {
+        let source_token = session
+            .tokenize(&class, &args.entity)
+            .map_err(map_bridge_error)?;
+        let request = BridgeRequest {
+            principal: principal.clone(),
+            tenant_id: principal.tenant_id.clone(),
+            workspace_id: principal.workspace_id.clone(),
+            agent_run_id: "gaze-index-cli".to_string(),
+            conversation_session_id: session.session_id().to_string(),
+            tool_name: LOCAL_TOOL_NAME.to_string(),
+            action: LOCAL_ACTION.to_string(),
+            purpose: LOCAL_PURPOSE.to_string(),
+            source_token,
+            target_domain: args.domain.clone(),
+            requested_scope: RequestedScope::SameDomain,
+        };
+        match bridge.search(&session, &request) {
+            BridgeSearchOutcome::Allowed(response) if !response.results.is_empty() => {
+                for hit in response.results {
+                    if seen_doc_ids.insert(hit.doc_id.clone()) {
+                        println!("doc: {}", hit.doc_id);
+                        println!("snippet: {}", hit.snippet);
+                    }
+                }
             }
+            BridgeSearchOutcome::Allowed(_) => {}
+            BridgeSearchOutcome::Denied(reason) => return Err(index_denied(reason)),
         }
-        BridgeSearchOutcome::Allowed(_) => {
-            println!("no hits");
-        }
-        BridgeSearchOutcome::Denied(reason) => return Err(index_denied(reason)),
+    }
+
+    if seen_doc_ids.is_empty() {
+        println!("no hits");
     }
     println!("raw PII never shown (owner-side only)");
 
@@ -295,14 +310,6 @@ fn index_kiji_safety_net(
     Err(CliError::SafetyNetConfigDetail(
         "gaze index requires gaze-cli feature safety-net-kiji".to_string(),
     ))
-}
-
-fn infer_class(entity: &str) -> PiiClass {
-    if entity.contains('@') {
-        PiiClass::Email
-    } else {
-        PiiClass::Name
-    }
 }
 
 fn local_principal(domain: &gaze_token_bridge::model::IndexDomain) -> Principal {

--- a/crates/gaze-cli/tests/index_cli.rs
+++ b/crates/gaze-cli/tests/index_cli.rs
@@ -409,6 +409,236 @@ fn index_ingest_fails_closed_without_kiji_model_or_command() {
     );
 }
 
+#[test]
+#[file_serial(gaze_subprocess)]
+fn index_search_without_class_finds_organization_and_custom_class_entities() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("data.md"),
+        "Organization: Globex GmbH\nCustomer ID: 90210\n",
+    )
+    .expect("write data");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .arg("ingest")
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+    let ingest_stdout = String::from_utf8_lossy(&ingest.stdout).to_string();
+    assert!(
+        ingest_stdout.contains("entities: 2"),
+        "expected organization + custom entities, got: {ingest_stdout}"
+    );
+
+    // Armed `--class` searches confirm both entities are actually indexed.
+    let org_armed = gaze_index_command(&fake_kiji)
+        .args(["search", "Globex GmbH"])
+        .args(["--class", "org", "--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search --class org");
+    assert!(org_armed.status.success(), "org armed search failed");
+    let org_armed_stdout = String::from_utf8_lossy(&org_armed.stdout).to_string();
+    assert!(
+        org_armed_stdout.contains("doc: doc:"),
+        "--class org must find indexed org: {org_armed_stdout}"
+    );
+    assert!(org_armed_stdout.contains(":Organization_"));
+
+    let custom_armed = gaze_index_command(&fake_kiji)
+        .args(["search", "90210"])
+        .args([
+            "--class",
+            "custom:customer_id",
+            "--domain",
+            DOMAIN,
+            "--index-path",
+        ])
+        .arg(&index)
+        .output()
+        .expect("run index search --class custom:customer_id");
+    assert!(custom_armed.status.success(), "custom armed search failed");
+    let custom_armed_stdout = String::from_utf8_lossy(&custom_armed.stdout).to_string();
+    assert!(
+        custom_armed_stdout.contains("doc: doc:"),
+        "--class custom must find indexed custom: {custom_armed_stdout}"
+    );
+    assert!(custom_armed_stdout.contains(":Custom:customer_id_"));
+
+    // The bug: no `--class` must also reach both indexed classes.
+    let org_default = gaze_index_command(&fake_kiji)
+        .args(["search", "Globex GmbH"])
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search no --class (org)");
+    assert!(org_default.status.success(), "org default search failed");
+    let org_default_stdout = String::from_utf8_lossy(&org_default.stdout).to_string();
+    assert!(
+        org_default_stdout.contains("doc: doc:"),
+        "BUG[org]: no --class search missed indexed org: {org_default_stdout}"
+    );
+    assert!(org_default_stdout.contains(":Organization_"));
+    assert!(
+        !org_default_stdout.contains("no hits"),
+        "no --class search for indexed org must not say no hits: {org_default_stdout}"
+    );
+
+    let custom_default = gaze_index_command(&fake_kiji)
+        .args(["search", "90210"])
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search no --class (custom)");
+    assert!(
+        custom_default.status.success(),
+        "custom default search failed"
+    );
+    let custom_default_stdout = String::from_utf8_lossy(&custom_default.stdout).to_string();
+    assert!(
+        custom_default_stdout.contains("doc: doc:"),
+        "BUG[custom]: no --class search missed indexed custom: {custom_default_stdout}"
+    );
+    assert!(custom_default_stdout.contains(":Custom:customer_id_"));
+    assert!(
+        !custom_default_stdout.contains("no hits"),
+        "no --class search for indexed custom must not say no hits: {custom_default_stdout}"
+    );
+
+    // Raw PII never leaks on the default path; the owner-side footer still prints.
+    for stdout in [&org_default_stdout, &custom_default_stdout] {
+        for raw in ["Globex GmbH", "90210"] {
+            assert!(
+                !stdout.contains(raw),
+                "default search leaked raw fixture value {raw}: {stdout}"
+            );
+        }
+        assert!(
+            stdout.contains("raw PII never shown (owner-side only)"),
+            "default search must show owner-side footer: {stdout}"
+        );
+    }
+}
+
+#[test]
+#[file_serial(gaze_subprocess)]
+fn index_search_without_class_still_finds_name_email_and_reports_no_hits_when_absent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    fs::write(
+        corpus.join("people.md"),
+        "\
+Name: Dr. Schmidt
+Email: alice@example.invalid
+Organization: Globex GmbH
+",
+    )
+    .expect("write people");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .arg("ingest")
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    // Name entity reachable without --class (regression guard for the old Name default).
+    let name_default = gaze_index_command(&fake_kiji)
+        .args(["search", "Dr. Schmidt"])
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search no --class (name)");
+    assert!(name_default.status.success(), "name default search failed");
+    let name_default_stdout = String::from_utf8_lossy(&name_default.stdout).to_string();
+    assert!(
+        name_default_stdout.contains("doc: doc:"),
+        "no --class search for indexed name must hit: {name_default_stdout}"
+    );
+    assert!(name_default_stdout.contains(":Name_"));
+    assert!(
+        !name_default_stdout.contains("no hits"),
+        "no --class search for indexed name must not say no hits: {name_default_stdout}"
+    );
+
+    // Email entity reachable without --class (regression guard for the old Email heuristic).
+    let email_default = gaze_index_command(&fake_kiji)
+        .args(["search", "alice@example.invalid"])
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search no --class (email)");
+    assert!(
+        email_default.status.success(),
+        "email default search failed"
+    );
+    let email_default_stdout = String::from_utf8_lossy(&email_default.stdout).to_string();
+    assert!(
+        email_default_stdout.contains("doc: doc:"),
+        "no --class search for indexed email must hit: {email_default_stdout}"
+    );
+    assert!(email_default_stdout.contains(":Email_"));
+    assert!(
+        !email_default_stdout.contains("no hits"),
+        "no --class search for indexed email must not say no hits: {email_default_stdout}"
+    );
+
+    // A value absent from the index under every class still reports `no hits`.
+    let miss_default = gaze_index_command(&fake_kiji)
+        .args(["search", "nobody-nowhere-cafebabe"])
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index search no --class (absent)");
+    assert!(
+        miss_default.status.success(),
+        "absent default search failed"
+    );
+    let miss_default_stdout = String::from_utf8_lossy(&miss_default.stdout).to_string();
+    assert!(
+        miss_default_stdout.contains("no hits"),
+        "absent value must still report no hits: {miss_default_stdout}"
+    );
+
+    // No raw PII leaks; owner-side footer present on every default search.
+    for stdout in [
+        &name_default_stdout,
+        &email_default_stdout,
+        &miss_default_stdout,
+    ] {
+        for raw in ["Dr. Schmidt", "alice@example.invalid", "Globex GmbH"] {
+            assert!(
+                !stdout.contains(raw),
+                "default search leaked raw fixture value {raw}: {stdout}"
+            );
+        }
+        assert!(
+            stdout.contains("raw PII never shown (owner-side only)"),
+            "default search must show owner-side footer: {stdout}"
+        );
+    }
+}
+
 fn gaze_index_command(fake_kiji: &Path) -> Command {
     gaze_index_command_with_key(fake_kiji, TEST_INDEX_KEY)
 }
@@ -503,6 +733,70 @@ print(json.dumps(spans))
     permissions.set_mode(0o755);
     fs::set_permissions(&script, permissions).expect("chmod residual fake kiji");
     script
+}
+
+#[test]
+#[file_serial(gaze_subprocess)]
+fn index_search_explicit_disallowed_class_returns_policy_denial_not_no_hits() {
+    // Regression: the new `allows_class` guard must NOT apply when `--class` is
+    // explicitly supplied.  Previously the bridge returned DenyReason::ClassNotAllowed
+    // (non-zero exit, PolicyConfig in stderr).  The guard silently turned that into a
+    // successful "no hits", hiding the authorization failure.
+    let temp = tempfile::tempdir().expect("tempdir");
+    let corpus = temp.path().join("corpus");
+    let index = temp.path().join("owner-index");
+    let fake_kiji = write_fake_kiji(&temp);
+    fs::create_dir_all(&corpus).expect("corpus dir");
+    // Built-in classes are always allowed; this corpus introduces no custom class.
+    fs::write(
+        corpus.join("email-only.md"),
+        "Email: alice@example.invalid\n",
+    )
+    .expect("write email-only");
+
+    let ingest = gaze_index_command(&fake_kiji)
+        .arg("ingest")
+        .arg(&corpus)
+        .args(["--domain", DOMAIN, "--index-path"])
+        .arg(&index)
+        .output()
+        .expect("run index ingest");
+    assert!(
+        ingest.status.success(),
+        "ingest failed: stderr={}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    // An unconfigured custom class must reach bridge authorization and be denied.
+    let search = gaze_index_command(&fake_kiji)
+        .args(["search", "alice@example.invalid"])
+        .args([
+            "--class",
+            "custom:unconfigured",
+            "--domain",
+            DOMAIN,
+            "--index-path",
+        ])
+        .arg(&index)
+        .output()
+        .expect("run index search");
+
+    // Must fail with a non-zero exit (policy denial), not succeed with "no hits".
+    assert!(
+        !search.status.success(),
+        "explicit disallowed class must return non-zero exit, got success with stdout={}",
+        String::from_utf8_lossy(&search.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&search.stderr);
+    assert!(
+        stderr.contains("PolicyConfig") || stderr.contains("ClassNotAllowed"),
+        "stderr must contain policy denial reason, got: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&search.stdout);
+    assert!(
+        !stdout.contains("no hits"),
+        "explicit disallowed class must not produce 'no hits' success: {stdout}"
+    );
 }
 
 fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {


### PR DESCRIPTION
Searches without `--class` now probe each class declared by the encrypted index domain, so indexed organizations and custom entities are found. Each class still goes through the bridge authorization and output safety checks; results are deduplicated by document ID. Explicit disallowed classes retain the existing policy denial and nonzero exit.

## Review verdict
NITS: reviewed revised head 8ca5ca7d against current main, the complete search function, bridge authorization/canonicalization/output safety callers, and synthetic CLI regressions. Applied the patch cleanly and normalized test formatting. The bot denial test failed because all built-in classes, including `org`, are allowed even for an email-only corpus; changed it to the unconfigured `custom:unconfigured` class. The round-1 denial guard is removed; the existing document-ID set replaces the mirrored hit boolean. The new explicit-denial regression would fail with the old guard: `custom:unconfigured` is outside the domain, so the guard skips the sole candidate and incorrectly returns successful `no hits`.

## Validation
Rust 1.96.0, worktree-local target directory, `-j 4`: workspace/all-feature/all-target clippy passed; all-feature gaze-cli suite passed (including all 10 index CLI tests); formatting check passed. Mutation proof: reinstating the round-1 allow-list guard makes the corrected explicit-denial test fail with successful `no hits`; restoring the revised logic makes it pass.

## Axes
Reliability and trust retain typed, fail-closed bridge authorization and output safety checks. Reversibility remains session/manifest based. Agentic fit and adopter ergonomics improve through class-independent lookup. No axis weakened.

## Structure and data-model review
- Verdict: implement.
- Opportunity: the existing `seen_doc_ids` set is the sole hit-state record, with policy ownership retained in the bridge.
- Why: removes mirrored `any_hits` state and the duplicated allow-list branch that suppressed denials.
- Scope: the CLI search loop and its regression tests only. Included in the revised patch; no additional abstraction.
- Validation: full caller-chain review and CLI tests, including explicit disallowed class, implicit organization/custom/name/email lookup, and absent values.

## Signed commit
Fresh machine-authored SSH-signed commit with DCO sign-off; original unsigned ancestry not carried.

Supersedes #517
Closes #483
Resolves solo todo #3523 (partial; orchestrator completes)
